### PR TITLE
fix(models): build quantized Jamba MoE experts through the shared SwitchGLU

### DIFF
--- a/src/lib/mlxcel-core/src/layers.rs
+++ b/src/lib/mlxcel-core/src/layers.rs
@@ -1392,9 +1392,12 @@ pub const SUPPORTED_QUANTIZATION_MODES: [&str; 4] = ["affine", "mxfp4", "mxfp8",
 ///          constructor [`QuantizedWeight::new_with_mode`], which never reaches
 ///          the reconciler; [`validate_quantization_biases`]; and in the
 ///          consuming crate `crate::models::switch_layers::SwitchLinear`
-///          (MoE experts), `crate::models::gpt_oss` (the one family that reads
-///          `quantization.mode` out of `config.json`, at both
+///          (MoE experts), `crate::models::gpt_oss` (which reads
+///          `quantization.mode` out of `config.json` at both
 ///          `Quantization::validate` and `ExpertLinear::from_weights`),
+///          `crate::models::jamba::JambaModel::from_weights` (which reads the
+///          declared mode only to refuse anything its affine-only loaders would
+///          silently reinterpret),
 ///          `crate::models::config::QuantizationArgs::get_mode` and
 ///          `crate::models::gemma4::validate_quantization_scheme`
 pub fn validate_quantization_mode(mode: &str) -> Result<(), String> {

--- a/src/models/jamba.rs
+++ b/src/models/jamba.rs
@@ -17,7 +17,8 @@
 //
 // Key features:
 // - Interleaved Mamba and Attention blocks (configurable pattern)
-// - Optional Sparse MoE (SwitchGLU)
+// - Optional Sparse MoE through the shared `switch_layers::SwitchGLU`
+//   (quantized experts via gather_qmm, dense via gather_mm)
 // - Mamba blocks with dt/b/c layernorms
 // - Mixed cache: KVCache for attention, MambaCache for Mamba
 
@@ -25,7 +26,7 @@ use mlxcel_core::generate::LanguageModel;
 use mlxcel_core::layers::{
     FusedQKVLinear, KVCache, Linear, RMSNorm, UnifiedEmbedding, UnifiedLinear,
 };
-use mlxcel_core::utils::{create_causal_mask, silu, slice_axis, stack_arrays};
+use mlxcel_core::utils::{create_causal_mask, silu, slice_axis};
 use mlxcel_core::weights::WeightMap;
 use mlxcel_core::{MlxArray, UniquePtr, concatenate};
 use serde::Deserialize;
@@ -33,12 +34,18 @@ use std::path::Path;
 
 use super::model_owned::ModelOwnedSequenceState;
 use super::recurrent_snapshot::{push_optional, restore_optional};
+use super::switch_layers::{SwitchGLU, moe_weighted_sum};
 
 // Configuration.
 #[derive(Debug, Clone, Deserialize)]
 pub struct Quantization {
     pub group_size: i32,
     pub bits: i32,
+    /// Declared quantization mode. Absent means `"affine"`, which is what every
+    /// published Jamba conversion declares. Read so the loader can refuse a mode
+    /// it would otherwise silently reinterpret; see [`JambaConfig::quantization_mode`].
+    #[serde(default = "default_quantization_mode")]
+    pub mode: String,
 }
 
 #[derive(Debug, Clone, Deserialize)]
@@ -110,6 +117,19 @@ impl JambaConfig {
     pub fn bits(&self) -> i32 {
         self.quantization.as_ref().map(|q| q.bits).unwrap_or(4)
     }
+
+    /// The declared quantization mode, defaulting to `"affine"` when the
+    /// `quantization` block is absent or does not name one.
+    pub fn quantization_mode(&self) -> &str {
+        self.quantization
+            .as_ref()
+            .map(|q| q.mode.as_str())
+            .unwrap_or("affine")
+    }
+}
+
+fn default_quantization_mode() -> String {
+    "affine".to_string()
 }
 
 fn default_rms_norm_eps() -> f32 {
@@ -331,119 +351,41 @@ impl JambaMLP {
     }
 }
 
-// SwitchLinear for MoE.
-// Kept local: uses take+matmul (not gather_mm), different forward shape handling
-#[allow(dead_code)]
-enum SwitchLinear {
-    Quantized {
-        weight: UniquePtr<MlxArray>,
-        scales: UniquePtr<MlxArray>,
-        biases: UniquePtr<MlxArray>,
-        group_size: i32,
-        bits: i32,
-    },
-    Regular {
-        weight: UniquePtr<MlxArray>, // [num_experts, out_features, in_features]
-    },
-}
-
-impl SwitchLinear {
-    fn forward(&self, x: &MlxArray, indices: &MlxArray) -> UniquePtr<MlxArray> {
-        match self {
-            Self::Quantized {
-                weight,
-                scales,
-                biases,
-                group_size,
-                bits,
-            } => {
-                // Use gather_qmm for quantized MoE experts
-                unsafe {
-                    mlxcel_core::gather_qmm(
-                        x,
-                        weight,
-                        scales,
-                        biases
-                            .as_ref()
-                            .map(|b| b as *const _)
-                            .unwrap_or(std::ptr::null()),
-                        std::ptr::null(),
-                        indices as *const _,
-                        true,
-                        *group_size,
-                        *bits,
-                        false,
-                        "affine",
-                    )
-                }
-            }
-            Self::Regular { weight } => {
-                // Gather weights for selected experts, then batched matmul
-                let w = mlxcel_core::take(weight, indices, 0);
-                let x_shape = mlxcel_core::array_shape(x);
-                let x_reshaped = mlxcel_core::reshape(x, &[x_shape[0], x_shape[1], 1, x_shape[2]]);
-                let w_transposed = mlxcel_core::transpose_axes(&w, &[0, 1, 3, 2]);
-                let result = mlxcel_core::matmul(&x_reshaped, &w_transposed);
-                mlxcel_core::squeeze_axis(&result, 2)
-            }
-        }
-    }
-}
-
-// SwitchGLU (MoE FFN).
-struct SwitchGLU {
-    gate_proj: SwitchLinear,
-    up_proj: SwitchLinear,
-    down_proj: SwitchLinear,
-}
-
-impl SwitchGLU {
-    fn forward(&self, x: &MlxArray, indices: &MlxArray) -> UniquePtr<MlxArray> {
-        let shape = mlxcel_core::array_shape(x);
-        let batch = shape[0];
-        let seq_len = shape[1];
-
-        // Expand x for expert routing: [batch, seq, hidden] -> [batch, seq, 1, hidden]
-        let x_exp = mlxcel_core::reshape(x, &[batch, seq_len, 1, shape[2]]);
-
-        // Forward through gate and up projections
-        let x_gate = self.gate_proj.forward(&x_exp, indices);
-        let x_up = self.up_proj.forward(&x_exp, indices);
-
-        // SiLU activation on gate
-        let gated = mlxcel_core::multiply(&silu(&x_gate), &x_up);
-
-        // Reshape for down projection
-        let gated_shape = mlxcel_core::array_shape(&gated);
-        let k = gated_shape[2]; // num_experts_per_tok
-
-        let flat = mlxcel_core::reshape(&gated, &[batch * seq_len, k, gated_shape[3]]);
-
-        // Flatten indices too
-        let indices_flat = mlxcel_core::reshape(indices, &[-1, k]);
-
-        // Down projection
-        let out = self.down_proj.forward(&flat, &indices_flat);
-
-        // Reshape back to [batch, seq, k, hidden]
-        let out_shape = mlxcel_core::array_shape(&out);
-        mlxcel_core::reshape(&out, &[batch, seq_len, k, out_shape[out_shape.len() - 1]])
-    }
-}
-
 // Sparse MoE Block.
 struct JambaSparseMoeBlock {
-    router: Linear,
+    /// Loaded through `UnifiedLinear` rather than the plain `load_linear`
+    /// because real quantized Jamba MoE conversions ship the router packed with
+    /// its own `.scales` / `.biases`, at a width that need not match the
+    /// top-level one (`ncls-p/AI21-Jamba2-Mini-mlx-4Bit` declares 8-bit routers
+    /// under a 4-bit default). `UnifiedLinear` infers the per-tensor width from
+    /// the packed-weight and scales shapes, so both widths load correctly.
+    router: UnifiedLinear,
     switch_mlp: SwitchGLU,
     num_experts_per_tok: usize,
 }
 
 impl JambaSparseMoeBlock {
     fn forward(&self, x: &MlxArray) -> UniquePtr<MlxArray> {
-        let gates = self.router.forward(x);
+        // The shared `SwitchGLU` takes a 2D `[tokens, hidden]` activation and a
+        // 2D `[tokens, top_k]` index plane (it does its own `expand_dims` before
+        // the gather), so flatten the leading dims here and restore them at the
+        // end. The family-local `SwitchGLU` this replaced passed a 3D `x`
+        // straight through and then expanded it twice, which made every routed
+        // token abort in `reshape` before it ever reached an expert (#974).
+        let orig_shape = mlxcel_core::array_shape(x);
+        let hidden = orig_shape[orig_shape.len() - 1];
+        let x_flat = if orig_shape.len() > 2 {
+            let tokens: i32 = orig_shape[..orig_shape.len() - 1].iter().product();
+            mlxcel_core::reshape(x, &[tokens, hidden])
+        } else {
+            mlxcel_core::copy(x)
+        };
+
+        let gates = self.router.forward(&x_flat);
         let k = self.num_experts_per_tok as i32;
 
-        // Get top-k expert indices using argpartition
+        // Top-k expert selection: argpartition over the negated logits puts the
+        // k largest first, so the head slice is the top-k set.
         let neg_gates = mlxcel_core::negative(&gates);
         let inds = mlxcel_core::argpartition(&neg_gates, k - 1, -1);
         let inds = slice_axis(&inds, -1, 0, k);
@@ -452,17 +394,15 @@ impl JambaSparseMoeBlock {
         let scores = mlxcel_core::take_along_axis(&gates, &inds, -1);
         let scores = mlxcel_core::softmax(&scores, -1);
 
-        // Apply MoE
-        let y = self.switch_mlp.forward(x, &inds);
+        // [tokens, top_k, hidden]
+        let expert_out = self.switch_mlp.forward(&x_flat, &inds);
+        let combined = moe_weighted_sum(&expert_out, &scores, mlxcel_core::array_dtype(&x_flat));
 
-        // Weighted sum: y * scores[..., None]
-        let mut scores_shape = mlxcel_core::array_shape(&scores);
-        scores_shape.push(1);
-        let scores_exp = mlxcel_core::reshape(&scores, &scores_shape);
-        let weighted = mlxcel_core::multiply(&y, &scores_exp);
-
-        // Sum over expert dimension
-        mlxcel_core::sum_axis(&weighted, -2, false)
+        if orig_shape.len() > 2 {
+            mlxcel_core::reshape(&combined, &orig_shape)
+        } else {
+            combined
+        }
     }
 }
 
@@ -1070,31 +1010,15 @@ impl JambaModel {
             weights.remove("lm_head.weight");
         }
 
-        // Handle MoE weight conversion (experts.N -> switch_mlp)
-        for l in 0..config.num_hidden_layers {
-            let base = format!("model.layers.{}.feed_forward", l);
-            let has_experts = weights
-                .keys()
-                .any(|k| k.starts_with(&format!("{}.experts.", base)));
-            if !has_experts {
-                continue;
-            }
-
-            for proj in ["gate_proj", "down_proj", "up_proj"] {
-                let mut expert_tensors: Vec<UniquePtr<MlxArray>> = Vec::new();
-                let mut e = 0;
-                while let Some(w) =
-                    weights.remove(&format!("{}.experts.{}.{}.weight", base, e, proj))
-                {
-                    expert_tensors.push(w);
-                    e += 1;
-                }
-                if !expert_tensors.is_empty() {
-                    let stacked = stack_arrays(&expert_tensors, 0);
-                    weights.insert(format!("{}.switch_mlp.{}.weight", base, proj), stacked);
-                }
-            }
-        }
+        // The per-expert (`experts.{idx}`) to stacked (`switch_mlp`) remap that
+        // used to live here carried `.weight` alone, so a quantized per-expert
+        // export lost its `.scales` / `.biases` and the layer was then built
+        // dense from packed `uint32` (#974). `SwitchLinear::from_weights` now
+        // handles both layouts through `switch_layers::stack_individual_experts`,
+        // which stacks all three planes, and it derives the same expert keys
+        // from the `{root}.switch_mlp.{proj}` prefix this loop used to write. It
+        // also runs for `from_weights` callers that never went through
+        // `sanitize_weights`, which this loop did not.
 
         weights
     }
@@ -1114,6 +1038,25 @@ impl JambaModel {
         // Get quantization parameters
         let group_size = config.group_size();
         let bits = config.bits();
+
+        // Bound the declared mode before any loader consumes it (#973, #974).
+        // Every Jamba loader below builds affine planes: `UnifiedLinear`,
+        // `UnifiedEmbedding`, `FusedQKVLinear` and `SwitchGLU` all take the
+        // `"affine"` entry points. An unparseable mode reaches MLX verbatim and
+        // a block-float one would be silently reinterpreted as affine, and both
+        // cross the cxx bridge as an uncatchable abort at the first forward pass
+        // rather than a load error. Refuse them here instead, naming the mode.
+        let mode = config.quantization_mode();
+        mlxcel_core::layers::validate_quantization_mode(mode)?;
+        if mode != "affine" {
+            return Err(format!(
+                "quantization.mode is {mode:?}, but every Jamba projection and expert plane \
+                 is built as affine, so a block-float checkpoint would be reinterpreted as \
+                 affine and abort inside the kernel instead of failing here. Only \"affine\" \
+                 is supported for this architecture"
+            )
+            .into());
+        }
 
         // Build quantized embeddings
         let embed_tokens =
@@ -1220,38 +1163,31 @@ impl JambaModel {
 
             // Build feed forward (MLP or MoE)
             let feed_forward = if config.is_expert_layer(i) {
-                let router = load_linear(&mut weights, &format!("{}.feed_forward.router", prefix))?;
+                let router = UnifiedLinear::from_weights(
+                    &weights,
+                    &format!("{}.feed_forward.router", prefix),
+                    group_size,
+                    bits,
+                )?;
 
-                let gate_weight = weights
-                    .remove(&format!(
-                        "{}.feed_forward.switch_mlp.gate_proj.weight",
-                        prefix
-                    ))
-                    .ok_or(format!("Missing MoE gate_proj for layer {}", i))?;
-                let up_weight = weights
-                    .remove(&format!(
-                        "{}.feed_forward.switch_mlp.up_proj.weight",
-                        prefix
-                    ))
-                    .ok_or(format!("Missing MoE up_proj for layer {}", i))?;
-                let down_weight = weights
-                    .remove(&format!(
-                        "{}.feed_forward.switch_mlp.down_proj.weight",
-                        prefix
-                    ))
-                    .ok_or(format!("Missing MoE down_proj for layer {}", i))?;
+                // The shared loader branches on `.scales` presence, so a
+                // quantized expert plane reaches `gather_qmm` instead of being
+                // handed to `gather_mm` as raw packed `uint32`. It bounds the
+                // declared `group_size` / `bits` pair and the affine/`.biases`
+                // pairing before storing anything derived from them, and it
+                // accepts both the pre-stacked `switch_mlp` layout and the
+                // per-expert `experts.{idx}` one. The error it returns already
+                // names the full tensor prefix, so no layer wrapper is needed.
+                let switch_mlp = SwitchGLU::from_weights(
+                    &weights,
+                    &format!("{}.feed_forward.switch_mlp", prefix),
+                    group_size,
+                    bits,
+                )?;
 
                 FeedForward::MoE(JambaSparseMoeBlock {
                     router,
-                    switch_mlp: SwitchGLU {
-                        gate_proj: SwitchLinear::Regular {
-                            weight: gate_weight,
-                        },
-                        up_proj: SwitchLinear::Regular { weight: up_weight },
-                        down_proj: SwitchLinear::Regular {
-                            weight: down_weight,
-                        },
-                    },
+                    switch_mlp,
                     num_experts_per_tok: config.num_experts_per_tok,
                 })
             } else {

--- a/src/models/jamba_tests.rs
+++ b/src/models/jamba_tests.rs
@@ -132,3 +132,311 @@ fn jamba_attention_layer_snapshot_restore_round_trips_kv_state() {
         super::JambaLayerCache::Mamba(_) => panic!("restored wrong cache variant"),
     }
 }
+
+// Quantized MoE expert plane (issue #974).
+//
+// Jamba declared a family-local `SwitchLinear::Quantized` variant that nothing
+// ever constructed, so a pre-stacked quantized `switch_mlp` plane was built as a
+// dense plane from packed `uint32` weights and the `.scales` / `.biases` planes
+// were dropped on the floor. `ncls-p/AI21-Jamba2-Mini-mlx-4Bit` ships exactly
+// that layout: `num_experts: 16` over 32 layers, 48 `.weight` / 48 `.scales` /
+// 48 `.biases` pre-stacked `switch_mlp` tensors, and 8-bit routers declared
+// under a 4-bit top level.
+//
+// These drive `JambaModel::from_weights` itself rather than a loader helper in
+// isolation, and assert on the returned `Result` without running a forward
+// pass: `gather_qmm` and `quantized_matmul` cross the cxx bridge as
+// `UniquePtr<MlxArray>` rather than `Result`, so an MLX C++ throw is an
+// uncatchable `std::terminate` that would take the whole test binary down with
+// SIGABRT instead of failing cleanly here.
+//
+// The hostile-parameter walk is also what proves the quantized branch is live at
+// all: the dense `gather_mm` path ignores the declared `group_size` / `bits`
+// pair entirely, so before the fix every hostile pair loaded without complaint.
+
+use super::{JambaConfig, JambaModel};
+use crate::models::switch_layers::{HOSTILE_QUANT_PARAMS, insert_stacked_quantized_expert_plane};
+use mlxcel_core::weights::WeightMap;
+
+/// Honest 4-bit geometry: `packed_in * 32 == bits * num_groups * group_size`
+/// on both projection shapes, so the positive controls below are planes MLX can
+/// actually describe.
+const HIDDEN: i32 = 64;
+const INTERMEDIATE: i32 = 128;
+const VOCAB: i32 = 32;
+const EXPERTS: i32 = 2;
+const GROUP_SIZE: i32 = 64;
+const BITS: i32 = 4;
+
+const MOE_PREFIX: &str = "model.layers.0.feed_forward.switch_mlp";
+const GATE_PLANE: &str = "model.layers.0.feed_forward.switch_mlp.gate_proj";
+
+/// One MoE layer: `expert_layer_period` 1 with `num_experts` 2 makes layer 0 an
+/// expert layer, and `attn_layer_period` 1 makes it an attention layer, so the
+/// fixture does not also have to carry a Mamba block.
+fn moe_config(quantization: &str) -> JambaConfig {
+    serde_json::from_str(&format!(
+        r#"{{
+            "model_type": "jamba",
+            "hidden_size": {HIDDEN},
+            "intermediate_size": {INTERMEDIATE},
+            "num_hidden_layers": 1,
+            "num_attention_heads": 4,
+            "num_key_value_heads": 4,
+            "vocab_size": {VOCAB},
+            "attn_layer_period": 1,
+            "attn_layer_offset": 0,
+            "expert_layer_period": 1,
+            "expert_layer_offset": 0,
+            "num_experts": {EXPERTS},
+            "num_experts_per_tok": 2,
+            "tie_word_embeddings": true,
+            "quantization": {quantization}
+        }}"#
+    ))
+    .expect("jamba MoE test config")
+}
+
+fn quant_block(group_size: i32, bits: i32) -> String {
+    format!(r#"{{"group_size": {group_size}, "bits": {bits}}}"#)
+}
+
+fn put_f32(weights: &mut WeightMap, name: &str, shape: &[i32], value: f32) {
+    let n: usize = shape.iter().map(|d| *d as usize).product();
+    weights.insert(
+        name.to_string(),
+        mlxcel_core::from_slice_f32(&vec![value; n], shape),
+    );
+}
+
+/// Everything a one-layer attention-plus-MoE Jamba needs except the three
+/// expert planes, which each test supplies in the layout it is exercising.
+fn backbone_weights() -> WeightMap {
+    let mut weights = WeightMap::new();
+    put_f32(
+        &mut weights,
+        "model.embed_tokens.weight",
+        &[VOCAB, HIDDEN],
+        0.02,
+    );
+    for proj in ["q_proj", "k_proj", "v_proj", "o_proj"] {
+        put_f32(
+            &mut weights,
+            &format!("model.layers.0.self_attn.{proj}.weight"),
+            &[HIDDEN, HIDDEN],
+            0.02,
+        );
+    }
+    put_f32(
+        &mut weights,
+        "model.layers.0.feed_forward.router.weight",
+        &[EXPERTS, HIDDEN],
+        0.02,
+    );
+    put_f32(
+        &mut weights,
+        "model.layers.0.input_layernorm.weight",
+        &[HIDDEN],
+        1.0,
+    );
+    put_f32(
+        &mut weights,
+        "model.layers.0.pre_ff_layernorm.weight",
+        &[HIDDEN],
+        1.0,
+    );
+    put_f32(&mut weights, "model.final_layernorm.weight", &[HIDDEN], 1.0);
+    weights
+}
+
+/// Pre-stacked affine expert planes, the layout every mlx-community style
+/// conversion (and `ncls-p/AI21-Jamba2-Mini-mlx-4Bit`) ships.
+fn stacked_quantized_weights() -> WeightMap {
+    let mut weights = backbone_weights();
+    for (proj, out, in_features) in [
+        ("gate_proj", INTERMEDIATE, HIDDEN),
+        ("up_proj", INTERMEDIATE, HIDDEN),
+        ("down_proj", HIDDEN, INTERMEDIATE),
+    ] {
+        insert_stacked_quantized_expert_plane(
+            &mut weights,
+            &format!("{MOE_PREFIX}.{proj}"),
+            EXPERTS,
+            out,
+            in_features * BITS / 32,
+            in_features / GROUP_SIZE,
+        );
+    }
+    weights
+}
+
+/// The same three planes shipped unstacked, one tensor per expert, which is the
+/// layout `sanitize_weights` used to stack by hand while carrying `.weight`
+/// alone and dropping `.scales` / `.biases`.
+fn per_expert_quantized_weights() -> WeightMap {
+    let mut weights = backbone_weights();
+    for (proj, out, in_features) in [
+        ("gate_proj", INTERMEDIATE, HIDDEN),
+        ("up_proj", INTERMEDIATE, HIDDEN),
+        ("down_proj", HIDDEN, INTERMEDIATE),
+    ] {
+        let packed_in = in_features * BITS / 32;
+        let num_groups = in_features / GROUP_SIZE;
+        for e in 0..EXPERTS {
+            let prefix = format!("model.layers.0.feed_forward.experts.{e}.{proj}");
+            let n = (out * packed_in) as usize;
+            let packed = mlxcel_core::from_slice_f32(&vec![0.0f32; n], &[out, packed_in]);
+            weights.insert(
+                format!("{prefix}.weight"),
+                mlxcel_core::astype(&packed, mlxcel_core::dtype::UINT32),
+            );
+            put_f32(
+                &mut weights,
+                &format!("{prefix}.scales"),
+                &[out, num_groups],
+                1.0,
+            );
+            put_f32(
+                &mut weights,
+                &format!("{prefix}.biases"),
+                &[out, num_groups],
+                0.0,
+            );
+        }
+    }
+    weights
+}
+
+/// Dense bf16-style experts: one stacked `[experts, out, in]` plane per
+/// projection and no `.scales`, so the declared pair is inert.
+fn dense_expert_weights() -> WeightMap {
+    let mut weights = backbone_weights();
+    for (proj, out, in_features) in [
+        ("gate_proj", INTERMEDIATE, HIDDEN),
+        ("up_proj", INTERMEDIATE, HIDDEN),
+        ("down_proj", HIDDEN, INTERMEDIATE),
+    ] {
+        put_f32(
+            &mut weights,
+            &format!("{MOE_PREFIX}.{proj}.weight"),
+            &[EXPERTS, out, in_features],
+            0.02,
+        );
+    }
+    weights
+}
+
+/// A quantized expert plane must reach the `gather_qmm` path with its declared
+/// `group_size` / `bits` bounded first.
+///
+/// This is also the discriminator for the bug itself. The dense `gather_mm`
+/// path never reads the declared pair, so while Jamba built every expert plane
+/// as `Regular` a `"bits": 0` loaded silently and then aborted the process
+/// inside the kernel at the first routed token. A load that now refuses the
+/// hostile pair is a load that took the quantized branch.
+#[test]
+fn jamba_rejects_expert_quantization_params_that_would_abort_gather_qmm() {
+    // Positive control first, so a guard that rejected every quantized plane
+    // could not pass this test.
+    match JambaModel::from_weights(
+        moe_config(&quant_block(GROUP_SIZE, BITS)),
+        stacked_quantized_weights(),
+    ) {
+        Ok(_) => {}
+        Err(e) => panic!("honest 4-bit pre-stacked Jamba expert planes must load: {e}"),
+    }
+
+    for (group_size, bits, field) in HOSTILE_QUANT_PARAMS {
+        let err = match JambaModel::from_weights(
+            moe_config(&quant_block(group_size, bits)),
+            stacked_quantized_weights(),
+        ) {
+            Ok(_) => panic!(
+                "(group_size {group_size}, bits {bits}) must be refused at load, \
+                 not stored for gather_qmm"
+            ),
+            Err(e) => e.to_string(),
+        };
+        assert!(
+            err.contains(field),
+            "(group_size {group_size}, bits {bits}) must be blamed on {field}, got: {err}"
+        );
+        assert!(
+            err.contains(GATE_PLANE),
+            "the load error must name the offending tensor {GATE_PLANE}, got: {err}"
+        );
+    }
+}
+
+/// Unstacked per-expert quantized planes must be stacked with their `.scales`
+/// and `.biases`, not with `.weight` alone.
+///
+/// The hostile pair is the probe: it can only be rejected if the stacked plane
+/// carried scales into the quantized branch. When the per-expert remap copied
+/// `.weight` alone, the scales stayed behind in the weight map and the layer was
+/// built dense from packed `uint32`.
+#[test]
+fn jamba_stacks_per_expert_scales_and_biases_rather_than_dropping_them() {
+    match JambaModel::from_weights(
+        moe_config(&quant_block(GROUP_SIZE, BITS)),
+        per_expert_quantized_weights(),
+    ) {
+        Ok(_) => {}
+        Err(e) => panic!("honest 4-bit per-expert Jamba expert planes must load: {e}"),
+    }
+
+    for (group_size, bits, field) in HOSTILE_QUANT_PARAMS {
+        let err = match JambaModel::from_weights(
+            moe_config(&quant_block(group_size, bits)),
+            per_expert_quantized_weights(),
+        ) {
+            Ok(_) => panic!(
+                "(group_size {group_size}, bits {bits}) must be refused for the per-expert \
+                 layout too; accepting it means the .scales plane was dropped"
+            ),
+            Err(e) => e.to_string(),
+        };
+        assert!(
+            err.contains(field),
+            "(group_size {group_size}, bits {bits}) must be blamed on {field}, got: {err}"
+        );
+    }
+}
+
+/// A dense expert plane carries no packing and no `.scales`, so the declared
+/// pair is inert on the `gather_mm` path and must not gate the load.
+#[test]
+fn jamba_dense_expert_planes_load_with_an_unset_quantization_pair() {
+    match JambaModel::from_weights(moe_config(&quant_block(0, 0)), dense_expert_weights()) {
+        Ok(_) => {}
+        Err(e) => panic!("a non-quantized Jamba expert plane must load with an unset pair: {e}"),
+    }
+}
+
+/// Every Jamba loader builds affine planes, so a declared block-float or
+/// unparseable mode has to fail at load rather than be silently reinterpreted as
+/// affine and abort inside the kernel.
+#[test]
+fn jamba_rejects_a_declared_quantization_mode_its_loaders_cannot_honor() {
+    for mode in ["mxfp4", "nvfp4", "mxfp8", "gptq", "", "Affine"] {
+        let quantization =
+            format!(r#"{{"group_size": {GROUP_SIZE}, "bits": {BITS}, "mode": "{mode}"}}"#);
+        match JambaModel::from_weights(moe_config(&quantization), stacked_quantized_weights()) {
+            Ok(_) => panic!("declared mode {mode:?} must be refused at load"),
+            Err(e) => {
+                let err = e.to_string();
+                assert!(
+                    err.contains("mode"),
+                    "the load error for {mode:?} must name the mode, got: {err}"
+                );
+            }
+        }
+    }
+
+    // An explicitly declared "affine" is the norm and must still load.
+    let affine = format!(r#"{{"group_size": {GROUP_SIZE}, "bits": {BITS}, "mode": "affine"}}"#);
+    match JambaModel::from_weights(moe_config(&affine), stacked_quantized_weights()) {
+        Ok(_) => {}
+        Err(e) => panic!("an explicitly declared affine mode must load: {e}"),
+    }
+}

--- a/src/models/switch_layers.rs
+++ b/src/models/switch_layers.rs
@@ -15,7 +15,8 @@
 //! Shared SwitchLinear / SwitchGLU for MoE models
 //!
 //! Used by: KimiLinear, LongcatFlashNgram, DeepSeekV3, DeepSeekV32, GLM4Moe,
-//!          GLM4MoeLite, ExaOneMoe, Mixtral, Qwen2Moe, Qwen3Moe, PhiMoE, OLMoE, etc.
+//!          GLM4MoeLite, ExaOneMoe, Jamba, Mixtral, Qwen2Moe, Qwen3Moe, PhiMoE,
+//!          OLMoE, etc.
 //!
 //! SwitchLinear: per-expert 3D matmul (quantized via gather_qmm, regular via gather_mm)
 //! SwitchGLU: SwiGLU MLP routing through SwitchLinear
@@ -540,8 +541,8 @@ impl SwitchLinear {
 /// Used by: every family behind the shared `SwitchGLU` / `SwitchLinear`, which
 ///          reaches this through `SwitchLinear::from_weights_with_mode`
 ///          whenever its checkpoint ships experts unstacked (BailingMoe,
-///          Cohere2Moe, Dots1, Gemma4, GraniteMoeHybrid, KimiLinear, Lfm2,
-///          Llada2Moe, LongcatFlashNgram, Mellum, MiniMax, MiniMaxM3Moe,
+///          Cohere2Moe, Dots1, Gemma4, GraniteMoeHybrid, Jamba, KimiLinear,
+///          Lfm2, Llada2Moe, LongcatFlashNgram, Mellum, MiniMax, MiniMaxM3Moe,
 ///          Mistral4, Mixtral, Moondream3, OLMoE, PhiMoE, Qwen2Moe,
 ///          SolarOpen), plus DeepSeek v1 (`src/models/deepseek.rs`), which
 ///          calls it directly for the `baidu/Unlimited-OCR` raw per-expert
@@ -884,9 +885,9 @@ fn scatter_unsort(x: &MlxArray, inv_order: &MlxArray, orig_shape: &[i32]) -> Uni
 /// Weighted sum over selected expert outputs while preserving the residual dtype.
 ///
 /// Used by: BailingMoe, DeepSeek, DeepSeekV3, DeepSeekV32, ExaOneMoe,
-///          Ernie4_5Moe, GLM4Moe, GLM4MoeLite, GptOss, HunyuanMoe, KimiLinear,
-///          MiniMax, Mistral4, Mixtral, Moondream3, OLMoE, PhiMoE, Qwen2Moe,
-///          Qwen3Moe, Qwen3Next, Qwen3VLMoe, SolarOpen, Step3p5
+///          Ernie4_5Moe, GLM4Moe, GLM4MoeLite, GptOss, HunyuanMoe, Jamba,
+///          KimiLinear, MiniMax, Mistral4, Mixtral, Moondream3, OLMoE, PhiMoE,
+///          Qwen2Moe, Qwen3Moe, Qwen3Next, Qwen3VLMoe, SolarOpen, Step3p5
 ///
 /// The old `nkh,nk->nh` einsum contraction promotes the combine to float32
 /// on M5 for bf16/f16 activations. Match mlx-lm's `y * scores[..., None]`


### PR DESCRIPTION
## Summary

Jamba declared a family-local `SwitchLinear::Quantized` variant that nothing constructed, behind an `#[allow(dead_code)]`, so a checkpoint shipping quantized MoE experts loaded silently and built its expert planes from packed `uint32` weights on the dense path. Settling the issue's two readings turned up a second defect: the dense path was itself broken, so Jamba's MoE branch could never run for any checkpoint.

## The determination

Reading B, established without the 29 GB download. Full evidence is recorded in lablup/mlxcel#974.

**Such checkpoints exist, from two publishers.** Confirmed from the Hub API and `model.safetensors.index.json` alone: `ncls-p/AI21-Jamba2-Mini-mlx-4Bit` and `ssdataanalysis/AI21-Jamba2-Mini-mlx-8Bit` both declare `num_experts: 16` and ship 144 pre-stacked `switch_mlp` tensors (48 `.weight`, 48 `.scales`, 48 `.biases`) with zero `.experts.N` keys. The keys match the loader's lookup verbatim. No `mlx-community` Jamba conversion has `num_experts > 1`, which is why the gap survived.

**The synthetic route confirmed the load gap and refuted part of the issue's prediction.** `from_weights` returns `Ok` on a genuinely packed `uint32` plane, as predicted. But the first forward never reaches `mlxcel_core::matmul`, so `[matmul] Only inexact types are supported` is not the message. It aborts two lines earlier:

```
libc++abi: terminating due to uncaught exception of type std::invalid_argument:
[reshape] Cannot reshape array of size 256 into shape (1,4,1,1).
```

and it aborts identically on **dense f32** expert planes. `SwitchGLU::forward` expanded `x` from `[b, s, h]` to `[b, s, 1, h]`, then `SwitchLinear::Regular::forward` expanded it again as if it were still 3D. The comment justifying the local enum by its "different forward shape handling" was describing a bug.

## What changed

- `src/models/jamba.rs`: deleted the family-local `SwitchLinear` and `SwitchGLU` and routed the family through `switch_layers::SwitchGLU` (the issue's step 2 preference). That branches on `.scales` presence so quantized experts reach `gather_qmm`, bounds the declared `group_size` / `bits` pair and the affine/`.biases` pairing in `from_stacked_parts` before storing anything derived from them, and accepts the per-expert `experts.{idx}` layout through `stack_individual_experts`.
- `src/models/jamba.rs`: `JambaSparseMoeBlock::forward` flattens to the shared `[tokens, hidden]` / `[tokens, top_k]` contract and combines through `moe_weighted_sum`. The top-k routing math is unchanged.
- `src/models/jamba.rs`: removed the hand-rolled per-expert remap in `sanitize_weights`, which carried `.weight` alone and dropped `.scales` / `.biases`. The shared loader handles both layouts and derives the same expert keys, and it also runs for callers entering at `from_weights`, which the removed loop did not.
- `src/models/jamba.rs`: the router moves from `load_linear` to `UnifiedLinear`. Real conversions ship it packed with its own `.scales` / `.biases` at a width that need not match the top level (`ncls-p` declares 8-bit routers under a 4-bit default), and `load_linear` reads `.weight` and `.bias` only.
- `src/models/jamba.rs`: `quantization.mode` is now read and bounded at load via `mlxcel_core::layers::validate_quantization_mode` (#973). Every Jamba loader builds affine planes, so non-affine is refused with the mode named rather than silently reinterpreted and aborted in the kernel.
- `src/models/jamba_tests.rs`: four regression tests driving `JambaModel::from_weights` over pre-stacked, per-expert and dense expert layouts.
- `src/models/switch_layers.rs`, `src/lib/mlxcel-core/src/layers.rs`: comment-only. Added Jamba to the `Used by:` lists on the module, `stack_individual_experts`, `moe_weighted_sum` and `validate_quantization_mode`.

## Notes for review

`#[allow(dead_code)]` is gone because the enum it guarded is gone.

On the issue's step 3: the bound lands via `SwitchLinear::from_stacked_parts`, which already calls `mlxcel_core::layers::validate_quantization_params` with the offending tensor prefix in the error. A second `validate_expert_quantization_params` call would be a duplicate guard, so Jamba is not added to that helper's `Used by:` list. The tests still walk the shared `HOSTILE_QUANT_PARAMS` table.

The hostile-parameter walk is the discriminator for the bug, not just a bounds check. The dense `gather_mm` path never reads the declared pair, so before this change `"bits": 0` loaded without complaint. A load that now refuses it is a load that took the quantized branch.

Tests assert on the returned `Result` and never run a forward pass, per the convention PR #972 settled on: `gather_qmm` crosses the cxx bridge as `UniquePtr<MlxArray>` rather than `Result`, so a regression would abort the test binary with SIGABRT instead of failing cleanly.

## Test plan

- [x] `models/jamba-v0.1-4bit` generates byte-identical output to main on the same raw prompt (`-p "The capital of France is" -n 20 --no-chat-template`). It is the regression control for the dense path: `num_experts: 1` means it never enters the MoE branch.
- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --release --all-targets --features metal,accelerate -- -D warnings`
- [x] `cargo clippy -p mlxcel-core --release --all-targets --features metal,accelerate -- -D warnings`
- [x] `cargo test --release --features metal,accelerate --no-fail-fast`: lib 4849 passed, 0 failed. The only two failures are `granite4_vision_parity::text_only_forward_produces_finite_logits` (#997) and `ernie4_5_moe_vl_parity::text_only_forward_produces_finite_logits`, both the same concurrent-large-model-load flake; both pass in isolation, verified.
- [x] `cargo test --release -p mlxcel-core --features metal,accelerate --no-fail-fast`: 1409 passed, 1 failed, the pre-existing `fused_moe_parity_tests::fused_moe_geglu_kernel_matches_references_gemma4_shape` (#964).

Not verifiable here: end-to-end generation on a real quantized Jamba MoE checkpoint. The smallest is roughly 29 GB and every `AI21-Jamba2-3B` MLX conversion is `num_experts: 1`, so no small MoE Jamba exists to test against. The acceptance criterion asking for an `mlx-lm` reference comparison on such a checkpoint is left open.

Closes #974
