### PR TITLE
fix(models): MLA kv_b_proj sanitizers reject scales-without-biases

### DIFF
--- a/src/models/deepseek_v3.rs
+++ b/src/models/deepseek_v3.rs
@@ -1136,9 +1136,23 @@ impl DeepSeekV3Model {
                 let s = weights
                     .remove(&format!("{}.kv_b_proj.scales", prefix))
                     .unwrap();
-                let b = weights
-                    .remove(&format!("{}.kv_b_proj.biases", prefix))
-                    .unwrap();
+                // `is_quantized` gates on `.scales` alone, and the block-float
+                // modes (mxfp4 / nvfp4 / mxfp8) ship scales with no zero
+                // points, so a block-float export satisfies that gate and
+                // arrives here carrying no `.biases` plane. The `.unwrap()`
+                // this replaces turned that into a panic during sanitization,
+                // which in the server takes the process down rather than
+                // rejecting one model load (issue #1026). `dequantize` below is
+                // hardcoded `"affine"` and so could not decompose such a plane
+                // in any case; what this buys is a load error naming the key
+                // that is missing.
+                let b_key = format!("{}.kv_b_proj.biases", prefix);
+                let b = weights.remove(&b_key).ok_or_else(|| {
+                    format!(
+                        "layer {l}: kv_b_proj has scales but no biases at key `{b_key}`; \
+                         the checkpoint may be corrupted or only partially converted"
+                    )
+                })?;
 
                 // Solve the packed pair from the shapes and bound it before it
                 // reaches `dequantize`. The shared helper checks each divisor
@@ -1978,6 +1992,44 @@ mod tests {
         }
     }
 
+    /// An affine 4-bit `kv_b_proj` for every layer in `cfg`.
+    ///
+    /// Honest geometry at `kv_lora_rank` 16: packed_in * 32 == bits *
+    /// num_groups * group_size (2 * 32 == 4 * 1 * 16). `test_config_dense_direct_q`
+    /// gives num_attention_heads 2, qk_nope_head_dim 4, v_head_dim 4, so
+    /// rows = 2 * 8 = 16.
+    ///
+    /// The packed plane is UINT32, not a float ramp: `dequantize` rejects any
+    /// other packed dtype by throwing, and that throw is the uncatchable abort
+    /// these guards exist to keep out of the forward path.
+    fn affine_kv_b_proj_weights(cfg: &DeepSeekV3Config) -> WeightMap {
+        let heads = cfg.num_attention_heads as i32;
+        let head_dim = (cfg.qk_nope_head_dim + cfg.v_head_dim) as i32;
+        let rows = heads * head_dim;
+        let mut weights = WeightMap::new();
+        for l in 0..cfg.num_hidden_layers {
+            let prefix = format!("model.layers.{l}.self_attn.kv_b_proj");
+            weights.insert(
+                format!("{prefix}.weight"),
+                mlxcel_core::zeros(&[rows, 2], mlxcel_core::dtype::UINT32),
+            );
+            insert_ramp(&mut weights, &format!("{prefix}.scales"), &[rows, 1]);
+            insert_ramp(&mut weights, &format!("{prefix}.biases"), &[rows, 1]);
+        }
+        weights
+    }
+
+    /// The same plane an mxfp4 / nvfp4 / mxfp8 export ships: `.scales`
+    /// present, `.biases` absent, because the block-float modes carry no zero
+    /// points.
+    fn block_float_kv_b_proj_weights(cfg: &DeepSeekV3Config) -> WeightMap {
+        let mut weights = affine_kv_b_proj_weights(cfg);
+        for l in 0..cfg.num_hidden_layers {
+            weights.remove(&format!("model.layers.{l}.self_attn.kv_b_proj.biases"));
+        }
+        weights
+    }
+
     /// The MLA `kv_b_proj` pair `DeepSeekV3Model::sanitize_weights` decomposes
     /// is solved from `kv_lora_rank` and two tensor axes rather than declared,
     /// and every input is untrusted: `kv_lora_rank` comes from `config.json`
@@ -1994,36 +2046,13 @@ mod tests {
     /// a regression fails cleanly here instead of aborting the test binary.
     #[test]
     fn quantized_kv_b_proj_rejects_a_kv_lora_rank_no_packing_can_describe() {
-        // Honest affine 4-bit geometry: packed_in * 32 == bits * num_groups *
-        // group_size (2 * 32 == 4 * 1 * 16). `test_config_dense_direct_q`
-        // gives num_attention_heads 2, qk_nope_head_dim 4, v_head_dim 4, so
-        // rows = 2 * 8 = 16.
-        let build = |cfg: &DeepSeekV3Config| {
-            let heads = cfg.num_attention_heads as i32;
-            let head_dim = (cfg.qk_nope_head_dim + cfg.v_head_dim) as i32;
-            let rows = heads * head_dim;
-            let mut weights = WeightMap::new();
-            for l in 0..cfg.num_hidden_layers {
-                let prefix = format!("model.layers.{l}.self_attn.kv_b_proj");
-                // UINT32, not a float ramp: `dequantize` rejects any other
-                // packed dtype by throwing, and that throw is the uncatchable
-                // abort this guard exists to keep out of the forward path.
-                weights.insert(
-                    format!("{prefix}.weight"),
-                    mlxcel_core::zeros(&[rows, 2], mlxcel_core::dtype::UINT32),
-                );
-                insert_ramp(&mut weights, &format!("{prefix}.scales"), &[rows, 1]);
-                insert_ramp(&mut weights, &format!("{prefix}.biases"), &[rows, 1]);
-            }
-            weights
-        };
-
         // Positive control first, so a guard that rejected every quantized
         // kv_b_proj could not pass this test.
         let mut honest = test_config_dense_direct_q();
         honest.kv_lora_rank = 16;
-        let sanitized = DeepSeekV3Model::sanitize_weights(build(&honest), &honest)
-            .expect("an honest quantized kv_b_proj must still sanitize");
+        let sanitized =
+            DeepSeekV3Model::sanitize_weights(affine_kv_b_proj_weights(&honest), &honest)
+                .expect("an honest quantized kv_b_proj must still sanitize");
         assert!(sanitized.contains_key("model.layers.0.self_attn.embed_q.weight"));
 
         // A zero `kv_lora_rank` is Rust integer division by zero on the very
@@ -2031,18 +2060,20 @@ mod tests {
         // than after.
         let mut zero_rank = honest.clone();
         zero_rank.kv_lora_rank = 0;
-        let err = DeepSeekV3Model::sanitize_weights(build(&zero_rank), &zero_rank)
-            .err()
-            .unwrap_or_else(|| panic!("kv_lora_rank 0 must be refused, not divided by"));
+        let err =
+            DeepSeekV3Model::sanitize_weights(affine_kv_b_proj_weights(&zero_rank), &zero_rank)
+                .err()
+                .unwrap_or_else(|| panic!("kv_lora_rank 0 must be refused, not divided by"));
         assert!(err.contains("kv_lora_rank"), "unhelpful error: {err}");
 
         // A large `kv_lora_rank` truncates the solved bit width to 0, which
         // is the divisor MLX would then divide by.
         let mut wide_rank = honest.clone();
         wide_rank.kv_lora_rank = 4096;
-        let err = DeepSeekV3Model::sanitize_weights(build(&wide_rank), &wide_rank)
-            .err()
-            .unwrap_or_else(|| panic!("a solved bit width of 0 must be refused"));
+        let err =
+            DeepSeekV3Model::sanitize_weights(affine_kv_b_proj_weights(&wide_rank), &wide_rank)
+                .err()
+                .unwrap_or_else(|| panic!("a solved bit width of 0 must be refused"));
         assert!(err.contains("bits"), "unhelpful error: {err}");
 
         // A non-quantized kv_b_proj carries no packing, so the pair is never
@@ -2060,5 +2091,45 @@ mod tests {
         );
         DeepSeekV3Model::sanitize_weights(float_only, &wide_rank)
             .expect("a float kv_b_proj must not be gated on quantization params");
+    }
+
+    /// Issue #1026: `sanitize_weights` decides `kv_b_proj` is quantized on
+    /// `.scales` alone, then used to take `.biases` with `.unwrap()`.
+    ///
+    /// Affine stores zero points; the block-float modes (mxfp4 / nvfp4 /
+    /// mxfp8) do not, which is exactly what `infer_quantization_mode` keys on.
+    /// A block-float `kv_b_proj` therefore satisfies the `.scales` gate and
+    /// arrives at the `.biases` removal with nothing to take, and the
+    /// `.unwrap()` made that a panic during weight sanitization. In the server
+    /// that takes the process down rather than rejecting one model load, which
+    /// is strictly worse than the load error it should be.
+    ///
+    /// The decomposition still dequantizes as `"affine"`, so a genuine
+    /// block-float `kv_b_proj` is not supported either way: what this pins is
+    /// that it is refused by name instead of unwinding. The assertion is on
+    /// the returned `Result` and no forward pass runs, so a regression fails
+    /// cleanly here.
+    #[test]
+    fn quantized_kv_b_proj_rejects_scales_with_no_biases() {
+        let mut cfg = test_config_dense_direct_q();
+        cfg.kv_lora_rank = 16;
+
+        // Positive control first, so a check that rejected every quantized
+        // kv_b_proj could not pass this test.
+        let sanitized = DeepSeekV3Model::sanitize_weights(affine_kv_b_proj_weights(&cfg), &cfg)
+            .expect("a kv_b_proj carrying both planes must still sanitize");
+        assert!(sanitized.contains_key("model.layers.0.self_attn.embed_q.weight"));
+
+        let err = DeepSeekV3Model::sanitize_weights(block_float_kv_b_proj_weights(&cfg), &cfg)
+            .err()
+            .expect("scales with no biases must be refused at load, not unwrapped");
+        assert!(
+            err.contains("model.layers.0.self_attn.kv_b_proj.biases"),
+            "the error must name the key that is missing, got: {err}"
+        );
+        assert!(
+            err.contains("scales but no biases"),
+            "the wording must match the other four MLA sanitizers, got: {err}"
+        );
     }
 }

--- a/src/models/deepseek_v32.rs
+++ b/src/models/deepseek_v32.rs
@@ -918,9 +918,23 @@ impl DeepSeekV32Model {
                 let s = weights
                     .remove(&format!("{}.kv_b_proj.scales", prefix))
                     .unwrap();
-                let b = weights
-                    .remove(&format!("{}.kv_b_proj.biases", prefix))
-                    .unwrap();
+                // `is_quantized` gates on `.scales` alone, and the block-float
+                // modes (mxfp4 / nvfp4 / mxfp8) ship scales with no zero
+                // points, so a block-float export satisfies that gate and
+                // arrives here carrying no `.biases` plane. The `.unwrap()`
+                // this replaces turned that into a panic during sanitization,
+                // which in the server takes the process down rather than
+                // rejecting one model load (issue #1026). `dequantize` below is
+                // hardcoded `"affine"` and so could not decompose such a plane
+                // in any case; what this buys is a load error naming the key
+                // that is missing.
+                let b_key = format!("{}.kv_b_proj.biases", prefix);
+                let b = weights.remove(&b_key).ok_or_else(|| {
+                    format!(
+                        "layer {l}: kv_b_proj has scales but no biases at key `{b_key}`; \
+                         the checkpoint may be corrupted or only partially converted"
+                    )
+                })?;
                 // Solve the packed pair from the shapes and bound it before it
                 // reaches `dequantize`. The shared helper checks each divisor
                 // before dividing: `kv_lora_rank` is a config field and the

--- a/src/models/deepseek_v32_tests.rs
+++ b/src/models/deepseek_v32_tests.rs
@@ -539,6 +539,41 @@ fn deepseek_v32_switch_linear_rejects_quantization_params_that_would_abort_gathe
     }
 }
 
