### PR TITLE
fix(core): bound the declared quantization mode string at load

### DIFF
--- a/src/lib/mlxcel-core/src/layers.rs
+++ b/src/lib/mlxcel-core/src/layers.rs
@@ -73,7 +73,24 @@ impl QuantizedWeight {
         }
     }
 
-    /// Create a new quantized weight with explicit mode
+    /// Create a new quantized weight with explicit mode.
+    ///
+    /// Fallible on purpose (issue #973), on the same reasoning that made
+    /// [`QuantizedEmbedding::new`] fallible for the declared `group_size` /
+    /// `bits` pair. This is the one way to build a `QuantizedWeight` with a
+    /// caller-chosen mode without going through
+    /// [`reconcile_quantization_layout`], and therefore without the allowlist it
+    /// now carries. The stored string goes straight to `quantized_matmul` /
+    /// `dequantize`, which cross the cxx bridge as `UniquePtr<MlxArray>` rather
+    /// than `Result`, so a mode MLX cannot parse is an uncatchable abort at the
+    /// first forward pass rather than a load error. Returning `Result` puts the
+    /// bound on the path the next family that builds one directly will take;
+    /// nothing in the tree calls this today. It is a strong default rather than
+    /// an enforced invariant, since the fields are `pub` and a struct literal
+    /// still bypasses it.
+    ///
+    /// [`validate_quantization_biases`] also rejects a mode that contradicts the
+    /// `biases` argument, which MLX throws on just as hard.
     pub fn new_with_mode(
         weight: UniquePtr<MlxArray>,
         scales: UniquePtr<MlxArray>,
@@ -81,8 +98,10 @@ impl QuantizedWeight {
         group_size: i32,
         bits: i32,
         mode: String,
-    ) -> Self {
-        Self {
+    ) -> Result<Self, String> {
+        validate_quantization_params(group_size, bits)?;
+        validate_quantization_biases(&mode, biases.is_some())?;
+        Ok(Self {
             weight,
             scales,
             biases,
@@ -90,7 +109,7 @@ impl QuantizedWeight {
             bits,
             mode,
             global_scale: None,
-        }
+        })
     }
 
     /// Get raw pointer to biases (null if not present, e.g. mxfp4/nvfp4/mxfp8)
@@ -334,6 +353,15 @@ impl QuantizedEmbedding {
         let layout = reconcile_quantization_layout_logged(
             &w_shape, &s_shape, group_size, bits, mode, prefix,
         )?;
+
+        // The reconciler bounds the mode string itself; this additionally
+        // refuses a valid mode that contradicts the `.biases` plane the
+        // checkpoint ships, which MLX throws on just as uncatchably (issue
+        // #973). A caller that reached here through `from_weights` cannot trip
+        // it, because `infer_quantization_mode` derives the mode from exactly
+        // this predicate.
+        validate_quantization_biases(mode, biases.is_some())
+            .map_err(|e| format!("{e} (prefix: {prefix})"))?;
 
         Ok(Self {
             weight,
@@ -1277,7 +1305,9 @@ pub struct ReconciledQuant {
 /// when the declared one disagrees (see [`reconcile_quantization_layout`]), and
 /// an allowlist of `{2,3,4,5,6,8}` would reject the mixed-precision exports
 /// that behavior exists to serve. Only values that can describe no packing at
-/// all are refused.
+/// all are refused. The declared `mode` in the same `quantization` block is the
+/// opposite case and is an allowlist, for the reasons on
+/// [`validate_quantization_mode`].
 ///
 /// Used by: every quantizing family through [`reconcile_quantization_layout`]
 ///          (dense projections and quantized embeddings) and through
@@ -1310,6 +1340,121 @@ pub fn validate_quantization_params(group_size: i32, bits: i32) -> Result<(), St
         ));
     }
     Ok(())
+}
+
+/// Every quantization mode MLX accepts, in the order its own parser tests them.
+///
+/// This mirrors `string_to_quantization_mode` in
+/// [ml-explore/mlx `mlx/primitives.cpp`](https://github.com/ml-explore/mlx/blob/main/mlx/primitives.cpp),
+/// which is a closed four-value C++ enum with no interior values. Exposed so
+/// the family-level config guards (gemma4's `validate_quantization_scheme`)
+/// cannot keep a private copy that drifts from the one the loaders enforce.
+///
+/// Used by: [`validate_quantization_mode`], [`infer_quantization_mode`] (which
+///          returns only values from this set by construction), and
+///          `crate::models::gemma4::validate_quantization_scheme` in the
+///          consuming crate
+pub const SUPPORTED_QUANTIZATION_MODES: [&str; 4] = ["affine", "mxfp4", "mxfp8", "nvfp4"];
+
+/// Reject a declared quantization mode MLX cannot parse.
+///
+/// Unlike [`validate_quantization_params`] this is an allowlist, and the
+/// reasoning that made the `group_size` / `bits` guard a bounds check does not
+/// transfer. That guard stays permissive because mlxcel deliberately re-derives
+/// an effective bit width from the tensor shapes (see
+/// [`reconcile_quantization_layout`]), so an allowlist of the widths MLX
+/// supports would reject legitimate mixed-precision exports. There is no
+/// analogous re-derivation from the declared mode string:
+/// [`infer_quantization_mode`] derives a mode from bias presence and ignores
+/// the declaration entirely, and the accepted set is a closed four-value C++
+/// enum. Mirroring MLX's own parser is the whole check.
+///
+/// An unrecognized mode is not rejected and not silently defaulted anywhere
+/// else. On the shared loader path it takes the block-float branch of
+/// [`reconcile_quantization_layout`], which on a genuine affine tensor
+/// re-derives the group size back onto the declared value, so not even the
+/// divergence warning fires; the string is then stored verbatim and handed to
+/// `quantized_matmul` / `gather_qmm` / `dequantize` on every forward pass.
+/// Those cross the cxx bridge as `UniquePtr<MlxArray>` rather than `Result`, so
+/// MLX's `std::invalid_argument` is an uncatchable `std::terminate` at the
+/// FIRST forward pass rather than a load error (issue #973).
+///
+/// The comparison is exact: no trimming, no case folding, and an empty string
+/// is rejected rather than read as "not declared". The string compared here has
+/// to be byte-identical to the one MLX parses, because it is the same string:
+/// normalizing before the comparison would accept `" Affine"` and then store
+/// and forward the raw spelling, which is precisely the gap this exists to
+/// close. "Not declared" is expressed by the absence of the key, which every
+/// config reader already resolves to `"affine"` before calling here.
+///
+/// Used by: every quantizing family through [`reconcile_quantization_layout`]
+///          (dense projections and quantized embeddings); the by-hand
+///          constructor [`QuantizedWeight::new_with_mode`], which never reaches
+///          the reconciler; [`validate_quantization_biases`]; and in the
+///          consuming crate `crate::models::switch_layers::SwitchLinear`
+///          (MoE experts), `crate::models::gpt_oss` (the one family that reads
+///          `quantization.mode` out of `config.json`, at both
+///          `Quantization::validate` and `ExpertLinear::from_weights`),
+///          `crate::models::config::QuantizationArgs::get_mode` and
+///          `crate::models::gemma4::validate_quantization_scheme`
+pub fn validate_quantization_mode(mode: &str) -> Result<(), String> {
+    if SUPPORTED_QUANTIZATION_MODES.contains(&mode) {
+        return Ok(());
+    }
+    let accepted = SUPPORTED_QUANTIZATION_MODES.join(", ");
+    Err(format!(
+        "quantization.mode ({mode:?}) must be one of {accepted}: MLX parses the mode with an \
+         exact, case-sensitive string comparison in string_to_quantization_mode and throws on \
+         anything else, and that throw crosses the cxx bridge as an uncatchable abort at the \
+         first forward pass rather than a load error"
+    ))
+}
+
+/// Reject a declared mode that contradicts the `.biases` plane the checkpoint
+/// actually ships.
+///
+/// MLX's `validate_mode_with_type` (see
+/// [ml-explore/mlx `mlx/ops.cpp`](https://github.com/ml-explore/mlx/blob/main/mlx/ops.cpp))
+/// requires zero-point `biases` for `affine` and requires them to be absent for
+/// every block-float mode, throwing `Biases must be provided for affine
+/// quantization` or `Biases must be null for quantization mode '<mode>'`
+/// otherwise. Both throws are the same uncatchable-abort class as an invalid
+/// mode string, and both are reachable from a checkpoint whose `config.json`
+/// declares a mode that its tensors do not match.
+///
+/// The shared loaders never trip this because they ignore the declaration and
+/// call [`infer_quantization_mode`] on bias presence, which is consistent by
+/// construction. Only a caller that threads a config-declared mode can, which
+/// today is gpt-oss. Because this is exactly MLX's own precondition, it can
+/// only reject a load that was already going to abort: it cannot refuse a
+/// checkpoint that works.
+///
+/// Validates `mode` itself first, so a caller needs one call rather than two.
+///
+/// Used by: UnifiedLinear::from_weights_with_mode,
+///          QuantizedEmbedding::from_weights_with_mode,
+///          QuantizedWeight::new_with_mode, `SwitchLinear::from_stacked_parts`
+///          and `GptOss ExpertLinear::from_weights` in the consuming crate
+pub fn validate_quantization_biases(mode: &str, has_biases: bool) -> Result<(), String> {
+    validate_quantization_mode(mode)?;
+    match (mode == "affine", has_biases) {
+        (true, false) => Err(
+            "quantization.mode is \"affine\" but the checkpoint ships no .biases plane: MLX \
+             requires zero points for affine quantization and throws \"Biases must be provided \
+             for affine quantization\" otherwise, which crosses the cxx bridge as an uncatchable \
+             abort at the first forward pass rather than a load error. Either the declared mode \
+             is wrong for these tensors (a block-float export mislabelled affine) or the .biases \
+             plane is missing from the checkpoint"
+                .to_string(),
+        ),
+        (false, true) => Err(format!(
+            "quantization.mode is {mode:?} but the checkpoint ships a .biases plane: the \
+             block-float modes carry no zero points and MLX throws \"Biases must be null for \
+             quantization mode '{mode}'\", which crosses the cxx bridge as an uncatchable abort \
+             at the first forward pass rather than a load error"
+        )),
+        _ => Ok(()),
+    }
 }
 
 /// Recover the `group_size` / `bits` a packed MLA `kv_b_proj` was quantized
@@ -1425,6 +1570,10 @@ const MAX_QUANT_GROUP_SIZE: i32 = 1 << 20;
 /// so the linear loader, the embedding loader, and the family-level weight
 /// validators cannot drift apart on which mode a given triple will load as.
 ///
+/// Every arm returns a member of [`SUPPORTED_QUANTIZATION_MODES`] by
+/// construction, which is why a caller that goes through here can never trip
+/// [`validate_quantization_mode`] or [`validate_quantization_biases`].
+///
 /// Used by: UnifiedLinear::from_weights, QuantizedEmbedding::from_weights,
 ///          BailingMoe weight validation
 pub fn infer_quantization_mode(has_biases: bool, group_size: i32, bits: i32) -> &'static str {
@@ -1456,6 +1605,10 @@ pub fn infer_quantization_mode(has_biases: bool, group_size: i32, bits: i32) -> 
 /// * returns `Err` for a declared `group_size` / `bits` pair that can describe
 ///   no packing at all, before it looks at the shapes (issue #929) — see
 ///   [`validate_quantization_params`],
+/// * returns `Err` for a `mode` MLX cannot parse, before it looks at the shapes
+///   (issue #973), see [`validate_quantization_mode`]. This also makes the
+///   `mode == "affine"` branch below total: without it, any unrecognized string
+///   silently took the block-float branch,
 /// * returns `Err` with an actionable message when the affine shapes match no
 ///   valid bit width — the signature of a misdeclared / unsupported external
 ///   packing that must not be dequantized as standard affine and served as
@@ -1479,6 +1632,15 @@ pub fn reconcile_quantization_layout(
     // separate: degenerate *shapes* still stay permissive, degenerate *params*
     // do not. See [`validate_quantization_params`].
     validate_quantization_params(group_size, bits)?;
+
+    // A `mode` MLX cannot parse is refused on the same terms and for the same
+    // reason (issue #973). Checking it here rather than only at the storage
+    // points covers every `UnifiedLinear` and `UnifiedEmbedding` in one place,
+    // and turns the two-way branch below from a silent fallthrough into a total
+    // one: an unrecognized string used to take the block-float path, which on a
+    // genuine affine tensor re-derives the declared group size back onto itself,
+    // so the layout looked reconciled and not even the divergence warning fired.
+    validate_quantization_mode(mode)?;
 
     // Insufficient shape info: trust the caller, mirroring the historical
     // early-return in `infer_quantization_bits` for empty / scalar shapes.
@@ -1818,6 +1980,16 @@ impl UnifiedLinear {
                 &w_shape, &s_shape, group_size, bits, mode, prefix,
             )?;
             let (effective_bits, effective_group_size) = (layout.bits, layout.group_size);
+
+            // The reconciler bounds the mode string itself; this additionally
+            // refuses a valid mode that contradicts the `.biases` plane the
+            // checkpoint ships, which MLX throws on just as uncatchably (issue
+            // #973). A caller that reached here through `from_weights` cannot
+            // trip it, because `infer_quantization_mode` derives the mode from
+            // exactly this predicate; only a caller threading a config-declared
+            // mode (gpt-oss) can.
+            validate_quantization_biases(mode, biases.is_some())
+                .map_err(|e| format!("{e} (prefix: {prefix})"))?;
 
             // Optional native-NVFP4 global-scale sidecar (`weight_scale_2`).
             // Emitted by the direct ModelOpt transcode (issue #693); absent for
@@ -5197,6 +5369,204 @@ mod tests {
                     });
             assert!(err.contains(field), "unhelpful error: {err}");
         }
+    }
+
+    /// The declared `mode` is the third value in the same `quantization` block
+    /// and, unlike `group_size` / `bits`, is bounded by an allowlist: MLX's
+    /// `string_to_quantization_mode` is a closed four-value enum and mlxcel
+    /// re-derives nothing from the declared string, so mirroring that parser is
+    /// the whole check (issue #973).
+    #[test]
+    fn quantization_mode_allowlist_mirrors_mlx_exactly() {
+        for mode in SUPPORTED_QUANTIZATION_MODES {
+            validate_quantization_mode(mode)
+                .unwrap_or_else(|e| panic!("MLX accepts {mode:?}, so mlxcel must too: {e}"));
+        }
+
+        // `infer_quantization_mode` is the only producer of a mode on the shared
+        // loader path, so every value it can return must be accepted or the
+        // guard would reject checkpoints that load today.
+        for has_biases in [true, false] {
+            for (group_size, bits) in [(64, 4), (32, 4), (16, 4), (64, 8)] {
+                let mode = infer_quantization_mode(has_biases, group_size, bits);
+                validate_quantization_mode(mode).unwrap_or_else(|e| {
+                    panic!("inferred mode {mode:?} must be in the allowlist: {e}")
+                });
+            }
+        }
+
+        // The comparison is exact on purpose: no trimming, no case folding, and
+        // an empty string is a declared value rather than "not declared". The
+        // string checked here is the same string MLX parses byte-for-byte, so
+        // normalizing would accept a spelling that is then stored and forwarded
+        // verbatim into the abort this exists to prevent.
+        for mode in [
+            "optiq", "gptq", "int4", "", "  ", "Affine", "AFFINE", " mxfp4", "mxfp4 ",
+        ] {
+            let Err(err) = validate_quantization_mode(mode) else {
+                panic!("MLX would throw on {mode:?}, so the load must fail first")
+            };
+            assert!(
+                err.contains("affine") && err.contains("nvfp4"),
+                "the message must name the accepted set: {err}"
+            );
+        }
+    }
+
+    /// The reconciler is the one place every `UnifiedLinear` and
+    /// `UnifiedEmbedding` passes through, so bounding the mode there covers the
+    /// whole dense surface at once. It also makes the `mode == "affine"` branch
+    /// total: an unrecognized string used to take the block-float branch, which
+    /// on a genuine affine tensor re-derives the declared group size back onto
+    /// itself, so nothing diverged and not even the warning fired (issue #973).
+    #[test]
+    fn reconciler_rejects_a_mode_mlx_cannot_parse() {
+        // Honest affine 4-bit geometry: packed_in * 32 == bits * groups * gs.
+        let (weight, scales) = (&[4, 8][..], &[4, 1][..]);
+
+        // Positive control first, so a guard that rejects everything cannot pass.
+        let ok = reconcile_quantization_layout(weight, scales, 64, 4, "affine")
+            .expect("an honest affine layout must still reconcile");
+        assert_eq!((ok.bits, ok.group_size, ok.reconciled), (4, 64, false));
+
+        for mode in ["optiq", "", "Affine"] {
+            let err = reconcile_quantization_layout(weight, scales, 64, 4, mode)
+                .expect_err("an unparseable mode must be refused");
+            assert!(err.contains("mode"), "unhelpful error: {err}");
+        }
+
+        // Degenerate shapes take an early return that trusts the caller, but the
+        // mode is checked before it, exactly as the param bound is.
+        assert!(reconcile_quantization_layout(&[], &[], 64, 4, "optiq").is_err());
+    }
+
+    /// A mode that parses but contradicts the `.biases` plane aborts just as
+    /// hard, inside MLX's `validate_mode_with_type`. Rejecting it at load can
+    /// only refuse a checkpoint that was already going to abort, because the
+    /// predicate is MLX's own (issue #973).
+    #[test]
+    fn declared_mode_must_agree_with_bias_presence() {
+        validate_quantization_biases("affine", true).expect("affine with zero points is the norm");
+        for mode in ["mxfp4", "mxfp8", "nvfp4"] {
+            validate_quantization_biases(mode, false)
+                .unwrap_or_else(|e| panic!("{mode} without zero points is the norm: {e}"));
+        }
+
+        let err = validate_quantization_biases("affine", false)
+            .expect_err("affine without zero points aborts in MLX");
+        assert!(err.contains("affine") && err.contains("biases"), "{err}");
+
+        for mode in ["mxfp4", "mxfp8", "nvfp4"] {
+            let err = validate_quantization_biases(mode, true)
+                .expect_err("block-float with zero points aborts in MLX");
+            assert!(err.contains(mode) && err.contains("biases"), "{err}");
+        }
+
+        // An unparseable mode fails here too, so a caller needs one call.
+        assert!(validate_quantization_biases("optiq", true).is_err());
+        assert!(validate_quantization_biases("optiq", false).is_err());
+    }
+
+    /// `QuantizedWeight::new_with_mode` is the by-hand constructor that takes an
+    /// unbounded mode string and never reaches the reconciler. It has no callers
+    /// in the tree, which is exactly why the bound belongs on the signature: the
+    /// next family to build one directly inherits it (issue #973).
+    #[test]
+    fn hand_built_quantized_weight_bounds_its_declared_mode() {
+        let plane = |last: i32| ffi::from_slice_f32(&vec![0.0; (4 * last) as usize], &[4, last]);
+
+        // Positive controls first, in both bias conventions.
+        QuantizedWeight::new_with_mode(plane(8), plane(1), Some(plane(1)), 64, 4, "affine".into())
+            .expect("an honest affine triple must still build");
+        QuantizedWeight::new_with_mode(plane(8), plane(1), None, 32, 4, "mxfp4".into())
+            .expect("an honest mxfp4 pair must still build");
+
+        for mode in ["optiq", "", "Affine"] {
+            let err =
+                QuantizedWeight::new_with_mode(plane(8), plane(1), None, 64, 4, mode.to_string())
+                    .err()
+                    .unwrap_or_else(|| panic!("an unparseable mode {mode:?} must be refused"));
+            assert!(err.contains("mode"), "unhelpful error: {err}");
+        }
+
+        // The declared pair is still bounded here as well.
+        assert!(
+            QuantizedWeight::new_with_mode(
+                plane(8),
+                plane(1),
+                Some(plane(1)),
+                0,
+                4,
+                "affine".into()
+            )
+            .is_err()
+        );
+        // And the mode must agree with the biases argument.
+        assert!(
+            QuantizedWeight::new_with_mode(plane(8), plane(1), None, 64, 4, "affine".into())
+                .is_err()
+        );
+    }
+
+    /// The two shared loaders that accept an explicit mode are what gpt-oss
+    /// threads its `config.json` string into, so drive them rather than the
+    /// helpers in isolation. The assertions are on the load `Result` and no
+    /// forward pass runs, so a regression fails cleanly here instead of aborting
+    /// the test binary the way it would in production (issue #973).
+    #[test]
+    fn explicit_mode_loaders_reject_a_config_declared_bad_mode() {
+        // Honest affine 4-bit geometry: 8 * 32 == 4 * 1 * 64.
+        let plane = |last: i32| ffi::from_slice_f32(&vec![0.0; (4 * last) as usize], &[4, last]);
+        let mut affine = crate::weights::WeightMap::new();
+        affine.insert("q_proj.weight".to_string(), plane(8));
+        affine.insert("q_proj.scales".to_string(), plane(1));
+        affine.insert("q_proj.biases".to_string(), plane(1));
+
+        // Positive controls first, so a guard that rejects everything quantized
+        // cannot pass this test.
+        UnifiedLinear::from_weights_with_mode(&affine, "q_proj", 64, 4, "affine")
+            .expect("an honest affine projection must still load");
+        QuantizedEmbedding::from_weights_with_mode(&affine, "q_proj", 64, 4, "affine")
+            .expect("an honest affine embedding must still load");
+
+        for mode in ["optiq", "gptq", "", "Affine"] {
+            let err = UnifiedLinear::from_weights_with_mode(&affine, "q_proj", 64, 4, mode)
+                .err()
+                .unwrap_or_else(|| panic!("an unparseable mode {mode:?} must be refused at load"));
+            assert!(
+                err.contains("mode") && err.contains("q_proj"),
+                "the message must name the field and the prefix: {err}"
+            );
+            let err = QuantizedEmbedding::from_weights_with_mode(&affine, "q_proj", 64, 4, mode)
+                .err()
+                .unwrap_or_else(|| panic!("an unparseable mode {mode:?} must be refused at load"));
+            assert!(err.contains("mode"), "unhelpful error: {err}");
+        }
+
+        // A parseable mode that contradicts the plane is refused too. Declaring
+        // block-float over a plane that ships zero points is the mirror of the
+        // affine-without-biases case, and MLX throws on both.
+        let err = UnifiedLinear::from_weights_with_mode(&affine, "q_proj", 32, 4, "mxfp4")
+            .err()
+            .unwrap_or_else(|| panic!("mxfp4 over a .biases-carrying plane aborts in MLX"));
+        assert!(err.contains("biases"), "unhelpful error: {err}");
+
+        let mut block_float = crate::weights::WeightMap::new();
+        block_float.insert("gate_proj.weight".to_string(), plane(8));
+        block_float.insert("gate_proj.scales".to_string(), plane(1));
+        UnifiedLinear::from_weights_with_mode(&block_float, "gate_proj", 32, 4, "mxfp4")
+            .expect("an honest mxfp4 projection must still load");
+        let err = UnifiedLinear::from_weights_with_mode(&block_float, "gate_proj", 64, 4, "affine")
+            .err()
+            .unwrap_or_else(|| panic!("affine over a plane with no zero points aborts in MLX"));
+        assert!(err.contains("biases"), "unhelpful error: {err}");
+
+        // A non-quantized projection carries no packing and no mode, so it must
+        // not be gated on either.
+        let mut regular = crate::weights::WeightMap::new();
+        regular.insert("o_proj.weight".to_string(), plane(8));
+        UnifiedLinear::from_weights_with_mode(&regular, "o_proj", 64, 4, "optiq")
+            .expect("a non-quantized projection must not be gated on the declared mode");
     }
 
     /// `QuantizedMultiLinear::from_weights` is a shared loader that stores the

