### PR TITLE
fix(ci): report unfinished nightly runs and cut the test build cost

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -35,7 +35,7 @@ For inference changes, real-checkpoint validation is required — synthetic-only
 
 - [ ] `cargo fmt --all -- --check` (enforced by CI — violations block merge)
 - [ ] `cargo clippy --all-targets -- -D warnings`
-- [ ] `cargo test --release`
+- [ ] `cargo test --profile test-fast`
 - [ ] `cargo deny check`
 - [ ] Validated with a real checkpoint (specify which, e.g. `mlx-community/Qwen3.5-0.8B-OptiQ-4bit`): ...
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,7 @@
 #     for why it is nightly rather than per-PR.
 #
 # Quality gate still lives locally at PR time. Pre-push checklist:
-#   make verify         # fmt + clippy(metal,accelerate, -D warnings) + test(release)
+#   make verify         # fmt + clippy(metal,accelerate, -D warnings) + test(test-fast)
 #   make verify-clean   # same, after `cargo clean` — use when clippy's
 #                       # per-crate cache may be hiding a regression
 #

--- a/.github/workflows/nightly-verify.yml
+++ b/.github/workflows/nightly-verify.yml
@@ -163,12 +163,36 @@ jobs:
       - name: Ensure build tools
         run: |
           set -euo pipefail
+
+          # Put Homebrew on PATH before looking for anything. A non-login shell
+          # on this runner does not source the profile that `brew shellenv`
+          # writes, so neither `cmake` nor `brew` itself is resolvable by
+          # default. Runs 30842184319 (2026-08-03 schedule) and 30870790330
+          # (2026-08-04 dispatch) both died here in about one second: `cmake`
+          # was not found, the fallback ran `brew install cmake`, and `brew`
+          # was not found either, so the step exited 127. Both prefixes are
+          # listed because Apple Silicon installs under /opt/homebrew and
+          # Intel under /usr/local; adding a directory that does not exist is
+          # harmless.
+          export PATH="/opt/homebrew/bin:/usr/local/bin:$PATH"
+
           # cmake is required by the mlxcel-core and sentencepiece-sys build scripts.
           if ! command -v cmake >/dev/null 2>&1; then
+            if ! command -v brew >/dev/null 2>&1; then
+              echo "::error::Neither cmake nor brew is on PATH after adding the Homebrew prefixes." >&2
+              echo "This is a runner provisioning problem, not a code failure." >&2
+              echo "PATH=$PATH" >&2
+              exit 1
+            fi
             echo "cmake not found, installing via Homebrew..."
             brew install cmake
           fi
           echo "cmake: $(cmake --version | head -1)"
+
+          # Every later step gets the same PATH; `export` above is scoped to
+          # this step's shell only.
+          echo "/opt/homebrew/bin" >> "$GITHUB_PATH"
+          echo "/usr/local/bin" >> "$GITHUB_PATH"
 
       # rust-toolchain.toml pins the channel (and the rustfmt/clippy
       # components) that every cargo invocation below actually resolves to, so
@@ -256,6 +280,10 @@ jobs:
           COMMIT_SHA: ${{ github.sha }}
           EVENT_NAME: ${{ github.event_name }}
           VERIFY_RESULT: ${{ needs.verify.result }}
+          # A `workflow_dispatch` can target any branch, so the report must not
+          # claim `main` is red when it was verifying something else.
+          REF_NAME: ${{ github.ref_name }}
+          DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
           # These do survive a `timeout-minutes` cancellation, so the usual
           # timeout report is fully populated. They are empty only if the runner
           # is lost outright, which the `unknown` default below covers.
@@ -265,12 +293,33 @@ jobs:
         run: |
           set -euo pipefail
 
+          # Name the ref when it is not the default branch. A dispatch against a
+          # PR branch says nothing about `main`, and a title claiming otherwise
+          # sends the reader to the wrong place. Keeping the bare title for the
+          # default branch also keeps the dedup key stable for the scheduled
+          # runs, which are the ones that matter; a branch run gets its own
+          # issue and does not reuse `main`'s.
+          if [ "$REF_NAME" = "$DEFAULT_BRANCH" ]; then
+            SUBJECT='main'
+            SCOPE=''
+          else
+            SUBJECT="\`$REF_NAME\`"
+            SCOPE=" ($REF_NAME)"
+          fi
+
           if [ "$VERIFY_RESULT" = "cancelled" ]; then
-            TITLE='[nightly-verify] the run did not finish'
+            TITLE="[nightly-verify] the run did not finish${SCOPE}"
             HEADLINE='The nightly `make verify` run did not finish. GitHub reports a `timeout-minutes` kill and a human cancel with the same `cancelled` conclusion, so compare the duration below against `timeout-minutes` in `.github/workflows/nightly-verify.yml`: at or just under the budget means the job ran out of time, anything well short of it means someone cancelled the run.'
           else
-            TITLE='[nightly-verify] main is red'
-            HEADLINE='The nightly `make verify` run on `self-hosted-macos-26-arm64` failed. At least one of the three gates below is genuinely red on the commit named at the bottom.'
+            TITLE="[nightly-verify] ${SUBJECT} is red${SCOPE}"
+            # Deliberately not "at least one of the three gates is red": a setup
+            # step (toolchain, build tools) can fail the job before any gate
+            # runs, and then the gates report `failure` only because cargo was
+            # never installed. Run 30870790330 was exactly that, and a headline
+            # asserting a genuine code failure would have pointed the reader at
+            # the wrong thing. Say the job failed and let the table and the log
+            # say where.
+            HEADLINE='The nightly `make verify` run on `self-hosted-macos-26-arm64` failed. Check the first failing step in the run log before reading the gate table below: a setup step that fails leaves the gates reporting `failure` for want of a toolchain rather than because the code is red.'
           fi
           export TITLE
 

--- a/.github/workflows/nightly-verify.yml
+++ b/.github/workflows/nightly-verify.yml
@@ -238,8 +238,9 @@ jobs:
       ${{ always()
           && github.repository == 'lablup/mlxcel'
           && (needs.verify.result == 'failure' || needs.verify.result == 'cancelled') }}