+/// An affine 4-bit `kv_b_proj` for every layer in `args`.
+///
+/// Honest geometry at `kv_lora_rank` 16: packed_in * 32 == bits * num_groups *
+/// group_size (2 * 32 == 4 * 1 * 16).
+///
+/// The packed plane is UINT32, not a float weight: `dequantize` rejects any
+/// other packed dtype by throwing, and that throw is the uncatchable abort
+/// these guards exist to keep out of the forward path.
+fn affine_kv_b_proj_weights(args: &ModelArgs) -> WeightMap {
+    let num_heads = args.num_attention_heads as i32;
+    let head_dim = (args.qk_nope_head_dim + args.v_head_dim) as i32;
+    let rows = num_heads * head_dim;
+    let mut weights = WeightMap::new();
+    for l in 0..args.num_hidden_layers {
+        let prefix = format!("model.layers.{l}.self_attn.kv_b_proj");
+        weights.insert(
+            format!("{prefix}.weight"),
+            mlxcel_core::zeros(&[rows, 2], mlxcel_core::dtype::UINT32),
+        );
+        weights.insert(format!("{prefix}.scales"), f32_weight(&[rows, 1]));
+        weights.insert(format!("{prefix}.biases"), f32_weight(&[rows, 1]));
+    }
+    weights
+}
+
+/// The same plane an mxfp4 / nvfp4 / mxfp8 export ships: `.scales` present,
+/// `.biases` absent, because the block-float modes carry no zero points.
+fn block_float_kv_b_proj_weights(args: &ModelArgs) -> WeightMap {
+    let mut weights = affine_kv_b_proj_weights(args);
+    for l in 0..args.num_hidden_layers {
+        weights.remove(&format!("model.layers.{l}.self_attn.kv_b_proj.biases"));
+    }
+    weights
+}
+
 /// The MLA `kv_b_proj` pair `DeepSeekV32Model::sanitize_weights` decomposes is
 /// solved from `kv_lora_rank` and two tensor axes rather than declared, and
 /// every input is untrusted: `kv_lora_rank` comes from `config.json` and the