--- a/src/models/config.rs
+++ b/src/models/config.rs
@@ -264,9 +264,26 @@ impl QuantizationArgs {
         self.bits.unwrap_or(4)
     }
 
-    /// Get quantization mode, defaulting to "affine"
-    pub fn get_mode(&self) -> &str {
-        self.mode.as_deref().unwrap_or("affine")
+    /// Get the declared quantization mode, defaulting to `"affine"` when the
+    /// key is absent.
+    ///
+    /// Fallible on purpose (issue #973). This helper has no production callers
+    /// yet and is the obvious thing for the next family that needs a declared
+    /// mode to reach for; handing back an unchecked `&str` would let it inherit
+    /// the hole silently, because the returned string goes on to
+    /// `quantized_matmul` / `gather_qmm` / `dequantize`, which cross the cxx
+    /// bridge as `UniquePtr<MlxArray>` rather than `Result`, so a mode MLX
+    /// cannot parse is an uncatchable abort at the first forward pass rather
+    /// than a load error. Returning `Result` makes the check impossible to skip
+    /// at the point the value is read.
+    ///
+    /// The `None` case is the absent key and resolves to `"affine"`; a present
+    /// but empty or misspelled string is rejected. See
+    /// [`mlxcel_core::layers::validate_quantization_mode`].
+    pub fn get_mode(&self) -> Result<&str, String> {
+        let mode = self.mode.as_deref().unwrap_or("affine");
+        mlxcel_core::layers::validate_quantization_mode(mode)?;
+        Ok(mode)
     }
 }
 