-    # GitHub-hosted, which is what makes reasons 1 and 3 above actually go away:
-    # `ubuntu-latest` ships `gh` preinstalled, so nothing here needs Homebrew.
+    # Being a separate job is what answers reasons 2 and 3; being GitHub-hosted
+    # is what answers reason 1, since `ubuntu-latest` ships `gh` preinstalled
+    # and nothing here needs Homebrew.
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -255,8 +256,9 @@ jobs:
           COMMIT_SHA: ${{ github.sha }}
           EVENT_NAME: ${{ github.event_name }}
           VERIFY_RESULT: ${{ needs.verify.result }}
-          # Empty when `verify` was torn down before it could publish outputs,
-          # which is exactly the timeout case. Defaulted to `unknown` below.
+          # These do survive a `timeout-minutes` cancellation, so the usual
+          # timeout report is fully populated. They are empty only if the runner
+          # is lost outright, which the `unknown` default below covers.
           FMT_OUTCOME: ${{ needs.verify.outputs.fmt }}
           CLIPPY_OUTCOME: ${{ needs.verify.outputs.clippy }}
           TEST_OUTCOME: ${{ needs.verify.outputs.test }}

--- a/.github/workflows/nightly-verify.yml
+++ b/.github/workflows/nightly-verify.yml
@@ -308,7 +308,7 @@ jobs:
             echo "Commit: \`${COMMIT_SHA}\`"
             echo "Run: ${RUN_URL}"
             echo
-            echo "An \`unknown\` step outcome means the job was torn down before it could publish one, which is the normal reading when the job did not finish."
+            echo "An \`unknown\` step outcome means the job published no outcome for that step. A \`timeout-minutes\` cancellation still publishes them, so \`unknown\` points at the runner being lost outright rather than at the budget."
             echo
             echo "Reproduce locally with \`make verify\` (or the single failing target above)."
             echo "This issue is reused by subsequent nightly reports of the same kind while it stays open."

--- a/.github/workflows/nightly-verify.yml
+++ b/.github/workflows/nightly-verify.yml
@@ -194,6 +194,43 @@ jobs:
           echo "/opt/homebrew/bin" >> "$GITHUB_PATH"
           echo "/usr/local/bin" >> "$GITHUB_PATH"
 
+          # The Metal shader compiler must be resolvable by xcrun, or every COLD
+          # MLX C++ build dies with
+          #   xcrun: error: unable to find utility "metal", not a developer tool or in PATH
+          # once cmake reaches the kernel headers. This is the same condition
+          # docs/mla-absorbed-decode.md and docs/sparse-paged-decode.md tell
+          # developers to fix with DEVELOPER_DIR: `xcode-select -p` points at
+          # CommandLineTools, which ships no metal compiler.
+          #
+          # It stayed hidden because a warm CARGO_TARGET_DIR skips the MLX build
+          # entirely. Run 30761020020 passed with a 71-second clippy for exactly
+          # that reason. Run 30870981405 was the first to need a cold build (a
+          # new profile for tests, and a debug tree that had gone stale) and both
+          # clippy and test failed here. release.yml prunes that directory every
+          # 7 days, so this was going to surface on its own.
+          if ! xcrun -f metal >/dev/null 2>&1; then
+            for candidate in /Applications/Xcode*.app/Contents/Developer; do
+              [ -d "$candidate" ] || continue
+              if DEVELOPER_DIR="$candidate" xcrun -f metal >/dev/null 2>&1; then
+                export DEVELOPER_DIR="$candidate"
+                echo "DEVELOPER_DIR=$candidate" >> "$GITHUB_ENV"
+                echo "xcrun could not find metal; selected DEVELOPER_DIR=$candidate"
+                break
+              fi
+            done
+          fi
+
+          if ! xcrun -f metal >/dev/null 2>&1; then
+            echo "::error::xcrun cannot resolve the metal compiler, so any cold MLX C++ build will fail." >&2
+            echo "This is a runner provisioning problem, not a code failure." >&2
+            echo "xcode-select -p: $(xcode-select -p 2>&1 || true)" >&2
+            echo "Xcode installs found: $(ls -d /Applications/Xcode*.app 2>/dev/null | tr '\n' ' ')" >&2
+            echo "Install Xcode (not just the Command Line Tools) and its Metal toolchain," >&2
+            echo "then either 'sudo xcode-select -s' it or leave DEVELOPER_DIR set for the runner." >&2
+            exit 1
+          fi
+          echo "metal: $(xcrun -f metal)"
+
       # rust-toolchain.toml pins the channel (and the rustfmt/clippy
       # components) that every cargo invocation below actually resolves to, so
       # this step exists to guarantee rustup is present and current, not to

--- a/.github/workflows/nightly-verify.yml
+++ b/.github/workflows/nightly-verify.yml
@@ -12,10 +12,13 @@
 #
 # WHY NIGHTLY AND NOT PR-TIME
 #
-# `clippy + test` on this target takes ~30 min on the shared self-hosted
-# runner. #21 moved that gate from PR time to release time and #23 removed it
-# entirely, for a cost reason that still holds: a slow shared resource blocking
-# every PR is worse than `make verify` on the developer's machine. This
+# `clippy + test` on this target was ~30 min on the shared self-hosted runner
+# when #21 moved that gate from PR time to release time and #23 removed it
+# entirely. Treat that number as historical: the one run that ever completed a
+# full pass under `[profile.release]`, 30761020020 on 2026-08-02, took 2h56m,
+# of which 2h54m was the `cargo test` step. The cost reason still holds either
+# way, and more strongly than when it was written: a slow shared resource
+# blocking every PR is worse than `make verify` on the developer's machine. This
 # workflow does not reinstate the PR-time gate. It consumes the shared runner
 # once per day at a quiet hour, blocks nothing, and bounds how long a red
 # `main` can hide from 26 days to about one.
