### PR TITLE
fix(models): mamba and mamba2 treat a scales-without-biases embedding as non-quantized

### DIFF
--- a/docs/adding-models.md
+++ b/docs/adding-models.md
@@ -238,9 +238,18 @@ What already carries the bound, so you inherit it for free:
 | `reconcile_quantization_layout` | every `UnifiedLinear` / `UnifiedEmbedding` |
 | `SwitchLinear::from_stacked_parts` | MoE experts via the shared `switch_layers` loader |
 | `QuantizedMultiLinear::{new, from_weights}` | MLA `embed_q` / `unembed_out` |
-| `QuantizedEmbedding::new` | hand-built embeddings that skip the map loader |
 | `FusedQKVLinear::from_weights_separate_with_mode` | fused QKV projections |
 | `infer_mla_quantization_params` | the MLA `kv_b_proj` decomposition in `sanitize_weights` |
+
+There is deliberately no hand-built `QuantizedEmbedding` constructor on that
+list any more. One existed for Mamba / Mamba2, which resolve their table under
+two possible prefixes and so looked unable to address the single-prefix map
+loader. It hardcoded `mode: "affine"` and required a `biases` argument, and that
+is exactly how those two families came to treat a block-float embedding
+(`.scales`, no `.biases`) as non-quantized (issue #976). If your checkpoint
+spells the embedding prefix more than one way, resolve the prefix with a
+`contains_key` probe and pass it to `UnifiedEmbedding::from_weights`; do not
+hand-build the layer.
 
 What you must do yourself:
 

--- a/src/lib/mlxcel-core/src/layers.rs
+++ b/src/lib/mlxcel-core/src/layers.rs
@@ -76,7 +76,7 @@ impl QuantizedWeight {
     /// Create a new quantized weight with explicit mode.
     ///
     /// Fallible on purpose (issue #973), on the same reasoning that made
-    /// [`QuantizedEmbedding::new`] fallible for the declared `group_size` /
+    /// [`QuantizedMultiLinear::new`] fallible for the declared `group_size` /
     /// `bits` pair. This is the one way to build a `QuantizedWeight` with a
     /// caller-chosen mode without going through
     /// [`reconcile_quantization_layout`], and therefore without the allowlist it
@@ -250,53 +250,17 @@ pub struct QuantizedEmbedding {
 }
 
 impl QuantizedEmbedding {
-    /// Create a new quantized embedding layer (affine mode) from tensors the
-    /// caller already owns.
-    ///
-    /// Fallible on purpose (issue #958). This is the one way to build a
-    /// `QuantizedEmbedding` without going through
-    /// [`Self::from_weights_with_mode`], and therefore without
-    /// [`reconcile_quantization_layout`] and the bound it now carries. A caller
-    /// that hand-builds the layer is exactly the caller whose declared
-    /// `group_size` / `bits` have never been looked at, and the stored pair goes
-    /// straight to `quantized_embedding` / `quantized_matmul`, which cross the
-    /// cxx bridge as `UniquePtr<MlxArray>` rather than `Result`: a C++ throw
-    /// there is an uncatchable abort at the first forward pass rather than a
-    /// load error. Returning `Result` puts the bound on the path the next family
-    /// that builds one directly will take, which is the whole reason the
-    /// signature changed rather than the two existing call sites being patched.
-    /// It is a strong default rather than an enforced invariant: the fields
-    /// above are `pub`, so a struct literal still bypasses this entirely.
-    /// Nothing in the tree does that today.
-    ///
-    /// This bounds the declared pair only; it does not reconcile against the
-    /// tensor shapes the way `from_weights_with_mode` does, because the shapes
-    /// arrive here already detached from the prefix the reconciler names in its
-    /// divergence warning.
-    ///
-    /// Used by: Mamba, Mamba2 (both take the table out of the `WeightMap` by
-    ///          `remove`, under either the `backbone.embeddings` or the
-    ///          `model.embed_tokens` spelling, so neither can address the
-    ///          single-prefix map loader)
-    pub fn new(
-        weight: UniquePtr<MlxArray>,
-        scales: UniquePtr<MlxArray>,
-        biases: UniquePtr<MlxArray>,
-        group_size: i32,
-        bits: i32,
-    ) -> Result<Self, String> {
-        validate_quantization_params(group_size, bits)?;
-        Ok(Self {
-            weight,
-            scales,
-            biases: Some(biases),
-            group_size,
-            bits,
-            mode: "affine".to_string(),
-        })
-    }
-
     /// Load from weight map
+    ///
+    /// There is deliberately no by-hand `new` beside this. One existed for
+    /// Mamba / Mamba2, which took their table out of the `WeightMap` by
+    /// `remove` under two possible prefixes and so could not address a
+    /// single-prefix map loader; it hardcoded `mode: "affine"` and required a
+    /// `biases` argument, which is precisely how those two families came to
+    /// treat a block-float embedding (`.scales`, no `.biases`) as
+    /// non-quantized (issue #976). Both now resolve the prefix and come through
+    /// here, and the constructor is gone so the next family cannot rebuild the
+    /// same defect. Prefer resolving a prefix over hand-building a layer.
     pub fn from_weights(
         weights: &crate::weights::WeightMap,
         prefix: &str,
@@ -485,7 +449,7 @@ impl UnifiedEmbedding {
     /// a packed table describes, which `is_quantized()` alone cannot give them.
     ///
     /// Used by: the shared `validate_embedding_table` guard (BailingMoe, Gpt2,
-    ///          GptBigCode, GptNeoX)
+    ///          GptBigCode, GptNeoX, Mamba, Mamba2)
     pub fn quantized(&self) -> Option<&QuantizedEmbedding> {
         match self {
             Self::Quantized(e) => Some(e),
@@ -1312,8 +1276,7 @@ pub struct ReconciledQuant {
 /// Used by: every quantizing family through [`reconcile_quantization_layout`]
 ///          (dense projections and quantized embeddings) and through
 ///          `SwitchLinear::from_stacked_parts` (MoE experts); the by-hand
-///          constructors [`QuantizedEmbedding::new`],
-///          [`QuantizedMultiLinear::new`] and
+///          constructors [`QuantizedMultiLinear::new`] and
 ///          [`QuantizedMultiLinear::from_weights`], which never reach the
 ///          reconciler; every family-local MoE expert loader through
 ///          `crate::models::switch_layers::validate_expert_quantization_params`
@@ -1808,7 +1771,7 @@ pub struct QuantizedTensorShapes<'a> {
 ///
 /// Used by: BailingMoe weight validation (token table, dense projections,
 ///          stacked experts) and the shared `validate_embedding_table` guard
-///          (BailingMoe, Gpt2, GptBigCode, GptNeoX)
+///          (BailingMoe, Gpt2, GptBigCode, GptNeoX, Mamba, Mamba2)
 pub fn validate_quantized_packing(
     label: &str,
     shapes: &QuantizedTensorShapes<'_>,
@@ -2821,9 +2784,15 @@ impl QuantizedMultiLinear {
     /// Create a new quantized multi-linear layer from tensors the caller
     /// already owns.
     ///
-    /// Fallible for the same reason as [`QuantizedEmbedding::new`] (issue
-    /// #958): the stored pair reaches `quantized_matmul` unmediated, and nothing
-    /// else on this path bounds it.
+    /// Fallible on purpose (issue #958): the stored pair reaches
+    /// `quantized_matmul` unmediated, without
+    /// [`reconcile_quantization_layout`] and the bound it carries, and nothing
+    /// else on this path bounds it. Unlike the `QuantizedEmbedding` constructor
+    /// this once mirrored (removed in issue #976), it takes `biases` as an
+    /// `Option` and so cannot express a mode that contradicts the planes the
+    /// checkpoint ships. Nothing in the tree calls it today; it is a strong
+    /// default for the next caller that hand-builds one, not an enforced
+    /// invariant, since the fields are `pub`.
     pub fn new(
         weight: UniquePtr<MlxArray>,
         scales: UniquePtr<MlxArray>,
@@ -5328,24 +5297,40 @@ mod tests {
         }
     }
 
-    /// The two by-hand constructors are the only way to build a quantized layer
-    /// without going through `reconcile_quantization_layout`, which is exactly
-    /// how `mamba` / `mamba2` reached `quantized_embedding` with an unbounded
-    /// pair (issue #958). They are fallible so the bound cannot be skipped, and
-    /// this drives the real constructors rather than the pure helper, so the
-    /// guard is exercised where a checkpoint actually reaches it. Losing it turns
-    /// a rejected load into an uncatchable abort at the first forward pass in
-    /// production; here the assertions are on the constructor result, so a
-    /// regression fails cleanly rather than aborting the test binary.
+    /// A quantized layer built without going through
+    /// `reconcile_quantization_layout` stores the declared `group_size` / `bits`
+    /// verbatim, which is exactly how `mamba` / `mamba2` reached
+    /// `quantized_embedding` with an unbounded pair (issue #958). Both halves
+    /// here drive a real entry point rather than the pure helper, so the guard
+    /// is exercised where a checkpoint actually reaches it, and both assert on
+    /// the constructor result with no forward pass, so a regression fails
+    /// cleanly rather than aborting the test binary.
+    ///
+    /// The embedding half targets `QuantizedEmbedding::from_weights`, the path
+    /// production now uses: the by-hand `QuantizedEmbedding::new` was removed in
+    /// issue #976, because requiring a `biases` argument is what made a
+    /// block-float table look non-quantized to the two families that called it.
+    /// `QuantizedMultiLinear::new` stays and is still hand-built here: it takes
+    /// `Option<biases>` and so cannot express that defect, and it remains the
+    /// bound for the next caller that builds one directly.
     #[test]
     fn hand_built_quantized_layers_bound_their_declared_params() {
+        use crate::weights::WeightMap;
+
         // Honest affine 4-bit geometry: packed_in * 32 == bits * groups * gs,
         // i.e. 8 * 32 == 4 * 1 * 64.
         let plane = |last: i32| ffi::from_slice_f32(&vec![0.0; (4 * last) as usize], &[4, last]);
+        let embed_weights = || {
+            let mut weights = WeightMap::new();
+            weights.insert("embed.weight".to_string(), plane(8));
+            weights.insert("embed.scales".to_string(), plane(1));
+            weights.insert("embed.biases".to_string(), plane(1));
+            weights
+        };
 
         // Positive control first, so a guard that rejects everything quantized
         // cannot pass this test.
-        QuantizedEmbedding::new(plane(8), plane(1), plane(1), 64, 4)
+        QuantizedEmbedding::from_weights(&embed_weights(), "embed", 64, 4)
             .expect("an honest affine pair must still build a quantized embedding");
         QuantizedMultiLinear::new(plane(8), plane(1), Some(plane(1)), 64, 4)
             .expect("an honest affine pair must still build a quantized MultiLinear");
@@ -5357,10 +5342,10 @@ mod tests {
             (0, 4, "group_size"),
             (-64, 4, "group_size"),
         ] {
-            let err = QuantizedEmbedding::new(plane(8), plane(1), plane(1), group_size, bits)
+            let err = QuantizedEmbedding::from_weights(&embed_weights(), "embed", group_size, bits)
                 .err()
                 .unwrap_or_else(|| {
-                    panic!("QuantizedEmbedding::new must reject {group_size} / {bits}")
+                    panic!("QuantizedEmbedding::from_weights must reject {group_size} / {bits}")
                 });
             assert!(err.contains(field), "unhelpful error: {err}");
 

--- a/src/models/gpt2.rs
+++ b/src/models/gpt2.rs
@@ -851,7 +851,7 @@ pub(crate) fn dim_eq(dim: i32, expected: usize) -> bool {
 /// `std::terminate` at the first forward pass. The reconstruction is shared with
 /// the dense projections via `mlxcel_core::layers::validate_quantized_packing`.
 ///
-/// Used by: BailingMoe, Gpt2, GptBigCode, GptNeoX
+/// Used by: BailingMoe, Gpt2, GptBigCode, GptNeoX, Mamba, Mamba2
 pub(crate) fn validate_embedding_table(
     table: &UnifiedEmbedding,
     key: &str,

--- a/src/models/mamba.rs
+++ b/src/models/mamba.rs
@@ -25,6 +25,7 @@ use std::path::Path;
 
 use super::model_owned::ModelOwnedSequenceState;
 use super::recurrent_snapshot::{push_optional, restore_optional};
+use crate::models::gpt2::validate_embedding_table;
 
 /// Parse eos_token_id from config.json. Can be a single int, an array of ints, or absent.
 /// Used by: Mamba, Mamba2
@@ -526,36 +527,50 @@ impl MambaModel {
         let group_size = config.group_size();
         let bits = config.bits();
 
-        // Build embeddings (auto-detect quantization)
-        let embed_weight = weights
-            .remove("backbone.embeddings.weight")
-            .or_else(|| weights.remove("model.embed_tokens.weight"))
-            .ok_or("Missing embedding weight")?;
-        let embed_scales = weights
-            .remove("backbone.embeddings.scales")
-            .or_else(|| weights.remove("model.embed_tokens.scales"));
-        let embed_biases = weights
-            .remove("backbone.embeddings.biases")
-            .or_else(|| weights.remove("model.embed_tokens.biases"));
+        // Build embeddings (auto-detect quantization).
+        //
+        // The table ships under either the `backbone.embeddings` spelling (the
+        // original mamba export) or the `model.embed_tokens` one (the
+        // transformers conversion), which is the only thing the shared loader
+        // cannot do on its own: resolve the prefix here, then hand it the whole
+        // map. This used to hand-build the layer from three `remove` calls
+        // instead, which cost it both of the guards below.
+        //
+        // The quantized branch is gated on `.scales` alone, not on `.scales`
+        // and `.biases`. Affine stores zero points; the block-float modes
+        // (mxfp4 / nvfp4 / mxfp8) carry none by design, so requiring both sent
+        // every block-float embedding down the non-quantized branch and built a
+        // plain `Embedding` over the raw packed uint32 table, whose lookup is a
+        // bare `take` with no dequantization (issue #976).
+        // `UnifiedEmbedding::from_weights` infers the mode from bias presence
+        // for exactly that reason, and reaching `QuantizedEmbedding` through it
+        // also runs `reconcile_quantization_layout` and therefore
+        // `validate_quantization_params`, which is what refuses a declared
+        // `"bits": 0` at load rather than dividing by it inside
+        // `quantized_embedding` at the first token (issue #958).
+        let embed_prefix = ["backbone.embeddings", "model.embed_tokens"]
+            .into_iter()
+            .find(|prefix| weights.contains_key(&format!("{prefix}.weight")))
+            .ok_or(
+                "Missing embedding weight (tried backbone.embeddings.weight and \
+                 model.embed_tokens.weight)",
+            )?;
+        let embeddings = UnifiedEmbedding::from_weights(&weights, embed_prefix, group_size, bits)?;
 
-        // The table is taken out of the map by `remove`, under either the
-        // `backbone.embeddings` or the `model.embed_tokens` spelling, so this
-        // cannot go through the single-prefix `UnifiedEmbedding::from_weights`
-        // and therefore never reaches `reconcile_quantization_layout`. The bound
-        // that loader carries lives in `QuantizedEmbedding::new` instead (issue
-        // #958); without it a declared `"bits": 0` was stored here and divided
-        // by inside `quantized_embedding` at the first token.
-        let embeddings = if let (Some(scales), Some(biases)) = (embed_scales, embed_biases) {
-            UnifiedEmbedding::Quantized(mlxcel_core::layers::QuantizedEmbedding::new(
-                embed_weight,
-                scales,
-                biases,
-                group_size,
-                bits,
-            )?)
-        } else {
-            UnifiedEmbedding::Regular(mlxcel_core::layers::Embedding::new(embed_weight))
-        };
+        // The shared table guard four other families already run. It is what
+        // makes a mis-loaded embedding a load error instead of a first-token
+        // abort: a packed table taken for a float one has a last axis of
+        // `hidden_size * bits / 32` rather than `hidden_size`, and a config that
+        // overstates `vocab_size` indexes past the end of a gather that does not
+        // range-check a positive index.
+        validate_embedding_table(
+            &embeddings,
+            embed_prefix,
+            config.vocab_size,
+            "vocab_size",
+            config.hidden_size,
+            "hidden_size",
+        )?;
 
         // Build layers
         let mut layers = Vec::with_capacity(config.num_hidden_layers);

--- a/src/models/mamba2.rs
+++ b/src/models/mamba2.rs
@@ -25,6 +25,7 @@ use std::path::Path;
 
 use super::model_owned::ModelOwnedSequenceState;
 use super::recurrent_snapshot::{push_optional, restore_optional};
+use crate::models::gpt2::validate_embedding_table;
 
 // Configuration.
 #[derive(Debug, Clone, Deserialize)]
@@ -755,36 +756,50 @@ impl Mamba2Model {
         let group_size = config.group_size();
         let bits = config.bits();
 
-        // Build embeddings (auto-detect quantization)
-        let embed_weight = weights
-            .remove("backbone.embeddings.weight")
-            .or_else(|| weights.remove("model.embed_tokens.weight"))
-            .ok_or("Missing embedding weight")?;
-        let embed_scales = weights
-            .remove("backbone.embeddings.scales")
-            .or_else(|| weights.remove("model.embed_tokens.scales"));
-        let embed_biases = weights
-            .remove("backbone.embeddings.biases")
-            .or_else(|| weights.remove("model.embed_tokens.biases"));
+        // Build embeddings (auto-detect quantization).
+        //
+        // The table ships under either the `backbone.embeddings` spelling (the
+        // original mamba export) or the `model.embed_tokens` one (the
+        // transformers conversion), which is the only thing the shared loader
+        // cannot do on its own: resolve the prefix here, then hand it the whole
+        // map. This used to hand-build the layer from three `remove` calls
+        // instead, which cost it both of the guards below.
+        //
+        // The quantized branch is gated on `.scales` alone, not on `.scales`
+        // and `.biases`. Affine stores zero points; the block-float modes
+        // (mxfp4 / nvfp4 / mxfp8) carry none by design, so requiring both sent
+        // every block-float embedding down the non-quantized branch and built a
+        // plain `Embedding` over the raw packed uint32 table, whose lookup is a
+        // bare `take` with no dequantization (issue #976).
+        // `UnifiedEmbedding::from_weights` infers the mode from bias presence
+        // for exactly that reason, and reaching `QuantizedEmbedding` through it
+        // also runs `reconcile_quantization_layout` and therefore
+        // `validate_quantization_params`, which is what refuses a declared
+        // `"bits": 0` at load rather than dividing by it inside
+        // `quantized_embedding` at the first token (issue #958).
+        let embed_prefix = ["backbone.embeddings", "model.embed_tokens"]
+            .into_iter()
+            .find(|prefix| weights.contains_key(&format!("{prefix}.weight")))
+            .ok_or(
+                "Missing embedding weight (tried backbone.embeddings.weight and \
+                 model.embed_tokens.weight)",
+            )?;
+        let embeddings = UnifiedEmbedding::from_weights(&weights, embed_prefix, group_size, bits)?;
 
-        // The table is taken out of the map by `remove`, under either the
-        // `backbone.embeddings` or the `model.embed_tokens` spelling, so this
-        // cannot go through the single-prefix `UnifiedEmbedding::from_weights`
-        // and therefore never reaches `reconcile_quantization_layout`. The bound
-        // that loader carries lives in `QuantizedEmbedding::new` instead (issue
-        // #958); without it a declared `"bits": 0` was stored here and divided
-        // by inside `quantized_embedding` at the first token.
-        let embeddings = if let (Some(scales), Some(biases)) = (embed_scales, embed_biases) {
-            UnifiedEmbedding::Quantized(mlxcel_core::layers::QuantizedEmbedding::new(
-                embed_weight,
-                scales,
-                biases,
-                group_size,
-                bits,
-            )?)
-        } else {
-            UnifiedEmbedding::Regular(mlxcel_core::layers::Embedding::new(embed_weight))
-        };
+        // The shared table guard four other families already run. It is what
+        // makes a mis-loaded embedding a load error instead of a first-token
+        // abort: a packed table taken for a float one has a last axis of
+        // `hidden_size * bits / 32` rather than `hidden_size`, and a config that
+        // overstates `vocab_size` indexes past the end of a gather that does not
+        // range-check a positive index.
+        validate_embedding_table(
+            &embeddings,
+            embed_prefix,
+            config.vocab_size,
+            "vocab_size",
+            config.hidden_size,
+            "hidden_size",
+        )?;
 
         // Build layers
         let mut layers = Vec::with_capacity(config.num_hidden_layers);

--- a/src/models/mamba2_tests.rs
+++ b/src/models/mamba2_tests.rs
@@ -310,3 +310,39 @@ fn mamba2_rejects_an_embedding_table_narrower_than_hidden_size() {
         .to_string();
     assert!(err.contains("hidden_size"), "unhelpful error: {err}");
 }
+
+/// The test above exercises the guard's width clause; this one exercises its
+/// row-count clause, `claimed_rows > rows`. Token ids are bounded by
+/// `vocab_size`, not by the rows actually present in the table, and MLX's
+/// embedding gather wraps a negative index but performs no range check on a
+/// positive one, so a config that overstates `vocab_size` turns an ordinary
+/// prompt into an out-of-bounds read whose result reaches the logits rather
+/// than faulting. It is also the one place a caller can silently mis-wire the
+/// shared guard by passing the wrong config field into the `claimed_rows`
+/// slot, so this pins Mamba2 to `config.vocab_size` specifically, not merely
+/// to some `usize` that happens to be lying around.
+#[test]
+fn mamba2_rejects_a_config_that_overstates_vocab_size() {
+    use super::Mamba2Model;
+
+    let mut narrow = embedding_test_base_weights();
+    narrow.insert(
+        "backbone.embeddings.weight".to_string(),
+        mlxcel_core::from_slice_f32(&[0.0; 24], &[3, 8]),
+    );
+    let err = Mamba2Model::from_weights(embedding_config(0, 0), narrow)
+        .err()
+        .expect("a config that overstates the embeddings table must fail the load")
+        .to_string();
+    assert!(err.contains("vocab_size"), "unhelpful error: {err}");
+
+    // The other direction is safe: a table padded with more rows than
+    // vocab_size keeps the bound inside it.
+    let mut padded = embedding_test_base_weights();
+    padded.insert(
+        "backbone.embeddings.weight".to_string(),
+        mlxcel_core::from_slice_f32(&[0.0; 512], &[64, 8]),
+    );
+    Mamba2Model::from_weights(embedding_config(0, 0), padded)
+        .expect("a table with more rows than vocab_size must still load");
+}

--- a/src/models/mamba2_tests.rs
+++ b/src/models/mamba2_tests.rs
@@ -14,6 +14,7 @@
 
 //! Regression tests for Mamba2 conv_state contiguous fix.
 
+use mlxcel_core::weights::WeightMap;
 use mlxcel_core::{dtype, generate::ModelStateSnapshot, utils::slice_axis};
 
 /// Simulate 50 decode steps of conv-state update and assert the stored shape
@@ -99,13 +100,87 @@ fn mamba2_cache_snapshot_restore_round_trips_state_shapes() {
     assert_eq!(mlxcel_core::array_shape(ssm), vec![1, 2, 4, 8]);
 }
 
-/// Mamba2 hand-builds its `QuantizedEmbedding` for the same reason Mamba does
-/// (the table is taken out of the map by `remove`, under either the
-/// `backbone.embeddings` or the `model.embed_tokens` spelling), so it bypassed
-/// `reconcile_quantization_layout` and stored the declared pair verbatim. The
-/// pair then reached `quantized_embedding`, which crosses the cxx bridge as
-/// `UniquePtr<MlxArray>` rather than `Result`, so the C++ throw was an
-/// uncatchable abort at the first token rather than a load error (issue #958).
+/// The config every embedding-load test below shares.
+///
+/// `num_hidden_layers: 0` plus tied embeddings reduces the load to the
+/// embedding table and the final norm, so an honest case loads all the way
+/// through rather than stopping at an unrelated missing weight. `vocab_size`
+/// and `hidden_size` are both 8, which is the width every fixture geometry
+/// below is sized against.
+fn embedding_config(group_size: i32, bits: i32) -> super::Mamba2Config {
+    serde_json::from_value(serde_json::json!({
+        "model_type": "mamba2",
+        "vocab_size": 8,
+        "hidden_size": 8,
+        "num_heads": 2,
+        "head_dim": 4,
+        "state_size": 4,
+        "num_hidden_layers": 0,
+        "conv_kernel": 4,
+        "n_groups": 1,
+        "tie_word_embeddings": true,
+        "quantization": { "group_size": group_size, "bits": bits },
+    }))
+    .expect("test config must parse")
+}
+
+/// The final norm, the only non-embedding weight a `num_hidden_layers: 0` load
+/// still asks for.
+fn embedding_test_base_weights() -> WeightMap {
+    let mut weights = WeightMap::new();
+    weights.insert(
+        "backbone.norm_f.weight".to_string(),
+        mlxcel_core::from_slice_f32(&[1.0; 8], &[8]),
+    );
+    weights
+}
+
+/// Affine 4-bit table under `prefix`, honest at `embedding_config(8, 4)`:
+/// packed_in * 32 == bits * groups * gs, i.e. 1 * 32 == 4 * 1 * 8, and the
+/// dequantized width scales.shape(-1) * group_size == 8 == hidden_size. The
+/// table is [vocab, packed_in].
+fn affine_embedding_weights(prefix: &str) -> WeightMap {
+    let mut weights = embedding_test_base_weights();
+    weights.insert(
+        format!("{prefix}.weight"),
+        mlxcel_core::from_slice_f32(&[0.0; 8], &[8, 1]),
+    );
+    weights.insert(
+        format!("{prefix}.scales"),
+        mlxcel_core::from_slice_f32(&[1.0; 8], &[8, 1]),
+    );
+    weights.insert(
+        format!("{prefix}.biases"),
+        mlxcel_core::from_slice_f32(&[0.0; 8], &[8, 1]),
+    );
+    weights
+}
+
+/// Block-float table under `prefix`: `.scales` and no `.biases`, which is what
+/// an mxfp4 / nvfp4 / mxfp8 export ships. `packed_in` is the stored width, so
+/// the dequantized width is packed_in * 32 / bits and must come out at
+/// hidden_size (8) for the declared bits.
+fn block_float_embedding_weights(prefix: &str, packed_in: i32) -> WeightMap {
+    let mut weights = embedding_test_base_weights();
+    let elems = 8 * packed_in as usize;
+    weights.insert(
+        format!("{prefix}.weight"),
+        mlxcel_core::from_slice_f32(&vec![0.0; elems], &[8, packed_in]),
+    );
+    weights.insert(
+        format!("{prefix}.scales"),
+        mlxcel_core::from_slice_f32(&[1.0; 8], &[8, 1]),
+    );
+    weights
+}
+
+/// Mamba2 reaches `QuantizedEmbedding` through `UnifiedEmbedding::from_weights`
+/// for the same reason Mamba does, and therefore through
+/// `reconcile_quantization_layout`. Before issue #958 it hand-built the layer
+/// and stored the declared pair verbatim; the pair then reached
+/// `quantized_embedding`, which crosses the cxx bridge as `UniquePtr<MlxArray>`
+/// rather than `Result`, so the C++ throw was an uncatchable abort at the first
+/// token rather than a load error.
 ///
 /// This drives the real `Mamba2Model::from_weights` rather than the pure bounds
 /// helper, so the guard is exercised where a checkpoint actually reaches it. The
@@ -113,72 +188,125 @@ fn mamba2_cache_snapshot_restore_round_trips_state_shapes() {
 /// fails cleanly here rather than aborting the test binary.
 #[test]
 fn mamba2_rejects_quantization_params_that_would_abort_the_embedding_lookup() {
-    use super::{Mamba2Config, Mamba2Model};
-    use mlxcel_core::weights::WeightMap;
-
-    // `num_hidden_layers: 0` plus tied embeddings reduces the load to the
-    // embedding table and the final norm, so the honest case loads all the way
-    // through rather than stopping at an unrelated missing weight.
-    let config_with = |group_size: i32, bits: i32| -> Mamba2Config {
-        serde_json::from_value(serde_json::json!({
-            "model_type": "mamba2",
-            "vocab_size": 8,
-            "hidden_size": 8,
-            "num_heads": 2,
-            "head_dim": 4,
-            "state_size": 4,
-            "num_hidden_layers": 0,
-            "conv_kernel": 4,
-            "n_groups": 1,
-            "tie_word_embeddings": true,
-            "quantization": { "group_size": group_size, "bits": bits },
-        }))
-        .expect("test config must parse")
-    };
-
-    // Honest affine 4-bit geometry: packed_in * 32 == bits * groups * gs,
-    // i.e. 1 * 32 == 4 * 1 * 8. The table is [vocab, packed_in].
-    let build_weights = || {
-        let mut weights = WeightMap::new();
-        weights.insert(
-            "backbone.embeddings.weight".to_string(),
-            mlxcel_core::from_slice_f32(&[0.0; 8], &[8, 1]),
-        );
-        weights.insert(
-            "backbone.embeddings.scales".to_string(),
-            mlxcel_core::from_slice_f32(&[1.0; 8], &[8, 1]),
-        );
-        weights.insert(
-            "backbone.embeddings.biases".to_string(),
-            mlxcel_core::from_slice_f32(&[0.0; 8], &[8, 1]),
-        );
-        weights.insert(
-            "backbone.norm_f.weight".to_string(),
-            mlxcel_core::from_slice_f32(&[1.0; 8], &[8]),
-        );
-        weights
-    };
+    use super::Mamba2Model;
 
     // Positive control first, so a guard that rejects everything quantized
     // cannot pass this test.
-    Mamba2Model::from_weights(config_with(8, 4), build_weights())
-        .expect("an honest affine pair must still load a quantized Mamba2 embedding");
+    Mamba2Model::from_weights(
+        embedding_config(8, 4),
+        affine_embedding_weights("backbone.embeddings"),
+    )
+    .expect("an honest affine pair must still load a quantized Mamba2 embedding");
 
     for (group_size, bits, field) in crate::models::switch_layers::HOSTILE_QUANT_PARAMS {
-        let err = Mamba2Model::from_weights(config_with(group_size, bits), build_weights())
-            .err()
-            .unwrap_or_else(|| {
-                panic!("Mamba2 must reject group_size {group_size} / bits {bits} at load")
-            })
-            .to_string();
+        let err = Mamba2Model::from_weights(
+            embedding_config(group_size, bits),
+            affine_embedding_weights("backbone.embeddings"),
+        )
+        .err()
+        .unwrap_or_else(|| {
+            panic!("Mamba2 must reject group_size {group_size} / bits {bits} at load")
+        })
+        .to_string();
         assert!(err.contains(field), "unhelpful error: {err}");
     }
 
     // A float embedding table carries no packing, so the params are irrelevant
-    // there and must not be enforced.
-    let mut regular = build_weights();
-    regular.remove("backbone.embeddings.scales");
-    regular.remove("backbone.embeddings.biases");
-    Mamba2Model::from_weights(config_with(0, 0), regular)
+    // there and must not be enforced. It has to be a genuine [vocab, hidden]
+    // table rather than the packed one with its scales stripped, because the
+    // shared table guard now checks the width of a non-quantized table against
+    // hidden_size (see `mamba2_rejects_an_embedding_table_narrower_than_hidden_size`).
+    let mut regular = embedding_test_base_weights();
+    regular.insert(
+        "backbone.embeddings.weight".to_string(),
+        mlxcel_core::from_slice_f32(&[0.0; 64], &[8, 8]),
+    );
+    Mamba2Model::from_weights(embedding_config(0, 0), regular)
         .expect("a float embedding table must not be gated on quantization params");
+}
+
+/// Issue #976: a block-float embedding carries `.scales` and no `.biases`, and
+/// must still load as quantized.
+///
+/// Affine stores zero points; mxfp4 / nvfp4 / mxfp8 do not, which is what
+/// `infer_quantization_mode` keys on. The old gate required both planes, so a
+/// block-float table fell to `Embedding::new` over the raw packed uint32 tensor,
+/// whose lookup is a bare `take` with no dequantization: the result is a uint32
+/// array whose last axis is the packed width rather than hidden_size.
+///
+/// The assertion is that the load succeeds, not that the variant is `Quantized`:
+/// `Mamba2Model::embeddings` is private and this is a sibling module, and a
+/// forward pass on a regressed load aborts the test binary rather than failing
+/// it. The shared table guard supplies the observable instead, because a
+/// regression stores a [8, packed_in] table as non-quantized and the guard
+/// rejects a non-quantized width that is not hidden_size.
+#[test]
+fn mamba2_loads_a_block_float_embedding_as_quantized() {
+    use super::Mamba2Model;
+
+    // mxfp4: infer_quantization_mode(false, 8, 4) == "mxfp4", dequantized width
+    // packed_in * 32 / bits == 1 * 8 == 8 == hidden_size.
+    Mamba2Model::from_weights(
+        embedding_config(8, 4),
+        block_float_embedding_weights("backbone.embeddings", 1),
+    )
+    .expect("an mxfp4 embedding (scales, no biases) must load as quantized");
+
+    // mxfp8: bits 8 picks the mode, and 8-bit packing doubles the stored width
+    // for the same dequantized 8, so packed_in is 2 here.
+    Mamba2Model::from_weights(
+        embedding_config(8, 8),
+        block_float_embedding_weights("backbone.embeddings", 2),
+    )
+    .expect("an mxfp8 embedding (scales, no biases) must load as quantized");
+}
+
+/// The embedding prefix is checkpoint-dependent: `backbone.embeddings` in the
+/// original mamba export, `model.embed_tokens` in the transformers conversion.
+/// Resolving it is the only reason this cannot pass a fixed prefix to the shared
+/// loader, so both spellings must reach the same code path, and a checkpoint
+/// carrying neither must say so naming both.
+#[test]
+fn mamba2_resolves_both_embedding_prefix_spellings() {
+    use super::Mamba2Model;
+
+    Mamba2Model::from_weights(
+        embedding_config(8, 4),
+        affine_embedding_weights("model.embed_tokens"),
+    )
+    .expect("the transformers spelling must load an affine embedding");
+    Mamba2Model::from_weights(
+        embedding_config(8, 4),
+        block_float_embedding_weights("model.embed_tokens", 1),
+    )
+    .expect("the transformers spelling must load a block-float embedding");
+
+    let err = Mamba2Model::from_weights(embedding_config(8, 4), embedding_test_base_weights())
+        .err()
+        .expect("a checkpoint with no embedding table at all must fail the load")
+        .to_string();
+    assert!(err.contains("backbone.embeddings.weight"), "{err}");
+    assert!(err.contains("model.embed_tokens.weight"), "{err}");
+}
+
+/// The shared `validate_embedding_table` guard is new for this family. A
+/// non-quantized table whose width is not the model width feeds a wrong-width
+/// hidden state into the first norm, which throws inside MLX and crosses the cxx
+/// bridge as an uncatchable abort rather than a load error, so it has to be
+/// caught here. The message names the config field the reader will find in their
+/// `config.json`.
+#[test]
+fn mamba2_rejects_an_embedding_table_narrower_than_hidden_size() {
+    use super::Mamba2Model;
+
+    let mut narrow = embedding_test_base_weights();
+    narrow.insert(
+        "backbone.embeddings.weight".to_string(),
+        mlxcel_core::from_slice_f32(&[0.0; 8], &[8, 1]),
+    );
+    let err = Mamba2Model::from_weights(embedding_config(0, 0), narrow)
+        .err()
+        .expect("a float embedding table narrower than hidden_size must fail the load")
+        .to_string();
+    assert!(err.contains("hidden_size"), "unhelpful error: {err}");
 }

--- a/src/models/mamba_tests.rs
+++ b/src/models/mamba_tests.rs
@@ -312,3 +312,39 @@ fn mamba_rejects_an_embedding_table_narrower_than_hidden_size() {
         .to_string();
     assert!(err.contains("hidden_size"), "unhelpful error: {err}");
 }
+
+/// The test above exercises the guard's width clause; this one exercises its
+/// row-count clause, `claimed_rows > rows`. Token ids are bounded by
+/// `vocab_size`, not by the rows actually present in the table, and MLX's
+/// embedding gather wraps a negative index but performs no range check on a
+/// positive one, so a config that overstates `vocab_size` turns an ordinary
+/// prompt into an out-of-bounds read whose result reaches the logits rather
+/// than faulting. It is also the one place a caller can silently mis-wire the
+/// shared guard by passing the wrong config field into the `claimed_rows`
+/// slot, so this pins Mamba to `config.vocab_size` specifically, not merely
+/// to some `usize` that happens to be lying around.
+#[test]
+fn mamba_rejects_a_config_that_overstates_vocab_size() {
+    use super::MambaModel;
+
+    let mut narrow = embedding_test_base_weights();
+    narrow.insert(
+        "backbone.embeddings.weight".to_string(),
+        mlxcel_core::from_slice_f32(&[0.0; 24], &[3, 8]),
+    );
+    let err = MambaModel::from_weights(embedding_config(0, 0), narrow)
+        .err()
+        .expect("a config that overstates the embeddings table must fail the load")
+        .to_string();
+    assert!(err.contains("vocab_size"), "unhelpful error: {err}");
+
+    // The other direction is safe: a table padded with more rows than
+    // vocab_size keeps the bound inside it.
+    let mut padded = embedding_test_base_weights();
+    padded.insert(
+        "backbone.embeddings.weight".to_string(),
+        mlxcel_core::from_slice_f32(&[0.0; 512], &[64, 8]),
+    );
+    MambaModel::from_weights(embedding_config(0, 0), padded)
+        .expect("a table with more rows than vocab_size must still load");
+}

--- a/src/models/mamba_tests.rs
+++ b/src/models/mamba_tests.rs
@@ -14,6 +14,7 @@
 
 //! Regression tests for Mamba conv_state contiguous fix.
 
+use mlxcel_core::weights::WeightMap;
 use mlxcel_core::{dtype, generate::ModelStateSnapshot, utils::slice_axis};
 
 /// Simulate 50 decode steps of conv-state update and assert the stored shape
@@ -103,14 +104,85 @@ fn mamba_cache_snapshot_restore_round_trips_state_shapes() {
     assert_eq!(mlxcel_core::array_shape(ssm), vec![1, 2, 4, 8]);
 }
 
-/// Mamba takes its embedding table out of the `WeightMap` by `remove`, under
-/// either the `backbone.embeddings` or the `model.embed_tokens` spelling, so it
-/// cannot address the single-prefix `UnifiedEmbedding::from_weights` and never
-/// reaches `reconcile_quantization_layout`. Before issue #958 the declared pair
-/// was stored verbatim on a hand-built `QuantizedEmbedding` and divided by
-/// inside `quantized_embedding` at the first token, which crosses the cxx
-/// bridge as `UniquePtr<MlxArray>` rather than `Result` and therefore aborts the
-/// process instead of failing the load.
+/// The config every embedding-load test below shares.
+///
+/// `num_hidden_layers: 0` plus tied embeddings reduces the load to the
+/// embedding table and the final norm, so an honest case loads all the way
+/// through rather than stopping at an unrelated missing weight. `vocab_size`
+/// and `hidden_size` are both 8, which is the width every fixture geometry
+/// below is sized against.
+fn embedding_config(group_size: i32, bits: i32) -> super::MambaConfig {
+    serde_json::from_value(serde_json::json!({
+        "model_type": "mamba",
+        "vocab_size": 8,
+        "hidden_size": 8,
+        "intermediate_size": 16,
+        "state_size": 4,
+        "num_hidden_layers": 0,
+        "conv_kernel": 4,
+        "time_step_rank": 1,
+        "tie_word_embeddings": true,
+        "quantization": { "group_size": group_size, "bits": bits },
+    }))
+    .expect("test config must parse")
+}
+
+/// The final norm, the only non-embedding weight a `num_hidden_layers: 0` load
+/// still asks for.
+fn embedding_test_base_weights() -> WeightMap {
+    let mut weights = WeightMap::new();
+    weights.insert(
+        "backbone.norm_f.weight".to_string(),
+        mlxcel_core::from_slice_f32(&[1.0; 8], &[8]),
+    );
+    weights
+}
+
+/// Affine 4-bit table under `prefix`, honest at `embedding_config(8, 4)`:
+/// packed_in * 32 == bits * groups * gs, i.e. 1 * 32 == 4 * 1 * 8, and the
+/// dequantized width scales.shape(-1) * group_size == 8 == hidden_size. The
+/// table is [vocab, packed_in].
+fn affine_embedding_weights(prefix: &str) -> WeightMap {
+    let mut weights = embedding_test_base_weights();
+    weights.insert(
+        format!("{prefix}.weight"),
+        mlxcel_core::from_slice_f32(&[0.0; 8], &[8, 1]),
+    );
+    weights.insert(
+        format!("{prefix}.scales"),
+        mlxcel_core::from_slice_f32(&[1.0; 8], &[8, 1]),
+    );
+    weights.insert(
+        format!("{prefix}.biases"),
+        mlxcel_core::from_slice_f32(&[0.0; 8], &[8, 1]),
+    );
+    weights
+}
+
+/// Block-float table under `prefix`: `.scales` and no `.biases`, which is what
+/// an mxfp4 / nvfp4 / mxfp8 export ships. `packed_in` is the stored width, so
+/// the dequantized width is packed_in * 32 / bits and must come out at
+/// hidden_size (8) for the declared bits.
+fn block_float_embedding_weights(prefix: &str, packed_in: i32) -> WeightMap {
+    let mut weights = embedding_test_base_weights();
+    let elems = 8 * packed_in as usize;
+    weights.insert(
+        format!("{prefix}.weight"),
+        mlxcel_core::from_slice_f32(&vec![0.0; elems], &[8, packed_in]),
+    );
+    weights.insert(
+        format!("{prefix}.scales"),
+        mlxcel_core::from_slice_f32(&[1.0; 8], &[8, 1]),
+    );
+    weights
+}
+
+/// Mamba reaches `QuantizedEmbedding` through `UnifiedEmbedding::from_weights`,
+/// and therefore through `reconcile_quantization_layout`. Before issue #958 it
+/// hand-built the layer and stored the declared pair verbatim; the pair was then
+/// divided by inside `quantized_embedding` at the first token, which crosses the
+/// cxx bridge as `UniquePtr<MlxArray>` rather than `Result` and therefore aborts
+/// the process instead of failing the load.
 ///
 /// This drives the real `MambaModel::from_weights` rather than the pure bounds
 /// helper, so the guard is exercised where a checkpoint actually reaches it. The
@@ -118,71 +190,125 @@ fn mamba_cache_snapshot_restore_round_trips_state_shapes() {
 /// fails cleanly here rather than aborting the test binary.
 #[test]
 fn mamba_rejects_quantization_params_that_would_abort_the_embedding_lookup() {
-    use super::{MambaConfig, MambaModel};
-    use mlxcel_core::weights::WeightMap;
-
-    // `num_hidden_layers: 0` plus tied embeddings reduces the load to the
-    // embedding table and the final norm, so the honest case loads all the way
-    // through rather than stopping at an unrelated missing weight.
-    let config_with = |group_size: i32, bits: i32| -> MambaConfig {
-        serde_json::from_value(serde_json::json!({
-            "model_type": "mamba",
-            "vocab_size": 8,
-            "hidden_size": 8,
-            "intermediate_size": 16,
-            "state_size": 4,
-            "num_hidden_layers": 0,
-            "conv_kernel": 4,
-            "time_step_rank": 1,
-            "tie_word_embeddings": true,
-            "quantization": { "group_size": group_size, "bits": bits },
-        }))
-        .expect("test config must parse")
-    };
-
-    // Honest affine 4-bit geometry: packed_in * 32 == bits * groups * gs,
-    // i.e. 1 * 32 == 4 * 1 * 8. The table is [vocab, packed_in].
-    let build_weights = || {
-        let mut weights = WeightMap::new();
-        weights.insert(
-            "backbone.embeddings.weight".to_string(),
-            mlxcel_core::from_slice_f32(&[0.0; 8], &[8, 1]),
-        );
-        weights.insert(
-            "backbone.embeddings.scales".to_string(),
-            mlxcel_core::from_slice_f32(&[1.0; 8], &[8, 1]),
-        );
-        weights.insert(
-            "backbone.embeddings.biases".to_string(),
-            mlxcel_core::from_slice_f32(&[0.0; 8], &[8, 1]),
-        );
-        weights.insert(
-            "backbone.norm_f.weight".to_string(),
-            mlxcel_core::from_slice_f32(&[1.0; 8], &[8]),
-        );
-        weights
-    };
+    use super::MambaModel;
 
     // Positive control first, so a guard that rejects everything quantized
     // cannot pass this test.
-    MambaModel::from_weights(config_with(8, 4), build_weights())
-        .expect("an honest affine pair must still load a quantized Mamba embedding");
+    MambaModel::from_weights(
+        embedding_config(8, 4),
+        affine_embedding_weights("backbone.embeddings"),
+    )
+    .expect("an honest affine pair must still load a quantized Mamba embedding");
 
     for (group_size, bits, field) in crate::models::switch_layers::HOSTILE_QUANT_PARAMS {
-        let err = MambaModel::from_weights(config_with(group_size, bits), build_weights())
-            .err()
-            .unwrap_or_else(|| {
-                panic!("Mamba must reject group_size {group_size} / bits {bits} at load")
-            })
-            .to_string();
+        let err = MambaModel::from_weights(
+            embedding_config(group_size, bits),
+            affine_embedding_weights("backbone.embeddings"),
+        )
+        .err()
+        .unwrap_or_else(|| {
+            panic!("Mamba must reject group_size {group_size} / bits {bits} at load")
+        })
+        .to_string();
         assert!(err.contains(field), "unhelpful error: {err}");
     }
 
     // A float embedding table carries no packing, so the params are irrelevant
-    // there and must not be enforced.
-    let mut regular = build_weights();
-    regular.remove("backbone.embeddings.scales");
-    regular.remove("backbone.embeddings.biases");
-    MambaModel::from_weights(config_with(0, 0), regular)
+    // there and must not be enforced. It has to be a genuine [vocab, hidden]
+    // table rather than the packed one with its scales stripped, because the
+    // shared table guard now checks the width of a non-quantized table against
+    // hidden_size (see `mamba_rejects_an_embedding_table_narrower_than_hidden_size`).
+    let mut regular = embedding_test_base_weights();
+    regular.insert(
+        "backbone.embeddings.weight".to_string(),
+        mlxcel_core::from_slice_f32(&[0.0; 64], &[8, 8]),
+    );
+    MambaModel::from_weights(embedding_config(0, 0), regular)
         .expect("a float embedding table must not be gated on quantization params");
+}
+
+/// Issue #976: a block-float embedding carries `.scales` and no `.biases`, and
+/// must still load as quantized.
+///
+/// Affine stores zero points; mxfp4 / nvfp4 / mxfp8 do not, which is what
+/// `infer_quantization_mode` keys on. The old gate required both planes, so a
+/// block-float table fell to `Embedding::new` over the raw packed uint32 tensor,
+/// whose lookup is a bare `take` with no dequantization: the result is a uint32
+/// array whose last axis is the packed width rather than hidden_size.
+///
+/// The assertion is that the load succeeds, not that the variant is `Quantized`:
+/// `MambaModel::embeddings` is private and this is a sibling module, and a
+/// forward pass on a regressed load aborts the test binary rather than failing
+/// it. The shared table guard supplies the observable instead, because a
+/// regression stores a [8, packed_in] table as non-quantized and the guard
+/// rejects a non-quantized width that is not hidden_size.
+#[test]
+fn mamba_loads_a_block_float_embedding_as_quantized() {
+    use super::MambaModel;
+
+    // mxfp4: infer_quantization_mode(false, 8, 4) == "mxfp4", dequantized width
+    // packed_in * 32 / bits == 1 * 8 == 8 == hidden_size.
+    MambaModel::from_weights(
+        embedding_config(8, 4),
+        block_float_embedding_weights("backbone.embeddings", 1),
+    )
+    .expect("an mxfp4 embedding (scales, no biases) must load as quantized");
+
+    // mxfp8: bits 8 picks the mode, and 8-bit packing doubles the stored width
+    // for the same dequantized 8, so packed_in is 2 here.
+    MambaModel::from_weights(
+        embedding_config(8, 8),
+        block_float_embedding_weights("backbone.embeddings", 2),
+    )
+    .expect("an mxfp8 embedding (scales, no biases) must load as quantized");
+}
+
+/// The embedding prefix is checkpoint-dependent: `backbone.embeddings` in the
+/// original mamba export, `model.embed_tokens` in the transformers conversion.
+/// Resolving it is the only reason this cannot pass a fixed prefix to the shared
+/// loader, so both spellings must reach the same code path, and a checkpoint
+/// carrying neither must say so naming both.
+#[test]
+fn mamba_resolves_both_embedding_prefix_spellings() {
+    use super::MambaModel;
+
+    MambaModel::from_weights(
+        embedding_config(8, 4),
+        affine_embedding_weights("model.embed_tokens"),
+    )
+    .expect("the transformers spelling must load an affine embedding");
+    MambaModel::from_weights(
+        embedding_config(8, 4),
+        block_float_embedding_weights("model.embed_tokens", 1),
+    )
+    .expect("the transformers spelling must load a block-float embedding");
+
+    let err = MambaModel::from_weights(embedding_config(8, 4), embedding_test_base_weights())
+        .err()
+        .expect("a checkpoint with no embedding table at all must fail the load")
+        .to_string();
+    assert!(err.contains("backbone.embeddings.weight"), "{err}");
+    assert!(err.contains("model.embed_tokens.weight"), "{err}");
+}
+
+/// The shared `validate_embedding_table` guard is new for this family. A
+/// non-quantized table whose width is not the model width feeds a wrong-width
+/// hidden state into the first norm, which throws inside MLX and crosses the cxx
+/// bridge as an uncatchable abort rather than a load error, so it has to be
+/// caught here. The message names the config field the reader will find in their
+/// `config.json`.
+#[test]
+fn mamba_rejects_an_embedding_table_narrower_than_hidden_size() {
+    use super::MambaModel;
+
+    let mut narrow = embedding_test_base_weights();
+    narrow.insert(
+        "backbone.embeddings.weight".to_string(),
+        mlxcel_core::from_slice_f32(&[0.0; 8], &[8, 1]),
+    );
+    let err = MambaModel::from_weights(embedding_config(0, 0), narrow)
+        .err()
+        .expect("a float embedding table narrower than hidden_size must fail the load")
+        .to_string();
+    assert!(err.contains("hidden_size"), "unhelpful error: {err}");
 }


### PR DESCRIPTION
## Summary

`MambaModel::from_weights` and `Mamba2Model::from_weights` decided whether the embedding table was quantized by requiring both `.scales` and `.biases`. Affine quantization stores zero-point biases; the block-float modes (mxfp4, nvfp4, mxfp8) carry none by design, which is exactly what `infer_quantization_mode` keys on. A block-float embedding export therefore fell to the else branch and built a plain `Embedding` over the raw packed uint32 table. `Embedding::forward` is a bare `mlx::core::take` with no dequantization, so the lookup returned a uint32 array whose last axis was the packed width (`hidden_size * bits / 32`) rather than `hidden_size`. Nothing rejected it at load: the model reported as loaded and the failure surfaced later as garbage hidden states, or as an MLX C++ throw crossing the cxx bridge as an uncatchable `std::terminate` at the first forward pass.

The defect is latent today because no mamba or mamba2 checkpoint in the recommended set ships a block-float embedding. It goes live the moment one appears, and it would present as wrong output rather than as a load error, which is the expensive way to find it.

Both files now resolve the embedding prefix (`backbone.embeddings` or `model.embed_tokens`, one `contains_key` probe) and hand the whole map to `UnifiedEmbedding::from_weights`, which gates on `.scales` alone and infers the mode from bias presence.

## This supersedes PR #972

#972, merged for issue #958, declined to route mamba through the shared loader and instead made the hand-built `QuantizedEmbedding::new` fallible. Two of its four stated reasons do not hold:

- "takes the table out of the map by `remove`, so it cannot address a single-prefix map loader": the prefix is resolvable at the call site with one `contains_key`, and the `remove` maintains no invariant. The same function already loads in_proj / x_proj / dt_proj / out_proj / lm_head through `UnifiedLinear::from_weights(&weights, ...)`, which copies and leaves the keys in the map, and there is no leftover-weight check anywhere in the load path.
- "treats `.biases` as optional where mamba requires both": that requirement is the bug this PR fixes, so the reason is circular.

The other two reasons are real, and this PR accepts them as costs:

- Routing costs one lazy `ffi::copy` (`mlx::core::copy`) of the embedding table instead of moving it out of the map. That is a lazy-array node share rather than an element copy, and it is what every other model already pays.
- The loader stores the reconciled pair rather than the declared one. For a uniform-quant checkpoint reconciliation is a no-op and emits no warning; for a mixed-precision one it is a strict improvement, since the declared top-level pair is the wrong one for an embedding quantized at a different bit width.

Routing through the shared loader also picks up `reconcile_quantization_layout` and therefore `validate_quantization_params`, which is the bound `QuantizedEmbedding::new` was carrying on its own since #958.

## New load-time rejection for these two families

Both files now call `validate_embedding_table` (`src/models/gpt2.rs`) right after the embedding loads. This is a NEW rejection for mamba and mamba2: it requires a 2-D table with non-zero rows, `vocab_size <= rows`, and, for a non-quantized table, a width equal to `hidden_size` (for a quantized table it reconstructs the dequantized width as `scales.shape(-1) * group_size` through `validate_quantized_packing`). It is the same guard BailingMoe, Gpt2, GptBigCode and GptNeoX already run, so this is not a new policy, only a new caller.

It is also what gives the regression tests an observable. `MambaModel::embeddings` is private and the test module is a sibling rather than a descendant, so a test cannot inspect the variant, and a forward pass on a regressed load aborts the test binary instead of failing it. With the guard in place the assertion is simply that the block-float load succeeds, because the regressed path (a `Regular` embedding over the packed table) now fails at load.

## `QuantizedEmbedding::new` removed

After this change it has zero production callers across all four workspace members (verified by grep). It is removed, so the next family cannot rebuild the same defect by hand-building an affine-only layer that requires a `biases` argument. `QuantizedMultiLinear::new` stays: it is pre-emptive and also callerless, but it takes `Option<biases>` and so cannot express this bug.

## What changed

- `src/models/mamba.rs`, `src/models/mamba2.rs`: prefix resolution plus `UnifiedEmbedding::from_weights`, then `validate_embedding_table`. The missing-embedding error still names both spellings rather than regressing to the loader's single-prefix "Weight not found". The stale comment describing the `remove` chain is replaced with one that says why the gate is `.scales`-only.
- `src/lib/mlxcel-core/src/layers.rs`: `QuantizedEmbedding::new` removed, with the reason recorded on `from_weights`; the three doc references to it retargeted; the `QuantizedEmbedding` half of `hand_built_quantized_layers_bound_their_declared_params` retargeted at `QuantizedEmbedding::from_weights` over a synthetic `WeightMap`, keeping the `QuantizedMultiLinear::new` half intact.
- `src/models/mamba_tests.rs`, `src/models/mamba2_tests.rs`: the existing fixture closures hoisted into shared helpers, the existing test's doc comment corrected, and three new tests per family (see below).
- `src/models/gpt2.rs`, `src/lib/mlxcel-core/src/layers.rs`: "Used by" lists updated to include Mamba and Mamba2.
- `docs/adding-models.md`: `QuantizedEmbedding::new` removed from the table of loaders that already carry the quant bound, with a note explaining why hand-building an embedding is no longer the answer for a multi-spelling prefix.

## Tests

Per family:

- The block-float regression (`*_loads_a_block_float_embedding_as_quantized`): mxfp4 at `packed_in` 1 and mxfp8 at `packed_in` 2, both dequantizing to `hidden_size` 8, `.scales` present and `.biases` absent, load must succeed. nvfp4 is not covered because group_size 16 cannot describe a width of 8 with a non-zero number of groups, and inventing a second `hidden_size` for it would have been dishonest geometry.
- Both prefix spellings (`*_resolves_both_embedding_prefix_spellings`): affine and block-float both load under `model.embed_tokens.*`, and a checkpoint carrying neither spelling fails with a message naming both.
- The guard itself (`*_rejects_an_embedding_table_narrower_than_hidden_size`): a float table whose width is not `hidden_size` errors at load with a message naming `hidden_size`.
- The existing float-table case in `*_rejects_quantization_params_that_would_abort_the_embedding_lookup` now inserts a genuine [8, 8] float table instead of reusing the packed [8, 1] one with its scales stripped, because the new guard correctly rejects the latter. The guard was not weakened to accommodate the old fixture.
- The hostile-pair loop over `switch_layers::HOSTILE_QUANT_PARAMS` is unchanged and still passes: with `.biases` present the inferred mode is affine, and `reconcile_quantization_layout` calls `validate_quantization_params` before it looks at any shape.

The block-float tests were confirmed to fail on regression by temporarily restoring the bias-requiring gate in `mamba.rs`: both new cases failed with `backbone.embeddings.weight is [8, 1] but hidden_size is 8`, which is a load error rather than an abort. The temporary change was reverted before committing.

## Test plan

Commands actually run, all green:

- [x] `cargo fmt --check`
- [x] `cargo clippy --lib --tests -- -D warnings`
- [x] `cargo clippy -p mlxcel-core --lib --tests -- -D warnings`
- [x] `cargo check --lib --tests`
- [x] `cargo check -p mlxcel-core --lib --tests`
- [x] `cargo test --lib models::mamba` (14 passed, 2 ignored; the ignored two are the pre-existing `requires serial MLX execution` conv-state tests)
- [x] `cargo test -p mlxcel-core --lib layers::tests` (72 passed), including `hand_built_quantized_layers_bound_their_declared_params`
- [x] `cargo test --lib models::gpt2::tests` (27 passed), since the shared guard gained callers

Orchestrator-side, after the above:

- [x] `cargo clippy --workspace --all-targets -- -D warnings` (all four workspace members, every target), exit 0
- [x] `cargo fmt --all -- --check`, the exact CI gate
- [x] Real-checkpoint shape verification of the new guard against `falcon-mamba-7b-4bit`, `mamba2-1.3b-4bit` and `mamba2-130m`, see the comment below

Pre-existing and unrelated: a bare `cargo test --workspace --lib` on a Linux/CUDA box built without `--features cuda` aborts the root lib test binary with `terminate called ... [cuda_kernel] No CUDA back-end` (SIGABRT) after roughly 1926 tests. This was confirmed to reproduce identically on `main` at e1ea5c2f with the same warm target directory (1927 tests, same abort), so it is a property of this build configuration rather than of this branch. Every candidate test in the in-flight window passes when run individually. CI does not use this configuration.

Not run: the acceptance criterion comparing `models/falcon-mamba-7b-4bit` output before and after. No mamba or mamba2 checkpoint is present under `models/` on this machine, so the affine path was not confirmed against real weights. The affine path is covered by the synthetic positive control in the existing guard test, which is weaker evidence. `cargo clippy --all-targets -- -D warnings` and the full workspace test suite were also not run here; only `--lib --tests` was, plus the narrow test filters above.

Closes #976