@@ -308,5 +325,37 @@ mod tests {
         assert!(!args.is_quantized());
         assert_eq!(args.get_group_size(), 64);
         assert_eq!(args.get_bits(), 4);
+    }
+
+    /// `get_mode` has no production callers and is the obvious thing for the
+    /// next family that needs a declared mode to reach for, so the bound belongs
+    /// on the signature rather than on each future caller (issue #973).
+    #[test]
+    fn get_mode_bounds_the_declared_string() {
+        // An absent key is "not declared" and resolves to affine.
+        assert_eq!(
+            QuantizationArgs::default().get_mode().as_deref(),
+            Ok("affine")
+        );
+
+        for mode in mlxcel_core::layers::SUPPORTED_QUANTIZATION_MODES {
+            let args = QuantizationArgs {
+                mode: Some(mode.to_string()),
+                ..Default::default()
+            };
+            assert_eq!(args.get_mode().as_deref(), Ok(mode));
+        }
+
+        // A present but unparseable string is not "not declared".
+        for mode in ["optiq", "gptq", "", "  ", "Affine"] {
+            let args = QuantizationArgs {
+                mode: Some(mode.to_string()),
+                ..Default::default()
+            };
+            let err = args
+                .get_mode()
+                .expect_err("a mode MLX cannot parse must not be handed out");
+            assert!(err.contains("mode"), "unhelpful error: {err}");
+        }
     }
 }