@@ -43,12 +46,51 @@
 # are `#[ignore]`d. What this run actually gates is the weight-free unit and
 # contract suite, which is exactly where both known failures lived.
 #
+# WHICH PROFILE THE TESTS BUILD UNDER, AND WHAT THAT GIVES UP
+#
+# `make verify-test` builds under `[profile.test-fast]`, not `[profile.release]`
+# (#1000). The budget was going almost entirely to codegen and linking rather
+# than to running tests: on 2026-08-02 the `cargo test` step spent 179 minutes
+# and was killed with zero `Running tests/` lines in the log and `ld`/`clang`
+# among the processes the runner terminated. `[profile.release]` is fat LTO
+# plus `codegen-units = 1`, which is 4 to 6 minutes per incremental rebuild of
+# the ~390k-line main crate, paid once per test binary across roughly 77 of
+# them. `test-fast` keeps `opt-level = 3`, so the optimized MLX numerics these
+# tests depend on are unchanged, and relaxes only what exists to shrink or
+# speed up a *shipped* binary (thin LTO, parallel codegen, incremental, no
+# strip).
+#
+# What that gives up: the suite no longer runs under the exact codegen the
+# release binary ships with. A defect that only appears under fat LTO or
+# `codegen-units = 1` (the f16 reduction-order jitter class this repo has hit
+# before, for instance) could in principle differ here. release.yml still
+# builds and links the shipping artifacts under `[profile.release]`, so the
+# shipped binary is unaffected, but it does not run this suite. A second cost:
+# the nightly no longer refreshes `[profile.release]` artifacts in the shared
+# `$HOME/.cargo-target/mlxcel`, so release.yml's first build after a prune is
+# colder than it used to be.
+#
 # HOW A FAILURE IS REPORTED
 #
 # A red Actions run that nobody opens is the same blind spot in a new place, so
-# a failed scheduled run files (or comments on) a GitHub issue. If a day of
-# exposure ever proves too long, the next step is adding `push: [main]` here,
-# which costs one run per merge instead of one per day.
+# a failed or unfinished run files (or comments on) a GitHub issue.
+#
+# The old reporting step was a final step of `verify` conditioned on
+# `failure()`, and it reported nothing on the 180-minute runs of 2026-07-30,
+# 08-01 and 08-02. The reason is narrower than it looks: a `timeout-minutes`
+# kill surfaces as *cancellation*, and `failure()` is false while a job is
+# cancelled, so the condition simply did not match. Later steps still run. A
+# throwaway probe on a job with `timeout-minutes: 1` confirmed it directly:
+# after the timeout, a step with `if: always()` ran, a step with
+# `if: cancelled()` ran, and only the `if: failure()` step was skipped. Job
+# outputs survived the cancellation too.
+#
+# So a step-level condition fix would have covered the timeout case. Reporting
+# still lives in a separate job, for the failure modes a step-level fix cannot
+# reach; see the `report` job for the three of them.
+#
+# If a day of exposure ever proves too long, the next step is adding
+# `push: [main]` here, which costs one run per merge instead of one per day.
 
 name: Nightly verify
 
@@ -75,13 +117,24 @@ jobs:
     # against runner labels it does not own.
     if: github.repository == 'lablup/mlxcel'
     runs-on: self-hosted-macos-26-arm64 # Self-hosted Apple Silicon runner with macOS 26 SDK + Metal 4
-    # Generous because the FIRST run is a cold MLX C++ build plus a release
-    # link of every integration-test binary. Steady state, with the persistent
-    # target dir below, is the ~30 min `make verify` takes locally.
+    # Generous because a cold run is a full MLX C++ build plus a link of every
+    # integration-test binary. Note that the FIRST run after the switch to
+    # `[profile.test-fast]` is cold by construction: a different profile means a
+    # different OUT_DIR for the mlxcel-core build script, so that run rebuilds
+    # MLX C++ from scratch against the persistent target dir below and should
+    # not be read as the steady-state cost.
     timeout-minutes: 180
     permissions:
       contents: read
-      issues: write
+
+    # Surfaced to the `report` job, which cannot see `steps.*.outcome` across a
+    # job boundary. These do survive a `timeout-minutes` cancellation (probed
+    # directly), but they will be empty if the runner is lost outright, so the
+    # reporter treats an empty value as unknown rather than failing on it.
+    outputs:
+      fmt: ${{ steps.fmt.outcome }}
+      clippy: ${{ steps.clippy.outcome }}
+      test: ${{ steps.test.outcome }}
 
     steps:
       - name: Checkout code
@@ -92,9 +145,14 @@ jobs:
 
       # Mirrors release.yml, deliberately including the same path: a persistent
       # target dir outside the workspace so the nightly is incremental instead
-      # of a cold MLX C++ build every time, and so the daily run keeps the
-      # release job's cache warm. release.yml owns the 7-day prune of this
-      # directory; cargo's own file lock serializes the rare overlap.
+      # of a cold MLX C++ build every time. release.yml owns the 7-day prune of
+      # this directory; cargo's own file lock serializes the rare overlap.
+      #
+      # Since #1000 this job populates a `test-fast/` tree here while release.yml
+      # populates `release/`, so the directory holds two profile trees instead of
+      # one (order of 10 GiB each) and the nightly no longer keeps release.yml's
+      # artifacts warm. Both are bounded by the same prune, which drops the whole
+      # directory rather than a single profile, so no third prune rule is needed.
       - name: Setup persistent cache paths (self-hosted)
         run: |
           set -euo pipefail
@@ -134,55 +192,137 @@ jobs:
         if: ${{ !cancelled() }}
         run: make verify-clippy
 
-      - name: cargo test (release, metal,accelerate)
+      - name: cargo test (test-fast profile, metal,accelerate)
         id: test
         if: ${{ !cancelled() }}
         run: make verify-test
 
