### PR TITLE
fix(tests): remove the dead-callsite race behind drafter log assertions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1962,7 +1962,6 @@ dependencies = [
  "thiserror",
  "tokenizers 0.22.2",
  "tracing",
- "tracing-test",
  "unicode-script",
 ]
 
@@ -3645,27 +3644,6 @@ dependencies = [
  "tracing",
  "tracing-core",
  "tracing-log",
-]
-
-[[package]]
-name = "tracing-test"
-version = "0.2.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19a4c448db514d4f24c5ddb9f73f2ee71bfb24c526cf0c570ba142d1119e0051"
-dependencies = [
- "tracing-core",
- "tracing-subscriber",
- "tracing-test-macro",
-]
-
-[[package]]
-name = "tracing-test-macro"
-version = "0.2.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ad06847b7afb65c7866a36664b75c40b895e318cea4f71299f013fb22965329d"
-dependencies = [
- "quote",
- "syn 2.0.118",
 ]
 
 [[package]]

--- a/src/lib/mlxcel-core/Cargo.toml
+++ b/src/lib/mlxcel-core/Cargo.toml
@@ -30,7 +30,6 @@ tracing = "0.1"
 
 [dev-dependencies]
 tempfile = "3"
-tracing-test = "0.2"
 
 [build-dependencies]
 cxx-build = "1.0"

--- a/src/lib/mlxcel-core/src/drafter/mod.rs
+++ b/src/lib/mlxcel-core/src/drafter/mod.rs
@@ -99,6 +99,10 @@ pub mod gemma4_assistant;
 /// — landed here independently so the layer can
 /// be unit-tested in isolation before integration.
 pub mod masked_embedder;
+/// Test-only capture of this module's `tracing` output, used by the
+/// assertions on [`resolve_drafter_kind`]'s operator-facing diagnostics.
+#[cfg(test)]
+mod test_log_capture;
 
 /// Drafter shapes recognised by mlxcel.
 ///
