### PR TITLE
fix(models): read the declared quantization block in deepseek::ModelArgs

### DIFF
--- a/src/loading/vlm_deepseekocr.rs
+++ b/src/loading/vlm_deepseekocr.rs
@@ -63,15 +63,35 @@ fn remap_deepseekocr_weights(weights: WeightMap) -> WeightMap {
     out
 }
 
-pub(crate) fn load_deepseekocr_vlm(model_path: &Path) -> Result<LoadedModel> {
-    let (_config_str, full_config) = read_sanitized_vlm_config(model_path)?;
-
-    // Text decoder config from `language_config`, inheriting the root
-    // quantization block and a `model_type` (the sub-config omits both).
+/// Build the shared DeepSeek v1 text-decoder args out of a DeepSeek-OCR-family
+/// `config.json`.
+///
+/// All three loaders in this file need the identical two-step fixup, because
+/// their `language_config` sub-config declares neither a `model_type` nor a
+/// `quantization` block: default the former to `"deepseek"`, and inherit the
+/// root block for the latter unless the sub-config declared one of its own.
+///
+/// It lives in one function rather than inline at each call site because of
+/// issue #975. The inheritance was already written three times and already
+/// correct three times, but `deepseek::ModelArgs` had no nested `quantization`
+/// field, so serde dropped the inherited block on all three and
+/// `args.group_size()` / `args.bits()` returned the hardcoded `64` / `4` for
+/// every DeepSeek-OCR checkpoint no matter what it declared. A single funnel
+/// with a test over it makes that failure mode reproducible without a
+/// checkpoint on disk, and keeps the three from drifting apart.
+///
+/// `family` names the caller in the parse error so the message still points at
+/// the right loader.
+///
+/// Used by: load_deepseekocr_vlm, load_unlimited_ocr_vlm, load_deepseekocr_2_vlm
+fn deepseekocr_language_args(
+    full_config: &serde_json::Value,
+    family: &str,
+) -> Result<models::deepseek::ModelArgs> {
     let mut lc = full_config
         .get("language_config")
         .cloned()
-        .ok_or_else(|| anyhow::anyhow!("Missing language_config in DeepSeek-OCR config"))?;
+        .ok_or_else(|| anyhow::anyhow!("Missing language_config in {} config", family))?;
     if let Some(obj) = lc.as_object_mut() {
         obj.entry("model_type".to_string())
             .or_insert_with(|| json!("deepseek"));
@@ -81,8 +101,14 @@ pub(crate) fn load_deepseekocr_vlm(model_path: &Path) -> Result<LoadedModel> {
             obj.insert("quantization".to_string(), q.clone());
         }
     }
-    let args: models::deepseek::ModelArgs = serde_json::from_value(lc)
-        .map_err(|e| anyhow::anyhow!("Failed to parse DeepSeek-OCR language_config: {}", e))?;
+    serde_json::from_value(lc)
+        .map_err(|e| anyhow::anyhow!("Failed to parse {} language_config: {}", family, e))
+}
+
+pub(crate) fn load_deepseekocr_vlm(model_path: &Path) -> Result<LoadedModel> {
+    let (_config_str, full_config) = read_sanitized_vlm_config(model_path)?;
+
+    let args = deepseekocr_language_args(&full_config, "DeepSeek-OCR")?;
     let (gs, bits) = (args.group_size(), args.bits());
 
     let weights = remap_deepseekocr_weights(load_vlm_weights_common(model_path, None)?);
@@ -125,6 +151,22 @@ pub(crate) fn load_deepseekocr_vlm(model_path: &Path) -> Result<LoadedModel> {
 
 const DEFAULT_SLIDING_WINDOW: i32 = 128;
 
+/// Ring-cache window for Unlimited-OCR, from `language_config.sliding_window_size`.
+///
+/// Read off the untouched `full_config` rather than the args struct because
+/// `deepseek::ModelArgs` has no field for it. Clamped to at least 1 so a
+/// checkpoint declaring 0 or a negative window does not produce a degenerate
+/// cache.
+fn unlimited_ocr_sliding_window(full_config: &serde_json::Value) -> i32 {
+    full_config
+        .get("language_config")
+        .and_then(|lc| lc.get("sliding_window_size"))
+        .and_then(|v| v.as_i64())
+        .map(|v| v as i32)
+        .unwrap_or(DEFAULT_SLIDING_WINDOW)
+        .max(1)
+}
+
 /// Load `baidu/Unlimited-OCR`. The vision + text stack is the DeepSeek-OCR V1
 /// layout (SAM + CLIP + linear projector + DeepSeek MoE decoder) shipped under
 /// the same layout-B `model.*` prefixes, so it loads exactly like
@@ -136,27 +178,8 @@ const DEFAULT_SLIDING_WINDOW: i32 = 128;
 pub(crate) fn load_unlimited_ocr_vlm(model_path: &Path) -> Result<LoadedModel> {
     let (_config_str, full_config) = read_sanitized_vlm_config(model_path)?;
 
-    let mut lc = full_config
-        .get("language_config")
-        .cloned()
-        .ok_or_else(|| anyhow::anyhow!("Missing language_config in Unlimited-OCR config"))?;
-    let window = lc
-        .get("sliding_window_size")
-        .and_then(|v| v.as_i64())
-        .map(|v| v as i32)
-        .unwrap_or(DEFAULT_SLIDING_WINDOW)
-        .max(1);
-    if let Some(obj) = lc.as_object_mut() {
-        obj.entry("model_type".to_string())
-            .or_insert_with(|| json!("deepseek"));
-        if !obj.contains_key("quantization")
-            && let Some(q) = full_config.get("quantization")
-        {
-            obj.insert("quantization".to_string(), q.clone());
-        }
-    }
-    let args: models::deepseek::ModelArgs = serde_json::from_value(lc)
-        .map_err(|e| anyhow::anyhow!("Failed to parse Unlimited-OCR language_config: {}", e))?;
+    let window = unlimited_ocr_sliding_window(&full_config);
+    let args = deepseekocr_language_args(&full_config, "Unlimited-OCR")?;
     let (gs, bits) = (args.group_size(), args.bits());
 
     let weights = remap_deepseekocr_weights(load_vlm_weights_common(model_path, None)?);
@@ -235,21 +258,7 @@ fn remap_deepseekocr_2_weights(weights: WeightMap) -> WeightMap {
 pub(crate) fn load_deepseekocr_2_vlm(model_path: &Path) -> Result<LoadedModel> {
     let (_config_str, full_config) = read_sanitized_vlm_config(model_path)?;
 
-    let mut lc = full_config
-        .get("language_config")
-        .cloned()
-        .ok_or_else(|| anyhow::anyhow!("Missing language_config in DeepSeek-OCR 2 config"))?;
-    if let Some(obj) = lc.as_object_mut() {
-        obj.entry("model_type".to_string())
-            .or_insert_with(|| json!("deepseek"));
-        if !obj.contains_key("quantization")
-            && let Some(q) = full_config.get("quantization")
-        {
-            obj.insert("quantization".to_string(), q.clone());
-        }
-    }
-    let args: models::deepseek::ModelArgs = serde_json::from_value(lc)
-        .map_err(|e| anyhow::anyhow!("Failed to parse DeepSeek-OCR 2 language_config: {}", e))?;
+    let args = deepseekocr_language_args(&full_config, "DeepSeek-OCR 2")?;
     let (gs, bits) = (args.group_size(), args.bits());
 
     let weights = remap_deepseekocr_2_weights(load_vlm_weights_common(model_path, None)?);
@@ -293,3 +302,7 @@ pub(crate) fn load_deepseekocr_2_vlm(model_path: &Path) -> Result<LoadedModel> {
     };
     Ok(LoadedModel::DeepSeekOcr2VLM(vlm))
 }
+
+#[cfg(test)]
+#[path = "vlm_deepseekocr_tests.rs"]
+mod tests;

--- a/src/loading/vlm_deepseekocr_tests.rs
+++ b/src/loading/vlm_deepseekocr_tests.rs
@@ -1,0 +1,235 @@
+// Copyright 2025-2026 Lablup Inc. and Jeongkyu Shin
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Config-plumbing coverage for the DeepSeek-OCR family (issue #975).
+//!
+//! Everything here runs on JSON alone, with no checkpoint on disk and no
+//! forward pass. That is deliberate: the defect these guard is a silent one at
+//! the deserialization boundary, and a test that reached a quantized kernel
+//! with a mismatched `group_size` would abort the whole test binary with
+//! SIGABRT rather than fail, because `gather_qmm` crosses the cxx bridge as
+//! `UniquePtr<MlxArray>` rather than `Result`.
+
+use super::{deepseekocr_language_args, unlimited_ocr_sliding_window};
+use serde_json::{Value, json};
+
+/// The `family` labels the three loaders in this module pass to
+/// [`deepseekocr_language_args`]: `load_deepseekocr_vlm`,
+/// `load_unlimited_ocr_vlm` and `load_deepseekocr_2_vlm`, in that order.
+///
+/// Issue #975 asks for the inheritance to be verified at each of the three
+/// sites rather than only the first. The three now funnel through one helper,
+/// so every assertion below is driven once per label to keep that explicit: if
+/// a future edit gives one loader its own inline copy of the fixup again, the
+/// label it no longer passes here is the thing that goes stale.
+const FAMILIES: [&str; 3] = ["DeepSeek-OCR", "Unlimited-OCR", "DeepSeek-OCR 2"];
+
+/// A `language_config` in the shape the DeepSeek-OCR checkpoints ship: the
+/// structural fields the decoder needs, and no quantization declaration of its
+/// own, which is exactly why the loaders inherit the root block.
+fn language_config() -> Value {
+    json!({
+        "vocab_size": 129280,
+        "hidden_size": 1280,
+        "intermediate_size": 6848,
+        "num_hidden_layers": 12,
+        "num_attention_heads": 10,
+        "num_key_value_heads": 10,
+        "max_position_embeddings": 8192,
+        "n_routed_experts": 64,
+        "num_experts_per_tok": 6,
+        "moe_intermediate_size": 896,
+        "n_shared_experts": 2,
+        "first_k_dense_replace": 1,
+    })
+}
+
+fn full_config(root_quantization: Option<Value>, lc_quantization: Option<Value>) -> Value {
+    let mut lc = language_config();
+    if let Some(q) = lc_quantization {
+        lc.as_object_mut().unwrap().insert("quantization".into(), q);
+    }
+    let mut full = json!({ "model_type": "deepseekocr", "language_config": lc });
+    if let Some(q) = root_quantization {
+        full.as_object_mut()
+            .unwrap()
+            .insert("quantization".into(), q);
+    }
+    full
+}
+
+/// The regression this issue is about. The loaders copy the root
+/// `quantization` object into `language_config`; before #975
+/// `deepseek::ModelArgs` had no field to receive it, so serde discarded the
+/// block and the accessors returned the hardcoded 64 / 4 for every checkpoint.
+#[test]
+fn inherits_the_root_quantization_block_into_the_text_args() {
+    let full = full_config(
+        Some(json!({"group_size": 32, "bits": 8, "mode": "affine"})),
+        None,
+    );
+
+    for family in FAMILIES {
+        let args = deepseekocr_language_args(&full, family)
+            .unwrap_or_else(|e| panic!("{family} language_config must parse: {e}"));
+        assert_eq!(args.group_size(), 32, "{family} group_size");
+        assert_eq!(args.bits(), 8, "{family} bits");
+        assert_eq!(args.quantization_mode().unwrap(), "affine", "{family} mode");
+    }
+}
+
+/// The `!obj.contains_key("quantization")` guard in the helper: a sub-config
+/// that declares its own block keeps it, and the root block does not overwrite
+/// it.
+#[test]
+fn a_declared_language_config_block_beats_the_inherited_root_block() {
+    let full = full_config(
+        Some(json!({"group_size": 64, "bits": 4})),
+        Some(json!({"group_size": 32, "bits": 8})),
+    );
+
+    for family in FAMILIES {
+        let args = deepseekocr_language_args(&full, family)
+            .unwrap_or_else(|e| panic!("{family} language_config must parse: {e}"));
+        assert_eq!(args.group_size(), 32, "{family} group_size");
+        assert_eq!(args.bits(), 8, "{family} bits");
+    }
+}
+
+/// The two in-tree checkpoints, `models/deepseek-ocr-4bit` and
+/// `models/deepseek-ocr-2-4bit`, both declare exactly `{"group_size": 64,
+/// "bits": 4, "mode": "affine"}` at the root, which is also what the accessors
+/// fall back to. This pins that the fix changes nothing for them: the resolved
+/// pair is the same one they loaded with before, so their OCR output is
+/// unchanged by construction.
+#[test]
+fn the_in_tree_checkpoint_declaration_resolves_to_the_previous_fallback() {
+    let full = full_config(
+        Some(json!({"group_size": 64, "bits": 4, "mode": "affine"})),
+        None,
+    );
+
+    for family in FAMILIES {
+        let args = deepseekocr_language_args(&full, family)
+            .unwrap_or_else(|e| panic!("{family} language_config must parse: {e}"));
+        assert_eq!(args.group_size(), 64, "{family} group_size");
+        assert_eq!(args.bits(), 4, "{family} bits");
+    }
+}
+
+/// No declaration anywhere still resolves to the family defaults rather than
+/// failing, which is what a bf16 checkpoint relies on.
+#[test]
+fn an_undeclared_quantization_block_keeps_the_family_defaults() {
+    let full = full_config(None, None);
+
+    for family in FAMILIES {
+        let args = deepseekocr_language_args(&full, family)
+            .unwrap_or_else(|e| panic!("{family} language_config must parse: {e}"));
+        assert_eq!(args.group_size(), 64, "{family} group_size");
+        assert_eq!(args.bits(), 4, "{family} bits");
+        assert_eq!(args.quantization_mode().unwrap(), "affine", "{family} mode");
+    }
+}
+
+/// The sub-config omits `model_type`, so the helper supplies it. Without this
+/// the required field would fail deserialization.
+#[test]
+fn supplies_the_missing_model_type_for_the_sub_config() {
+    let full = full_config(None, None);
+
+    for family in FAMILIES {
+        let args = deepseekocr_language_args(&full, family)
+            .unwrap_or_else(|e| panic!("{family} language_config must parse: {e}"));
+        assert_eq!(args.model_type, "deepseek", "{family} model_type");
+    }
+}
+
+/// A partially declared block resolves per key rather than failing to
+/// deserialize, because `QuantizationArgs` keeps all three fields optional.
+/// An 8-bit export that names only `bits` still loads, and the unnamed
+/// `group_size` falls back.
+#[test]
+fn a_partial_quantization_block_resolves_per_key() {
+    let full = full_config(Some(json!({"bits": 8})), None);
+
+    for family in FAMILIES {
+        let args = deepseekocr_language_args(&full, family)
+            .unwrap_or_else(|e| panic!("{family} language_config must parse: {e}"));
+        assert_eq!(args.group_size(), 64, "{family} group_size");
+        assert_eq!(args.bits(), 8, "{family} bits");
+    }
+}
+
+/// A mode MLX cannot parse is rejected at the point it is read rather than
+/// stored and handed to a kernel (#973). The inherited block is the route that
+/// carries it here.
+#[test]
+fn an_unparseable_inherited_mode_is_rejected() {
+    let full = full_config(
+        Some(json!({"group_size": 64, "bits": 4, "mode": "Affine"})),
+        None,
+    );
+
+    for family in FAMILIES {
+        let args = deepseekocr_language_args(&full, family)
+            .unwrap_or_else(|e| panic!("{family} language_config must parse: {e}"));
+        let err = args
+            .quantization_mode()
+            .expect_err("a misspelled mode must not resolve");
+        assert!(
+            err.contains("quantization.mode"),
+            "{family} error should name the field: {err}"
+        );
+    }
+}
+
+/// A missing `language_config` is still an error, and the message still names
+/// the loader that asked.
+#[test]
+fn a_missing_language_config_names_the_family() {
+    let full = json!({ "model_type": "deepseekocr" });
+
+    for family in FAMILIES {
+        let err = deepseekocr_language_args(&full, family)
+            .expect_err("a config without language_config must not parse")
+            .to_string();
+        assert!(err.contains(family), "error should name {family}: {err}");
+    }
+}
+
+/// The Unlimited-OCR ring-cache window reads through the untouched
+/// `full_config`, so pulling the quantization fixup into a shared helper did
+/// not change which key it comes from.
+#[test]
+fn unlimited_ocr_window_reads_the_declared_sliding_window() {
+    let mut full = full_config(None, None);
+    full["language_config"]["sliding_window_size"] = json!(512);
+    assert_eq!(unlimited_ocr_sliding_window(&full), 512);
+}
+
+/// Undeclared falls back, and a non-positive declaration is clamped rather than
+/// producing a degenerate cache.
+#[test]
+fn unlimited_ocr_window_falls_back_and_clamps() {
+    let full = full_config(None, None);
+    assert_eq!(
+        unlimited_ocr_sliding_window(&full),
+        super::DEFAULT_SLIDING_WINDOW
+    );
+
+    let mut zero = full_config(None, None);
+    zero["language_config"]["sliding_window_size"] = json!(0);
+    assert_eq!(unlimited_ocr_sliding_window(&zero), 1);
+}

--- a/src/models/config.rs
+++ b/src/models/config.rs
@@ -240,6 +240,20 @@ where
 // Quantization Configuration.
 /// Common quantization arguments
 /// Supports affine (default), mxfp4, nvfp4, and mxfp8 quantization modes.
+///
+/// This is the shared spelling of the MLX-style nested `"quantization"` block
+/// that every conversion tool emits. Families under `src/models/` overwhelmingly
+/// declare a private near-copy of it instead, and the divergence between two
+/// such copies is what produced issue #975: `deepseek.rs` had no nested field at
+/// all while its sibling `deepseek_v2.rs` did, so the byte-identical
+/// sub-config inheritance in the two VLM loaders behaved differently. Prefer
+/// this type over a new private struct.
+///
+/// All three fields are optional so a partially declared block resolves through
+/// the accessors below rather than failing deserialization, which matters for a
+/// family that reads the block out of an inherited sub-config.
+///
+/// Used by: `crate::models::deepseek::ModelArgs` (issue #975)
 #[derive(Debug, Clone, Default, Deserialize)]
 pub struct QuantizationArgs {
     #[serde(default)]
@@ -267,19 +281,21 @@ impl QuantizationArgs {
     /// Get the declared quantization mode, defaulting to `"affine"` when the
     /// key is absent.
     ///
-    /// Fallible on purpose (issue #973). This helper has no production callers
-    /// yet and is the obvious thing for the next family that needs a declared
-    /// mode to reach for; handing back an unchecked `&str` would let it inherit
-    /// the hole silently, because the returned string goes on to
-    /// `quantized_matmul` / `gather_qmm` / `dequantize`, which cross the cxx
-    /// bridge as `UniquePtr<MlxArray>` rather than `Result`, so a mode MLX
-    /// cannot parse is an uncatchable abort at the first forward pass rather
-    /// than a load error. Returning `Result` makes the check impossible to skip
-    /// at the point the value is read.
+    /// Fallible on purpose (issue #973): handing back an unchecked `&str` would
+    /// let each caller inherit the hole silently, because the returned string
+    /// goes on to `quantized_matmul` / `gather_qmm` / `dequantize`, which cross
+    /// the cxx bridge as `UniquePtr<MlxArray>` rather than `Result`, so a mode
+    /// MLX cannot parse is an uncatchable abort at the first forward pass
+    /// rather than a load error. Returning `Result` makes the check impossible
+    /// to skip at the point the value is read.
     ///
     /// The `None` case is the absent key and resolves to `"affine"`; a present
     /// but empty or misspelled string is rejected. See
     /// [`mlxcel_core::layers::validate_quantization_mode`].
+    ///
+    /// Used by: `crate::models::deepseek::ModelArgs::quantization_mode`
+    ///          (issue #975), which is also the family that adopted this whole
+    ///          struct rather than declaring another private `Quantization`
     pub fn get_mode(&self) -> Result<&str, String> {
         let mode = self.mode.as_deref().unwrap_or("affine");
         mlxcel_core::layers::validate_quantization_mode(mode)?;

--- a/src/models/deepseek.rs
+++ b/src/models/deepseek.rs
@@ -22,7 +22,10 @@
 //! - routed_scaling_factor for expert outputs (default 1.0)
 //! - Top-k routing with softmax scoring
 
-use crate::models::switch_layers::validate_expert_quantization_params;
+use crate::models::config::QuantizationArgs;
+use crate::models::switch_layers::{
+    validate_expert_quantization_params, validate_expert_quantization_shapes,
+};
 use mlxcel_core::generate::LanguageModel;
 use mlxcel_core::layers::{KVCache, RMSNorm, UnifiedEmbedding, UnifiedLinear};
 use mlxcel_core::weights::WeightMap;
@@ -66,6 +69,33 @@ pub struct ModelArgs {
     #[serde(default)]
     pub attention_bias: bool,
 
+    /// The MLX-style nested block, `"quantization": {"group_size": N, "bits":
+    /// M, "mode": "affine"}`, which is the only spelling any conversion tool
+    /// emits (issue #975).
+    ///
+    /// It arrives two ways. A plain `deepseek` `config.json` carries it at the
+    /// top level, where [`DeepSeekModel::load`] deserializes the whole file
+    /// into this struct. The three DeepSeek-OCR loaders in
+    /// `crate::loading::vlm_deepseekocr` instead inherit the root block into
+    /// `language_config` before deserializing, because that sub-config declares
+    /// no quantization of its own; see
+    /// `crate::loading::vlm_deepseekocr::deepseekocr_language_args`.
+    ///
+    /// Until #975 this field did not exist, so serde silently discarded the
+    /// block on both routes and the accessors below returned the hardcoded
+    /// fallbacks no matter what the checkpoint declared. That is not a
+    /// load-time failure on any path: a wrong `group_size` re-solves inside
+    /// [`mlxcel_core::layers::reconcile_quantization_layout`] onto a
+    /// self-consistent pair that MLX accepts, so the dense projections, the
+    /// embedding and the OCR projector produce silently wrong numbers, while
+    /// the MoE expert planes, which never reach the reconciler, abort
+    /// uncatchably inside `gather_qmm` at the first routed forward pass.
+    #[serde(default)]
+    pub quantization: Option<QuantizationArgs>,
+
+    /// Flat top-level `group_size` / `bits` keys, kept as a fallback for
+    /// whatever checkpoint spelling these fields were originally added for.
+    /// [`Self::quantization`] wins when both are present.
     #[serde(default)]
     pub group_size: Option<i32>,
 
@@ -94,12 +124,39 @@ impl ModelArgs {
         self.hidden_size / self.num_attention_heads
     }
 
+    /// The declared quantization group size: nested block first, flat key
+    /// second, family default last.
     pub fn group_size(&self) -> i32 {
-        self.group_size.unwrap_or(64)
+        self.quantization
+            .as_ref()
+            .and_then(|q| q.group_size)
+            .or(self.group_size)
+            .unwrap_or(64)
     }
 
+    /// The declared quantization bit width, resolved in the same order as
+    /// [`Self::group_size`].
     pub fn bits(&self) -> i32 {
-        self.bits.unwrap_or(4)
+        self.quantization
+            .as_ref()
+            .and_then(|q| q.bits)
+            .or(self.bits)
+            .unwrap_or(4)
+    }
+
+    /// The declared quantization mode, or `"affine"` when no block names one.
+    ///
+    /// Fallible because [`QuantizationArgs::get_mode`] validates against
+    /// [`mlxcel_core::layers::SUPPORTED_QUANTIZATION_MODES`] at the point the
+    /// value is read (issue #973): the string would otherwise reach
+    /// `quantized_matmul` / `gather_qmm` verbatim across a cxx bridge that
+    /// carries no `Result`, making an unparseable mode an uncatchable abort at
+    /// the first forward pass rather than a load error.
+    pub fn quantization_mode(&self) -> Result<&str, String> {
+        match self.quantization.as_ref() {
+            Some(quantization) => quantization.get_mode(),
+            None => Ok("affine"),
+        }
     }
 }
 
@@ -620,6 +677,26 @@ impl DeepSeekModel {
 
     /// Create model from loaded weights
     pub fn from_weights(weights: &WeightMap, args: &ModelArgs) -> Result<Self, String> {
+        // Bound the declared mode before any loader below consumes the pair it
+        // sits next to (#973, #975). Every plane this family builds is affine:
+        // `UnifiedEmbedding`, `UnifiedLinear` and `SwitchLinear::Quantized` all
+        // take the affine entry points, and `from_stacked_parts` selects the
+        // quantized arm only when a `.biases` plane is present, which is the
+        // affine layout by construction. A block-float checkpoint would
+        // therefore land on the `Regular` arm with a packed uint32 weight and
+        // be reinterpreted rather than refused, and an unparseable mode string
+        // is the abort-at-first-forward class described on
+        // `ModelArgs::quantization_mode`. Refuse both here, naming the mode.
+        let mode = args.quantization_mode()?;
+        if mode != "affine" {
+            return Err(format!(
+                "quantization.mode is {mode:?}, but every DeepSeek v1 projection, embedding and \
+                 expert plane is built as affine, so a block-float checkpoint would be \
+                 reinterpreted rather than loaded. Only \"affine\" is supported for this \
+                 architecture"
+            ));
+        }
+
         // Load quantized embedding
         let embed_tokens = UnifiedEmbedding::from_weights(
             weights,
@@ -874,6 +951,14 @@ impl SwitchLinear {
     /// `group_size` / `bits` and hands them to `gather_qmm`, and this family
     /// never reaches `reconcile_quantization_layout`, so the bound has to live
     /// here. `prefix` is threaded in only so the error names the expert plane.
+    ///
+    /// Since #975 the pair is also cross-checked against the tensors it is being
+    /// stored on. Before that issue this family read the hardcoded `64` / `4` no
+    /// matter what the checkpoint declared, so the pair could not disagree with
+    /// an mlx-community export; now that the declaration actually arrives, a
+    /// block that describes different tensors has to fail here rather than
+    /// abort uncatchably inside `gather_qmm`. See
+    /// [`validate_expert_quantization_shapes`].
     fn from_stacked_parts(
         prefix: &str,
         weight: UniquePtr<MlxArray>,
@@ -881,11 +966,19 @@ impl SwitchLinear {
         biases: Option<UniquePtr<MlxArray>>,
         args: &ModelArgs,
     ) -> Result<Self, String> {
-        let num_experts = mlxcel_core::array_shape(&weight)[0] as usize;
+        let weight_shape = mlxcel_core::array_shape(&weight);
+        let num_experts = weight_shape[0] as usize;
         Ok(match (scales, biases) {
             (Some(scales), Some(biases)) => {
                 let (group_size, bits) = (args.group_size(), args.bits());
                 validate_expert_quantization_params(prefix, group_size, bits)?;
+                validate_expert_quantization_shapes(
+                    prefix,
+                    &weight_shape,
+                    &mlxcel_core::array_shape(&scales),
+                    group_size,
+                    bits,
+                )?;
                 Self::Quantized {
                     weight,
                     scales,

--- a/src/models/deepseek_tests.rs
+++ b/src/models/deepseek_tests.rs
@@ -18,7 +18,9 @@
 //! `switch_layers::stack_individual_experts` helper).
 
 use super::{ModelArgs, SwitchLinear};
+use crate::models::config::QuantizationArgs;
 use mlxcel_core::weights::WeightMap;
+use serde_json::json;
 
 fn test_args(n_routed_experts: Option<usize>) -> ModelArgs {
     ModelArgs {
@@ -40,6 +42,7 @@ fn test_args(n_routed_experts: Option<usize>) -> ModelArgs {
         first_k_dense_replace: 0,
         routed_scaling_factor: 1.0,
         attention_bias: false,
+        quantization: None,
         group_size: None,
         bits: None,
     }
@@ -99,13 +102,24 @@ fn switch_linear_accepts_full_expert_count() {
     assert_eq!(sl.num_experts(), 4);
 }
 
-/// The same minimal config with an explicit quantization pair. DeepSeek v1
-/// declares `group_size` / `bits` as flat top-level keys rather than a nested
-/// `quantization` block, so those are the two fields the guard reads.
+/// The same minimal config with an explicit quantization pair in the flat
+/// top-level spelling, which the accessors keep as a fallback.
 fn quant_args(group_size: i32, bits: i32) -> ModelArgs {
     let mut args = test_args(None);
     args.group_size = Some(group_size);
     args.bits = Some(bits);
+    args
+}
+
+/// The same pair in the nested `quantization` spelling that every conversion
+/// tool actually emits (#975).
+fn nested_quant_args(group_size: i32, bits: i32) -> ModelArgs {
+    let mut args = test_args(None);
+    args.quantization = Some(QuantizationArgs {
+        group_size: Some(group_size),
+        bits: Some(bits),
+        mode: None,
+    });
     args
 }
 
@@ -169,4 +183,231 @@ fn deepseek_switch_linear_rejects_quantization_params_that_would_abort_gather_qm
     );
     SwitchLinear::from_weights(&regular, &quant_args(0, 0), PREFIX)
         .expect("a bf16 expert plane must not be gated on quantization params");
+}
+
+/// The MoE half of issue #975. `SwitchLinear::from_stacked_parts` stores the
+/// pair `args.group_size()` / `args.bits()` resolves to and hands it straight
+/// to `gather_qmm` with no reconciliation, so a nested block that never reached
+/// the accessors meant every DeepSeek-OCR expert plane was built with 64 / 4
+/// regardless of the checkpoint. This drives the expert loader through the
+/// nested spelling: the honest pair loads, and a pair MLX cannot describe is
+/// refused at load rather than stored for an uncatchable abort.
+#[test]
+fn deepseek_switch_linear_reads_the_nested_quantization_block() {
+    const EXPERTS: i32 = 3;
+    const OUT: i32 = 4;
+    const PACKED_IN: i32 = 8;
+    const NUM_GROUPS: i32 = 1;
+    const GROUP_SIZE: i32 = 64;
+    const BITS: i32 = 4;
+    const PREFIX: &str = "model.layers.0.mlp.switch_mlp.gate_proj";
+
+    let mut weights = WeightMap::new();
+    crate::models::switch_layers::insert_stacked_quantized_expert_plane(
+        &mut weights,
+        PREFIX,
+        EXPERTS,
+        OUT,
+        PACKED_IN,
+        NUM_GROUPS,
+    );
+
+    SwitchLinear::from_weights(&weights, &nested_quant_args(GROUP_SIZE, BITS), PREFIX)
+        .expect("an honest nested-declared 4-bit expert plane must load");
+
+    for (group_size, bits, field) in crate::models::switch_layers::HOSTILE_QUANT_PARAMS {
+        let err = match SwitchLinear::from_weights(
+            &weights,
+            &nested_quant_args(group_size, bits),
+            PREFIX,
+        ) {
+            Ok(_) => panic!(
+                "nested (group_size {group_size}, bits {bits}) must reach the guard, \
+                     not be dropped in favour of the 64 / 4 fallback"
+            ),
+            Err(e) => e,
+        };
+        assert!(
+            err.contains(field),
+            "nested (group_size {group_size}, bits {bits}) must be blamed on {field}, got: {err}"
+        );
+    }
+}
+
+/// A plain `deepseek` `config.json`, which `DeepSeekModel::load` deserializes
+/// whole. The nested block is the only spelling any MLX conversion tool emits,
+/// and before #975 this struct had no field for it.
+#[test]
+fn model_args_reads_a_nested_quantization_block() {
+    let args: ModelArgs = serde_json::from_value(json!({
+        "model_type": "deepseek",
+        "vocab_size": 8,
+        "hidden_size": 8,
+        "intermediate_size": 8,
+        "num_hidden_layers": 0,
+        "num_attention_heads": 1,
+        "num_key_value_heads": 1,
+        "max_position_embeddings": 16,
+        "quantization": {"group_size": 32, "bits": 8, "mode": "affine"},
+    }))
+    .expect("a plain deepseek config.json must parse");
+
+    assert_eq!(args.group_size(), 32);
+    assert_eq!(args.bits(), 8);
+    assert_eq!(args.quantization_mode().unwrap(), "affine");
+}
+
+/// The flat spelling these two fields were originally added for keeps loading
+/// with its declared values, so the new nested field is additive.
+#[test]
+fn model_args_still_reads_the_flat_quantization_keys() {
+    let args: ModelArgs = serde_json::from_value(json!({
+        "model_type": "deepseek",
+        "vocab_size": 8,
+        "hidden_size": 8,
+        "intermediate_size": 8,
+        "num_hidden_layers": 0,
+        "num_attention_heads": 1,
+        "num_key_value_heads": 1,
+        "max_position_embeddings": 16,
+        "group_size": 128,
+        "bits": 6,
+    }))
+    .expect("the flat spelling must keep parsing");
+
+    assert_eq!(args.group_size(), 128);
+    assert_eq!(args.bits(), 6);
+}
+
+/// Documented precedence when a config carries both spellings.
+#[test]
+fn model_args_prefers_the_nested_block_over_the_flat_keys() {
+    let mut args = nested_quant_args(32, 8);
+    args.group_size = Some(128);
+    args.bits = Some(4);
+
+    assert_eq!(args.group_size(), 32);
+    assert_eq!(args.bits(), 8);
+}
+
+/// Each key falls back independently, so a block naming only one of the two
+/// resolves rather than failing to deserialize. `QuantizationArgs` keeps all
+/// three fields optional for exactly this reason.
+#[test]
+fn model_args_falls_back_per_key_across_the_two_spellings() {
+    let mut args = test_args(None);
+    args.quantization = Some(QuantizationArgs {
+        group_size: None,
+        bits: Some(8),
+        mode: None,
+    });
+    args.group_size = Some(32);
+
+    assert_eq!(args.group_size(), 32, "the flat key fills the nested gap");
+    assert_eq!(args.bits(), 8, "the nested key wins where it is declared");
+}
+
+/// No declaration at all keeps the family defaults, which is what the two
+/// in-tree DeepSeek-OCR checkpoints and every bf16 checkpoint rely on.
+#[test]
+fn model_args_defaults_without_any_quantization_declaration() {
+    let args = test_args(None);
+
+    assert_eq!(args.group_size(), 64);
+    assert_eq!(args.bits(), 4);
+    assert_eq!(args.quantization_mode().unwrap(), "affine");
+}
+
+/// The declared mode is validated where it is read (#973). An absent block and
+/// an absent `mode` key both resolve to `"affine"`; anything MLX's own parser
+/// would reject is refused here instead of reaching a kernel.
+#[test]
+fn model_args_bounds_the_declared_quantization_mode() {
+    for mode in mlxcel_core::layers::SUPPORTED_QUANTIZATION_MODES {
+        let mut args = test_args(None);
+        args.quantization = Some(QuantizationArgs {
+            group_size: Some(64),
+            bits: Some(4),
+            mode: Some(mode.to_string()),
+        });
+        assert_eq!(
+            args.quantization_mode().expect("a supported mode"),
+            mode,
+            "{mode} is one of MLX's own four modes"
+        );
+    }
+
+    for mode in ["Affine", " affine", "", "int4"] {
+        let mut args = test_args(None);
+        args.quantization = Some(QuantizationArgs {
+            group_size: Some(64),
+            bits: Some(4),
+            mode: Some(mode.to_string()),
+        });
+        let err = args
+            .quantization_mode()
+            .expect_err("a mode MLX cannot parse must not resolve");
+        assert!(
+            err.contains("quantization.mode"),
+            "{mode:?} must be blamed on quantization.mode, got: {err}"
+        );
+    }
+}
+
+/// A pair that is individually in range can still describe a different tensor
+/// than the one on disk. `validate_expert_quantization_params` cannot see that,
+/// because it deliberately stays a range so mixed-precision exports keep
+/// loading, and this family never reaches `reconcile_quantization_layout`. Now
+/// that #975 lets a declared block actually arrive here, the mismatch has to be
+/// a load error rather than an uncatchable `gather_qmm` abort at the first
+/// routed forward pass.
+#[test]
+fn deepseek_switch_linear_rejects_a_pair_that_does_not_describe_the_expert_plane() {
+    // packed_in * 32 == 256, so (64, 4) is the honest pair for this plane.
+    const EXPERTS: i32 = 3;
+    const OUT: i32 = 4;
+    const PACKED_IN: i32 = 8;
+    const NUM_GROUPS: i32 = 1;
+    const PREFIX: &str = "model.layers.0.mlp.switch_mlp.gate_proj";
+
+    let mut weights = WeightMap::new();
+    crate::models::switch_layers::insert_stacked_quantized_expert_plane(
+        &mut weights,
+        PREFIX,
+        EXPERTS,
+        OUT,
+        PACKED_IN,
+        NUM_GROUPS,
+    );
+
+    // Positive control: the honest pair still loads through both spellings.
+    SwitchLinear::from_weights(&weights, &quant_args(64, 4), PREFIX)
+        .expect("the honest pair must load");
+    SwitchLinear::from_weights(&weights, &nested_quant_args(64, 4), PREFIX)
+        .expect("the honest pair must load through the nested spelling too");
+
+    // Both of these pass the range bound (`1..=32` bits, `1..=MAX` group size)
+    // and both describe a plane this checkpoint does not ship.
+    for (group_size, bits) in [(64, 8), (32, 4), (128, 4)] {
+        let err = match SwitchLinear::from_weights(
+            &weights,
+            &nested_quant_args(group_size, bits),
+            PREFIX,
+        ) {
+            Ok(_) => panic!(
+                "(group_size {group_size}, bits {bits}) describes a different plane and must be \
+                 refused at load, not stored for gather_qmm"
+            ),
+            Err(e) => e,
+        };
+        assert!(
+            err.contains("does not describe this expert plane"),
+            "(group_size {group_size}, bits {bits}) must be blamed on the shape mismatch, \
+             got: {err}"
+        );
+        assert!(
+            err.contains(PREFIX),
+            "the error must name the offending plane, got: {err}"
+        );
+    }
 }

--- a/src/models/switch_layers.rs
+++ b/src/models/switch_layers.rs
@@ -178,6 +178,64 @@ pub(crate) fn validate_expert_quantization_params(
         .map_err(|e| format!("{prefix}: {e}"))
 }
 
+/// Cross-check a declared `group_size` / `bits` pair against the expert plane it
+/// is about to be stored on (issue #975).
+///
+/// [`validate_expert_quantization_params`] above bounds the pair on its own, and
+/// deliberately stays a range rather than an allowlist so mixed-precision
+/// exports keep loading. That leaves the other half open: a pair that is
+/// individually in range can still describe a different tensor than the one on
+/// disk, and nothing on the expert path notices. The dense projections are
+/// covered, because `reconcile_quantization_layout` re-derives an effective pair
+/// from the shapes, but `SwitchLinear::from_stacked_parts` stores what it was
+/// given and hands it to `gather_qmm`.
+///
+/// This is MLX's own precondition, restated where the shapes are still in hand.
+/// `gather_qmm` reaches `extract_quantized_matmul_dims`, which requires
+/// `packed_in * 32 == bits * num_groups * group_size` for a `[experts, out,
+/// packed_in]` weight against `[experts, out, num_groups]` scales, and throws
+/// `The shapes of the weight and scales are incompatible based on bits and
+/// group_size` otherwise. Because `gather_qmm` crosses the cxx bridge as
+/// `UniquePtr<MlxArray>` rather than `Result`, that throw is an uncatchable
+/// `std::terminate` at the first routed forward pass. Checking the same equality
+/// here can only refuse a load that was already going to abort: it cannot reject
+/// a checkpoint that works.
+///
+/// The arithmetic is done in `i64` because `bits * num_groups * group_size`
+/// overflows `i32` well inside the range
+/// [`mlxcel_core::layers::validate_quantization_params`] accepts.
+///
+/// Used by: DeepSeek. The other eighteen families listed on
+///          [`validate_expert_quantization_params`] are the obvious next
+///          adopters and are left alone here so this stays one logical change;
+///          they are unaffected either way, because none of them reads a
+///          declared pair that this crate was previously discarding.
+pub(crate) fn validate_expert_quantization_shapes(
+    prefix: &str,
+    weight_shape: &[i32],
+    scales_shape: &[i32],
+    group_size: i32,
+    bits: i32,
+) -> Result<(), String> {
+    let (Some(&packed_in), Some(&num_groups)) = (weight_shape.last(), scales_shape.last()) else {
+        return Ok(());
+    };
+    let declared = i64::from(bits) * i64::from(num_groups) * i64::from(group_size);
+    let actual = i64::from(packed_in) * 32;
+    if declared == actual {
+        return Ok(());
+    }
+    Err(format!(
+        "{prefix}: the declared quantization pair (group_size {group_size}, bits {bits}) does not \
+         describe this expert plane: MLX requires packed_in * 32 == bits * num_groups * \
+         group_size, and the checkpoint ships weight {weight_shape:?} with scales \
+         {scales_shape:?}, giving {actual} against {declared}. Either the config declares a \
+         quantization block these tensors were not produced with, or the expert plane is from a \
+         different export. gather_qmm would otherwise throw at the first routed forward pass, and \
+         that throw crosses the cxx bridge as an uncatchable abort rather than a load error"
+    ))
+}
+
 /// Insert one affine expert plane in the pre-stacked `switch_mlp` layout that
 /// mlx-community conversions ship: a `[experts, out, packed_in]` packed weight
 /// with `[experts, out, num_groups]` scales and zero points.

--- a/src/vision/unlimited_ocr_tests.rs
+++ b/src/vision/unlimited_ocr_tests.rs
@@ -170,6 +170,7 @@ fn build_wrapper() -> UnlimitedOcrVlModel {
         first_k_dense_replace: 0,
         routed_scaling_factor: 1.0,
         attention_bias: false,
+        quantization: None,
         group_size: None,
         bits: None,
     };


### PR DESCRIPTION
## Summary

`deepseek::ModelArgs` declared only flat top-level `group_size` / `bits` keys and had no nested `quantization` field, so serde silently discarded the MLX-style `"quantization": {"group_size": N, "bits": M, "mode": ...}` block that every conversion tool emits. `group_size()` / `bits()` returned the hardcoded `64` / `4` regardless of what the checkpoint declared. The three DeepSeek-OCR loaders in `src/loading/vlm_deepseekocr.rs` copy the root block into `language_config` before deserializing into that struct, so the inheritance ran, succeeded, and accomplished nothing on all three; `DeepSeekModel::load` dropped the block the same way for a plain `deepseek` `config.json`.

The declared pair feeds four places in this family, and they fail differently. The dense projections, the embedding and the OCR projector go through `reconcile_quantization_layout`, which trusts `group_size` and re-derives `bits` from the tensor shapes. The MoE expert planes never reach the reconciler: `SwitchLinear::from_stacked_parts` stores the pair verbatim and hands it to `gather_qmm`, which crosses the cxx bridge as `UniquePtr<MlxArray>` rather than `Result`, so a mismatch is an uncatchable `std::terminate` at the first routed forward pass. Reading the declared block is what closes both at the root.

## What changed

- **`src/models/deepseek.rs`** gains `pub quantization: Option<QuantizationArgs>`. `group_size()` and `bits()` resolve nested block, then flat key, then family default, independently per key. A new `quantization_mode()` returns the declared mode (defaulting to `"affine"` when no block names one) through `QuantizationArgs::get_mode`, which validates against `SUPPORTED_QUANTIZATION_MODES`. `DeepSeekModel::from_weights` calls it and refuses anything but `"affine"`: every plane this family builds is affine, and `from_stacked_parts` takes its quantized arm only when a `.biases` plane is present, so a block-float checkpoint would land on the `Regular` arm with a packed `uint32` weight and be reinterpreted rather than refused. This mirrors the guard `jamba.rs` carries for the same reason.
- **`src/models/switch_layers.rs`** gains `validate_expert_quantization_shapes`, called from `deepseek::SwitchLinear::from_stacked_parts`. A declared pair now actually reaches `gather_qmm` for the first time on this family, and `validate_expert_quantization_params` deliberately stays a range rather than an allowlist (so mixed-precision exports keep loading), so an in-range pair can still describe a different tensor than the one on disk. This restates MLX's own `packed_in * 32 == bits * num_groups * group_size` precondition where the shapes are still in hand, so it can only refuse a load that was already going to abort. The other eighteen families on `validate_expert_quantization_params`'s `Used by:` list are left alone to keep this one logical change; they are unaffected either way, since none of them was discarding a declared pair.
- **`src/models/config.rs`**: doc only. The shared `QuantizationArgs` is adopted rather than a sixtieth private `Quantization` struct being added (`grep -c '^pub struct Quantization\b'` over `src/models/` gives 59, and the divergence between the `deepseek.rs` and `deepseek_v2.rs` copies is what produced this bug). `get_mode`'s "no production callers yet" note is now false and is replaced with a `Used by:` line, and the struct doc records why it is the type to reach for.
- **`src/loading/vlm_deepseekocr.rs`**: the triplicated `language_config` fixup collapses into one `deepseekocr_language_args(full_config, family)` helper used by all three loaders, and the Unlimited-OCR ring-cache window moves into `unlimited_ocr_sliding_window` so it still reads the untouched `full_config`. One funnel makes the inheritance testable without a checkpoint on disk and keeps the three from drifting apart again.
- **Tests**: new `src/loading/vlm_deepseekocr_tests.rs` drives the helper once per loader label (inherited block honoured, a `language_config`-declared block still winning over the root, the in-tree checkpoints' declaration resolving to the previous value, no declaration keeping the defaults, a partial block resolving per key, an unparseable inherited mode refused, `model_type` supplied, sliding-window fallback and clamp). `src/models/deepseek_tests.rs` adds a nested-spelling run of the expert-plane guard and a shape-mismatch case, so the MoE half is covered at the loader that stores the pair, plus the plain-`config.json` nested read, the flat-spelling fallback, precedence, per-key fallback and the mode allowlist. 21 tests in these two modules.

## Validation

Real checkpoints, `--temp 0`, one 1400x460 text image, `main` (`39e2ceb60`) versus this branch.

| Checkpoint | Declared block | Matches the old hardcoded 64 / 4? | Output before vs after |
|---|---|---|---|
| `models/deepseek-ocr-4bit` | `{"group_size": 64, "bits": 4, "mode": "affine"}` | yes | byte-identical, OCR correct both sides |
| `models/deepseek-ocr-2-4bit` | `{"group_size": 64, "bits": 4, "mode": "affine"}` | yes | byte-identical, OCR correct both sides |
| `models/deepseek-vl2-small-4bit` | `{"group_size": 64, "bits": 4}` | n/a (loads through `deepseek_v2`, which already had the field) | byte-identical |

Both DeepSeek-OCR checkpoints declare exactly the fallback pair, so the bug was latent rather than live for them and no output can change. To show the declared block now arrives, three symlinked copies of `deepseek-ocr-4bit` with only `config.json` edited (weights symlinked, nothing under `models/` written):

| Edited declaration | Before | After |
|---|---|---|
| `"mode": "mxfp4"` | loads, OCR identical to the honest checkpoint | clean load error naming the mode |
| `{"group_size": 64, "bits": 8}` | loads, OCR identical | clean load error naming the expert plane and the arithmetic (`weight [64, 896, 160]` with `scales [64, 896, 20]`, `5120` against `10240`) |
| `{"group_size": 32, "bits": 8}` | loads, OCR identical | `quantized_matmul` rejects it on the dense path |

The middle row is the one the new shape guard converts: without it, that config reached `gather_qmm` and killed the process with SIGABRT. The last row still aborts, and honestly so: the pair is self-consistent under `reconcile_quantization_layout`'s own arithmetic, and what rejects it is MLX comparing the expanded width against the activation width, which has no load-time equivalent because the activation is not in hand at load. That is the pre-existing #958 class, not something reading the block can close, and a candidate follow-up.

## Notes

- **The issue's "silently wrong output" prediction did not reproduce.** It expected a real group_size-32 4-bit tensor read as group_size 64 to land on a self-consistent `(64, 2)` pair that MLX accepts and compute wrong numbers. It is self-consistent by the reconciler's arithmetic, but the expanded input width it implies no longer matches the activation width, and MLX's `quantized_matmul` throws on exactly that. On these checkpoints the observed consequence of a wrong pair is an abort, not silent corruption, on both halves. That does not change the fix (the values still have to be read) but it is worth recording, because it means the defect's practical blast radius was "aborts on anything but a 64 / 4 export", not "quietly degrades".
- **#991 does not interact.** It was closed by #998, which made the `deepseek_v2` prefill causal: a masking defect in a different module, not config plumbing. Nothing here touches `deepseek_v2.rs`, and `models/deepseek-vl2-small-4bit` is re-run above as the cross-family control.
- **Two citation groups in the issue body have drifted** as `main` moved. `deepseek_v2.rs`'s nested field is at `:117` (struct `:121`, accessors `:184` / `:191`), not `:114` / `:118` / `:181` / `:188`. In `layers.rs`, `validate_quantization_params` is at `:1322`, `infer_quantization_bits` at `:1183`, `reconcile_quantization_layout` at `:1623` and the divergence `tracing::warn!` at `:1751`. Everything else checked out, including the 59 private `Quantization` copies, `QuantizationArgs` having zero production callers, the `lib.rs:1092` / `:1108` bridge citations, and both OCR checkpoints declaring exactly the fallback values.
- **Supersedes #989**, which diagnosed the same defect correctly and independently. That PR reuses `deepseek_v2::Quantization`, whose fields are required and which carries no `mode`, so a partially declared block would become a hard deserialization failure and the declared mode would stay invisible; it also predates #973 / #1006, which added the mode allowlist used here. It is a fork PR, so completing it in place would mean force-pushing over a contributor's branch.

## Test plan

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --release --lib --tests --features metal,accelerate -- -D warnings`
- [x] `cargo clippy -p mlxcel-core --release --all-targets --features metal,accelerate -- -D warnings`
- [x] `cargo test --release --features metal,accelerate` (77 targets, 5284 tests, 0 failures)
- [x] `cargo test --release -p mlxcel-core --features metal,accelerate --no-fail-fast -- --test-threads=1` (1411 tests, 1 failure: `fused_moe_parity_tests::fused_moe_geglu_kernel_matches_references_gemma4_shape`, the known deterministic failure tracked as #964; this PR changes no file under `src/lib/mlxcel-core/`)
- [x] Real-checkpoint before/after on `deepseek-ocr-4bit`, `deepseek-ocr-2-4bit` and `deepseek-vl2-small-4bit`, plus the three edited-config demonstrations above

Closes #975
