### PR TITLE
fix(tests): bound fused MoE GeGLU parity by the reference's measured jitter

### DIFF
--- a/src/lib/mlxcel-core/src/fused_moe_parity_tests.rs
+++ b/src/lib/mlxcel-core/src/fused_moe_parity_tests.rs
@@ -23,8 +23,10 @@
 //!
 //! 1. **Numeric parity**: the fused kernel must match an all-f32 dense
 //!    reference (dequantize + matmul + tanh-approx GeGLU) built from the very
-//!    same bf16 quantized weights, and the production `gather_qmm` fallback,
-//!    within a tolerance far below the greedy-argmax-flip scale.
+//!    same bf16 quantized weights, within a tolerance far below the
+//!    greedy-argmax-flip scale. The production `gather_qmm` fallback is held
+//!    to the same dense truth, and the two production paths to each other
+//!    within the fallback's own measured bf16 jitter (#964).
 //! 2. **Bitwise run-to-run determinism**: repeated invocations on identical
 //!    inputs must produce byte-identical outputs, including with allocator
 //!    churn between calls (dirty recycled buffers are what turn an
@@ -325,6 +327,27 @@ fn gpu_backend_or_skip() -> Option<&'static str> {
     }
 }
 
+/// Absolute ceiling on the `gather_qmm` fallback's own deviation from the
+/// dense f32 truth. `gather_qmm` rounds gate/up/activation through bf16
+/// between GEMMs, so on this synthetic shape it lands ~1.2e-2 nrms / ~4.2e-2
+/// nmax from ground truth, far above the ~1e-4 per-block perturbation the
+/// design harness measured on real checkpoints (random-normal activations
+/// through a GeGLU maximize the cancellation the bf16 intermediates lose).
+/// Pinning it serves two purposes: the production fallback gets a correctness
+/// gate of its own, and the relative bound below cannot silently widen with a
+/// reference that has itself drifted. Measured max over 27 seeds x 2 shapes on
+/// M1 Ultra / Metal: 1.803e-2 nrms, 5.429e-2 nmax.
+const GATHER_JITTER_NRMS_CEILING: f64 = 5e-2;
+const GATHER_JITTER_NMAX_CEILING: f64 = 2e-1;
+
+/// Margins applied to the measured `gather_qmm`-vs-dense jitter when bounding
+/// fused-vs-`gather_qmm`. The same 54-point sweep measured the ratio at
+/// 0.994..1.037 (nrms) and 0.932..1.192 (nmax) on Metal; the margins clear
+/// those with room for other backends' reduction orders, which this machine
+/// cannot measure.
+const GATHER_JITTER_NRMS_MARGIN: f64 = 1.5;
+const GATHER_JITTER_NMAX_MARGIN: f64 = 2.0;
+
 /// Gemma-4-26b-a4b decode-shape parity: fused kernel vs the all-f32 dense
 /// reference and vs the production `gather_qmm` fallback.
 ///
@@ -333,7 +356,13 @@ fn gpu_backend_or_skip() -> Option<&'static str> {
 /// reference rounded the same single time, the only legitimate differences
 /// are f32 summation order (~1e-6 relative) and sub-ulp rounding ties, so the
 /// bound is tight: any real math defect (a dropped lane, a wrong group, an