-      - name: Report a red main
-        # Only the scheduled run reports. A manual dispatch is someone already
-        # watching the run, and filing an issue at them is noise.
-        if: ${{ failure() && github.event_name == 'schedule' }}
+  # Reporting is a separate job, not a step of `verify` with a wider condition.
+  # A wider condition would have fixed the timeout case on its own (see the
+  # header comment for the probe that established that), but three failure modes
+  # remain that no step inside `verify` can cover:
+  #
+  #   1. Fate-sharing with the runner. On 2026-08-03 `verify` failed in "Ensure
+  #      build tools" because `brew` was not on the self-hosted runner's PATH,
+  #      and the in-job reporting step then died the same way, `brew install gh`
+  #      exiting 127. A genuinely red run reported nothing, for a reason that
+  #      has nothing to do with timeouts. A reporter must not depend on the
+  #      environment whose breakage it exists to announce.
+  #   2. Runner loss. If the self-hosted runner disappears mid-job, no step in
+  #      that job runs at all, whatever its condition says.
+  #   3. The post-cancellation window is bounded and short. The probe's step was
+  #      one `echo`. Real reporting may have to install `gh` and make several
+  #      API calls, which is far likelier to be cut off.
+  #
+  # It also keeps reporting off the shared macOS runner, which is the scarce
+  # resource this workflow is otherwise careful with.
+  report:
+    name: Report a red or unfinished main
+    needs: verify
+    # `always()` so a torn-down `verify` still gets reported. `needs.verify.result`
+    # is `failure` when the suite is genuinely red and `cancelled` when the job
+    # was killed by its budget (or cancelled by a person), and the two need
+    # different responses, so the report says which one happened. `success` and
+    # `skipped` (a fork, where `verify` is guarded off) report nothing.
+    #
+    # Deliberately NOT filtered to `github.event_name == 'schedule'`, which is a
+    # reversal of the previous rule. That rule assumed a manual dispatch is
+    # someone already watching, so reporting at them is noise. The 2026-08-02
+    # dispatch disproved it: it ran three hours, timed out, told nobody, and was
+    # only found because someone went looking days later. Nobody watches a job
+    # for three hours. The noise this reintroduces is bounded, because repeat
+    # dispatches comment on one deduplicated tracking issue rather than filing
+    # new ones, and the body names the trigger so a reader can dismiss a run
+    # they cancelled themselves.
+    if: >-
+      ${{ always()
+          && github.repository == 'lablup/mlxcel'
+          && (needs.verify.result == 'failure' || needs.verify.result == 'cancelled') }}
+    # GitHub-hosted, which is what makes reasons 1 and 3 above actually go away:
+    # `ubuntu-latest` ships `gh` preinstalled, so nothing here needs Homebrew.
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      issues: write
+
+    steps:
+      - name: File or update the tracking issue
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           REPO: ${{ github.repository }}
+          RUN_ID: ${{ github.run_id }}
           RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
           COMMIT_SHA: ${{ github.sha }}
-          FMT_OUTCOME: ${{ steps.fmt.outcome }}
-          CLIPPY_OUTCOME: ${{ steps.clippy.outcome }}
-          TEST_OUTCOME: ${{ steps.test.outcome }}
+          EVENT_NAME: ${{ github.event_name }}
+          VERIFY_RESULT: ${{ needs.verify.result }}
+          # Empty when `verify` was torn down before it could publish outputs,
+          # which is exactly the timeout case. Defaulted to `unknown` below.
+          FMT_OUTCOME: ${{ needs.verify.outputs.fmt }}
+          CLIPPY_OUTCOME: ${{ needs.verify.outputs.clippy }}
+          TEST_OUTCOME: ${{ needs.verify.outputs.test }}
         run: |
           set -euo pipefail
 
-          if ! command -v gh >/dev/null 2>&1; then
-            echo "gh not found, installing via Homebrew..."
-            brew install gh
+          if [ "$VERIFY_RESULT" = "cancelled" ]; then
+            TITLE='[nightly-verify] the run did not finish'
+            HEADLINE='The nightly `make verify` run did not finish. GitHub reports a `timeout-minutes` kill and a human cancel with the same `cancelled` conclusion, so compare the duration below against `timeout-minutes` in `.github/workflows/nightly-verify.yml`: at or just under the budget means the job ran out of time, anything well short of it means someone cancelled the run.'
+          else
+            TITLE='[nightly-verify] main is red'
+            HEADLINE='The nightly `make verify` run on `self-hosted-macos-26-arm64` failed. At least one of the three gates below is genuinely red on the commit named at the bottom.'
+          fi
+          export TITLE
+
+          # Best-effort: the duration is what separates "ran out of budget" from
+          # "someone cancelled it", but every step of computing it is guarded so
+          # a hiccup here can never be the reason a failure goes unreported.
+          DURATION_LINE='Duration: could not be determined; see the run page.'
+          # The filter must keep matching `jobs.verify.name` above. Everything
+          # after it is parameter expansion rather than a pipeline, so no part
+          # of this can fail the step under `set -euo pipefail`.
+          JOB_TIMES="$(gh api "repos/${REPO}/actions/runs/${RUN_ID}/jobs" \
+            --jq '.jobs[] | select(.name | startswith("fmt + clippy + test")) | "\(.started_at) \(.completed_at)"' 2>/dev/null || true)"
+          FIRST_JOB="${JOB_TIMES%%$'\n'*}"
+          STARTED="${FIRST_JOB%% *}"
+          ENDED="${FIRST_JOB##* }"
+          ELAPSED="$({ S="$(date -u -d "$STARTED" +%s)" && E="$(date -u -d "$ENDED" +%s)" && echo "$((E - S))"; } 2>/dev/null || true)"
+          if [ -n "$ELAPSED" ] && [ "$ELAPSED" -gt 0 ] 2>/dev/null; then
+            DURATION_LINE="Duration of the \`verify\` job: **$((ELAPSED / 60))m$((ELAPSED % 60))s**."
           fi
 