--- a/src/models/gemma4.rs
+++ b/src/models/gemma4.rs
@@ -3738,7 +3738,14 @@ pub(crate) fn slice_layer_input(
 /// Quantization schemes mlxcel can actually dequantize: MLX-native affine plus
 /// the block-float families. Anything else uses a packing mlxcel does not
 /// implement.
-const SUPPORTED_QUANT_SCHEMES: &[&str] = &["affine", "mxfp4", "nvfp4", "mxfp8"];
+///
+/// Borrowed from the core rather than re-listed here (issue #973). This used to
+/// be a private copy of the same four values, which is one list too many: the
+/// core one is what every loader enforces, so a private copy could only ever
+/// drift into accepting a mode the loaders reject or the reverse. `quant_method`
+/// is checked against it too, since a `quant_method` naming an MLX-native scheme
+/// is the same statement as a `mode` naming it.
+const SUPPORTED_QUANT_SCHEMES: [&str; 4] = mlxcel_core::layers::SUPPORTED_QUANTIZATION_MODES;
 
 /// Longest text-only prefill that still builds the dense `[l, l + offset]`
 /// f32 prefill masks. Above this, the mask pair is left `None` and `attend`
@@ -3765,6 +3772,12 @@ const DENSE_PREFILL_MASK_MAX_TOKENS: i32 = 4096;
 /// Inspects the top-level and `text_config`-nested `quantization` /
 /// `quantization_config` objects. Pure over the parsed config JSON so the
 /// policy is unit-testable without a model on disk.
+///
+/// The `mode` half of this is no longer gemma4-shaped and delegates to
+/// [`mlxcel_core::layers::validate_quantization_mode`] (issue #973), which every
+/// quantizing family now enforces at load. What stays here is the
+/// `quant_method` policy: the external-format rejection this function was added
+/// for and the ModelOpt NVFP4 exception that the gemma4 sanitize layer repacks.
 pub(crate) fn validate_quantization_scheme(config: &serde_json::Value) -> Result<(), String> {
     fn is_modelopt_nvfp4(obj: &serde_json::Value) -> bool {
         let method = obj
@@ -3805,25 +3818,44 @@ pub(crate) fn validate_quantization_scheme(config: &serde_json::Value) -> Result
             })
     }
 