@@ -555,34 +590,13 @@ fn deepseek_v32_switch_linear_rejects_quantization_params_that_would_abort_gathe
 /// fails cleanly here instead of aborting the test binary.
 #[test]
 fn quantized_kv_b_proj_rejects_a_kv_lora_rank_no_packing_can_describe() {
-    // Honest affine 4-bit geometry: packed_in * 32 == bits * num_groups *
-    // group_size (2 * 32 == 4 * 1 * 16).
-    let build = |args: &ModelArgs| {
-        let num_heads = args.num_attention_heads as i32;
-        let head_dim = (args.qk_nope_head_dim + args.v_head_dim) as i32;
-        let rows = num_heads * head_dim;
-        let mut weights = WeightMap::new();
-        for l in 0..args.num_hidden_layers {
-            let prefix = format!("model.layers.{l}.self_attn.kv_b_proj");
-            // UINT32, not a float weight: `dequantize` rejects any other
-            // packed dtype by throwing, and that throw is the uncatchable abort
-            // this guard exists to keep out of the forward path.
-            weights.insert(
-                format!("{prefix}.weight"),
-                mlxcel_core::zeros(&[rows, 2], mlxcel_core::dtype::UINT32),
-            );
-            weights.insert(format!("{prefix}.scales"), f32_weight(&[rows, 1]));
-            weights.insert(format!("{prefix}.biases"), f32_weight(&[rows, 1]));
-        }
-        weights
-    };
-
     // Positive control first, so a guard that rejected every quantized
     // kv_b_proj could not pass this test.
     let mut honest = tiny_mla_config(2048);
     honest.kv_lora_rank = 16;
-    let sanitized = super::DeepSeekV32Model::sanitize_weights(build(&honest), &honest)
-        .expect("an honest quantized kv_b_proj must still sanitize");
+    let sanitized =
+        super::DeepSeekV32Model::sanitize_weights(affine_kv_b_proj_weights(&honest), &honest)
+            .expect("an honest quantized kv_b_proj must still sanitize");
     assert!(sanitized.contains_key("model.layers.0.self_attn.embed_q.weight"));
 
     // A zero `kv_lora_rank` is Rust integer division by zero on the very
@@ -590,18 +604,20 @@ fn quantized_kv_b_proj_rejects_a_kv_lora_rank_no_packing_can_describe() {
     // after.
     let mut zero_rank = honest.clone();
     zero_rank.kv_lora_rank = 0;
-    let err = super::DeepSeekV32Model::sanitize_weights(build(&zero_rank), &zero_rank)
-        .err()
-        .unwrap_or_else(|| panic!("kv_lora_rank 0 must be refused, not divided by"));
+    let err =
+        super::DeepSeekV32Model::sanitize_weights(affine_kv_b_proj_weights(&zero_rank), &zero_rank)
+            .err()
+            .unwrap_or_else(|| panic!("kv_lora_rank 0 must be refused, not divided by"));
     assert!(err.contains("kv_lora_rank"), "unhelpful error: {err}");
 
     // A large `kv_lora_rank` truncates the solved bit width to 0, which is
     // the divisor MLX would then divide by.
     let mut wide_rank = honest.clone();
     wide_rank.kv_lora_rank = 4096;
-    let err = super::DeepSeekV32Model::sanitize_weights(build(&wide_rank), &wide_rank)
-        .err()
-        .unwrap_or_else(|| panic!("a solved bit width of 0 must be refused"));
+    let err =
+        super::DeepSeekV32Model::sanitize_weights(affine_kv_b_proj_weights(&wide_rank), &wide_rank)
+            .err()
+            .unwrap_or_else(|| panic!("a solved bit width of 0 must be refused"));
     assert!(err.contains("bits"), "unhelpful error: {err}");
 
     // A non-quantized kv_b_proj carries no packing, so the pair is never
@@ -618,4 +634,45 @@ fn quantized_kv_b_proj_rejects_a_kv_lora_rank_no_packing_can_describe() {
     );
     super::DeepSeekV32Model::sanitize_weights(float_only, &wide_rank)
         .expect("a float kv_b_proj must not be gated on quantization params");
+}
+
+/// Issue #1026: `sanitize_weights` decides `kv_b_proj` is quantized on
+/// `.scales` alone, then used to take `.biases` with `.unwrap()`.
+///
+/// Affine stores zero points; the block-float modes (mxfp4 / nvfp4 / mxfp8) do
+/// not, which is exactly what `infer_quantization_mode` keys on. A block-float
+/// `kv_b_proj` therefore satisfies the `.scales` gate and arrives at the
+/// `.biases` removal with nothing to take, and the `.unwrap()` made that a
+/// panic during weight sanitization. In the server that takes the process down
+/// rather than rejecting one model load, which is strictly worse than the load
+/// error it should be.
+///
+/// The decomposition below still dequantizes as `"affine"`, so a genuine
+/// block-float `kv_b_proj` is not supported either way: what this pins is that
+/// it is refused by name instead of unwinding. The assertion is on the returned
+/// `Result` and no forward pass runs, so a regression fails cleanly here.
+#[test]
+fn quantized_kv_b_proj_rejects_scales_with_no_biases() {
+    let mut args = tiny_mla_config(2048);
+    args.kv_lora_rank = 16;
+
+    // Positive control first, so a check that rejected every quantized
+    // kv_b_proj could not pass this test.
+    let sanitized =
+        super::DeepSeekV32Model::sanitize_weights(affine_kv_b_proj_weights(&args), &args)
+            .expect("a kv_b_proj carrying both planes must still sanitize");
+    assert!(sanitized.contains_key("model.layers.0.self_attn.embed_q.weight"));
+
+    let err =
+        super::DeepSeekV32Model::sanitize_weights(block_float_kv_b_proj_weights(&args), &args)
+            .err()
+            .expect("scales with no biases must be refused at load, not unwrapped");
+    assert!(
+        err.contains("model.layers.0.self_attn.kv_b_proj.biases"),
+        "the error must name the key that is missing, got: {err}"
+    );
+    assert!(
+        err.contains("scales but no biases"),
+        "the wording must match the other four MLA sanitizers, got: {err}"
+    );
 }

--- a/src/models/kimi_linear.rs
+++ b/src/models/kimi_linear.rs
@@ -164,6 +164,11 @@ struct MultiLinear {
     group_size: i32,
     bits: i32,
     is_quantized: bool,
+    /// Quantization mode resolved at load from the planes the checkpoint
+    /// actually ships, never hardcoded. `"affine"` for a `.biases`-carrying
+    /// plane, one of the block-float modes otherwise. See
+    /// [`Self::from_weights`] for why this is not read from `config.json`.
+    mode: &'static str,
 }
 
 impl MultiLinear {
@@ -183,7 +188,7 @@ impl MultiLinear {
                     transpose,
                     self.group_size,
                     self.bits,
-                    "affine",
+                    self.mode,
                 )
             }
         } else if transpose {
@@ -194,6 +199,31 @@ impl MultiLinear {
         }
     }
 