-          TITLE='[nightly-verify] main is red'
-          BODY_FILE="$(mktemp -t nightly-verify-body)"
+          BODY_FILE="$(mktemp -t nightly-verify-body.XXXXXX)"
           {
-            echo "The nightly \`make verify\` run on \`self-hosted-macos-26-arm64\` failed."
+            echo "$HEADLINE"
             echo
-            echo "| Step | Outcome |"
+            echo "| Field | Value |"
             echo "|---|---|"
-            echo "| \`make verify-fmt\` | \`${FMT_OUTCOME}\` |"
-            echo "| \`make verify-clippy\` | \`${CLIPPY_OUTCOME}\` |"
-            echo "| \`make verify-test\` | \`${TEST_OUTCOME}\` |"
+            echo "| \`verify\` job result | \`${VERIFY_RESULT}\` |"
+            echo "| \`make verify-fmt\` | \`${FMT_OUTCOME:-unknown}\` |"
+            echo "| \`make verify-clippy\` | \`${CLIPPY_OUTCOME:-unknown}\` |"
+            echo "| \`make verify-test\` | \`${TEST_OUTCOME:-unknown}\` |"
+            echo "| Trigger | \`${EVENT_NAME}\` |"
+            echo
+            echo "$DURATION_LINE"
             echo
             echo "Commit: \`${COMMIT_SHA}\`"
             echo "Run: ${RUN_URL}"
             echo
+            echo "An \`unknown\` step outcome means the job was torn down before it could publish one, which is the normal reading when the job did not finish."
+            echo
             echo "Reproduce locally with \`make verify\` (or the single failing target above)."
-            echo "This issue is reused by subsequent nightly failures while it stays open."
+            echo "This issue is reused by subsequent nightly reports of the same kind while it stays open."
           } > "$BODY_FILE"
+
+          cat "$BODY_FILE" >> "$GITHUB_STEP_SUMMARY"
+          echo "::error title=${TITLE}::verify job result: ${VERIFY_RESULT}. See the job summary."
 
           # `|| true` on purpose: a transient search failure must not swallow
           # the report. An empty result files a fresh issue, and a rare
-          # duplicate is a better failure mode than silence.
+          # duplicate is a better failure mode than silence. The exact-title
+          # filter keeps the two report kinds on two separate tracking issues,
+          # since the search itself matches loosely.
           EXISTING="$(gh issue list --repo "$REPO" --state open \
-            --search "in:title \"$TITLE\"" --limit 1 \
-            --json number -q '.[0].number // empty' || true)"
+            --search "in:title \"$TITLE\"" --limit 20 \
+            --json number,title -q 'map(select(.title == env.TITLE)) | .[0].number // empty' || true)"
 
           if [ -n "$EXISTING" ]; then
             gh issue comment "$EXISTING" --repo "$REPO" --body-file "$BODY_FILE"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -149,7 +149,7 @@ jobs:
       # machine in a fraction of the time.
       #
       # Quality gate lives locally now. Pre-push checklist:
-      #   make verify         # fmt + clippy(metal,accelerate, -D warnings) + test(release)
+      #   make verify         # fmt + clippy(metal,accelerate, -D warnings) + test(test-fast)
       #   make verify-clean   # same, after `cargo clean` — use when clippy's
       #                       # per-crate cache may be hiding a regression
       #

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -33,22 +33,22 @@ Thank you for your interest in contributing to mlxcel! This document covers the 
    ```bash
    # macOS (Apple Silicon)
    cargo build --release --features metal,accelerate
-   cargo test --release
+   cargo test --profile test-fast --features metal,accelerate
 
    # Linux / CUDA
    cargo build --release --features cuda
-   cargo test --release
+   cargo test --profile test-fast --features cuda
    ```
 4. Run the local quality gates:
    ```bash
    cargo fmt --all -- --check   # gated at PR time; fmt violations block merge
    cargo clippy --all-targets --features metal,accelerate -- -D warnings   # NOT gated at PR time; yours to run
-   cargo test --release --features metal,accelerate                        # NOT gated at PR time; yours to run
+   cargo test --profile test-fast --features metal,accelerate              # NOT gated at PR time; yours to run
    cargo deny check             # gated at PR time (advisories + licenses + sources)
    ```
-   PR-time CI runs only the cheap gates: `cargo fmt` and `cargo deny` in [`ci.yml`](.github/workflows/ci.yml), plus a path-filtered clippy and a `distributed::`-scoped `cargo test` in [`pipeline-parallel-ci.yml`](.github/workflows/pipeline-parallel-ci.yml) when you touch pipeline-parallel code. Clippy and the general unit suite are **not** enforced on your PR. They were moved in #21 and removed in #23 because ~30 min per run on the shared self-hosted Apple Silicon runner blocked PRs and releases for failures that `make verify` catches locally in a fraction of the time. [`nightly-verify.yml`](.github/workflows/nightly-verify.yml) runs the full `make verify` once a day on `self-hosted-macos-26-arm64` and files an issue when `main` goes red, so a broken suite surfaces within a day rather than on the next contributor's `make verify`. Treat that as a backstop, not a substitute: run the two commands above yourself before you push. CUDA verification is not gated at PR time either; that stays exclusive to `release.yml`.
+   PR-time CI runs only the cheap gates: `cargo fmt` and `cargo deny` in [`ci.yml`](.github/workflows/ci.yml), plus a path-filtered clippy and a `distributed::`-scoped `cargo test` in [`pipeline-parallel-ci.yml`](.github/workflows/pipeline-parallel-ci.yml) when you touch pipeline-parallel code. Clippy and the general unit suite are **not** enforced on your PR. They were moved in #21 and removed in #23 because ~30 min per run on the shared self-hosted Apple Silicon runner blocked PRs and releases for failures that `make verify` catches locally in a fraction of the time. [`nightly-verify.yml`](.github/workflows/nightly-verify.yml) runs the full `make verify` once a day on `self-hosted-macos-26-arm64` and files an issue when `main` goes red or when the run does not finish, so a broken suite surfaces within a day rather than on the next contributor's `make verify`. Treat that as a backstop, not a substitute: run the two commands above yourself before you push. CUDA verification is not gated at PR time either; that stays exclusive to `release.yml`.
 