@@ -840,7 +844,25 @@ mod tests {
     use super::*;
     use std::str::FromStr as _;
     use tempfile::tempdir;
-    use tracing_test::traced_test;
+
+    /// Call the resolver. Every test in this module must go through this
+    /// helper (or [`load`]) rather than calling the real function, because
+    /// `test_log_capture::install` has to have completed before any thread
+    /// reaches the resolver's tracing callsites. Skipping it reintroduces the
+    /// intermittent failure in the log assertions below that #1023 removed;
+    /// `test_log_capture` documents the mechanism and a guard test enforces
+    /// this rule.
+    fn resolve(path: &Path, kind: Option<DrafterKind>) -> Result<DrafterKind, DrafterError> {
+        test_log_capture::install();
+        super::resolve_drafter_kind(path, kind)
+    }
+
+    /// Load a drafter. Same install ordering requirement as [`resolve`],
+    /// which the factory reaches through.
+    fn load(path: &Path, kind: Option<DrafterKind>) -> Result<LoadedDrafter, DrafterError> {
+        test_log_capture::install();
+        super::load_drafter(path, kind)
+    }
 
     /// Helper: write a `config.json` with the given `model_type` into a
     /// fresh temp dir and return its path. Mirrors the smallest-possible
@@ -925,7 +947,7 @@ mod tests {
     fn auto_detect_gemma4_assistant_resolves_to_mtp() {
         let dir = tempdir().unwrap();
         write_drafter_config(&dir, Some("gemma4_assistant"));
-        let resolved = resolve_drafter_kind(dir.path(), None).unwrap();
+        let resolved = resolve(dir.path(), None).unwrap();
         assert_eq!(resolved, DrafterKind::Mtp);
     }
 
@@ -936,7 +958,7 @@ mod tests {
         // loop exactly like the non-unified `gemma4_assistant`.
         let dir = tempdir().unwrap();
         write_drafter_config(&dir, Some("gemma4_unified_assistant"));
-        let resolved = resolve_drafter_kind(dir.path(), None).unwrap();
+        let resolved = resolve(dir.path(), None).unwrap();
         assert_eq!(resolved, DrafterKind::Mtp);
     }
 
@@ -946,7 +968,7 @@ mod tests {
         // resolver MUST fall back to DEFAULT_DRAFTER_KIND (Dflash).
         let dir = tempdir().unwrap();
         write_drafter_config(&dir, None);
-        let resolved = resolve_drafter_kind(dir.path(), None).unwrap();
+        let resolved = resolve(dir.path(), None).unwrap();
         assert_eq!(resolved, DrafterKind::Dflash);
     }
 
@@ -955,7 +977,7 @@ mod tests {
         // Some random model_type the map doesn't know about -> still DFlash.
         let dir = tempdir().unwrap();
         write_drafter_config(&dir, Some("some_unknown_model_type_v2"));
-        let resolved = resolve_drafter_kind(dir.path(), None).unwrap();
+        let resolved = resolve(dir.path(), None).unwrap();
         assert_eq!(resolved, DrafterKind::Dflash);
     }
 
@@ -964,7 +986,7 @@ mod tests {
         // No config.json at all: upstream swallows the FileNotFoundError
         // and falls back to DEFAULT_DRAFTER_KIND; we must do the same.
         let dir = tempdir().unwrap();
-        let resolved = resolve_drafter_kind(dir.path(), None).unwrap();
+        let resolved = resolve(dir.path(), None).unwrap();
         assert_eq!(resolved, DrafterKind::Dflash);
     }
 
@@ -975,7 +997,7 @@ mod tests {
         // drafter dir does not break auto-detect.
         let dir = tempdir().unwrap();
         fs::write(dir.path().join("config.json"), "not valid json").unwrap();
-        let resolved = resolve_drafter_kind(dir.path(), None).unwrap();
+        let resolved = resolve(dir.path(), None).unwrap();
         assert_eq!(resolved, DrafterKind::Dflash);
     }
 
@@ -984,7 +1006,7 @@ mod tests {
         // model_type == "gemma4_assistant", caller passes Mtp -> Mtp.
         let dir = tempdir().unwrap();
         write_drafter_config(&dir, Some("gemma4_assistant"));
-        let resolved = resolve_drafter_kind(dir.path(), Some(DrafterKind::Mtp)).unwrap();
+        let resolved = resolve(dir.path(), Some(DrafterKind::Mtp)).unwrap();
         assert_eq!(resolved, DrafterKind::Mtp);
     }
 
@@ -994,17 +1016,16 @@ mod tests {
         // the DFlash path (DFlash configs have no dedicated model_type).
         let dir = tempdir().unwrap();
         write_drafter_config(&dir, None);
-        let resolved = resolve_drafter_kind(dir.path(), Some(DrafterKind::Dflash)).unwrap();
+        let resolved = resolve(dir.path(), Some(DrafterKind::Dflash)).unwrap();
         assert_eq!(resolved, DrafterKind::Dflash);
 
         // Also: an explicit Mtp against an unmapped config must pass
         // through unchanged (no "expected" to override against).
-        let resolved = resolve_drafter_kind(dir.path(), Some(DrafterKind::Mtp)).unwrap();
+        let resolved = resolve(dir.path(), Some(DrafterKind::Mtp)).unwrap();
         assert_eq!(resolved, DrafterKind::Mtp);
     }
 
     #[test]
-    #[traced_test]
     fn warn_and_honor_explicit_kind_when_disagreeing_with_model_type() {
         // model_type == "gemma4_assistant" maps to Mtp, but the caller
         // explicitly asked for DFlash. Resolver MUST honor the explicit
@@ -1016,19 +1037,20 @@ mod tests {
         // tracing::warn!".
         let dir = tempdir().unwrap();
         write_drafter_config(&dir, Some("gemma4_assistant"));
-        let resolved = resolve_drafter_kind(dir.path(), Some(DrafterKind::Dflash)).unwrap();
+        let (resolved, logs) =
+            test_log_capture::capture(|| resolve(dir.path(), Some(DrafterKind::Dflash)).unwrap());
         assert_eq!(
             resolved,
             DrafterKind::Dflash,
             "explicit choice must be honored"
         );
-        assert!(logs_contain(
-            "Explicit --draft-kind disagrees with drafter model_type"
-        ));
+        assert!(
+            logs.contains("Explicit --draft-kind disagrees with drafter model_type"),
+            "captured: {logs:?}"
+        );
     }
 
     #[test]
-    #[traced_test]
     fn warn_also_fires_when_explicit_mtp_disagrees_against_unmapped_inverse() {
         // This is the symmetric mismatch: caller passes Mtp but the
         // drafter's model_type maps to something else. Per the design
@@ -1039,23 +1061,25 @@ mod tests {
         // that boundary.
         let dir = tempdir().unwrap();
         write_drafter_config(&dir, None);
-        let resolved = resolve_drafter_kind(dir.path(), Some(DrafterKind::Mtp)).unwrap();
+        let (resolved, logs) =
+            test_log_capture::capture(|| resolve(dir.path(), Some(DrafterKind::Mtp)).unwrap());
         assert_eq!(resolved, DrafterKind::Mtp);
         assert!(
-            !logs_contain("Explicit --draft-kind disagrees"),
-            "no warn should fire when model_type is unknown / absent"
+            !logs.contains("Explicit --draft-kind disagrees"),
+            "no warn should fire when model_type is unknown / absent, captured: {logs:?}"
         );
     }
 
     #[test]
-    #[traced_test]
     fn auto_detect_emits_info_log_for_default_fallback() {
         let dir = tempdir().unwrap();
         write_drafter_config(&dir, None);
-        let _ = resolve_drafter_kind(dir.path(), None).unwrap();
-        assert!(logs_contain(
-            "Auto-detected --draft-kind using default fallback"
-        ));
+        let (resolved, logs) = test_log_capture::capture(|| resolve(dir.path(), None).unwrap());
+        assert_eq!(resolved, DEFAULT_DRAFTER_KIND);
+        assert!(
+            logs.contains("Auto-detected --draft-kind using default fallback"),
+            "captured: {logs:?}"
+        );
     }
 
     // ----- load_drafter ---------------------------------------------------
@@ -1068,7 +1092,7 @@ mod tests {
         // `Dflash` arm cannot silently regress to `NotYetImplemented`.
         let dir = tempdir().unwrap();
         write_drafter_config(&dir, None);
-        let err = load_drafter(dir.path(), Some(DrafterKind::Dflash))
+        let err = load(dir.path(), Some(DrafterKind::Dflash))
             .expect_err("load_drafter must fail on a config-only fixture with no safetensors");
         match err {
             DrafterError::LoadFailed { reason } => {
@@ -1093,7 +1117,7 @@ mod tests {
         // now dispatches into the concrete impl.
         let dir = tempdir().unwrap();
         write_drafter_config(&dir, Some("gemma4_assistant"));
-        let err = load_drafter(dir.path(), None).expect_err("stub config has no text_config");
+        let err = load(dir.path(), None).expect_err("stub config has no text_config");
         match err {
             DrafterError::NotYetImplemented { .. } => panic!(
                 "Mtp arm should no longer return NotYetImplemented; \
@@ -1112,7 +1136,7 @@ mod tests {
     fn load_drafter_returns_typed_not_yet_implemented_for_internal_mtp() {
         let dir = tempdir().unwrap();
         write_drafter_config(&dir, None);
-        let err = load_drafter(dir.path(), Some(DrafterKind::InternalMtp)).expect_err("stub");
+        let err = load(dir.path(), Some(DrafterKind::InternalMtp)).expect_err("stub");
         match err {
             DrafterError::NotYetImplemented { kind, issue } => {
                 assert_eq!(kind, DrafterKind::InternalMtp);

--- a/src/lib/mlxcel-core/src/drafter/test_log_capture.rs
+++ b/src/lib/mlxcel-core/src/drafter/test_log_capture.rs
@@ -1,0 +1,250 @@
+// Copyright 2025-2026 Lablup Inc. and Jeongkyu Shin
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Test-only capture of the `tracing` events emitted by this module.
+//!
+//! ## Why this exists instead of `tracing-test`
+//!
+//! `resolve_drafter_kind` emits operator-facing diagnostics, and three tests
+//! assert on them. Asserting on a log means depending on `tracing`'s
+//! process-global state, which is shared with every other test running
+//! concurrently in the same binary. Getting that dependency wrong does not
+//! fail loudly; it fails rarely, under load, in somebody else's test run.
+//!
+//! The trap is in how `tracing` caches per-callsite `Interest`:
+//!
+//! 1. Building a `Dispatch` (`Dispatch::new`, run by `set_global_default`'s
+//!    `Into<Dispatch>` conversion) registers the subscriber and publishes its
+//!    max-level hint globally, which is what un-gates the `info!` macros.
+//! 2. Installing it as the current default is a *separate*, later step, and
+//!    it does not rebuild the interest cache.
+//!
+//! Between those two steps the process has a permissive max level but
+//! `get_default()` still resolves to `NoSubscriber`. A callsite first reached
+//! inside that window asks `NoSubscriber` whether anyone is interested, is
+//! told `Interest::never()`, and caches that verdict permanently: the
+//! registration is one-shot, and nothing registers another dispatcher later
+//! to trigger a rebuild. That callsite is then dead for the rest of the
+//! process, so the event never fires and the assertion fails no matter how
+//! the capture is implemented.
+//!
+//! The window is only a few hundred nanoseconds wide, but the tests that
+//! reach these callsites are neighbours in the same module: they are
+//! dispatched to the test harness's worker threads at the same moment, and
+//! any one of them can land inside it. See issue #1023 for the measured
+//! dose-response.
+//!
+//! ## The invariant
+//!
+//! **No thread may reach a drafter callsite before this subscriber is the
+//! current default.** [`install`] is the barrier: it is `Once`-gated, so a
+//! caller either installs the subscriber or blocks until the installing
+//! thread has finished, and only then proceeds to the callsite. Every test in
+//! this module reaches `resolve_drafter_kind` / `load_drafter` through the
+//! `resolve` / `load` helpers in `mod.rs`, which call [`install`] first, so
+//! the window cannot be observed at these callsites at all. That is
+//! prevention, not mitigation: there is no interleaving left to lose.
+//!
+//! [`drafter_tests_reach_the_resolver_only_through_the_install_guard`] holds
+//! the invariant in place for tests added later. It checks the drafter test
+//! module, which is where the realistic mistake is (copying an existing test).
+//! `resolve_drafter_kind` and `load_drafter` currently have no in-crate caller
+//! outside that module; if one is added and some other test exercises it, that
+//! test needs [`install`] too, for the same reason.
+//!
+//! ## What is captured
+//!
+//! Events are recorded into a thread-local sink that is armed only for the
+//! duration of [`capture`], so concurrent tests cannot contaminate each
+//! other's assertions and no per-test scoping by span name is needed.
+
+use std::cell::RefCell;
+use std::fmt;
+use std::sync::Once;
+
+use tracing::field::{Field, Visit};
+use tracing::span::{Attributes, Id, Record};
+use tracing::{Event, Metadata, Subscriber};
+use tracing::{Level, level_filters::LevelFilter};
+
+/// Only events from this module tree are captured. This must be a decision
+/// the subscriber can make from `Metadata` alone: `Subscriber::enabled` is
+/// consulted once per callsite and the answer is cached globally, so it can
+/// never depend on which thread is asking or on whether a capture is armed.
+const TARGET_PREFIX: &str = "mlxcel_core::drafter";
+
+/// The most verbose level any captured event uses. Reported as the max-level
+/// hint, which keeps `debug!` / `trace!` callsites elsewhere in the crate
+/// switched off in test builds. Widen this together with [`TARGET_PREFIX`] if
+/// a future test needs to assert on a more verbose event.
+const MAX_CAPTURED_LEVEL: Level = Level::INFO;
+
+thread_local! {
+    /// `Some` only while this thread is inside [`capture`].
+    static SINK: RefCell<Option<Vec<String>>> = const { RefCell::new(None) };
+}
+
+static INSTALLED: Once = Once::new();
+
+/// Install the capture subscriber as the process-wide default, once.
+///
+/// Returns only when the subscriber is the current default, on every thread.
+/// Call this before reaching any callsite whose emission a test asserts on;
+/// see the module docs for why the ordering is load-bearing.
+pub(super) fn install() {
+    INSTALLED.call_once(|| {
+        tracing::subscriber::set_global_default(CaptureSubscriber)
+            .expect("no other subscriber may be installed in the mlxcel-core test binary");
+    });
+}
+
+/// Run `f` with the drafter events it emits on this thread recorded.
+pub(super) fn capture<T>(f: impl FnOnce() -> T) -> (T, Captured) {
+    install();
+    let armed = Armed::new();
+    let out = f();
+    (out, Captured(armed.take()))
+}
+
+/// Arms the thread-local sink and disarms it on drop, so a panicking `f`
+/// cannot leave a stale sink behind on a reused thread.
+struct Armed;
+
+impl Armed {
+    fn new() -> Self {
+        SINK.with(|sink| {
+            let previous = sink.borrow_mut().replace(Vec::new());
+            assert!(
+                previous.is_none(),
+                "captures cannot be nested: the outer sink would be discarded"
+            );
+        });
+        Self
+    }
+
+    fn take(&self) -> Vec<String> {
+        SINK.with(|sink| sink.borrow_mut().take())
+            .unwrap_or_default()
+    }
+}
+
+impl Drop for Armed {
+    fn drop(&mut self) {
+        SINK.with(|sink| {
+            sink.borrow_mut().take();
+        });
+    }
+}
+
+/// Events captured by [`capture`], one formatted line each.
+pub(super) struct Captured(Vec<String>);
+
+impl Captured {
+    /// Whether any captured event's rendered line contains `needle`.
+    pub(super) fn contains(&self, needle: &str) -> bool {
+        self.0.iter().any(|line| line.contains(needle))
+    }
+}
+
+impl fmt::Debug for Captured {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_list().entries(&self.0).finish()
+    }
+}
+
+struct CaptureSubscriber;
+
+impl Subscriber for CaptureSubscriber {
+    fn enabled(&self, metadata: &Metadata<'_>) -> bool {
+        metadata.target().starts_with(TARGET_PREFIX) && *metadata.level() <= MAX_CAPTURED_LEVEL
+    }
+
+    fn max_level_hint(&self) -> Option<LevelFilter> {
+        Some(LevelFilter::from_level(MAX_CAPTURED_LEVEL))
+    }
+
+    fn event(&self, event: &Event<'_>) {
+        SINK.with(|sink| {
+            let mut sink = sink.borrow_mut();
+            let Some(lines) = sink.as_mut() else {
+                // This thread is not capturing; drop the event.
+                return;
+            };
+            let meta = event.metadata();
+            let mut line = format!("{} {}:", meta.level(), meta.target());
+            event.record(&mut LineVisitor(&mut line));
+            lines.push(line);
+        });
+    }
+
+    // Spans are not used by any assertion here, so they are accepted and
+    // discarded rather than stored.
+    fn new_span(&self, _span: &Attributes<'_>) -> Id {
+        Id::from_u64(1)
+    }
+    fn record(&self, _span: &Id, _values: &Record<'_>) {}
+    fn record_follows_from(&self, _span: &Id, _follows: &Id) {}
+    fn enter(&self, _span: &Id) {}
+    fn exit(&self, _span: &Id) {}
+}
+
+/// Renders an event's fields onto one line: the `message` field as bare
+/// text, every other field as `name=value`.
+struct LineVisitor<'a>(&'a mut String);
+
+impl Visit for LineVisitor<'_> {
+    fn record_debug(&mut self, field: &Field, value: &dyn fmt::Debug) {
+        use fmt::Write as _;
+        if field.name() == "message" {
+            let _ = write!(self.0, " {value:?}");
+        } else {
+            let _ = write!(self.0, " {}={value:?}", field.name());
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    /// Holds the invariant documented at the top of this file: every call
+    /// into the resolver from the drafter test module must go through the
+    /// `resolve` / `load` helpers, which run [`super::install`] first.
+    ///
+    /// A test that calls the resolver directly would reintroduce the failure
+    /// this file exists to remove, and it would do so silently: the log
+    /// assertions would still pass almost every time. So the rule is checked
+    /// mechanically rather than left as a comment. The helpers are the only
+    /// place allowed to name the real functions, which they do through
+    /// `super::`.
+    #[test]
+    fn drafter_tests_reach_the_resolver_only_through_the_install_guard() {
+        let module = include_str!("mod.rs");
+        let test_module = module
+            .split_once("mod tests {")
+            .expect("drafter/mod.rs must contain a `mod tests {` block")
+            .1;
+
+        for symbol in ["resolve_drafter_kind(", "load_drafter("] {
+            let calls = test_module.matches(symbol).count();
+            let through_helper = test_module.matches(&format!("super::{symbol}")).count();
+            assert_eq!(
+                calls, through_helper,
+                "{calls} call(s) to `{symbol}` in drafter's test module but only \
+                 {through_helper} go through the `super::` helper. Tests must call \
+                 the `resolve` / `load` helpers so the capture subscriber is \
+                 installed before the callsite is first reached; see \
+                 drafter/test_log_capture.rs for why."
+            );
+        }
+    }
+}


### PR DESCRIPTION
## Summary

`drafter::tests::auto_detect_emits_info_log_for_default_fallback` was the one known intermittent that could turn the widened nightly gate red. The failure is not in how `tracing-test` scopes its capture buffer: the event was never emitted, because the `tracing` callsite it lives at had already cached `Interest::never()` and gone permanently dead. This removes that mechanism rather than making the test pass more often.

## The mechanism

`#[traced_test]` installs its subscriber from inside the test body, and the install is two steps, not one:

1. `tracing_test::internal::get_subscriber` returns a `Dispatch`. Building it runs `Dispatch::new`, which registers the subscriber and publishes its `TRACE` max-level hint globally. That hint is what un-gates every `info!` in the process.
2. `tracing::dispatcher::set_global_default` runs afterwards, and it does not rebuild the callsite interest cache.

Between those two statements the process has a permissive max level while `dispatcher::get_default()` still resolves to `NoSubscriber`. A callsite first reached inside that window takes `DefaultCallsite::register`. With a single registered dispatcher, `DISPATCHERS.rebuilder()` returns `Rebuilder::JustOne`, whose `for_each` consults `dispatcher::get_default()`. `NoSubscriber` answers `Interest::never()`, the callsite caches that verdict and marks itself `REGISTERED`, and nothing registers another dispatcher later in the process, so the rebuild that would repair it never runs. The callsite is dead for the rest of the binary: every later event there is skipped inside the macro, whichever subscriber is current by then.

Two details explain why this test specifically, and only sometimes:

- The `info!` it asserts on is also reached by four **non-traced** sibling tests in the same module (`auto_detect_unknown_model_type_...`, `..._unrecognised_...`, `..._missing_config_...`, `..._malformed_config_...`). They are adjacent in name order, so the harness hands them to its worker threads at the same moment as the traced test that is doing the install. Any one of them can land in the window.
- The `warn!` that `warn_and_honor_explicit_kind_when_disagreeing_with_model_type` asserts on has no non-traced sibling that reaches it, so it is only ever registered by its own test, after the install has completed. That is why the other positive log assertion never failed.

Confirmed at the source level in `tracing-core` 0.1.36 (`callsite.rs` `register` / `rebuild_interest` / `Rebuilder::JustOne`, `dispatcher.rs` `Dispatch::new` / `set_global_default`), then reproduced deterministically, then measured in the real test binary as a dose-response against the width of that window.

## Before / after

The natural window is a few hundred nanoseconds, so blind repetition does not converge: 500 unloaded runs and 300 runs under 3x CPU oversubscription both produced zero failures. Instead the predicted interleaving was forced, by sleeping between the two install steps and running the real binary's 24 drafter tests, 100 runs per point:

| window between the two install steps | before | after |
|---|---|---|
| 0 us (natural) | 0 / 100 | 0 / 100 |
| 50 us | 0 / 100 | not run |
| 200 us | 1 / 100 | not run |
| 1 ms | 15 / 100 | 0 / 100 |
| 5 ms | 100 / 100 | 0 / 100 |
| 20 ms | 100 / 100 | 0 / 100 |

On failure the diagnostic reported `msg_anywhere_in_buffer=false` with a non-empty buffer, which rules out both alternative explanations: the capture was working and holding other tests' events, and the asserted message was absent from it entirely.

## What changed

- **`src/lib/mlxcel-core/src/drafter/test_log_capture.rs`** (new): a test-only capture subscriber. `install()` is `Once`-gated, and capture is thread-local, armed only for the duration of a `capture` call.
- **`src/lib/mlxcel-core/src/drafter/mod.rs`**: the test module reaches `resolve_drafter_kind` / `load_drafter` only through `resolve` / `load` helpers that call `install()` first. The three `#[traced_test]` tests now use `capture` and assert on the returned lines.
- **`src/lib/mlxcel-core/Cargo.toml`**, **`Cargo.lock`**: drops the `tracing-test` dev-dependency. Those three tests were its only users in the workspace.

## Why this is correct and not merely sufficient

The barrier is what fixes it, not the new capture implementation. `Once::call_once` means a caller either performs the install or blocks until the installing thread has finished it, so once every path to these callsites runs `install()` first, **no thread can register them while the dispatcher is published but not yet current**. The window is not narrowed, it is unreachable from the callsites whose emission is asserted on. Any capture mechanism would have failed the same way without this, because the event is discarded at the macro before a subscriber is ever consulted.

Two alternatives were considered and rejected:

- **Serializing the `#[traced_test]` tests.** It does not address the mechanism. The poisoners are the four *non-traced* sibling tests, which serializing the traced tests leaves running concurrently.
- **Repairing the cache with `tracing_core::callsite::rebuild_interest_cache()` after `set_global_default`.** This works in the deterministic reproduction, but it is repair rather than prevention and it has a residual hole: a sibling that reads `get_default()` before the install lands, is descheduled, and stores its stale `Interest::never()` after the repair has run, wins.

`tracing-test` is replaced rather than kept because closing the window under it would mean reaching into `tracing_test::internal`, which the crate documents as unstable across patch releases, to share its `INITIALIZED` `Once`. Owning the ~90 lines also removes the unbounded global buffer and the per-event `print!` that the crate's `MockWriter` performed for every `mlxcel_core` trace-level event in the binary, and it makes the negative assertion exact instead of a substring scan over a buffer shared with every other test.

## Blast radius

`#[traced_test]` appeared exactly 3 times in the workspace, all in this one module, all converted, so the dev-dependency goes with them.

One other test asserts on tracing output: `sampling_observability_tests::lang_bias_tracing_fields_emitted_on_construction`, which builds an fmt subscriber over a shared buffer and runs `tracing::subscriber::with_default`. It is **not** exposed, and for a reason worth stating rather than assuming: the `debug!` it asserts on sits inside the test function itself, so no other test can reach that callsite. It is always registered by its own thread, inside the closure, with the capturing dispatcher already current. Left alone.

The same latent hazard does exist in the `mlxcel` bin test binary, where `resolve_drafter_kind` is called from tests and where that `with_default` raises the global max level while no global default is set, but no assertion there depends on a callsite staying live, so nothing can fail.

The new subscriber captures only `mlxcel_core::drafter` targets at `INFO` and above; widening either bound is a one-line change documented at the constants.

## Test plan

- [x] `cargo fmt --all -- --check`
- [x] `make verify-clippy` (workspace, all targets, `-D warnings`)
- [x] `make verify-test` (workspace, `test-fast`, `--no-fail-fast`)
- [x] Dose-response before/after, 100 runs per point, table above
- [x] Mutation check: removing the `info!` fails the assertion
- [x] Mutation check: calling the resolver directly fails the new guard test, with an actionable message

Closes #1023