+    /// Load a per-head MLA projection, resolving its quantization mode from the
+    /// planes present rather than assuming affine.
+    ///
+    /// The mode is inferred with
+    /// [`mlxcel_core::layers::infer_quantization_mode`] on `.biases` presence,
+    /// the same rule the shared `UnifiedLinear` / `UnifiedEmbedding` loaders
+    /// use, rather than read from `config.json`: KimiLinear's local
+    /// `Quantization` carries only `group_size` and `bits`, and every other
+    /// layer in this family already infers, so reading a declared mode here
+    /// alone would make one projection disagree with the rest of the model.
+    ///
+    /// Storing `"affine"` unconditionally, as this did, is what MLX's
+    /// `validate_mode_with_type` throws `Biases must be provided for affine
+    /// quantization` on when the plane carries no zero points, and
+    /// `quantized_matmul` crosses the cxx bridge as `UniquePtr<MlxArray>`
+    /// rather than `Result`, so that throw is an uncatchable `std::terminate`
+    /// at the first MLA forward rather than a load error (issue #1026).
+    ///
+    /// That path is not reachable today: `sanitize_weights` always dequantizes
+    /// `kv_b_proj` and inserts `embed_q.weight` / `unembed_out.weight` as dense
+    /// tensors with no `.scales`, and no shipped checkpoint ships those two
+    /// tensors itself, so `is_quantized` is always false here. This is a bound
+    /// on what a future change to that sanitizer can reintroduce, not a live
+    /// fix. `src/models/gpt_oss.rs` `ExpertLinear::from_weights` is the
+    /// in-tree precedent for the shape of it.
     fn from_weights(
         weights: &WeightMap,
         prefix: &str,
@@ -213,12 +243,28 @@ impl MultiLinear {
             .map(|w| mlxcel_core::copy(w));
 
         let is_quantized = scales.is_some();
+        // Inert on the dense `matmul` path, so it must not be resolved (or
+        // enforced) for a projection that carries no packing at all.
+        let mut mode = "affine";
         if is_quantized {
             // KimiLinear keeps a private `MultiLinear` rather than using
             // `mlxcel_core::layers::MultiLinear`, so it does not inherit the
             // bound that loader now carries. The stored pair goes straight to
             // `quantized_matmul` on every MLA forward (issue #958).
             validate_expert_quantization_params(prefix, group_size, bits)?;
+
+            mode = mlxcel_core::layers::infer_quantization_mode(biases.is_some(), group_size, bits);
+            // Consistent by construction with the line above, which keys the
+            // mode on the same `biases.is_some()` this re-checks, so it cannot
+            // fire as written. It is here because it is the assertion that
+            // couples the two helpers: the day the mode comes from anywhere
+            // else (a declared `quantization.mode`, a per-prefix override),
+            // the contradiction is caught at the point the mode is stored
+            // instead of inside `quantized_matmul`, where it is an uncatchable
+            // abort. The same pairing on a genuinely declared mode is
+            // `gpt_oss.rs` `ExpertLinear::from_weights`.
+            mlxcel_core::layers::validate_quantization_biases(mode, biases.is_some())
+                .map_err(|e| format!("{prefix}: {e}"))?;
         }
 
         Ok(Self {
@@ -228,6 +274,7 @@ impl MultiLinear {
             group_size,
             bits,
             is_quantized,
+            mode,
         })
     }
 }
@@ -1278,9 +1325,25 @@ impl KimiLinearModel {
                     let scales = weights
                         .remove(&format!("{}.kv_b_proj.scales", attn_prefix))
                         .unwrap();
-                    let biases = weights
-                        .remove(&format!("{}.kv_b_proj.biases", attn_prefix))
-                        .unwrap();
+                    // `is_quantized` gates on `.scales` alone, and the
+                    // block-float modes (mxfp4 / nvfp4 / mxfp8) ship scales
+                    // with no zero points, so a block-float export satisfies
+                    // that gate and arrives here carrying no `.biases` plane.
+                    // The `.unwrap()` this replaces turned that into a panic
+                    // during sanitization, which in the server takes the
+                    // process down rather than rejecting one model load
+                    // (issue #1026). `dequantize` below is hardcoded
+                    // `"affine"` and so could not decompose such a plane in
+                    // any case; what this buys is a load error naming the key
+                    // that is missing.
+                    let biases_key = format!("{}.kv_b_proj.biases", attn_prefix);
+                    let biases = weights.remove(&biases_key).ok_or_else(|| {
+                        format!(
+                            "layer {l}: kv_b_proj has scales but no biases at key \
+                             `{biases_key}`; the checkpoint may be corrupted or only \
+                             partially converted"
+                        )
+                    })?;
                     // Solve the packed pair from the shapes and bound it
                     // before it reaches `dequantize`. The shared helper checks
                     // each divisor before dividing: `kv_lora_rank` is a config

--- a/src/models/kimi_linear.rs
+++ b/src/models/kimi_linear.rs
@@ -217,12 +217,23 @@ impl MultiLinear {
     /// rather than `Result`, so that throw is an uncatchable `std::terminate`
     /// at the first MLA forward rather than a load error (issue #1026).
     ///
-    /// That path is not reachable today: `sanitize_weights` always dequantizes
-    /// `kv_b_proj` and inserts `embed_q.weight` / `unembed_out.weight` as dense
-    /// tensors with no `.scales`, and no shipped checkpoint ships those two
-    /// tensors itself, so `is_quantized` is always false here. This is a bound
-    /// on what a future change to that sanitizer can reintroduce, not a live
-    /// fix. `src/models/gpt_oss.rs` `ExpertLinear::from_weights` is the
+    /// This path is reachable today, not merely defended against a future
+    /// sanitizer change. `sanitize_weights` only inserts a dense
+    /// `embed_q.weight` / `unembed_out.weight` pair inside the
+    /// `if weights.contains_key(&kv_b_key)` guard, where `kv_b_key` is
+    /// `{attn_prefix}.kv_b_proj.weight`; when a checkpoint carries no
+    /// `kv_b_proj.weight` at all, that whole decomposition block is skipped,
+    /// so any `embed_q` / `unembed_out` planes the checkpoint shipped itself
+    /// pass through sanitization untouched. `MlaAttention::from_weights`
+    /// then calls this loader unconditionally for every non-linear-attention
+    /// layer, so a checkpoint that ships pre-decomposed, quantized
+    /// `embed_q.weight` plus `embed_q.scales` (and the matching pair for
+    /// `unembed_out`) with no `kv_b_proj.weight` to decompose from lands
+    /// here with `is_quantized == true`. Do not delete this branch as dead
+    /// code: it is live for that checkpoint shape, and removing it
+    /// reintroduces the same uncatchable abort described above, just reached
+    /// from a checkpoint layout other than the one issue #1026 was filed
+    /// against. `src/models/gpt_oss.rs` `ExpertLinear::from_weights` is the
     /// in-tree precedent for the shape of it.
     fn from_weights(
         weights: &WeightMap,

--- a/src/models/kimi_linear_tests.rs
+++ b/src/models/kimi_linear_tests.rs
@@ -283,12 +283,17 @@ fn kimi_linear_sanitize_rejects_a_kv_b_proj_with_scales_and_no_biases() {
 /// `UniquePtr<MlxArray>` rather than `Result`, so that throw is an uncatchable
 /// `std::terminate` at the first MLA forward.
 ///
-/// The branch is unreachable today: `sanitize_weights` always dequantizes
-/// `kv_b_proj` and inserts `embed_q.weight` / `unembed_out.weight` dense, and
-/// no shipped checkpoint carries those two tensors itself, so `is_quantized`
-/// is always false in production. This test drives the loader directly to pin
-/// the stored mode against the planes present, so a future sanitizer that does
-/// keep `embed_q` quantized cannot silently reintroduce the abort.
+/// This branch is reachable today, not merely defended against a future
+/// sanitizer change: `sanitize_weights` only dequantizes `kv_b_proj` and
+/// inserts `embed_q.weight` / `unembed_out.weight` dense inside its
+/// `if weights.contains_key(&kv_b_key)` guard, so a checkpoint that ships no
+/// `kv_b_proj.weight` at all skips that block outright and leaves its own
+/// pre-decomposed, quantized `embed_q` / `unembed_out` planes untouched;
+/// `MlaAttention::from_weights` then hands those planes straight to this
+/// loader with `is_quantized == true`. This test drives the loader directly
+/// rather than through a full checkpoint fixture, since that is the
+/// cheapest way to pin the stored mode against every plane combination
+/// without constructing that checkpoint shape end to end.
 #[test]
 fn kimi_linear_multi_linear_infers_its_quantization_mode_from_the_biases_plane() {
     let load = |group_size: i32, bits: i32, with_biases: bool| {
@@ -331,4 +336,5 @@ fn kimi_linear_multi_linear_infers_its_quantization_mode_from_the_biases_plane()
     let loaded = MultiLinear::from_weights(&dense, PREFIX, 0, 0)
         .expect("a non-quantized per-head projection must load with an unset pair");
     assert!(!loaded.is_quantized);
+    assert_eq!(loaded.mode, "affine");
 }

--- a/src/models/kimi_linear_tests.rs
+++ b/src/models/kimi_linear_tests.rs
@@ -12,9 +12,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//! Regression test for the bound on declared quantization params that
+//! Regression tests for the two quantization bounds on KimiLinear's MLA path:
+//! the bound on declared quantization params that
 //! `kimi_linear::MultiLinear::from_weights` applies before it stores them on a
-//! quantized per-head MLA projection (issue #958).
+//! quantized per-head projection (issue #958), and the rejection of a
+//! `kv_b_proj` plane that carries `.scales` with no `.biases` (issue #1026).
 
 use super::{KimiLinearConfig, KimiLinearModel, LinearAttnConfig, MultiLinear};
 use crate::models::switch_layers::{HOSTILE_QUANT_PARAMS, insert_stacked_quantized_expert_plane};
@@ -129,6 +131,49 @@ fn mla_config(kv_lora_rank: usize) -> KimiLinearConfig {
     }
 }
 
+/// An affine 4-bit `kv_b_proj` for every layer in `config`.
+///
+/// Honest geometry at `mla_config(16)`: packed_in * 32 == bits * num_groups *
+/// group_size (2 * 32 == 4 * 1 * 16), with num_heads 4 and qk_nope_head_dim =
+/// v_head_dim = 4 so rows = 4 * 8 = 32.
+///
+/// The packed plane is UINT32, not a float dtype: `dequantize` rejects any
+/// other packed dtype by throwing, and that throw is the uncatchable abort
+/// these guards exist to keep out of the forward path. A float fixture here
+/// takes the test binary down on the positive control.
+fn affine_kv_b_proj_weights(config: &KimiLinearConfig) -> WeightMap {
+    let rows = (config.num_attention_heads * (config.qk_nope() + config.v_head())) as i32;
+    let mut weights = WeightMap::new();
+    for layer_idx in 0..config.num_hidden_layers {
+        let prefix = format!("model.layers.{layer_idx}.self_attn.kv_b_proj");
+        weights.insert(
+            format!("{prefix}.weight"),
+            mlxcel_core::zeros(&[rows, 2], mlxcel_core::dtype::UINT32),
+        );
+        weights.insert(
+            format!("{prefix}.scales"),
+            mlxcel_core::zeros(&[rows, 1], mlxcel_core::dtype::FLOAT32),
+        );
+        weights.insert(
+            format!("{prefix}.biases"),
+            mlxcel_core::zeros(&[rows, 1], mlxcel_core::dtype::FLOAT32),
+        );
+    }
+    weights
+}
+
+/// The same plane an mxfp4 / nvfp4 / mxfp8 export ships: `.scales` present,
+/// `.biases` absent, because the block-float modes carry no zero points.
+fn block_float_kv_b_proj_weights(config: &KimiLinearConfig) -> WeightMap {
+    let mut weights = affine_kv_b_proj_weights(config);
+    for layer_idx in 0..config.num_hidden_layers {
+        weights.remove(&format!(
+            "model.layers.{layer_idx}.self_attn.kv_b_proj.biases"
+        ));
+    }
+    weights
+}
+
 /// The MLA `kv_b_proj` pair `KimiLinearModel::sanitize_weights` decomposes is
 /// solved from `kv_lora_rank` and two tensor axes rather than declared, and
 /// every input is untrusted: `kv_lora_rank` comes from `config.json` and the
@@ -145,48 +190,21 @@ fn mla_config(kv_lora_rank: usize) -> KimiLinearConfig {
 /// fails cleanly here instead of aborting the test binary.
 #[test]
 fn kimi_linear_sanitize_rejects_a_kv_lora_rank_no_packing_can_describe() {
-    // Honest affine 4-bit geometry: packed_in * 32 == bits * num_groups *
-    // group_size (2 * 32 == 4 * 1 * 16), with num_heads 4 and
-    // qk_nope_head_dim = v_head_dim = 4 so rows = 4 * 8 = 32.
-    let build = |config: &KimiLinearConfig| {
-        let rows = (config.num_attention_heads * (config.qk_nope() + config.v_head())) as i32;
-        let mut weights = WeightMap::new();
-        for layer_idx in 0..config.num_hidden_layers {
-            let prefix = format!("model.layers.{layer_idx}.self_attn.kv_b_proj");
-            // UINT32, not a float dtype: `dequantize` rejects any other packed
-            // dtype by throwing, and that throw is the uncatchable abort this
-            // guard exists to keep out of the forward path. A float fixture here
-            // takes the test binary down on the positive control.
-            weights.insert(
-                format!("{prefix}.weight"),
-                mlxcel_core::zeros(&[rows, 2], mlxcel_core::dtype::UINT32),
-            );
-            weights.insert(
-                format!("{prefix}.scales"),
-                mlxcel_core::zeros(&[rows, 1], mlxcel_core::dtype::FLOAT32),
-            );
-            weights.insert(
-                format!("{prefix}.biases"),
-                mlxcel_core::zeros(&[rows, 1], mlxcel_core::dtype::FLOAT32),
-            );
-        }
-        weights
-    };
-
     // Positive control first, so a guard that rejected every quantized
     // kv_b_proj could not pass this test.
     let honest = mla_config(16);
-    let sanitized = match KimiLinearModel::sanitize_weights(build(&honest), &honest) {
-        Ok(w) => w,
-        Err(e) => panic!("an honest quantized kv_b_proj must still sanitize: {e}"),
-    };
+    let sanitized =
+        match KimiLinearModel::sanitize_weights(affine_kv_b_proj_weights(&honest), &honest) {
+            Ok(w) => w,
+            Err(e) => panic!("an honest quantized kv_b_proj must still sanitize: {e}"),
+        };
     assert!(sanitized.contains_key("model.layers.0.self_attn.embed_q.weight"));
 
     // A zero `kv_lora_rank` is Rust integer division by zero on the very
     // first solve, so it has to be refused before the division rather than
     // after.
     let zero_rank = mla_config(0);
-    let err = KimiLinearModel::sanitize_weights(build(&zero_rank), &zero_rank)
+    let err = KimiLinearModel::sanitize_weights(affine_kv_b_proj_weights(&zero_rank), &zero_rank)
         .err()
         .unwrap_or_else(|| panic!("kv_lora_rank 0 must be refused, not divided by"));
     assert!(err.contains("kv_lora_rank"), "unhelpful error: {err}");
@@ -194,7 +212,7 @@ fn kimi_linear_sanitize_rejects_a_kv_lora_rank_no_packing_can_describe() {
     // A large `kv_lora_rank` truncates the solved bit width to 0, which is
     // the divisor MLX would then divide by.
     let wide_rank = mla_config(4096);
-    let err = KimiLinearModel::sanitize_weights(build(&wide_rank), &wide_rank)
+    let err = KimiLinearModel::sanitize_weights(affine_kv_b_proj_weights(&wide_rank), &wide_rank)
         .err()
         .unwrap_or_else(|| panic!("a solved bit width of 0 must be refused"));
     assert!(err.contains("bits"), "unhelpful error: {err}");
@@ -217,4 +235,100 @@ fn kimi_linear_sanitize_rejects_a_kv_lora_rank_no_packing_can_describe() {
         Ok(_) => {}
         Err(e) => panic!("a float kv_b_proj must not be gated on quantization params: {e}"),
     }
+}
+
+/// Issue #1026: `sanitize_weights` decides `kv_b_proj` is quantized on
+/// `.scales` alone, then used to take `.biases` with `.unwrap()`.
+///
+/// Affine stores zero points; the block-float modes (mxfp4 / nvfp4 / mxfp8) do
+/// not, which is exactly what `infer_quantization_mode` keys on. A block-float
+/// `kv_b_proj` therefore satisfies the `.scales` gate and arrives at the
+/// `.biases` removal with nothing to take, and the `.unwrap()` made that a
+/// panic during weight sanitization. In the server that takes the process down
+/// rather than rejecting one model load, which is strictly worse than the load
+/// error it should be.
+///
+/// The decomposition below still dequantizes as `"affine"`, so a genuine
+/// block-float `kv_b_proj` is not supported either way: what this pins is that
+/// it is refused by name instead of unwinding. The assertion is on the returned
+/// `Result` and no forward pass runs, so a regression fails cleanly here.
+#[test]
+fn kimi_linear_sanitize_rejects_a_kv_b_proj_with_scales_and_no_biases() {
+    let config = mla_config(16);
+
+    // Positive control first, so a check that rejected every quantized
+    // kv_b_proj could not pass this test.
+    let sanitized = KimiLinearModel::sanitize_weights(affine_kv_b_proj_weights(&config), &config)
+        .expect("a kv_b_proj carrying both planes must still sanitize");
+    assert!(sanitized.contains_key("model.layers.0.self_attn.embed_q.weight"));
+
+    let err = KimiLinearModel::sanitize_weights(block_float_kv_b_proj_weights(&config), &config)
+        .err()
+        .expect("scales with no biases must be refused at load, not unwrapped");
+    assert!(
+        err.contains("model.layers.0.self_attn.kv_b_proj.biases"),
+        "the error must name the key that is missing, got: {err}"
+    );
+    assert!(
+        err.contains("scales but no biases"),
+        "the wording must match the other four MLA sanitizers, got: {err}"
+    );
+}
+
+/// Issue #1026: `MultiLinear::forward` used to pass a hardcoded `"affine"` to
+/// `quantized_matmul` while `from_weights` accepted a `.biases`-less plane, so
+/// a block-float projection would have reached MLX's `validate_mode_with_type`
+/// as affine-with-null-biases and thrown `Biases must be provided for affine
+/// quantization`. `quantized_matmul` crosses the cxx bridge as
+/// `UniquePtr<MlxArray>` rather than `Result`, so that throw is an uncatchable
+/// `std::terminate` at the first MLA forward.
+///
+/// The branch is unreachable today: `sanitize_weights` always dequantizes
+/// `kv_b_proj` and inserts `embed_q.weight` / `unembed_out.weight` dense, and
+/// no shipped checkpoint carries those two tensors itself, so `is_quantized`
+/// is always false in production. This test drives the loader directly to pin
+/// the stored mode against the planes present, so a future sanitizer that does
+/// keep `embed_q` quantized cannot silently reintroduce the abort.
+#[test]
+fn kimi_linear_multi_linear_infers_its_quantization_mode_from_the_biases_plane() {
+    let load = |group_size: i32, bits: i32, with_biases: bool| {
+        let mut weights = WeightMap::new();
+        insert_stacked_quantized_expert_plane(
+            &mut weights,
+            PREFIX,
+            HEADS,
+            OUT,
+            PACKED_IN,
+            NUM_GROUPS,
+        );
+        if !with_biases {
+            weights.remove(&format!("{PREFIX}.biases"));
+        }
+        MultiLinear::from_weights(&weights, PREFIX, group_size, bits)
+            .unwrap_or_else(|e| panic!("({group_size}, {bits}, {with_biases}) must load: {e}"))
+    };
+
+    // Zero points present is the only signal for affine, and it outranks the
+    // pair: a `.biases`-carrying plane stays affine at every group_size / bits.
+    assert_eq!(load(GROUP_SIZE, BITS, true).mode, "affine");
+    assert_eq!(load(16, 4, true).mode, "affine");
+    assert_eq!(load(64, 8, true).mode, "affine");
+
+    // With no zero points the pair picks which block-float mode it is, on the
+    // same rule the shared `UnifiedLinear` / `UnifiedEmbedding` loaders use.
+    assert_eq!(load(GROUP_SIZE, BITS, false).mode, "mxfp4");
+    assert_eq!(load(16, 4, false).mode, "nvfp4");
+    assert_eq!(load(64, 8, false).mode, "mxfp8");
+
+    // A dense projection never reaches `quantized_matmul`, so the mode is inert
+    // there and must not be resolved from a pair the checkpoint does not carry.
+    let mut dense = WeightMap::new();
+    let n = (HEADS * OUT * PACKED_IN) as usize;
+    dense.insert(
+        format!("{PREFIX}.weight"),
+        mlxcel_core::from_slice_f32(&vec![0.0f32; n], &[HEADS, OUT, PACKED_IN]),
+    );
+    let loaded = MultiLinear::from_weights(&dense, PREFIX, 0, 0)
+        .expect("a non-quantized per-head projection must load with an unset pair");
+    assert!(!loaded.is_quantized);
 }

--- a/src/models/longcat_flash_ngram.rs
+++ b/src/models/longcat_flash_ngram.rs
@@ -1094,9 +1094,23 @@ pub fn sanitize_weights(
                 let s = weights
                     .remove(&format!("{prefix}.kv_b_proj.scales"))
                     .unwrap();
-                let b = weights
-                    .remove(&format!("{prefix}.kv_b_proj.biases"))
-                    .unwrap();
+                // `is_quantized` gates on `.scales` alone, and the block-float
+                // modes (mxfp4 / nvfp4 / mxfp8) ship scales with no zero
+                // points, so a block-float export satisfies that gate and
+                // arrives here carrying no `.biases` plane. The `.unwrap()`
+                // this replaces turned that into a panic during sanitization,
+                // which in the server takes the process down rather than
+                // rejecting one model load (issue #1026). `dequantize` below is
+                // hardcoded `"affine"` and so could not decompose such a plane
+                // in any case; what this buys is a load error naming the key
+                // that is missing.
+                let b_key = format!("{prefix}.kv_b_proj.biases");
+                let b = weights.remove(&b_key).ok_or_else(|| {
+                    format!(
+                        "layer {l}: kv_b_proj has scales but no biases at key `{b_key}`; \
+                         the checkpoint may be corrupted or only partially converted"
+                    )
+                })?;
                 // Solve the packed pair from the shapes and bound it before it
                 // reaches `dequantize`. The shared helper also checks each
                 // divisor before dividing: `kv_lora_rank` is a config field and
@@ -1194,6 +1208,51 @@ mod tests {
         serde_json::from_str(&json).expect("parse tiny longcat_flash config")
     }
 
+    /// An affine 4-bit `kv_b_proj` on sub-attention 0 of every layer in `args`.
+    ///
+    /// Honest geometry at `mla_config(16)`: packed_in * 32 == bits *
+    /// num_groups * group_size (2 * 32 == 4 * 1 * 16), with
+    /// num_attention_heads 2 and qk_nope_head_dim = v_head_dim = 4, so rows =
+    /// 2 * 8 = 16.
+    ///
+    /// The packed plane is UINT32, not a float dtype: `dequantize` rejects any
+    /// other packed dtype by throwing, and that throw is the uncatchable abort
+    /// these guards exist to keep out of the forward path. A float fixture
+    /// here takes the test binary down on the positive control.
+    fn affine_kv_b_proj_weights(args: &LongcatFlashNgramConfig) -> WeightMap {
+        let heads = args.num_attention_heads as i32;
+        let head_dim = (args.qk_nope_head_dim + args.v_head_dim) as i32;
+        let rows = heads * head_dim;
+        let mut weights = WeightMap::new();
+        for l in 0..args.num_layers {
+            let prefix = format!("model.layers.{l}.self_attn.0.kv_b_proj");
+            weights.insert(
+                format!("{prefix}.weight"),
+                mlxcel_core::zeros(&[rows, 2], mlxcel_core::dtype::UINT32),
+            );
+            weights.insert(
+                format!("{prefix}.scales"),
+                mlxcel_core::zeros(&[rows, 1], mlxcel_core::dtype::FLOAT32),
+            );
+            weights.insert(
+                format!("{prefix}.biases"),
+                mlxcel_core::zeros(&[rows, 1], mlxcel_core::dtype::FLOAT32),
+            );
+        }
+        weights
+    }
+
+    /// The same plane an mxfp4 / nvfp4 / mxfp8 export ships: `.scales`
+    /// present, `.biases` absent, because the block-float modes carry no zero
+    /// points.
+    fn block_float_kv_b_proj_weights(args: &LongcatFlashNgramConfig) -> WeightMap {
+        let mut weights = affine_kv_b_proj_weights(args);
+        for l in 0..args.num_layers {
+            weights.remove(&format!("model.layers.{l}.self_attn.0.kv_b_proj.biases"));
+        }
+        weights
+    }
+
     /// The MLA `kv_b_proj` pair `sanitize_weights` decomposes is solved from
     /// `kv_lora_rank` and two tensor axes rather than declared, and every
     /// input is untrusted: `kv_lora_rank` comes from `config.json` and the
@@ -1205,46 +1264,15 @@ mod tests {
     /// weight sanitization rather than failing the load.
     ///
     /// `sanitize_weights` decomposes both dual sub-attentions (`self_attn.0`
-    /// and `self_attn.1`) per layer; this fixture only builds `self_attn.0`,
-    /// and `self_attn.1` is skipped by the loader's own "no `kv_b_proj`
-    /// present" check, which is not what this test targets.
+    /// and `self_attn.1`) per layer; the fixtures above only build
+    /// `self_attn.0`, and `self_attn.1` is skipped by the loader's own "no
+    /// `kv_b_proj` present" check, which is not what this test targets.
     #[test]
     fn sanitize_rejects_a_kv_lora_rank_no_packing_can_describe() {
-        // Honest affine 4-bit geometry: packed_in * 32 == bits * num_groups *
-        // group_size (2 * 32 == 4 * 1 * 16), with num_attention_heads 2 and
-        // qk_nope_head_dim = v_head_dim = 4, so rows = 2 * 8 = 16.
-        let build = |args: &LongcatFlashNgramConfig| {
-            let heads = args.num_attention_heads as i32;
-            let head_dim = (args.qk_nope_head_dim + args.v_head_dim) as i32;
-            let rows = heads * head_dim;
-            let mut weights = WeightMap::new();
-            for l in 0..args.num_layers {
-                let prefix = format!("model.layers.{l}.self_attn.0.kv_b_proj");
-                // UINT32, not a float dtype: `dequantize` rejects any other
-                // packed dtype by throwing, and that throw is the uncatchable
-                // abort this guard exists to keep out of the forward path. A
-                // float fixture here takes the test binary down on the positive
-                // control.
-                weights.insert(
-                    format!("{prefix}.weight"),
-                    mlxcel_core::zeros(&[rows, 2], mlxcel_core::dtype::UINT32),
-                );
-                weights.insert(
-                    format!("{prefix}.scales"),
-                    mlxcel_core::zeros(&[rows, 1], mlxcel_core::dtype::FLOAT32),
-                );
-                weights.insert(
-                    format!("{prefix}.biases"),
-                    mlxcel_core::zeros(&[rows, 1], mlxcel_core::dtype::FLOAT32),
-                );
-            }
-            weights
-        };
-
         // Positive control first, so a guard that rejected every quantized
         // kv_b_proj could not pass this test.
         let honest = mla_config(16);
-        let sanitized = sanitize_weights(build(&honest), &honest)
+        let sanitized = sanitize_weights(affine_kv_b_proj_weights(&honest), &honest)
             .expect("an honest quantized kv_b_proj must still sanitize");
         assert!(sanitized.contains_key("model.layers.0.self_attn.0.embed_q.weight"));
 
@@ -1252,7 +1280,7 @@ mod tests {
         // first solve, so it has to be refused before the division rather
         // than after.
         let zero_rank = mla_config(0);
-        let err = sanitize_weights(build(&zero_rank), &zero_rank)
+        let err = sanitize_weights(affine_kv_b_proj_weights(&zero_rank), &zero_rank)
             .err()
             .unwrap_or_else(|| panic!("kv_lora_rank 0 must be refused, not divided by"));
         assert!(err.contains("kv_lora_rank"), "unhelpful error: {err}");
@@ -1260,7 +1288,7 @@ mod tests {
         // A large `kv_lora_rank` truncates the solved bit width to 0, which
         // is the divisor MLX would then divide by.
         let wide_rank = mla_config(4096);
-        let err = sanitize_weights(build(&wide_rank), &wide_rank)
+        let err = sanitize_weights(affine_kv_b_proj_weights(&wide_rank), &wide_rank)
             .err()
             .unwrap_or_else(|| panic!("a solved bit width of 0 must be refused"));
         assert!(err.contains("bits"), "unhelpful error: {err}");
@@ -1282,5 +1310,50 @@ mod tests {
         );
         sanitize_weights(float_only, &wide_rank)
             .expect("a float kv_b_proj must not be gated on quantization params");
+    }
+
+    /// Issue #1026: `sanitize_weights` decides `kv_b_proj` is quantized on
+    /// `.scales` alone, then used to take `.biases` with `.unwrap()`.
+    ///
+    /// Affine stores zero points; the block-float modes (mxfp4 / nvfp4 /
+    /// mxfp8) do not, which is exactly what `infer_quantization_mode` keys on.
+    /// A block-float `kv_b_proj` therefore satisfies the `.scales` gate and
+    /// arrives at the `.biases` removal with nothing to take, and the
+    /// `.unwrap()` made that a panic during weight sanitization. In the server
+    /// that takes the process down rather than rejecting one model load, which
+    /// is strictly worse than the load error it should be.
+    ///
+    /// This family is the one of the four whose prefix carries a sub-attention
+    /// index (`self_attn.0` / `self_attn.1`) rather than ending at
+    /// `self_attn`, so the key the error names is worth pinning here
+    /// specifically: it is the site where a copy of the fix could most easily
+    /// blame the wrong tensor.
+    ///
+    /// The decomposition still dequantizes as `"affine"`, so a genuine
+    /// block-float `kv_b_proj` is not supported either way: what this pins is
+    /// that it is refused by name instead of unwinding. The assertion is on
+    /// the returned `Result` and no forward pass runs, so a regression fails
+    /// cleanly here.
+    #[test]
+    fn sanitize_rejects_scales_with_no_biases() {
+        let args = mla_config(16);
+
+        // Positive control first, so a check that rejected every quantized
+        // kv_b_proj could not pass this test.
+        let sanitized = sanitize_weights(affine_kv_b_proj_weights(&args), &args)
+            .expect("a kv_b_proj carrying both planes must still sanitize");
+        assert!(sanitized.contains_key("model.layers.0.self_attn.0.embed_q.weight"));
+
+        let err = sanitize_weights(block_float_kv_b_proj_weights(&args), &args)
+            .err()
+            .expect("scales with no biases must be refused at load, not unwrapped");
+        assert!(
+            err.contains("model.layers.0.self_attn.0.kv_b_proj.biases"),
+            "the error must name the key that is missing, got: {err}"
+        );
+        assert!(
+            err.contains("scales but no biases"),
+            "the wording must match the other four MLA sanitizers, got: {err}"
+        );
     }
 }

--- a/src/models/youtu_vl_lm_sanitize.rs
+++ b/src/models/youtu_vl_lm_sanitize.rs
@@ -65,8 +65,16 @@ pub fn sanitize_text_weights(
         let w = weights.remove(&kv_b_key).unwrap();
         let w_full = if is_quantized {
             let s = weights.remove(&scales_key).unwrap();
-            // M1: biases are mandatory when scales are present; missing biases
-            // indicate a malformed or partially-converted checkpoint.
+            // `is_quantized` gates on `.scales` alone, and the block-float
+            // modes (mxfp4 / nvfp4 / mxfp8) ship scales with no zero points, so
+            // a block-float export satisfies that gate and arrives here
+            // carrying no `.biases` plane. Taking it with `.unwrap()` would
+            // turn that into a panic during sanitization, which in the server
+            // takes the process down rather than rejecting one model load
+            // (issue #1026 made the other four sanitizers match this site).
+            // `dequantize` below is hardcoded `"affine"` and so could not
+            // decompose such a plane in any case; what this buys is a load
+            // error naming the key that is missing.
             let b_key = format!("{}.kv_b_proj.biases", prefix);
             let b = weights.remove(&b_key).ok_or_else(|| {
                 format!(


### PR DESCRIPTION
## Summary

Four MLA `kv_b_proj` sanitizers decided the plane was quantized by probing for `.scales`, then unconditionally `.unwrap()`ed the `.biases` removal. Affine quantization stores zero-point `.biases`; the block-float modes (mxfp4, nvfp4, mxfp8) carry none by design, which is exactly what `infer_quantization_mode` keys on. A block-float `kv_b_proj` therefore satisfies the `.scales` gate and then panics. All four now use the `ok_or_else` form already in tree at `src/models/youtu_vl_lm_sanitize.rs:66-73`, the corrected fifth sibling of this exact code, with the same message wording so the five converge instead of diverging further.

This is latent today. No shipped checkpoint takes the path: `mlx-community/Kimi-Linear-48B-A3B-Instruct-4bit` and `-8bit` both ship `kv_b_proj` with `weight`, `scales` and `biases`, and `moonshotai/Kimi-Linear-48B-A3B-Instruct` ships `weight` only. It goes live the moment a block-float MLA export appears, and it presents as a process kill rather than a load error.

## What changed

- `src/models/kimi_linear.rs`, `src/models/deepseek_v3.rs`, `src/models/deepseek_v32.rs`, `src/models/longcat_flash_ngram.rs`: the `.biases` removal is now `ok_or_else(...)?` with the wording from `youtu_vl_lm_sanitize.rs`. **No signature changed**: every enclosing `sanitize_weights` already returns `Result<WeightMap, String>` and already used `?` for `infer_mla_quantization_params`, so the `?` had a home at all four sites. This was flagged as the interesting part of the task, and it turned out to be a non-event.
- The `dequantize` call stays hardcoded `"affine"` at all five sites. A genuine block-float `kv_b_proj` is still unsupported; what changes is that it is refused by name instead of unwinding. See "What this deliberately does not do" below.
- `src/models/youtu_vl_lm_sanitize.rs`: comment only. It carried a terse `M1:` review-artifact label; it now states the same rationale as the other four, so the five are identical in behavior, message and comment. The code there was already correct.
- `src/models/kimi_linear.rs` private `MultiLinear`: gained a `mode: &'static str` field, derived at load with `mlxcel_core::layers::infer_quantization_mode(biases.is_some(), group_size, bits)` and passed to `quantized_matmul` in place of the hardcoded `"affine"`, plus a `mlxcel_core::layers::validate_quantization_biases` call at load. `src/models/gpt_oss.rs:463` is the precedent.

## The `MultiLinear` change is reachable today

Correcting an earlier claim in the other direction, per the security review: the branch is **reachable today**, not merely a bound against a future sanitizer change. `sanitize_weights` (`src/models/kimi_linear.rs:1323-1325`) only inserts a dense `embed_q.weight` / `unembed_out.weight` pair inside its `if weights.contains_key(&kv_b_key)` guard, where `kv_b_key` is `{attn_prefix}.kv_b_proj.weight`; when a checkpoint carries no `kv_b_proj.weight` at all, that whole decomposition block is skipped, so any `embed_q` / `unembed_out` planes the checkpoint shipped itself pass through sanitization untouched. `MlaAttention::from_weights` (`src/models/kimi_linear.rs:576-577`) then calls this loader unconditionally for every non-linear-attention layer, so a checkpoint that ships pre-decomposed, quantized `embed_q.weight` plus `embed_q.scales` (and the matching pair for `unembed_out`) with no `kv_b_proj.weight` to decompose from lands here with `is_quantized == true` today. This branch must not be deleted as dead code.

One honest caveat on the `validate_quantization_biases` call: with the mode inferred from `biases.is_some()` on the line above, the check is consistent by construction and cannot fire as written. It is kept because it is the assertion that couples the two helpers, so the day the mode comes from anywhere else (a declared `quantization.mode`, a per-prefix override) the contradiction is caught where the mode is stored rather than inside `quantized_matmul`, where it is an uncatchable abort. The comment at the call site says exactly this rather than implying it is load-bearing.

## What this deliberately does not do

Supporting a genuine block-float `kv_b_proj` would mean threading the inferred mode into the `dequantize` call at all five sites and verifying the decomposition against a real block-float MLA export. That is a feature, not this bug fix, and the acceptance criteria here ask for a load error naming the missing key. Worth recording: for a genuine block-float export the shared message ("the checkpoint may be corrupted or only partially converted") understates the situation slightly, since such a checkpoint is well-formed and merely unsupported here. Wording consistency across the five sites was judged the more valuable property, per the issue.

## On issue item 3, the shared helper

Evaluated, and the recommendation is **yes, but not in this PR**. Detail so the next person does not have to re-derive it.

It is more feasible than the issue's caveat suggests. The differing config accessors are a non-issue: all five resolve to `i32` at the call site already, so a helper taking `(weights, prefix, num_heads, qk_nope, v_head, kv_lora_rank, layer_label)` and returning `Result<(wk, wv), String>` absorbs the whole block, and the per-family loop (kimi skipping linear-attention layers, longcat iterating two sub-attentions per layer) stays at the call site where it belongs. That is roughly 225 lines across five files collapsing to about 110. These five sites have now been touched twice for the same defect class, once for #958 and once here, which is the strongest argument for consolidating them.

What makes it wrong to do here is that the five are not actually identical, and unifying them forces three behavioral decisions that this PR is not equipped to make:

- `youtu_vl_lm_sanitize.rs` cross-checks `w_full` against `[num_heads * head_dim, kv_lora_rank]` before reshaping; the other four do not. A shared helper either adds a new load-time rejection to four families or drops an existing guard from one.
- `kimi_linear.rs` uses `mlxcel_core::slice` + `swap_axes` where the other four use `slice_axis` + `transpose_axes`. Equivalent, so this one is free.
- `kimi_linear.rs` does **not** `copy()` the `wk` / `wv` slices contiguous, where the other four do, with a comment in youtu saying it exists so `MultiLinear`'s matmul has well-formed strides regardless of the upstream backend. Unifying silently changes kimi's contiguity. That deserves to be the change under review, not a rider.

A refactor that adds a new rejection to four families and changes the contiguity of a fifth belongs in a PR where that is the headline. Happy to file it as a follow-up issue on request.

## Separately, a sibling that this PR does not touch

`mlxcel_core::layers::QuantizedMultiLinear` (`src/lib/mlxcel-core/src/layers.rs:2775`) has the identical defect in `forward` and `forward_no_transpose`: a null biases pointer under a hardcoded `"affine"`, with `from_weights` gating on `.scales` alone and taking `biases` as an `Option` with no validation. It is reached by DeepSeek V3, DeepSeek V3.2, GLM4 MoE Lite and LongCat Flash NGram through `MultiLinear::from_weights`, which also gates on `.scales` alone.

Its reachability story is arguably better than the `kimi_linear` one fixed here, because all four sanitizers skip decomposition when `embed_q.weight` already exists, so a checkpoint shipping a pre-decomposed quantized `embed_q` reaches it directly. Left out of scope on purpose: it is a different crate, the reachability claim needs verifying against what `mlx_lm.convert` actually emits for a pre-decomposed MLA model, and adding it would blur this PR's story. Flagging it rather than silently fixing or silently skipping it.

## Test plan

Commands actually run on this branch, all green:

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --lib --tests -- -D warnings`, exit 0
- [x] `cargo check --lib --tests`
- [x] `cargo test --lib models::kimi_linear` (4 passed)
- [x] `cargo test --lib models::deepseek_v3::` (14 passed)
- [x] `cargo test --lib models::deepseek_v32` (14 passed)
- [x] `cargo test --lib models::longcat_flash_ngram` (2 passed)
- [x] `cargo test --lib models::youtu_vl` (4 passed), since its comment was touched and it shares the message wording

New tests, one rejection case per family rather than the two families the issue required:

- `kimi_linear_sanitize_rejects_a_kv_b_proj_with_scales_and_no_biases`
- `quantized_kv_b_proj_rejects_scales_with_no_biases` (deepseek_v3)
- `quantized_kv_b_proj_rejects_scales_with_no_biases` (deepseek_v32)
- `sanitize_rejects_scales_with_no_biases` (longcat_flash_ngram), which pins the full key because this is the one family whose prefix carries a sub-attention index (`self_attn.0`), the site where a copy of the fix could most easily blame the wrong tensor
- `kimi_linear_multi_linear_infers_its_quantization_mode_from_the_biases_plane`, pinning the stored mode across affine, mxfp4, nvfp4 and mxfp8 planes and confirming a dense projection stays unquantized

Each assertion is on the load `Result` and its message, and no test runs a forward pass, because a forward pass on a bad load aborts the test binary instead of failing the test. Each rejection test keeps a both-planes-present positive control first, so a check that rejected every quantized `kv_b_proj` could not pass it. The per-family `build` fixture closures were hoisted into shared `affine_kv_b_proj_weights` / `block_float_kv_b_proj_weights` helpers so both tests in each family drive the same geometry.

Failure was confirmed rather than assumed: temporarily restoring the `.unwrap()` in `kimi_linear.rs` made the new test fail with `called Option::unwrap() on a None value` at that exact line, which confirms both that the failure mode is a Rust panic (not the `std::terminate` class, as the issue states) and that the test catches it. The temporary change was reverted before committing, and a grep confirms no `.unwrap()` remains on any `kv_b_proj` biases removal.

Not run here: `cargo clippy --workspace --all-targets -- -D warnings` and the full test suite, both left to the orchestrator. `mlxcel-core` was not modified, so no `-p mlxcel-core` run was made. No real MLA checkpoint is present on this machine, so the affine positive path was confirmed only against the synthetic UINT32 fixtures, not against real weights.

Closes #1026