-   While iterating, prefer `[profile.test-fast]` over `--release`: `make test-fast` / `make test-fast-cuda` (or `cargo test --profile test-fast --features <...>`) rebuild in seconds instead of minutes. It is for local/agent edit-test loops only; run the `--release` commands above (or `make verify`) before opening or updating a PR. See [`docs/installation.md`](docs/installation.md#fast-iteration-builds) for the measured comparison.
+   `make verify` runs exactly the three commands above, and the nightly invokes those same Makefile targets, so the local gate and CI cannot drift apart. Tests build under `[profile.test-fast]` rather than `--release`: `opt-level = 3` is kept so MLX numerics stay representative, while the fat LTO and single codegen unit that make a full `--release` test link take hours are dropped. `make test-fast` / `make test-fast-cuda` are the same profile with `--test-threads=1` and a `FILTER` hook for narrowing the run while you iterate. Reach for `cargo test --release --features metal,accelerate` by hand only when you suspect a defect specific to release codegen. See [`docs/installation.md`](docs/installation.md#fast-iteration-builds) for the measured comparison.
 5. For inference changes, validate against a real checkpoint. Synthetic or build-only validation is not enough: a shape-compatible change can compile, pass unit tests, and still produce wrong logits on an actual quantized checkpoint. Fetch one with `mlxcel download mlx-community/<model-id>`, and see [`docs/supported-models.md`](docs/supported-models.md) for the families each code path covers. A change to a shared component should be smoke-tested against at least two families.
 6. Commit with a conventional prefix (see below) and a clear message.
 7. Push to your fork and open a Pull Request. The PR template will prompt for a summary, test plan, and linked issues.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -255,7 +255,15 @@ panic = "unwind"
 # DO NOT use this profile for anything that ships or gets measured:
 # performance benchmarks, release binaries, or numbers quoted in a PR as
 # representative throughput/latency. Use `[profile.release]` (via
-# `make release*` / `make verify-test`) for those.
+# `make release*`) for those.
+#
+# As of #1000 this profile also backs `make verify-test`, so it is what the
+# CI-faithful gate and the nightly workflow run tests under. That is a
+# deliberate trade: `opt-level = 3` is what makes the optimised-codegen
+# argument for testing hold, and it is kept, while the fat LTO and single
+# codegen unit that were consuming the nightly's entire budget in linking are
+# not. It does not change what ships; release.yml still builds the shipped
+# binaries under `[profile.release]`.
 [profile.test-fast]
 inherits = "release"
 lto = "thin"           # cross-crate inlining kept; drops the whole-program fat-LTO link

--- a/Makefile
+++ b/Makefile
@@ -220,15 +220,19 @@ test-doc: ## Run documentation tests
 # ----------------------------------------------------------------------------
 # Fast dev-iteration test targets (issue #809)
 #
-# `test` / `verify-test` above build under [profile.release] (fat LTO,
-# codegen-units = 1), which is the right choice for CI-faithful and shipping
-# validation but measured at 4 to 6 minutes per incremental rebuild on the
-# ~390k-line main crate, which is expensive for the edit-test-edit loop of local and
-# agent development. These targets build under [profile.test-fast] instead
-# (thin LTO, parallel codegen, incremental compilation); see the profile's
-# Cargo.toml comment and docs/installation.md ("Fast iteration builds") for
-# the measured speedup. Set FILTER to narrow the run, e.g.
+# `release*` and a hand-run `cargo test --release` build under
+# [profile.release] (fat LTO, codegen-units = 1), which is the right choice for
+# shipping validation but measured at 4 to 6 minutes per incremental rebuild on
+# the ~390k-line main crate, which is expensive for the edit-test-edit loop of
+# local and agent development. These targets build under [profile.test-fast]
+# instead (thin LTO, parallel codegen, incremental compilation); see the
+# profile's Cargo.toml comment and docs/installation.md ("Fast iteration
+# builds") for the measured speedup. Set FILTER to narrow the run, e.g.
 # `make test-fast-cuda FILTER=server::chat_request`.
+#
+# `verify-test` below also builds under [profile.test-fast] as of #1000, so
+# these targets and the CI-faithful gate now differ only in feature set and
+# `--test-threads=1`, not in codegen.
 # ----------------------------------------------------------------------------
 
 .PHONY: test-fast
@@ -450,9 +454,17 @@ pre-commit: fmt clippy test ## Pre-commit checks
 #   2. `-D warnings` — promotes every clippy warning to an error, matching
 #      `-- -D warnings` in CI. The default `clippy` target uses `-W warnings`
 #      and silently hides regressions.
-#   3. `cargo test --release` — CI runs tests in release mode for realistic
-#      MLX/Metal codegen. Debug-mode tests can pass while release-mode tests
-#      hit different optimisation paths.
+#   3. `--profile test-fast`: CI runs tests optimised, not in debug, for
+#      realistic MLX/Metal codegen. Debug-mode tests can pass while optimised
+#      tests hit different paths. `test-fast` keeps `opt-level = 3`, which is
+#      what that argument actually rests on, and drops the fat LTO and
+#      `codegen-units = 1` of `[profile.release]`, which exist to tune a
+#      shipped binary and were costing the nightly its whole budget in
+#      codegen and linking (#1000). release.yml still builds and links what
+#      ships under `[profile.release]`. The residual gap is a defect that
+#      reproduces only under fat LTO or single-unit codegen; use
+#      `cargo test --release --features metal,accelerate` by hand when you
+#      are chasing one.
 #
 # Run `make verify` before opening or updating a PR. Run `make verify-clean`
 # (which prepends `cargo clean`) when you suspect clippy's per-crate result
@@ -471,9 +483,9 @@ verify-clippy: ## CI-faithful: clippy --all-targets --features metal,accelerate 
 	$(CARGO) clippy --all-targets --features metal,accelerate -- -D warnings
 
 .PHONY: verify-test
-verify-test: ## CI-faithful: cargo test --release --features metal,accelerate
-	@echo "$(CYAN)[verify] test (release, features=metal,accelerate)...$(RESET)"
-	$(CARGO) test --release --features metal,accelerate
+verify-test: ## CI-faithful: cargo test --profile test-fast --features metal,accelerate
+	@echo "$(CYAN)[verify] test (test-fast profile, features=metal,accelerate)...$(RESET)"
+	$(CARGO) test --profile test-fast --features metal,accelerate
 
 .PHONY: verify
 verify: verify-fmt verify-clippy verify-test ## Run the full CI-faithful gate locally (recommended before push)

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -277,17 +277,17 @@ racing another thread's stream capture) or, with graphs disabled, with
 binaries are unaffected; this is a test-parallelism artifact.
 
 ```bash
-cargo test --release --features cuda -- --test-threads=1
+cargo test --profile test-fast --features cuda -- --test-threads=1
 ```
 
 ## Fast iteration builds
 
-`cargo test --release` (and `cargo build --release`) use `[profile.release]`:
-fat LTO across all ~439 locked crates plus `codegen-units = 1` for the
-~390k-line main crate. That is the right tradeoff for CI-faithful validation
-and for anything you ship, but it is expensive for the day-to-day edit-test
-loop: measured at 4 to 6 minutes per incremental rebuild, so a typical issue
-cycle of several edit-test iterations pays 20+ minutes of pure compile time.
+`cargo build --release` (and a hand-run `cargo test --release`) use
+`[profile.release]`: fat LTO across all ~439 locked crates plus
+`codegen-units = 1` for the ~390k-line main crate. That is the right tradeoff
+for anything you ship, but it is expensive for the day-to-day edit-test loop:
+measured at 4 to 6 minutes per incremental rebuild, so a typical issue cycle of
+several edit-test iterations pays 20+ minutes of pure compile time.
 
 For local and agent development, use `[profile.test-fast]` instead (thin LTO,
 `codegen-units = 16`, incremental compilation, `strip = false`; still
@@ -317,10 +317,20 @@ versus 4 to 6 minutes under `[profile.release]`, roughly a 13x to 19x
 iteration speedup. A representative narrow test set (139 tests across model,
 server, sampling, and cache modules) passes identically under both profiles.
 
-`test-fast` is for iteration only. Use `[profile.release]` (`make release*`,
-`make verify-test`, or plain `cargo test --release`) for anything you ship,
-benchmark, or quote as representative performance: `test-fast` trades link
-time and binary size for rebuild speed and is not tuned for either.
+Use `[profile.release]` (`make release*`, or plain `cargo build --release`) for
+anything you ship, benchmark, or quote as representative performance:
+`test-fast` trades link time and binary size for rebuild speed and is not tuned
+for either.
+
+Running *tests* is the exception. `make verify-test`, and therefore the
+[nightly workflow](https://github.com/lablup/mlxcel/blob/main/.github/workflows/nightly-verify.yml)
+that invokes it, builds the test binaries under `test-fast` as well. Linking
+roughly 77 test binaries under fat LTO was costing that job its entire
+180-minute budget before a single test ran. `opt-level = 3` is unchanged, so
+the optimised MLX numerics the suite depends on are the same; what is no longer
+covered is a defect that reproduces only under fat LTO or `codegen-units = 1`.
+Reach for `cargo test --release --features metal,accelerate` by hand when you
+are chasing one of those.
 
 ## Troubleshooting
 


### PR DESCRIPTION
## Summary

`nightly-verify` had two independent defects: the `cargo test` step never finished inside the 180-minute job budget, and when the job was killed by that budget nobody was told. This fixes both. Coverage of the other three workspace members (#1007) is deliberately out of scope, and #964 is being fixed separately.

## Phase 1: make an unfinished run visible

The old `Report a red main` step was conditioned on `failure()` and reported nothing on the three-hour runs.

**A correction to the premise this was scoped on.** The step was not skipped because a job timeout tears the job down before later steps can run. It was skipped because the *condition did not match*: a `timeout-minutes` kill surfaces as cancellation, and `failure()` is false while a job is cancelled. Later steps do still run. A throwaway probe on a one-minute job settled it directly:

| probe step | condition | conclusion after the timeout |
|---|---|---|
| `sleep 300` | (none) | `cancelled` |
| `always step` | `if: always()` | **success, it ran** |
| `cancelled step` | `if: cancelled()` | **success, it ran** |
| `failure step` | `if: failure()` | `skipped` |

The probe also showed job **outputs survive** a timeout cancellation: the downstream job read both `steps.sleeper.outcome` (`cancelled`) and a custom output set before the sleep.

So a step-level condition fix would have covered the timeout case. Reporting still moves to a separate `report` job, for three failure modes no in-job step can reach:

1. **Fate-sharing, and this one actually happened.** The 2026-08-03 scheduled run (30842184319) failed in "Ensure build tools" because `brew` was not on the self-hosted runner's PATH, and the in-job reporting step then died the same way, `brew install gh` exiting 127. A genuinely red run reported nothing, for a reason unrelated to timeouts.
2. **Runner loss.** If the self-hosted runner disappears mid-job, no step in that job runs at all.
3. **The post-cancellation window is bounded.** The probe's step was one `echo`. A reporter that has to install `gh` and make several API calls is far likelier to be cut off.

The new job runs on `ubuntu-latest` (ships `gh`, no Homebrew needed, and keeps reporting off the scarce macOS runner), uses `needs: verify` + `if: always()`, and reads `needs.verify.result`. `failure` and `cancelled` produce **different titles**, so the two kinds dedup onto separate tracking issues:

- `failure` produces `[nightly-verify] main is red`
- `cancelled` produces `[nightly-verify] the run did not finish`

The existing body composition is preserved (step-outcome table, commit, run URL) with per-step outcomes passed across the boundary via job `outputs`, plus the `verify` job result, the trigger, and the job duration. Duration is what separates "ran out of budget" from "a person cancelled it", so the body states it and points at `timeout-minutes` rather than hardcoding 180, which would drift.

### `workflow_dispatch` reporting: now included

Reversed from the previous rule. That rule assumed a manual dispatch has someone watching, so filing at them is noise. The 2026-08-02 dispatch disproved it: it ran three hours, timed out, told nobody, and was only found because someone went looking. Nobody watches a job for three hours. The reintroduced noise is bounded because repeat dispatches comment on one deduplicated issue rather than filing new ones, and the body names the trigger so a reader can dismiss a run they cancelled themselves.

## Phase 2: cut the build cost

`verify-test` now builds under `[profile.test-fast]` instead of `[profile.release]`. `--profile test-fast` and `--release` are mutually exclusive, so the flag is replaced, not added.

The budget was going to codegen and linking, not to tests: run 30733081983 logged zero `Running tests/` lines and zero `test result:` lines, and the processes the runner terminated were `ld` and `clang`. `[profile.release]` is fat LTO plus `codegen-units = 1`, measured at 4 to 6 minutes per incremental rebuild of the ~390k-line main crate, paid across roughly 77 test binaries.

### The tradeoff, stated plainly

`opt-level = 3` is unchanged, so the optimized MLX numerics the suite depends on are the same. What is dropped is fat LTO and `codegen-units = 1`, which exist to tune a *shipped* binary.

**Still covered:** everything the suite asserts, under optimized codegen, with `metal,accelerate`, on the real hardware class. `panic = "unwind"` is inherited from release, so the `catch_unwind` isolation tests behave identically.

**No longer covered:** a defect that reproduces only under fat LTO or single-unit codegen. The f16 reduction-order jitter class this repo has hit before is the realistic example. `cargo test --release --features metal,accelerate` by hand remains the tool for chasing one, and is documented as such.

**Unaffected:** what ships. `release.yml` still builds and links the shipping artifacts under `[profile.release]`.

`verify-clippy` is left alone. It has no `--release` today, takes 67s warm on the runner, and changing it would risk a cold debug MLX build for no measured gain.

### Two operational notes

- **The first nightly after this lands will still be slow, and that is expected.** A different profile means a different `OUT_DIR` for the `mlxcel-core` build script, so the first run pays a full cold MLX C++ build against the persistent `$HOME/.cargo-target/mlxcel`. Do not read that run as a failed fix. Locally this cost was confirmed: a fresh 596M `target/test-fast/build/mlxcel-core-*/out` was produced.
- **Disk.** The persistent target dir now holds two profile trees rather than one, order of 10 GiB each (locally `target/release` is 9.9G and `target/test-fast` is 10G). `release.yml`'s 7-day prune is `rm -rf` of the whole directory, not a per-profile clean, so both are already bounded by it and no third rule is needed. A second cost worth naming: the nightly no longer refreshes `[profile.release]` artifacts, so `release.yml`'s first build after a prune is colder than it used to be.

## Local measurement, and its caveat

**Development machine, M1 Ultra, not the runner.** The self-hosted runner is a different and slower shared machine, so treat this as directional only.

```
cargo test --profile test-fast --features metal,accelerate --no-run
```

Cold for this profile, including the full MLX C++ build and the link of every root test binary: **14m56s wall clock**, exit 0, 76 test executables. For contrast, on the runner the release-profile equivalent did not finish in 179 minutes on 2026-08-02.

**The runner numbers are not mine to produce.** The workflow has not been dispatched from this branch. The PR is ready to have the nightly dispatched against it for before and after.

### One data point that arrived after the issue was written

Run 30761020020 (2026-08-02 schedule) **succeeded**, the first full pass the workflow has ever completed. Its `cargo test` step ran 2h54m34s inside the 180-minute budget: about 5 minutes of headroom, roughly 3%. That does not weaken the case, it sharpens it. The gate was passing on a knife edge, and #1007 proposes adding 1754 tests and three more link steps to it.

## What changed

- `.github/workflows/nightly-verify.yml`: new `report` job on `ubuntu-latest` with `needs: verify` and `if: always()`; `outputs` on `verify` to carry step outcomes across the boundary; the in-job `Report a red main` step removed; `issues: write` moved to the job that needs it; test step renamed; header comment updated for the profile tradeoff, the reporting rationale, the disk and cache-warming costs, and a correction to its stale "~30 min" figure that the 2h56m completed pass contradicts.
- `Makefile`: `verify-test` builds `--profile test-fast`; the "how these differ" comment block and the `test-fast` section comment updated.
- `Cargo.toml`: comment-only. `[profile.test-fast]` now documents that it backs `verify-test`, and the "do not use for anything that ships" note no longer points at `verify-test`.
- `CONTRIBUTING.md`, `docs/installation.md`, `.github/PULL_REQUEST_TEMPLATE.md`: the documented gate matches what the gate now runs.
- `.github/workflows/ci.yml`, `.github/workflows/release.yml`: comment-only, the quoted pre-push checklists said `test(release)`.

No Rust source is touched.

## Test plan

- [x] `cargo fmt --all -- --check` clean.
- [x] `cargo clippy --all-targets --profile test-fast --features metal,accelerate -- -D warnings` clean. Run under `test-fast` rather than a cold debug build because the diff contains no Rust changes and the `Cargo.toml` change is comment-only.
- [x] `cargo test --profile test-fast --features metal,accelerate --no-run`: exit 0, 76 executables, 14m56s cold.
- [x] Workflow YAML parses; both jobs and the `if:` expression resolve as intended.
- [x] The reporting script extracted and exercised as a standalone script against mocked `gh` and `date` in three states: timeout (`cancelled`, partial outputs, duration resolved to 180m21s from the real 30733081983 timings), genuine failure (`failure`, all outcomes present), and fully degraded (API unreachable and every output empty). All three exit 0 and emit a complete report; the degraded one reports `unknown` per step rather than failing.
- [x] Job-timeout semantics and output survival established by a throwaway probe run, branch deleted afterward.
- [x] `python3 scripts/ci/check_cross_repo_refs.py` clean.
- [ ] Runner before and after timings, owned by the maintainer dispatching the nightly against this branch.

Closes #1000