+    fn unsupported(raw: &str, location: &str, key: &str) -> String {
+        format!(
+            "Unsupported quantization scheme '{raw}' declared at {location}.{key}. \
+             mlxcel supports MLX-native affine and block-float (mxfp4 / nvfp4 / mxfp8) \
+             quantization only; external formats such as OptiQ / AWQ / GPTQ use a \
+             different packing that would dequantize to degenerate output. Re-export the \
+             model to an MLX affine quantization (mlx_lm.convert / mlx-vlm) before serving."
+        )
+    }
+
     fn check_obj(obj: &serde_json::Value, location: &str) -> Result<(), String> {
-        for key in ["quant_method", "mode"] {
-            let Some(raw) = obj.get(key).and_then(|v| v.as_str()) else {
-                continue;
-            };
+        // `mode` delegates to the core allowlist so this guard and the loaders
+        // cannot disagree about the same config (issue #973). The comparison
+        // there is exact, which is deliberately stricter than the normalized one
+        // still applied to `quant_method` below: `mode` is a string MLX itself
+        // parses byte-for-byte, so accepting `" Affine"` here would only mean
+        // storing and forwarding a spelling the kernel then throws on. An empty
+        // `mode` is rejected on the same grounds; "not declared" is the absent
+        // key, which every config reader resolves to `"affine"` on its own.
+        if let Some(raw) = obj.get("mode").and_then(|v| v.as_str())
+            && mlxcel_core::layers::validate_quantization_mode(raw).is_err()
+        {
+            return Err(unsupported(raw, location, "mode"));
+        }
+
+        // `quant_method` is a gemma4-shaped policy rather than a mode: it is the
+        // #467 external-format guard (OptiQ / AWQ / GPTQ) plus the ModelOpt
+        // NVFP4 exception, and it never reaches an MLX kernel, so it keeps the
+        // permissive normalization it has always had. The accepted set is still
+        // the core one, so the two cannot name different schemes.
+        if let Some(raw) = obj.get("quant_method").and_then(|v| v.as_str()) {
             let norm = raw.trim().to_ascii_lowercase();
-            if key == "quant_method" && norm == "modelopt" && is_modelopt_nvfp4(obj) {
-                continue;
+            let accepted = norm.is_empty()
+                || SUPPORTED_QUANT_SCHEMES.contains(&norm.as_str())
+                || (norm == "modelopt" && is_modelopt_nvfp4(obj));
+            if !accepted {
+                return Err(unsupported(raw, location, "quant_method"));
             }
-            if norm.is_empty() || SUPPORTED_QUANT_SCHEMES.contains(&norm.as_str()) {
-                continue;
-            }
-            return Err(format!(
-                "Unsupported quantization scheme '{raw}' declared at {location}.{key}. \
-                 mlxcel supports MLX-native affine and block-float (mxfp4 / nvfp4 / mxfp8) \
-                 quantization only; external formats such as OptiQ / AWQ / GPTQ use a \
-                 different packing that would dequantize to degenerate output. Re-export the \
-                 model to an MLX affine quantization (mlx_lm.convert / mlx-vlm) before serving."
-            ));
         }
         Ok(())
     }
@@ -5940,6 +5972,46 @@ mod quant_scheme_tests {
     fn rejects_unknown_mode() {
         let cfg = json!({ "quantization": { "group_size": 64, "bits": 4, "mode": "optiq" } });
         assert!(validate_quantization_scheme(&cfg).is_err());
+    }
+
+    /// The `mode` list is no longer owned here: it delegates to
+    /// `mlxcel_core::layers::validate_quantization_mode`, so this guard and the
+    /// loaders cannot disagree about the same config (issue #973). Delegation
+    /// also makes the comparison exact, which is stricter than the normalized
+    /// one this used to apply: a mode is a string MLX parses byte-for-byte, so
+    /// accepting a trimmed or case-folded spelling here would only mean storing
+    /// and forwarding a value the kernel then throws on.
+    #[test]
+    fn mode_check_delegates_to_the_core_allowlist() {
+        for mode in mlxcel_core::layers::SUPPORTED_QUANTIZATION_MODES {
+            let cfg = json!({ "quantization": { "group_size": 64, "bits": 4, "mode": mode } });
+            assert!(
+                validate_quantization_scheme(&cfg).is_ok(),
+                "MLX accepts {mode}, so this guard must too"
+            );
+        }
+
+        // Exact comparison: whitespace, casing and an empty string are all
+        // values MLX would throw on.
+        for mode in ["Affine", "AFFINE", " mxfp4", "mxfp4 ", "", "  "] {
+            let cfg = json!({ "quantization": { "group_size": 64, "bits": 4, "mode": mode } });
+            let err = validate_quantization_scheme(&cfg)
+                .expect_err("a spelling MLX cannot parse must be rejected");
+            assert!(
+                err.contains("Unsupported quantization scheme"),
+                "actionable message: {err}"
+            );
+        }
+
+        // `quant_method` is a separate, gemma4-shaped policy (issue #467) and
+        // keeps its permissive normalization: it never reaches an MLX kernel.
+        for method in ["AFFINE", " affine ", ""] {
+            let cfg = json!({ "quantization": { "quant_method": method } });
+            assert!(
+                validate_quantization_scheme(&cfg).is_ok(),
+                "quant_method {method:?} names an MLX-native scheme and must stay accepted"
+            );
+        }
     }
 
     #[test]

--- a/src/models/gpt_oss.rs
+++ b/src/models/gpt_oss.rs
@@ -130,18 +130,30 @@ impl Quantization {
     /// Entries whose value is not an object are the top-level scalars
     /// themselves (`group_size`, `bits`, `mode`) and are covered by the
     /// `defaults()` check rather than iterated as overrides.
+    ///
+    /// The declared `mode` is walked the same way (issue #973). gpt-oss is the
+    /// only family that reads `quantization.mode` out of `config.json` and
+    /// threads it into a loader, so this is the only place a hostile mode can be
+    /// blamed on the prefix that declared it. A mode-less override keeps
+    /// resolving to `"affine"` through `params_for` rather than inheriting the
+    /// top-level mode, which is what the 24 router overrides in the canonical
+    /// mxfp4 checkpoint rely on.
     fn validate(&self) -> Result<(), String> {
         let Quantization::Full(map) = self;
-        let (gs, bits, _) = self.defaults();
+        let (gs, bits, mode) = self.defaults();
         mlxcel_core::layers::validate_quantization_params(gs, bits)
+            .map_err(|e| format!("GptOss config.json quantization: {e}"))?;
+        mlxcel_core::layers::validate_quantization_mode(&mode)
             .map_err(|e| format!("GptOss config.json quantization: {e}"))?;
         for key in map.keys() {
             let Some(value) = map.get(key) else { continue };
             if !value.is_object() {
                 continue;
             }
-            let (gs, bits, _) = self.params_for(key);
+            let (gs, bits, mode) = self.params_for(key);
             mlxcel_core::layers::validate_quantization_params(gs, bits)
+                .map_err(|e| format!("GptOss config.json quantization.{key}: {e}"))?;
+            mlxcel_core::layers::validate_quantization_mode(&mode)
                 .map_err(|e| format!("GptOss config.json quantization.{key}: {e}"))?;
         }
         Ok(())
@@ -170,7 +182,8 @@ impl ModelArgs {
     /// still lives at each storage point (`ExpertLinear::from_weights` and the
     /// shared reconciler behind `UnifiedLinear` / `UnifiedEmbedding`); this
     /// exists because gpt-oss is the only family whose per-prefix overrides can
-    /// each carry their own hostile pair (issue #958).
+    /// each carry their own hostile pair (issue #958) or their own hostile
+    /// `mode` (issue #973).
     pub fn validate_quantization(&self) -> Result<(), String> {
         let Some(quantization) = self.quantization.as_ref() else {
             return Ok(());
@@ -433,6 +446,22 @@ impl ExpertLinear {
             let quant_biases = weights
                 .get(&format!("{}.biases", prefix))
                 .map(|w| mlxcel_core::copy(w));
+
+            // Bound the declared mode on the same terms as the pair, and on the
+            // same reasoning: it is stored below and handed to `gather_qmm`
+            // verbatim (issue #973). The bias-presence half matters here in a way
+            // it does not for the shared loaders: this branch selects the
+            // quantized path on `.scales` alone and makes `.biases` an `Option`
+            // that becomes a null pointer when absent, so a plane with scales and
+            // no zero points under a declared `affine` mode used to be built
+            // without complaint and abort in `gather_qmm` with "Biases must be
+            // provided for affine quantization". This is MLX's own precondition,
+            // so it refuses only a load that was already going to abort; the
+            // canonical mxfp4 checkpoint pairs its 72 mode-less expert planes with
+            // block-float and its 122 `.biases`-carrying planes with affine, and
+            // is unaffected.
+            mlxcel_core::layers::validate_quantization_biases(mode, quant_biases.is_some())
+                .map_err(|e| format!("{prefix}: {e}"))?;
 
             Ok(Self::Quantized {
                 weight,
@@ -1419,6 +1448,80 @@ mod tests {
             .expect("a non-quantized expert plane must not be gated on quantization params");
     }
 
+    /// The third value in the same `quantization` block. `ExpertLinear` stores
+    /// the declared mode and hands it to `gather_qmm`, and gpt-oss is the only
+    /// family that puts a `config.json` string there at all, so this is where a
+    /// hostile mode actually reaches a kernel (issue #973). No forward pass is
+    /// run, because MLX's throw would abort the test binary rather than fail it.
+    #[test]
+    fn gpt_oss_expert_linear_rejects_a_mode_that_would_abort_gather_qmm() {
+        let prefix = "model.layers.0.mlp.experts.gate_up_proj";
+        let mut affine = WeightMap::new();
+        crate::models::switch_layers::insert_stacked_quantized_expert_plane(
+            &mut affine,
+            prefix,
+            3,
+            4,
+            8,
+            1,
+        );
+
+        // Positive control first, so a guard that rejects everything quantized
+        // cannot pass this test.
+        ExpertLinear::from_weights(&affine, prefix, 64, 4, "affine")
+            .expect("an honest affine plane must still load");
+
+        for mode in crate::models::switch_layers::HOSTILE_QUANT_MODES {
+            let err = ExpertLinear::from_weights(&affine, prefix, 64, 4, mode)
+                .err()
+                .unwrap_or_else(|| panic!("ExpertLinear must reject mode {mode:?}"));
+            assert!(
+                err.contains("mode") && err.contains("gate_up_proj"),
+                "the message must name the field and the prefix: {err}"
+            );
+        }
+
+        // `from_weights` enters the quantized branch on `.scales` presence alone
+        // and makes `.biases` an `Option` that becomes a null pointer when
+        // absent, so a plane with scales and no zero points under a declared
+        // `affine` mode used to be built without complaint and abort in
+        // `gather_qmm`. This is MLX's own precondition, so it can only refuse a
+        // load that was already going to abort.
+        let mut no_biases = WeightMap::new();
+        for (leaf, last, value) in [("weight", 8, 0.0), ("scales", 1, 1.0)] {
+            no_biases.insert(
+                format!("{prefix}.{leaf}"),
+                mlxcel_core::from_slice_f32(&vec![value; (3 * 4 * last) as usize], &[3, 4, last]),
+            );
+        }
+        // The shape the canonical mxfp4 checkpoint actually ships: 72 expert
+        // planes with scales, no zero points, on the top-level block-float mode.
+        ExpertLinear::from_weights(&no_biases, prefix, 32, 4, "mxfp4")
+            .expect("the canonical mxfp4 expert plane must still load");
+        let err = ExpertLinear::from_weights(&no_biases, prefix, 64, 4, "affine")
+            .err()
+            .unwrap_or_else(|| panic!("affine over a plane with no zero points must be rejected"));
+        assert!(
+            err.contains("biases") && err.contains("gate_up_proj"),
+            "unhelpful error: {err}"
+        );
+
+        // And the mirror, which MLX rejects just as hard.
+        let err = ExpertLinear::from_weights(&affine, prefix, 32, 4, "mxfp4")
+            .err()
+            .unwrap_or_else(|| panic!("block-float over a .biases plane must be rejected"));
+        assert!(err.contains("biases"), "unhelpful error: {err}");
+
+        // A non-quantized expert plane carries no mode at all.
+        let mut regular = WeightMap::new();
+        regular.insert(
+            format!("{prefix}.weight"),
+            mlxcel_core::from_slice_f32(&vec![0.0; 3 * 4 * 8], &[3, 4, 8]),
+        );
+        ExpertLinear::from_weights(&regular, prefix, 0, 0, "optiq")
+            .expect("a non-quantized expert plane must not be gated on the declared mode");
+    }
+
     /// gpt-oss is the one family whose `quantization` block is a map of
     /// per-weight-prefix overrides, so a bound on the top-level defaults says
     /// nothing about what an individual projection loads with, and vice versa.
@@ -1510,5 +1613,91 @@ mod tests {
         .expect("test config must parse");
         args.validate_quantization()
             .expect("a bf16 checkpoint declares no quantization and must not be gated");
+    }
+
+    /// The declared `mode` has to be walked in both directions for the same
+    /// reason the pair does. The live gap is the top-level one: `MLPBlock`
+    /// reads `Quantization::defaults` for the experts rather than `quant_for`,
+    /// so a hostile top-level mode reaches `gather_qmm` while every guarded
+    /// sibling loader sees a good per-prefix mode, which is the shape every real
+    /// gpt-oss checkpoint ships (issue #973).
+    #[test]
+    fn gpt_oss_config_validation_walks_every_declared_mode() {
+        let args_from = |quantization: serde_json::Value| -> ModelArgs {
+            serde_json::from_value(serde_json::json!({
+                "model_type": "gpt_oss",
+                "vocab_size": 32,
+                "hidden_size": 8,
+                "intermediate_size": 8,
+                "num_hidden_layers": 1,
+                "num_attention_heads": 2,
+                "num_key_value_heads": 1,
+                "head_dim": 4,
+                "num_local_experts": 2,
+                "num_experts_per_tok": 1,
+                "rms_norm_eps": 1e-5,
+                "rope_theta": 150000.0,
+                "sliding_window": 8,
+                "quantization": quantization,
+            }))
+            .expect("test config must parse")
+        };
+
+        // Positive control: the exact shape `models/gpt-oss-20b-mxfp4` ships, a
+        // non-affine top-level mode with affine per-prefix overrides and a
+        // mode-less override that must keep resolving to affine rather than
+        // inheriting the top-level mxfp4.
+        let canonical = args_from(serde_json::json!({
+            "group_size": 32,
+            "bits": 4,
+            "mode": "mxfp4",
+            "model.embed_tokens": { "group_size": 64, "bits": 4, "mode": "affine" },
+            "model.layers.0.mlp.router": { "group_size": 64, "bits": 8 },
+        }));
+        canonical
+            .validate_quantization()
+            .expect("the canonical gpt-oss quantization block must still validate");
+        assert_eq!(canonical.quant_for("model.layers.0.mlp.router").2, "affine");
+        assert_eq!(canonical.quant_for("model.layers.0.mlp.experts").2, "mxfp4");
+
+        // Every mode MLX accepts still validates at the top level.
+        for mode in mlxcel_core::layers::SUPPORTED_QUANTIZATION_MODES {
+            args_from(serde_json::json!({ "group_size": 32, "bits": 4, "mode": mode }))
+                .validate_quantization()
+                .unwrap_or_else(|e| panic!("MLX accepts {mode}, so the config must too: {e}"));
+        }
+
+        for mode in crate::models::switch_layers::HOSTILE_QUANT_MODES {
+            // The live gap: a hostile top-level mode with a valid per-prefix
+            // override, which is what actually reaches the experts.
+            let err = args_from(serde_json::json!({
+                "group_size": 32,
+                "bits": 4,
+                "mode": mode,
+                "model.embed_tokens": { "group_size": 64, "bits": 4, "mode": "affine" },
+            }))
+            .validate_quantization()
+            .expect_err("a hostile top-level mode must be rejected");
+            assert!(err.contains("mode"), "unhelpful error: {err}");
+
+            // And the mirror: a hostile per-prefix mode under valid top-level
+            // defaults, which reaches the `UnifiedLinear` surface instead.
+            let err = args_from(serde_json::json!({
+                "group_size": 32,
+                "bits": 4,
+                "mode": "mxfp4",
+                "model.layers.0.self_attn.q_proj": {
+                    "group_size": 64,
+                    "bits": 4,
+                    "mode": mode,
+                },
+            }))
+            .validate_quantization()
+            .expect_err("a hostile per-prefix mode must be rejected");
+            assert!(
+                err.contains("mode") && err.contains("q_proj"),
+                "the message must name both the field and the override, got: {err}"
+            );
+        }
     }
 }

--- a/src/models/mod.rs
+++ b/src/models/mod.rs
@@ -26,6 +26,13 @@ mod recurrent_snapshot;
 mod sanitize;
 
 // Shared modules
+// `config` holds shared serde defaults and the common `QuantizationArgs`. It
+// was never declared here, so the file was orphaned: not compiled, not linted,
+// not tested. That is why its `get_mode` could hand out an unvalidated
+// quantization mode with nothing catching it (issue #973). Declaring it makes
+// the bound it now carries real rather than notional, so the next family that
+// reaches for the helper cannot inherit the hole.
+pub mod config;
 pub(crate) mod conv_decode;
 pub mod gated_delta;
 pub mod switch_layers;

--- a/src/models/switch_layers.rs
+++ b/src/models/switch_layers.rs
@@ -222,6 +222,19 @@ pub(crate) const HOSTILE_QUANT_PARAMS: [(i32, i32, &str); 5] = [
     (-64, 4, "group_size"),
 ];
 
+/// The `mode` strings MLX's `string_to_quantization_mode` refuses to parse.
+///
+/// `optiq` / `gptq` / `int4` are the external formats a mis-exported checkpoint
+/// actually tags itself with. The rest are the near misses: an empty string, a
+/// whitespace-only string, wrong casing, and stray leading whitespace. All four
+/// are rejected because MLX compares exactly and mlxcel deliberately does not
+/// normalize before handing the string over (issue #973).
+/// Every family's guard test walks this list so they cannot drift apart on
+/// which strings count as hostile.
+#[cfg(test)]
+pub(crate) const HOSTILE_QUANT_MODES: [&str; 7] =
+    ["optiq", "gptq", "int4", "", "  ", "Affine", " mxfp4"];
+
 /// Per-expert 3D linear layer (falls back to gather_mm for non-quantized models)
 /// Supports affine, mxfp4, nvfp4, and mxfp8 quantization modes.
 pub enum SwitchLinear {
@@ -383,7 +396,9 @@ impl SwitchLinear {
     /// `group_size` of 0 or a `bits` outside `1..=32` aborts the process at the
     /// first routed forward pass exactly as it would for a dense projection.
     /// Guarding only the reconciler would have left every quantized MoE
-    /// checkpoint exposed.
+    /// checkpoint exposed. The declared `mode` is bounded here for the same
+    /// reason (issue #973): `SwitchLinear::from_weights` hardcodes `"affine"`,
+    /// but `from_weights_with_mode` is `pub` and takes an unbounded `&str`.
     fn from_stacked_parts(
         prefix: &str,
         weight: UniquePtr<MlxArray>,
@@ -400,6 +415,14 @@ impl SwitchLinear {
                 // path, so a declared 0 would otherwise zero the denominator
                 // below, skip inference entirely, and be handed to the kernel.
                 mlxcel_core::layers::validate_quantization_params(group_size, bits)
+                    .map_err(|e| format!("{prefix}: {e}"))?;
+
+                // Same for the declared mode, which is stored verbatim below and
+                // handed to `gather_qmm` on every routed forward pass (issue
+                // #973). The bias-presence half of this is MLX's own
+                // `validate_mode_with_type` precondition, so it can only refuse
+                // a load that was already going to abort.
+                mlxcel_core::layers::validate_quantization_biases(mode, biases.is_some())
                     .map_err(|e| format!("{prefix}: {e}"))?;
 
                 // Infer the actual bit width from the packed weight and scales
@@ -1387,6 +1410,72 @@ mod tests {
         );
         SwitchLinear::from_weights(&regular, &stacked_prefix, 0, 0)
             .expect("a non-quantized expert plane must not be gated on quantization params");
+    }
+
+    #[test]
+    fn switch_linear_rejects_a_mode_that_would_abort_gather_qmm() {
+        // `SwitchLinear::from_weights` hardcodes `"affine"`, but
+        // `from_weights_with_mode` is `pub` and takes an unbounded `&str`, and
+        // the string it is handed is stored verbatim and passed to `gather_qmm`
+        // on every routed forward pass (issue #973). A regression here takes the
+        // whole test binary down with SIGABRT rather than failing cleanly, which
+        // is why the assertions stop at the load `Result`.
+        let group = 64i32;
+        let in_dim = 64i32;
+        let packed_in = in_dim / 8;
+        let num_groups = in_dim / group;
+        let prefix = "model.layers.0.mlp.switch_mlp.gate_proj";
+        let stacked = stacked_quantized_experts(prefix, 3, 4, packed_in, num_groups);
+
+        // Positive control first, so a guard that rejects everything quantized
+        // cannot pass this test.
+        SwitchLinear::from_weights_with_mode(&stacked, prefix, group, 4, "affine")
+            .expect("an honest affine plane must still load");
+
+        for mode in HOSTILE_QUANT_MODES {
+            let err = SwitchLinear::from_weights_with_mode(&stacked, prefix, group, 4, mode)
+                .err()
+                .unwrap_or_else(|| panic!("stacked experts must reject mode {mode:?}"));
+            assert!(
+                err.contains("mode") && err.contains("gate_proj"),
+                "the message must name the field and the prefix: {err}"
+            );
+        }
+
+        // A parseable mode that contradicts the plane aborts in MLX just as
+        // hard: these experts carry zero points, so block-float is a lie.
+        for mode in ["mxfp4", "mxfp8", "nvfp4"] {
+            let err = SwitchLinear::from_weights_with_mode(&stacked, prefix, group, 4, mode)
+                .err()
+                .unwrap_or_else(|| panic!("block-float over a .biases plane must be rejected"));
+            assert!(err.contains("biases"), "unhelpful error: {err}");
+        }
+
+        // And the mirror: an affine declaration over a plane with no zero points
+        // is the case that reaches `Biases must be provided for affine
+        // quantization`.
+        let mut no_biases = WeightMap::new();
+        for (leaf, last, value) in [("weight", packed_in, 0.0), ("scales", num_groups, 1.0)] {
+            no_biases.insert(
+                format!("{prefix}.{leaf}"),
+                mlxcel_core::from_slice_f32(&vec![value; (3 * 4 * last) as usize], &[3, 4, last]),
+            );
+        }
+        SwitchLinear::from_weights_with_mode(&no_biases, prefix, group, 4, "mxfp4")
+            .expect("an honest block-float plane must still load");
+        let err = SwitchLinear::from_weights_with_mode(&no_biases, prefix, group, 4, "affine")
+            .err()
+            .unwrap_or_else(|| panic!("affine over a plane with no zero points must be rejected"));
+        assert!(err.contains("biases"), "unhelpful error: {err}");
+
+        // A non-quantized expert plane carries no mode at all.
+        let mut regular = WeightMap::new();
+        regular.insert(
+            format!("{prefix}.weight"),
+            mlxcel_core::from_slice_f32(&vec![0.0; 3 * 4 * 8], &[3, 4, 8]),
+        );
+        SwitchLinear::from_weights_with_mode(&regular, prefix, group, 4, "optiq")
+            .expect("a non-quantized expert plane must not be gated on the declared mode");
     }
 
     #[test]


### PR DESCRIPTION
## Summary

`quantization.mode` was the one value in the `quantization` block that nothing in `mlxcel-core` bounded. #972 bounded `group_size` and `bits` and deliberately left the mode out of scope, and the only bound that existed anywhere was gemma4's private `SUPPORTED_QUANT_SCHEMES`. This adds `mlxcel_core::layers::validate_quantization_mode`, an allowlist mirroring MLX's own `string_to_quantization_mode`, and wires it into every path a declared mode can reach a kernel through.

An unrecognized mode was neither rejected nor defaulted. On the shared loader path it took the block-float branch of `reconcile_quantization_layout`, which on a genuine affine tensor re-derives the group size back onto the declared value, so nothing looked reconciled and not even the divergence warning fired. The string was then stored verbatim and handed to `quantized_matmul` / `gather_qmm` / `dequantize` on every forward pass. Those cross the cxx bridge as `UniquePtr<MlxArray>` rather than `Result`, so MLX's `std::invalid_argument` was an uncatchable `std::terminate` at the first forward pass, after the model had already loaded without a warning.

## Two decisions the issue asked to be made explicitly

**Exact comparison: no trimming, no case folding.** MLX compares the raw string byte-for-byte and has no normalization of its own, so `" Affine"` parses in gemma4's old check and throws in the kernel. Normalizing before the comparison would accept a spelling that is then stored and forwarded unchanged, which is exactly the gap being closed. mlxcel also does not silently rewrite declared metadata (the #467 policy is to warn, not override), so there is no correct place to put a normalized value even if one were computed. gemma4's `mode` check becomes stricter as a result, which is the right direction; its `quant_method` check keeps the permissive normalization it has always had, because a `quant_method` never reaches an MLX kernel.

**An empty string is a declared value, not "not declared".** `"mode": ""` survives `obj.get("mode").and_then(|v| v.as_str())` as `Some("")`, reaches `gather_qmm`, and aborts. "Not declared" is the absence of the key, which every config reader already resolves to `"affine"` before anything is validated. gemma4 used to accept an empty mode; it no longer does.

## Item 6: affine with no `.biases`

Rejected at load rather than repaired, and generalized to MLX's full precondition. Repairing via `infer_quantization_mode` would swap one uncatchable abort for another: relabelling a genuinely affine plane as block-float makes MLX throw `Scale type must be uint8 but received type float16` instead. It also guesses, and silently overrides a declaration, which is what #467 exists to prevent.

`validate_quantization_biases` instead enforces both halves of MLX's `validate_mode_with_type`: `affine` requires `.biases`, every block-float mode requires their absence. Because the predicate is MLX's own, it can only refuse a load that was already going to abort. It is a provable no-op for every caller that goes through `UnifiedLinear::from_weights` / `QuantizedEmbedding::from_weights`, which derive the mode from bias presence via `infer_quantization_mode` and are consistent by construction. Only a caller threading a config-declared mode can trip it, which today is gpt-oss alone.

## What changed

- `src/lib/mlxcel-core/src/layers.rs`: new `SUPPORTED_QUANTIZATION_MODES`, `validate_quantization_mode` and `validate_quantization_biases`; called from `reconcile_quantization_layout` (covering every `UnifiedLinear` and `UnifiedEmbedding`, and making the `mode == "affine"` branch total rather than a silent fallthrough), from `UnifiedLinear::from_weights_with_mode` and `QuantizedEmbedding::from_weights_with_mode` for the bias half, and from `QuantizedWeight::new_with_mode`, which becomes `Result` (it had no callers).
- `src/models/switch_layers.rs`: `SwitchLinear::from_stacked_parts` bounds the mode next to the existing `validate_quantization_params`, covering both the pre-stacked and per-expert layouts reached through the `pub` `from_weights_with_mode`. Adds the shared `HOSTILE_QUANT_MODES` table beside `HOSTILE_QUANT_PARAMS`.
- `src/models/gpt_oss.rs`: `Quantization::validate` stops discarding the mode and walks the top-level pair plus every per-prefix override, so a hostile mode is blamed on the prefix that declared it. `ExpertLinear::from_weights` bounds the mode and the bias pairing where it stores them.
- `src/models/config.rs`: `QuantizationArgs::get_mode` returns `Result<&str, String>`. It has no production callers and is the obvious thing for the next family to reach for, so the bound belongs on the signature.
- `src/models/mod.rs`: `pub mod config;`. See below.
- `src/models/gemma4.rs`: `SUPPORTED_QUANT_SCHEMES` is now the core constant rather than a private copy, and the `mode` comparison delegates to the core function. gemma4 keeps its `quant_method` and ModelOpt-NVFP4 policy, which is genuinely gemma4-shaped and covers #467.

## One premise corrected

The issue lists `QuantizedEmbedding::from_weights_with_mode` among the entry points that "never reach `reconcile_quantization_layout`". It does reach it, through `reconcile_quantization_layout_logged`, so the mode allowlist covers it via item 2 with no separate call needed. Only the bias-pairing half had to be added there. The numbered proposal's own item 3 lists a different (correct) set of four, naming `ExpertLinear::from_weights` in its place; all five surfaces are covered either way.

## Test plan

Real-model runs, since CI runs no `cargo test`:

- [x] `models/gpt-oss-20b-mxfp4` loads and generates unchanged. The one local checkpoint whose declared mode reaches a kernel: top-level `mxfp4` for the 72 expert planes, 98 `affine` per-prefix overrides, and 24 mode-less overrides that must keep resolving to `affine` rather than inheriting `mxfp4`.
- [x] Synthetic hostile configs (symlink farms in a scratchpad, the checkpoint itself untouched) fail at load with a message naming the four modes: hostile top level with valid overrides (the live gap, since the experts read `Quantization::defaults`), hostile per-prefix mode with a valid top level, and `affine` declared over the bias-less expert planes.
- [x] `models/minicpm-v-4.6-mxfp4` (block-float through `reconcile_quantization_layout`) unchanged.
- [x] `models/gemma-4-31b-it-nvfp4` (ModelOpt NVFP4, the #467 path) unchanged.
- [x] `models/qwen3-30b-a3b-4bit` and `models/qwen3.5-2b-4bit` (affine MoE and affine dense) unchanged.
- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --release --all-targets --features metal,accelerate -- -D warnings` (the release form; `make verify-clippy` uses the debug profile, which would cold-build MLX here)
- [x] `cargo test --release --features metal,accelerate --no-fail-fast`

Regression tests drive real load paths and assert on the returned `Result` without running a forward pass, because an MLX throw would abort the test binary rather than fail it. Each hostile case is paired with a positive control that loads first.

Closes #973