-/// extra rounding stage) shows up orders of magnitude above it.
+/// extra rounding stage) shows up orders of magnitude above it. That dense
+/// comparison is the sharp correctness gate for the kernel, and it strictly
+/// dominates any fused-vs-`gather_qmm` bound: `gather_qmm` is the noisier of
+/// the two references, so nothing can be caught against it that the dense
+/// comparison has not already caught. The `gather_qmm` assertions below
+/// therefore gate the fallback path itself and the two paths' mutual
+/// agreement, not the fused kernel's math (#964).
 #[test]
 fn fused_moe_geglu_kernel_matches_references_gemma4_shape() {
     let Some(backend) = gpu_backend_or_skip() else {
@@ -353,22 +382,42 @@ fn fused_moe_geglu_kernel_matches_references_gemma4_shape() {
 
         let (nrms_dense, nmax_dense) = normalized_deviation(&fused, &dense_bf16);
         let (nrms_gather, nmax_gather) = normalized_deviation(&fused, &gather);
-        let (nrms_ref_jitter, _) = normalized_deviation(&gather, &dense);
+        let (nrms_ref_jitter, nmax_ref_jitter) = normalized_deviation(&gather, &dense);
         println!(
             "fused_moe_geglu parity [{backend}, seed {seed}]: vs dense f32 (bf16-rounded) \
              nrms={nrms_dense:e} nmax={nmax_dense:e}; vs gather_qmm nrms={nrms_gather:e} \
-             nmax={nmax_gather:e}; gather-vs-dense baseline nrms={nrms_ref_jitter:e}"
+             nmax={nmax_gather:e}; gather-vs-dense baseline nrms={nrms_ref_jitter:e} \
+             nmax={nmax_ref_jitter:e}"
         );
         assert!(
             nrms_dense < 5e-4 && nmax_dense < 2e-2,
             "fused vs bf16-rounded dense f32 reference deviates (seed {seed}): \
              nrms={nrms_dense:e} nmax={nmax_dense:e}"
         );
-        // gather_qmm rounds gate/up/activation through bf16 between GEMMs, so
-        // the mutual deviation sits in the documented fp16-jitter class.
+        // The production fallback held to the same ground truth as the kernel.
         assert!(
-            nrms_gather < 5e-3 && nmax_gather < 5e-2,
-            "fused vs gather_qmm reference deviates (seed {seed}): nrms={nrms_gather:e} nmax={nmax_gather:e}"
+            nrms_ref_jitter < GATHER_JITTER_NRMS_CEILING
+                && nmax_ref_jitter < GATHER_JITTER_NMAX_CEILING,
+            "gather_qmm fallback deviates from the dense f32 reference (seed {seed}): \
+             nrms={nrms_ref_jitter:e} nmax={nmax_ref_jitter:e}"
+        );
+        // Cross-path agreement. The fused kernel matches the dense reference
+        // to `nrms_dense` above, which pins its distance from `gather_qmm` to
+        // `gather_qmm`'s own bf16 jitter; a fixed constant here measures that
+        // jitter rather than either path. #964: the previous 5e-3 nrms bound
+        // sat below the ~1.16e-2 baseline the test already computed and was
+        // unsatisfiable at every seed and both shapes. Scale with the jitter
+        // this run measured, never tighter than the project's 5e-3 / 5e-2
+        // fp16-parity allowance (which binds on a backend whose fallback is
+        // closer to exact than Metal's).
+        let nrms_gather_limit = (GATHER_JITTER_NRMS_MARGIN * nrms_ref_jitter).max(5e-3);
+        let nmax_gather_limit = (GATHER_JITTER_NMAX_MARGIN * nmax_ref_jitter).max(5e-2);
+        assert!(
+            nrms_gather < nrms_gather_limit && nmax_gather < nmax_gather_limit,
+            "fused and gather_qmm disagree beyond the fallback's own jitter (seed {seed}): \
+             nrms={nrms_gather:e} (limit {nrms_gather_limit:e}) \
+             nmax={nmax_gather:e} (limit {nmax_gather_limit:e}); \
+             baseline nrms={nrms_ref_jitter:e} nmax={nmax_ref_jitter:e}"
         );
     }
 }


### PR DESCRIPTION
## Summary

`fused_moe_parity_tests::fused_moe_geglu_kernel_matches_references_gemma4_shape` asserted `nrms_gather < 5e-3` for the fused kernel against the production `gather_qmm` fallback. That bound sits below the fallback's own deviation from the dense f32 ground truth, a quantity the test already computed as `nrms_ref_jitter` and then discarded. The assertion was measuring the reference's noise, not the kernel, and no implementation could satisfy it.

The failure is **deterministic, not seed-dependent**. Five consecutive runs of the unmodified test on `main` (`a86e6340a`) produced byte-identical numbers, and a 54-point sweep found the bound unreachable at every seed and both shapes. The "intermittent" reading is explained by #1007: the root-package `cargo test` does not build `mlxcel-core` at all, so a root run can observe this test neither passing nor failing.

## Evidence

At seed 886 the test's own diagnostic line contains the diagnosis:

| comparison | nrms | nmax |
|---|---|---|
| fused vs dense f32 (bf16-rounded) | `0e0` | `0e0` |
| fused vs `gather_qmm` | `1.1698e-2` | `4.5227e-2` |
| `gather_qmm` vs dense f32 (the reference's own error) | `1.1574e-2` | `4.2602e-2` |

The fused kernel is bit-exact against ground truth, so its distance from `gather_qmm` is forced to equal `gather_qmm`'s own error. A `5e-3` bound on that distance is unsatisfiable by construction.

### Seed sweep

27 seeds (886..905, 1, 31, 77, 2026, 4242, 12345, 999999) across two shapes (the gemma-4 decode shape `din 2816 / dff 704 / E 16 / K 8`, and a smaller `320 / 192 / E 16 / K 4`), M1 Ultra / Metal:

| quantity | min | median | max |
|---|---|---|---|
| `nrms_dense` (fused vs truth) | 0 | 0 | 1.843e-4 |
| `nmax_dense` | 0 | 0 | 6.916e-3 |
| `nrms_ref_jitter` (`gather_qmm` vs truth) | 6.107e-3 | 1.179e-2 | 1.803e-2 |
| `nmax_ref_jitter` | 2.072e-2 | 4.077e-2 | 5.429e-2 |
| ratio `nrms_gather / nrms_ref_jitter` | 0.9939 | 1.0106 | 1.0368 |
| ratio `nmax_gather / nmax_ref_jitter` | 0.9315 | 1.0060 | 1.1919 |

**54 of 54 points fail the old bound.** The ratio pinned near 1.0 at every point is exactly what "fused agrees with truth, so its distance from the reference is the reference's own error" predicts.

## Which bound was chosen, and why

Of the three options in the issue, this takes the second (bound relative to the measured baseline) and adds the piece the data demands.

The arithmetic driving the choice: comparing against a noisy reference can never be sharper than comparing against a clean one. `gather_qmm` carries ~1.2e-2 of error and the dense reference carries none, so **the dense assertion strictly dominates any fused-vs-`gather_qmm` bound**. No threshold on the gather comparison can catch a fused-kernel defect that `nrms_dense < 5e-4` has not already caught. Widening the gather constant, tightening it, or making it relative does not change that.

The three comparisons are therefore assigned to what each can actually gate:

1. **Fused vs dense f32** stays at `5e-4 / 2e-2`, unchanged. This is the sharp correctness gate for the kernel.
2. **`gather_qmm` vs dense f32** gets an absolute ceiling (`5e-2 / 2e-1`), derived from the measured max of `1.803e-2 / 5.429e-2` with headroom. This assertion is new: the test computed the quantity and discarded it, so the production fallback has never had a correctness gate here at all. It also stops the relative bound in (3) from silently widening along with a reference that has itself drifted.
3. **Fused vs `gather_qmm`** is bounded at `max(margin * measured_jitter, historical_constant)`: `1.5x` the measured nrms jitter or `5e-3`, and `2.0x` the measured nmax jitter or `5e-2`, whichever is larger. The floor keeps the project's standard fp16-parity allowance binding on any backend whose fallback is closer to exact than Metal's, so this is never looser than the old constant where the old constant was reachable.

The margins (1.5x / 2.0x) sit above the measured maxima (1.037 / 1.192) with deliberate headroom. This test also runs on CUDA per its module docs, and no CUDA node is reachable from this machine, so a snug margin would trade a deterministic failure for a flaky one on an unmeasured backend.

## Negative controls

Perturbation applied through a temporary scaffold (an exact alternating-sign relative perturbation of magnitude `eps`), exercising the committed assertions unmodified. The scaffold is not part of this PR.

**1. Fused-side perturbation, simulating a kernel regression (full test):**

| eps | result |
|---|---|
| 0, 1e-5, 1e-4, 2e-4, 5e-4 | pass |
| 1e-3 | **FAIL** `fused vs bf16-rounded dense f32 reference deviates (seed 886): nrms=1.0000e-3 nmax=3.7524e-3` |
| 5e-3, 1e-2, 2e-2, 5e-2 | **FAIL** (same gate) |

**2. `gather_qmm`-side perturbation, simulating a fallback regression (full test):**

| eps | result |
|---|---|
| 0, 1e-2, 3e-2 | pass |
| 5e-2 | **FAIL** `gather_qmm fallback deviates from the dense f32 reference (seed 886): nrms=5.1002e-2 nmax=1.8972e-1` |
| 7e-2, 1e-1 | **FAIL** (same gate) |

Before this PR the test could not detect this class of regression at all.

**3. Cross-path bound in isolation** (dense gate temporarily disabled so assertion 3 is reachable):

| eps | result |
|---|---|
| 0, 5e-3, 1e-2 | pass |
| 1.5e-2 | **FAIL** `fused and gather_qmm disagree beyond the fallback's own jitter (seed 886): nrms=1.9287e-2 (limit 1.7362e-2) nmax=7.9639e-2 (limit 8.5204e-2)` |
| 2e-2, 3e-2 | **FAIL** (same gate) |

The observed threshold matches the prediction `eps > sqrt(margin^2 - 1) * jitter = 1.118 * 1.1574e-2 = 1.29e-2`, so the relative bound is calibrated, not vacuous.

## What changed

`src/lib/mlxcel-core/src/fused_moe_parity_tests.rs` only, no production code:

- capture `nmax_ref_jitter` instead of discarding it, and print it in the diagnostic line
- add `GATHER_JITTER_{NRMS,NMAX}_CEILING` and `GATHER_JITTER_{NRMS,NMAX}_MARGIN`, with the measured values recorded in their doc comments
- add the `gather_qmm`-vs-dense assertion
- replace the fixed fused-vs-`gather_qmm` constants with the jitter-scaled limits
- update the module doc to describe the three-way structure

## Test plan

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --release -p mlxcel-core --all-targets --features metal,accelerate -- -D warnings`
- [x] `cargo clippy --release --all-targets --features metal,accelerate -- -D warnings`
- [x] `cargo test --release -p mlxcel-core --features metal,accelerate --no-fail-fast -- --test-threads=1`
- [x] Determinism established by 5 consecutive runs of the failing test on `main`
- [x] 54-point seed and shape sweep
- [x] Three negative controls above

Refs #1007 (which flips the CI gate to `cargo test --workspace`, and needs this landed first).

Closes #964
