### PR TITLE
fix(models): decompose kv_b_proj so GLM4 MoE Lite loads its own layout

### DIFF
--- a/src/distributed/pipeline/stage_executor/glm4.rs
+++ b/src/distributed/pipeline/stage_executor/glm4.rs
@@ -36,6 +36,16 @@ pub struct Glm4MoeStageExecutor {
     model: TransformerStageModel<Glm4MoeStageLayer>,
 }
 
+/// Stage-local executor for the MLA variant of the GLM4 family.
+///
+/// Unlike `Glm4StageExecutor` and `Glm4MoeStageExecutor`, this one has to
+/// sanitize the weight map before loading: every published `glm4_moe_lite`
+/// checkpoint stores the MLA up-projection as a single `self_attn.kv_b_proj`
+/// rather than the decomposed `embed_q` / `unembed_out` pair that
+/// `models::glm4_moe_lite::TransformerBlock::from_weights` reads
+/// unconditionally (issue #1029). The split runs on the full weight map,
+/// before the stage filter trims it, the same way `DeepSeekV3StageExecutor`
+/// and `GlmMoeDsaStageExecutor` order it.
 pub struct Glm4MoeLiteStageExecutor {
     model: TransformerStageModel<Glm4MoeLiteStageLayer>,
 }
@@ -47,6 +57,7 @@ impl Glm4StageExecutor {
                 model_dir,
                 filter,
                 stage_index,
+                no_sanitize,
                 models::glm4::TransformerBlock::from_weights,
                 |args: &models::glm4::ModelArgs| args.group_size(),
                 |args: &models::glm4::ModelArgs| args.bits(),
@@ -65,6 +76,7 @@ impl Glm4MoeStageExecutor {
                 model_dir,
                 filter,
                 stage_index,
+                no_sanitize,
                 models::glm4_moe::TransformerBlock::from_weights,
                 |args: &models::glm4_moe::ModelArgs| args.group_size(),
                 |args: &models::glm4_moe::ModelArgs| args.bits(),
@@ -83,6 +95,7 @@ impl Glm4MoeLiteStageExecutor {
                 model_dir,
                 filter,
                 stage_index,
+                models::glm4_moe_lite::sanitize_weights,
                 models::glm4_moe_lite::TransformerBlock::from_weights,
                 |args: &models::glm4_moe_lite::ModelArgs| args.group_size(),
                 |args: &models::glm4_moe_lite::ModelArgs| args.bits(),
@@ -186,10 +199,29 @@ impl TransformerStageLayer for Glm4MoeLiteStageLayer {
     }
 }
 
-fn load_glm4_family_stage_model<A, B, L, BuildLayer, GroupSize, Bits, RmsEps, TieEmbeddings, Wrap>(
+/// Glm4 and Glm4Moe store their attention projections in the layout
+/// `TransformerBlock::from_weights` already reads, so their stage load needs
+/// no weight surgery. Only the MLA variant does.
+fn no_sanitize<A>(weights: WeightMap, _args: &A) -> Result<WeightMap, String> {
+    Ok(weights)
+}
+
+fn load_glm4_family_stage_model<
+    A,
+    B,
+    L,
+    Sanitize,
+    BuildLayer,
+    GroupSize,
+    Bits,
+    RmsEps,
+    TieEmbeddings,
+    Wrap,
+>(
     model_dir: &Path,
     filter: &LayerFilter,
     stage_index: usize,
+    sanitize: Sanitize,
     build_layer: BuildLayer,
     group_size: GroupSize,
     bits: Bits,
@@ -200,6 +232,7 @@ fn load_glm4_family_stage_model<A, B, L, BuildLayer, GroupSize, Bits, RmsEps, Ti
 where
     A: DeserializeOwned,
     L: TransformerStageLayer,
+    Sanitize: Fn(WeightMap, &A) -> Result<WeightMap, String>,
     BuildLayer: Fn(&WeightMap, &A, usize) -> Result<B, String>,
     GroupSize: Fn(&A) -> i32,
     Bits: Fn(&A) -> i32,
@@ -208,7 +241,14 @@ where
     Wrap: Fn(B) -> L,
 {
     let args: A = parse_model_args(model_dir)?;
-    let mut weights = models::load_text_weights(model_dir, None).map_err(anyhow::Error::msg)?;
+    // Sanitation runs on the full weight map, before `filter_weight_map` trims
+    // it. Only the MLA variant of this family needs it, and it needs this
+    // ordering: `glm4_moe_lite` checkpoints ship `self_attn.kv_b_proj` instead
+    // of the `embed_q` / `unembed_out` pair the block loads (issue #1029), and
+    // the stage filter would drop the `kv_b_proj` keys of every out-of-range
+    // layer before the split could consume them.
+    let weights = models::load_text_weights(model_dir, None).map_err(anyhow::Error::msg)?;
+    let mut weights = sanitize(weights, &args).map_err(anyhow::Error::msg)?;
 
     let mut effective_filter = filter.clone();
     if tie_embeddings(&args) && filter.has_lm_head {

--- a/src/models/glm4_moe_lite.rs
+++ b/src/models/glm4_moe_lite.rs
@@ -31,6 +31,11 @@ use mlxcel_core::{MlxArray, UniquePtr};
 use serde::Deserialize;
 use std::path::Path;
 
+#[path = "glm4_moe_lite_sanitize.rs"]
+mod glm4_moe_lite_sanitize;
+
+pub use glm4_moe_lite_sanitize::sanitize_weights;
+
 // Configuration.
 #[derive(Debug, Clone, Deserialize)]
 pub struct ModelArgs {
@@ -861,6 +866,10 @@ impl Glm4MoeLiteModel {
             .map_err(|e| format!("Failed to parse config.json: {}", e))?;
 
         let weights = crate::models::load_text_weights(model_dir, None)?;
+        // Public checkpoints ship `kv_b_proj` and no `embed_q`, so this step is
+        // what makes the canonical layout loadable at all (issue #1029). The
+        // sibling MLA families call their own sanitizer from the same place.
+        let weights = sanitize_weights(weights, &args)?;
         let model = Self::from_weights(&weights, &args)?;
 
         Ok((model, args))

--- a/src/models/glm4_moe_lite_sanitize.rs
+++ b/src/models/glm4_moe_lite_sanitize.rs
@@ -1,0 +1,167 @@
+// Copyright 2025-2026 Lablup Inc. and Jeongkyu Shin
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Weight-map sanitization for GLM4 MoE Lite.
+//!
+//! Split out of `glm4_moe_lite.rs` rather than appended to it, the same way
+//! `youtu_vl_lm_sanitize.rs` was split out of `youtu_vl_lm.rs`: the runtime
+//! module is already well past the 500-line target and this keeps the new code
+//! from pushing it further. [`sanitize_weights`] is re-exported from
+//! `glm4_moe_lite` so call sites name it the way the other MLA families do.
+
+use mlxcel_core::utils::slice_axis;
+use mlxcel_core::weights::WeightMap;
+
+use super::ModelArgs;
+
+/// Decompose `kv_b_proj` into the per-head `embed_q` / `unembed_out` pair that
+/// `MlaAttention::from_weights` loads.
+///
+/// Every public `glm4_moe_lite` checkpoint stores the MLA up-projection as a
+/// single `self_attn.kv_b_proj.weight` and ships no `embed_q` tensor at all, so
+/// without this step the family cannot load the canonical layout of its own
+/// architecture: `MultiLinear::from_weights` fails with `Weight not found:
+/// model.layers.0.self_attn.embed_q.weight` (issue #1029). The other five MLA
+/// families in the tree (DeepSeek V3, DeepSeek V3.2, Kimi Linear, LongCat Flash
+/// NGram, Youtu-VL) all carry the same decomposition; this one is adapted from
+/// `youtu_vl_lm_sanitize.rs`, the only one that cross-checks the tensor shape
+/// against the config before reshaping.
+///
+/// A quantized `kv_b_proj` is dequantized before the split, because the split
+/// runs per head along the row axis and slicing in packed space would leave
+/// each half carrying group scales and biases that describe the whole row.
+///
+/// Returns `Err` rather than panicking or aborting when a `kv_b_proj` cannot be
+/// decomposed: scales with no biases, a solved quantization pair no packing can
+/// describe, or a tensor whose shape disagrees with `config.json`.
+///
+/// Used by: [`super::Glm4MoeLiteModel::load`].
+pub fn sanitize_weights(mut weights: WeightMap, args: &ModelArgs) -> Result<WeightMap, String> {
+    let num_heads = args.num_attention_heads as i32;
+    let head_dim = (args.qk_nope_head_dim + args.v_head_dim) as i32;
+    let qk_nope_head_dim = args.qk_nope_head_dim as i32;
+    let kv_lora_rank = args.kv_lora_rank as i32;
+
+    for layer_idx in 0..args.num_hidden_layers {
+        let prefix = format!("model.layers.{layer_idx}.self_attn");
+        let kv_b_key = format!("{prefix}.kv_b_proj.weight");
+        let embed_q_key = format!("{prefix}.embed_q.weight");
+
+        // A checkpoint that already ships the decomposed pair is left exactly as
+        // it is, matching the sibling sanitizers. Re-deriving the pair would at
+        // best duplicate work and at worst replace a quantized `embed_q` (which
+        // `MultiLinear` still loads through `QuantizedMultiLinear`) with a dense
+        // one built from a `kv_b_proj` the exporter may have left behind stale.
+        if weights.contains_key(&embed_q_key) || !weights.contains_key(&kv_b_key) {
+            continue;
+        }
+
+        let scales_key = format!("{prefix}.kv_b_proj.scales");
+        let is_quantized = weights.contains_key(&scales_key);
+
+        let w = weights.remove(&kv_b_key).unwrap();
+
+        let w_full = if is_quantized {
+            let s = weights.remove(&scales_key).unwrap();
+            // `is_quantized` gates on `.scales` alone, and the block-float modes
+            // (mxfp4 / nvfp4 / mxfp8) ship scales with no zero points, so a
+            // block-float export satisfies that gate and arrives here carrying
+            // no `.biases` plane. Taking it with `.unwrap()` would turn that
+            // into a panic during sanitization, which in the server takes the
+            // process down rather than rejecting one model load (issue #1026
+            // aligned the other five sanitizers on this wording). `dequantize`
+            // below is hardcoded `"affine"` and so could not decompose such a
+            // plane in any case; what this buys is a load error naming the key
+            // that is missing.
+            let b_key = format!("{prefix}.kv_b_proj.biases");
+            let b = weights.remove(&b_key).ok_or_else(|| {
+                format!(
+                    "layer {layer_idx}: kv_b_proj has scales but no biases at key `{b_key}`; \
+                     the checkpoint may be corrupted or only partially converted"
+                )
+            })?;
+
+            // Solve the packed pair from the shapes and bound it before it
+            // reaches `dequantize`. The shared helper also checks each divisor
+            // before dividing: `kv_lora_rank` is a config field and the scales
+            // axis is checkpoint data, so the naive form panics on a zero
+            // divisor and overflows i32 on a large packed axis, both before the
+            // bound could fire (issue #958).
+            let (inferred_gs, inferred_bits) = mlxcel_core::layers::infer_mla_quantization_params(
+                &mlxcel_core::array_shape(&w),
+                &mlxcel_core::array_shape(&s),
+                kv_lora_rank,
+                &format!("{prefix}.kv_b_proj"),
+            )?;
+
+            // SAFETY: `w`, `s` and `b` are live UniquePtr-owned arrays taken out
+            // of the weight map above and are not dropped until this call
+            // returns.
+            unsafe {
+                mlxcel_core::dequantize(
+                    &w,
+                    &s,
+                    &*b as *const _,
+                    inferred_gs,
+                    inferred_bits,
+                    "affine",
+                )
+            }
+        } else {
+            mlxcel_core::copy(&w)
+        };
+
+        // Cross-check the tensor against the config before reshaping. A
+        // mismatch means `config.json` and the stored tensor disagree, and the
+        // reshape below is the point where that stops being recoverable: MLX
+        // reports a bad reshape by throwing, and the throw crosses the cxx
+        // bridge as `UniquePtr<MlxArray>` rather than `Result`, so it aborts the
+        // process during weight sanitization instead of failing the load. Of
+        // the five sibling sanitizers only Youtu-VL carries this check.
+        let w_shape = mlxcel_core::array_shape(&w_full);
+        let expected_rows = num_heads * head_dim;
+        if w_shape.len() != 2 || w_shape[0] != expected_rows || w_shape[1] != kv_lora_rank {
+            return Err(format!(
+                "layer {layer_idx}: kv_b_proj shape mismatch: got {w_shape:?}, expected \
+                 [{expected_rows}, {kv_lora_rank}] (num_heads={num_heads}, head_dim={head_dim}, \
+                 kv_lora_rank={kv_lora_rank})"
+            ));
+        }
+
+        // [num_heads * head_dim, kv_lora_rank] -> [num_heads, head_dim, kv_lora_rank]
+        let w_3d = mlxcel_core::reshape(&w_full, &[num_heads, head_dim, -1]);
+
+        // wk = w[:, :qk_nope_head_dim, :]  (the nope half)
+        // wv = w[:, qk_nope_head_dim:, :]  (the v half)
+        let wk = slice_axis(&w_3d, 1, 0, qk_nope_head_dim);
+        let wv = slice_axis(&w_3d, 1, qk_nope_head_dim, -1);
+
+        // embed_q stores the swapped-axes form: [num_heads, kv_lora_rank, qk_nope_head_dim]
+        let wk = mlxcel_core::transpose_axes(&wk, &[0, 2, 1]);
+
+        // Copy both halves so `MultiLinear`'s matmul sees well-formed strides
+        // regardless of the backend, rather than a view into the parent tensor.
+        let wk = mlxcel_core::copy(&wk);
+        let wv = mlxcel_core::copy(&wv);
+
+        weights.insert(format!("{prefix}.embed_q.weight"), wk);
+        weights.insert(format!("{prefix}.unembed_out.weight"), wv);
+    }
+
+    Ok(weights)
+}
+
+#[cfg(test)]
+#[path = "glm4_moe_lite_sanitize_tests.rs"]
+mod tests;

--- a/src/models/glm4_moe_lite_sanitize_tests.rs
+++ b/src/models/glm4_moe_lite_sanitize_tests.rs
@@ -1,0 +1,343 @@
+// Copyright 2025-2026 Lablup Inc. and Jeongkyu Shin
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Tests for the GLM4 MoE Lite MLA `kv_b_proj` decomposition (issue #1029).
+//!
+//! Every assertion is on a `Result` from `sanitize_weights` or from the real
+//! `Glm4MoeLiteModel::from_weights`, and no test runs a forward pass. That is
+//! deliberate: a load that produced a malformed `embed_q` would reach MLX
+//! through the cxx bridge as `UniquePtr<MlxArray>` rather than `Result`, so a
+//! C++ throw there is an uncatchable abort that takes the whole test binary
+//! down instead of failing one test.
+
+use super::sanitize_weights;
+use crate::models::glm4_moe_lite::{Glm4MoeLiteModel, ModelArgs};
+use mlxcel_core::weights::WeightMap;
+use mlxcel_core::{MlxArray, UniquePtr};
+
+const VOCAB: i32 = 16;
+const HIDDEN: i32 = 8;
+const INTERMEDIATE: i32 = 8;
+const HEADS: i32 = 2;
+const KV_LORA_RANK: i32 = 16;
+const QK_NOPE: i32 = 4;
+const QK_ROPE: i32 = 2;
+const V_HEAD: i32 = 4;
+
+/// `[num_heads * (qk_nope_head_dim + v_head_dim), kv_lora_rank]`, the layout
+/// every public `glm4_moe_lite` checkpoint stores `kv_b_proj` in.
+const KV_B_ROWS: i32 = HEADS * (QK_NOPE + V_HEAD);
+
+const ATTN: &str = "model.layers.0.self_attn";
+
+/// One dense layer, so `is_moe_layer` stays false (`n_routed_experts` is left
+/// unset) and the fixture does not have to build a stacked expert plane, and
+/// `q_lora_rank` is null so the Q side is a single `q_proj`. Neither choice
+/// touches the MLA decomposition under test.
+fn tiny_config() -> ModelArgs {
+    let json = format!(
+        r#"{{
+        "model_type": "glm4_moe_lite",
+        "vocab_size": {VOCAB},
+        "hidden_size": {HIDDEN},
+        "intermediate_size": {INTERMEDIATE},
+        "moe_intermediate_size": {INTERMEDIATE},
+        "num_hidden_layers": 1,
+        "num_attention_heads": {HEADS},
+        "num_key_value_heads": {HEADS},
+        "rms_norm_eps": 1e-6,
+        "rope_theta": 10000.0,
+        "kv_lora_rank": {KV_LORA_RANK},
+        "q_lora_rank": null,
+        "qk_rope_head_dim": {QK_ROPE},
+        "qk_nope_head_dim": {QK_NOPE},
+        "v_head_dim": {V_HEAD}
+    }}"#
+    );
+    serde_json::from_str(&json).expect("parse tiny glm4_moe_lite config")
+}
+
+fn dense(shape: &[i32]) -> UniquePtr<MlxArray> {
+    let n: i32 = shape.iter().product();
+    mlxcel_core::from_slice_f32(&vec![0.0f32; n as usize], shape)
+}
+
+/// Everything `Glm4MoeLiteModel::from_weights` needs except the MLA pair, so
+/// the only reason a load can fail below is the `kv_b_proj` handling.
+fn checkpoint_without_the_mla_pair() -> WeightMap {
+    let q_head_dim = QK_NOPE + QK_ROPE;
+    let mut weights = WeightMap::new();
+    for (key, shape) in [
+        ("model.embed_tokens.weight", vec![VOCAB, HIDDEN]),
+        (
+            "model.layers.0.self_attn.q_proj.weight",
+            vec![HEADS * q_head_dim, HIDDEN],
+        ),
+        (
+            "model.layers.0.self_attn.kv_a_proj_with_mqa.weight",
+            vec![KV_LORA_RANK + QK_ROPE, HIDDEN],
+        ),
+        (
+            "model.layers.0.self_attn.kv_a_layernorm.weight",
+            vec![KV_LORA_RANK],
+        ),
+        (
+            "model.layers.0.self_attn.o_proj.weight",
+            vec![HIDDEN, HEADS * V_HEAD],
+        ),
+        (
+            "model.layers.0.mlp.gate_proj.weight",
+            vec![INTERMEDIATE, HIDDEN],
+        ),
+        (
+            "model.layers.0.mlp.up_proj.weight",
+            vec![INTERMEDIATE, HIDDEN],
+        ),
+        (
+            "model.layers.0.mlp.down_proj.weight",
+            vec![HIDDEN, INTERMEDIATE],
+        ),
+        ("model.layers.0.input_layernorm.weight", vec![HIDDEN]),
+        (
+            "model.layers.0.post_attention_layernorm.weight",
+            vec![HIDDEN],
+        ),
+        ("model.norm.weight", vec![HIDDEN]),
+        ("lm_head.weight", vec![VOCAB, HIDDEN]),
+    ] {
+        weights.insert(key.to_string(), dense(&shape));
+    }
+    weights
+}
+
+/// The layout the three public `glm4_moe_lite` repos actually ship: a float
+/// `kv_b_proj`, no `.scales`, no `.biases`, and no `embed_q` at all.
+fn float_kv_b_proj_checkpoint() -> WeightMap {
+    let mut weights = checkpoint_without_the_mla_pair();
+    weights.insert(
+        format!("{ATTN}.kv_b_proj.weight"),
+        dense(&[KV_B_ROWS, KV_LORA_RANK]),
+    );
+    weights
+}
+
+/// An affine 4-bit `kv_b_proj`. The geometry is honest: `packed_in * 32 == bits
+/// * num_groups * group_size` (2 * 32 == 4 * 1 * 16) against `kv_lora_rank` 16,
+/// which is what `infer_mla_quantization_params` solves the pair from.
+///
+/// The packed plane is UINT32, not a float dtype: `dequantize` rejects any
+/// other packed dtype by throwing, and that throw is the uncatchable abort this
+/// file exists to keep out of the test binary. A float fixture here would take
+/// the process down on the positive control.
+fn quantized_kv_b_proj_checkpoint() -> WeightMap {
+    let mut weights = checkpoint_without_the_mla_pair();
+    weights.insert(
+        format!("{ATTN}.kv_b_proj.weight"),
+        mlxcel_core::zeros(&[KV_B_ROWS, 2], mlxcel_core::dtype::UINT32),
+    );
+    weights.insert(format!("{ATTN}.kv_b_proj.scales"), dense(&[KV_B_ROWS, 1]));
+    weights.insert(format!("{ATTN}.kv_b_proj.biases"), dense(&[KV_B_ROWS, 1]));
+    weights
+}
+
+/// The same plane an mxfp4 / nvfp4 / mxfp8 export ships: `.scales` present,
+/// `.biases` absent, because the block-float modes carry no zero points.
+fn block_float_kv_b_proj_checkpoint() -> WeightMap {
+    let mut weights = quantized_kv_b_proj_checkpoint();
+    weights.remove(&format!("{ATTN}.kv_b_proj.biases"));
+    weights
+}
+
+/// A checkpoint that already carries the decomposed pair, and a stale
+/// `kv_b_proj` alongside it.
+fn predecomposed_checkpoint() -> WeightMap {
+    let mut weights = float_kv_b_proj_checkpoint();
+    weights.insert(
+        format!("{ATTN}.embed_q.weight"),
+        dense(&[HEADS, KV_LORA_RANK, QK_NOPE]),
+    );
+    weights.insert(
+        format!("{ATTN}.unembed_out.weight"),
+        dense(&[HEADS, V_HEAD, KV_LORA_RANK]),
+    );
+    weights
+}
+
+fn shape_of(weights: &WeightMap, key: &str) -> Vec<i32> {
+    mlxcel_core::array_shape(weights.get(key).unwrap_or_else(|| panic!("missing {key}")))
+}
+
+/// Issue #1029: `glm4_moe_lite` had no `sanitize_weights` and no `kv_b_proj`
+/// decomposition anywhere, while `MlaAttention::from_weights` loads `embed_q`
+/// and `unembed_out` unconditionally. Since no published checkpoint ships
+/// either tensor, the family could not load the canonical layout of its own
+/// architecture.
+///
+/// The first assertion is the failure the issue reports, taken from the real
+/// loader rather than restated, so this test would still fail if the
+/// decomposition were removed and `MlaAttention` were relaxed to tolerate a
+/// missing `embed_q` instead.
+#[test]
+fn sanitize_synthesizes_the_mla_pair_no_checkpoint_ships() {
+    let args = tiny_config();
+
+    let err = Glm4MoeLiteModel::from_weights(&float_kv_b_proj_checkpoint(), &args)
+        .err()
+        .expect("an unsanitized kv_b_proj checkpoint has no embed_q to load");
+    assert_eq!(
+        err, "Weight not found: model.layers.0.self_attn.embed_q.weight",
+        "the unsanitized failure this test pins must stay the one issue #1029 reports"
+    );
+
+    let sanitized = sanitize_weights(float_kv_b_proj_checkpoint(), &args)
+        .expect("a float kv_b_proj must decompose");
+
+    assert!(
+        !sanitized.contains_key(&format!("{ATTN}.kv_b_proj.weight")),
+        "the decomposed kv_b_proj must be consumed, not left beside the pair"
+    );
+    assert_eq!(
+        shape_of(&sanitized, &format!("{ATTN}.embed_q.weight")),
+        vec![HEADS, KV_LORA_RANK, QK_NOPE],
+        "embed_q holds the nope half with its last two axes swapped"
+    );
+    assert_eq!(
+        shape_of(&sanitized, &format!("{ATTN}.unembed_out.weight")),
+        vec![HEADS, V_HEAD, KV_LORA_RANK],
+        "unembed_out holds the v half unswapped"
+    );
+
+    Glm4MoeLiteModel::from_weights(&sanitized, &args)
+        .expect("the sanitized checkpoint must load through the real loader");
+}
+
+/// The split runs per head along the row axis, so it has to happen in dense
+/// space: slicing the packed plane would leave each half carrying group scales
+/// and biases that describe the whole row.
+#[test]
+fn sanitize_dequantizes_kv_b_proj_before_the_per_head_split() {
+    let args = tiny_config();
+
+    let sanitized = sanitize_weights(quantized_kv_b_proj_checkpoint(), &args)
+        .expect("an honest affine kv_b_proj must decompose");
+
+    for suffix in ["weight", "scales", "biases"] {
+        assert!(
+            !sanitized.contains_key(&format!("{ATTN}.kv_b_proj.{suffix}")),
+            "all three kv_b_proj planes are consumed by the dequantize, `{suffix}` survived"
+        );
+    }
+    // No `.scales` on either half is what makes `MultiLinear::from_weights`
+    // take its dense branch; a re-quantized pair would need planes this
+    // decomposition never rebuilds.
+    for name in ["embed_q", "unembed_out"] {
+        assert!(
+            !sanitized.contains_key(&format!("{ATTN}.{name}.scales")),
+            "{name} must be stored dense after the dequantize"
+        );
+    }
+    assert_eq!(
+        shape_of(&sanitized, &format!("{ATTN}.embed_q.weight")),
+        vec![HEADS, KV_LORA_RANK, QK_NOPE],
+        "the dequantized plane must split to the same shape the float one does"
+    );
+
+    Glm4MoeLiteModel::from_weights(&sanitized, &args)
+        .expect("the dequantized pair must load through the real loader");
+}
+
+/// Issue #1026 / PR #1027: the quantized branch decides `kv_b_proj` is
+/// quantized on `.scales` alone. Affine stores zero points; the block-float
+/// modes (mxfp4 / nvfp4 / mxfp8) do not. A block-float `kv_b_proj` therefore
+/// satisfies the `.scales` gate and reaches the `.biases` removal with nothing
+/// to take, and an `.unwrap()` there is a panic during weight sanitization,
+/// which in the server takes the process down rather than rejecting one load.
+///
+/// The decomposition still dequantizes as `"affine"`, so a genuine block-float
+/// `kv_b_proj` is not supported either way. What this pins is that it is
+/// refused by name, in the wording the other five sanitizers share.
+#[test]
+fn sanitize_rejects_scales_with_no_biases() {
+    let args = tiny_config();
+
+    // Positive control first, so a check that rejected every quantized
+    // kv_b_proj could not pass this test.
+    sanitize_weights(quantized_kv_b_proj_checkpoint(), &args)
+        .expect("a kv_b_proj carrying both planes must still sanitize");
+
+    let err = sanitize_weights(block_float_kv_b_proj_checkpoint(), &args)
+        .err()
+        .expect("scales with no biases must be refused at load, not unwrapped");
+    assert!(
+        err.contains("model.layers.0.self_attn.kv_b_proj.biases"),
+        "the error must name the key that is missing, got: {err}"
+    );
+    assert!(
+        err.contains("scales but no biases"),
+        "the wording must match the other five MLA sanitizers, got: {err}"
+    );
+}
+
+/// A checkpoint that already ships the pair is skipped, matching the `continue`
+/// in every sibling sanitizer. This is not hypothetical: once a converter emits
+/// a pre-decomposed quantized `embed_q`, rebuilding it here from a stale
+/// `kv_b_proj` would silently replace the quantized plane with a dense one.
+#[test]
+fn sanitize_leaves_an_already_decomposed_checkpoint_alone() {
+    let args = tiny_config();
+
+    let sanitized = sanitize_weights(predecomposed_checkpoint(), &args)
+        .expect("a pre-decomposed checkpoint must sanitize");
+
+    // The decomposition removes `kv_b_proj.weight`, so its survival is the
+    // observable proof that the skip fired rather than the split running.
+    assert!(
+        sanitized.contains_key(&format!("{ATTN}.kv_b_proj.weight")),
+        "an existing embed_q must stop the decomposition before it consumes kv_b_proj"
+    );
+    assert_eq!(
+        shape_of(&sanitized, &format!("{ATTN}.embed_q.weight")),
+        vec![HEADS, KV_LORA_RANK, QK_NOPE],
+        "the shipped embed_q must survive untouched"
+    );
+}
+
+/// The reshape below the split is where a `config.json` that disagrees with the
+/// stored tensor stops being recoverable: MLX reports a bad reshape by
+/// throwing, and that throw crosses the cxx bridge as `UniquePtr<MlxArray>`
+/// rather than `Result`, so it aborts during weight sanitization instead of
+/// failing the load. The cross-check turns that into an error naming both
+/// shapes.
+#[test]
+fn sanitize_rejects_a_kv_b_proj_that_disagrees_with_the_config() {
+    let args = tiny_config();
+
+    let mut weights = checkpoint_without_the_mla_pair();
+    weights.insert(
+        format!("{ATTN}.kv_b_proj.weight"),
+        dense(&[KV_B_ROWS + QK_NOPE + V_HEAD, KV_LORA_RANK]),
+    );
+
+    let err = sanitize_weights(weights, &args)
+        .err()
+        .expect("a kv_b_proj carrying an extra head must be refused before the reshape");
+    assert!(
+        err.contains("shape mismatch"),
+        "the error must say what is wrong, got: {err}"
+    );
+    assert!(
+        err.contains(&format!("[{KV_B_ROWS}, {KV_LORA_RANK}]")),
+        "the error must name the shape the config describes, got: {err}"
+    );
+}

--- a/src/models/glm4_moe_lite_sanitize_tests.rs
+++ b/src/models/glm4_moe_lite_sanitize_tests.rs
@@ -33,11 +33,19 @@ const HEADS: i32 = 2;
 const KV_LORA_RANK: i32 = 16;
 const QK_NOPE: i32 = 4;
 const QK_ROPE: i32 = 2;
-const V_HEAD: i32 = 4;
+/// Deliberately different from [`QK_NOPE`]. While the two half-widths were
+/// equal, `[HEADS, KV_LORA_RANK, QK_NOPE]` and `[HEADS, V_HEAD, KV_LORA_RANK]`
+/// stayed valid with the nope and v halves swapped, so every shape assertion in
+/// this file passed whichever half each output was built from.
+const V_HEAD: i32 = 6;
 
 /// `[num_heads * (qk_nope_head_dim + v_head_dim), kv_lora_rank]`, the layout
 /// every public `glm4_moe_lite` checkpoint stores `kv_b_proj` in.
 const KV_B_ROWS: i32 = HEADS * (QK_NOPE + V_HEAD);
+
+/// The per-head row block of `kv_b_proj`: `qk_nope_head_dim` rows of the nope
+/// half first, then `v_head_dim` rows of the v half.
+const HEAD_DIM: i32 = QK_NOPE + V_HEAD;
 
 const ATTN: &str = "model.layers.0.self_attn";
 
@@ -132,6 +140,20 @@ fn float_kv_b_proj_checkpoint() -> WeightMap {
     weights
 }
 
+/// The same float layout, but with `kv_b_proj` filled with a `0, 1, 2, ...`
+/// ramp in row-major order over `[KV_B_ROWS, KV_LORA_RANK]`, so every element
+/// carries its own flat source index and the decomposition's element mapping
+/// becomes observable. The zero-filled fixtures above cannot show it.
+fn ramp_kv_b_proj_checkpoint() -> (WeightMap, Vec<f32>) {
+    let kv_b: Vec<f32> = (0..KV_B_ROWS * KV_LORA_RANK).map(|i| i as f32).collect();
+    let mut weights = checkpoint_without_the_mla_pair();
+    weights.insert(
+        format!("{ATTN}.kv_b_proj.weight"),
+        mlxcel_core::from_slice_f32(&kv_b, &[KV_B_ROWS, KV_LORA_RANK]),
+    );
+    (weights, kv_b)
+}
+
 /// An affine 4-bit `kv_b_proj`. The geometry is honest: `packed_in * 32 == bits
 /// * num_groups * group_size` (2 * 32 == 4 * 1 * 16) against `kv_lora_rank` 16,
 /// which is what `infer_mla_quantization_params` solves the pair from.
@@ -176,6 +198,18 @@ fn predecomposed_checkpoint() -> WeightMap {
 
 fn shape_of(weights: &WeightMap, key: &str) -> Vec<i32> {
     mlxcel_core::array_shape(weights.get(key).unwrap_or_else(|| panic!("missing {key}")))
+}
+
+/// Read an array back as flat row-major `f32`. Reading values out over the cxx
+/// bridge is safe in a way a forward pass is not: it neither reshapes nor
+/// matmuls, so there is no C++ throw to abort the test binary.
+fn read_f32(arr: &MlxArray) -> Vec<f32> {
+    let a = mlxcel_core::astype(arr, mlxcel_core::dtype::FLOAT32);
+    mlxcel_core::eval(&a);
+    mlxcel_core::array_to_raw_bytes(&a)
+        .chunks_exact(4)
+        .map(|c| f32::from_le_bytes([c[0], c[1], c[2], c[3]]))
+        .collect()
 }
 
 /// Issue #1029: `glm4_moe_lite` had no `sanitize_weights` and no `kv_b_proj`
@@ -340,4 +374,75 @@ fn sanitize_rejects_a_kv_b_proj_that_disagrees_with_the_config() {
         err.contains(&format!("[{KV_B_ROWS}, {KV_LORA_RANK}]")),
         "the error must name the shape the config describes, got: {err}"
     );
+}
+
+/// Pins the element mapping, not just the shapes: which half of `kv_b_proj`
+/// each output is built from, and which axis order it lands in.
+///
+/// Every other assertion in this file is blind to both. Shapes cannot catch a
+/// swapped nope / v half once the two half-widths are told apart only by
+/// [`QK_NOPE`] and [`V_HEAD`], and cannot catch a wrong reshape or transpose
+/// axis order at all, so the ramp fixture is what makes either failure
+/// observable.
+///
+/// This matters more than a load error would. A decomposition that picks the
+/// wrong half or the wrong axis order still produces tensors of the right
+/// shape, so the model loads, runs, and emits plausible text built on weights
+/// that mean something else. A missing `embed_q` at least stops at the loader.
+///
+/// The two expectations come from the HF definition: `kv_b_proj =
+/// nn.Linear(kv_lora_rank, num_heads * (qk_nope_head_dim + v_head_dim))`, so
+/// the stored `weight` is `[num_heads * head_dim, kv_lora_rank]` row-major and
+/// head-major, and within each head the `qk_nope` rows precede the `v_head`
+/// ones (`expand_kv` views `(..., -1, qk_nope + v_head)` then splits on the
+/// last axis). `embed_q` is the nope half transposed; `unembed_out` is the v
+/// half as stored.
+#[test]
+fn sanitize_splits_the_halves_in_the_order_the_reference_layout_stores_them() {
+    let args = tiny_config();
+    let (weights, kv_b) = ramp_kv_b_proj_checkpoint();
+
+    let sanitized = sanitize_weights(weights, &args).expect("a float kv_b_proj must decompose");
+
+    let embed_q = read_f32(
+        sanitized
+            .get(&format!("{ATTN}.embed_q.weight"))
+            .expect("embed_q"),
+    );
+    let unembed_out = read_f32(
+        sanitized
+            .get(&format!("{ATTN}.unembed_out.weight"))
+            .expect("unembed_out"),
+    );
+    assert_eq!(embed_q.len(), (HEADS * KV_LORA_RANK * QK_NOPE) as usize);
+    assert_eq!(unembed_out.len(), (HEADS * V_HEAD * KV_LORA_RANK) as usize);
+
+    for h in 0..HEADS {
+        // embed_q[h][r][c] is the nope row `c` of head `h`, column `r`: the
+        // last two axes of the nope half swapped.
+        for r in 0..KV_LORA_RANK {
+            for c in 0..QK_NOPE {
+                let got = embed_q[((h * KV_LORA_RANK + r) * QK_NOPE + c) as usize];
+                let want = kv_b[((h * HEAD_DIM + c) * KV_LORA_RANK + r) as usize];
+                assert_eq!(
+                    got, want,
+                    "embed_q[{h}][{r}][{c}] must be the transposed nope half, not the v half \
+                     or an untransposed view"
+                );
+            }
+        }
+        // unembed_out[h][d][r] is v row `d` of head `h`, stored as it is: the v
+        // rows start `QK_NOPE` into the head's row block.
+        for d in 0..V_HEAD {
+            for r in 0..KV_LORA_RANK {
+                let got = unembed_out[((h * V_HEAD + d) * KV_LORA_RANK + r) as usize];
+                let want = kv_b[((h * HEAD_DIM + QK_NOPE + d) * KV_LORA_RANK + r) as usize];
+                assert_eq!(
+                    got, want,
+                    "unembed_out[{h}][{d}][{r}] must be the untransposed v half, not the nope \
+                     half"
+                );
+            }
+        }
+    }
 }


### PR DESCRIPTION
## Summary

`src/models/glm4_moe_lite.rs` had no `sanitize_weights` and no MLA `kv_b_proj` decomposition anywhere, while `MlaAttention::from_weights` loads `embed_q` and `unembed_out` unconditionally (`src/models/glm4_moe_lite.rs:327-333`). Every published `glm4_moe_lite` checkpoint stores the MLA up-projection as a single `self_attn.kv_b_proj.weight` and ships no `embed_q` tensor at all, so the family failed the canonical layout of its own architecture with `Weight not found: model.layers.0.self_attn.embed_q.weight`. This is a live failure, not a latent one, and every other MLA family in the tree already carries this decomposition.

## What changed

- `src/models/glm4_moe_lite_sanitize.rs` (new): `sanitize_weights` decomposes `kv_b_proj` into the per-head `embed_q` / `unembed_out` pair. Adapted from `src/models/youtu_vl_lm_sanitize.rs`, the most complete of the five existing implementations and the only one that cross-checks the tensor against `[num_heads * head_dim, kv_lora_rank]` before reshaping. Reuses `mlxcel_core::layers::infer_mla_quantization_params` for the packed pair (issue #958) and refuses a scales-without-biases plane in the wording standardized across all five sanitizers in PR #1027 (issue #1026), verbatim.
- `src/models/glm4_moe_lite.rs`: declares the sanitize module, re-exports `sanitize_weights`, and calls it from `Glm4MoeLiteModel::load` between `load_text_weights` and `from_weights`.
- `src/models/glm4_moe_lite_sanitize_tests.rs` (new): five tests.

The code lives in its own module rather than being appended to `glm4_moe_lite.rs`, the same split `youtu_vl_lm_sanitize.rs` uses, because the runtime module is already well past the repo's 500-line target.

### Why the shape cross-check is carried over

Of the five sibling sanitizers only Youtu-VL cross-checks the tensor shape, and it is worth having. The reshape below the split is where a `config.json` that disagrees with the stored tensor stops being recoverable: MLX reports a bad reshape by throwing, and that throw crosses the cxx bridge as `UniquePtr<MlxArray>` rather than `Result`, so it aborts the process during weight sanitization instead of failing the load. The check cannot reject anything that would otherwise have worked, because a row count that disagrees with `num_heads * head_dim` produces a latent width the forward path cannot consume even when the reshape happens to succeed.

### Why the quantized plane is dequantized first

The split runs per head along the row axis. Slicing the packed plane would leave each half carrying group scales and biases that describe the whole row, so the halves have to be produced in dense space. `dequantize` is hardcoded `"affine"` here, the same as in all five siblings, which is why a block-float `kv_b_proj` is refused by name rather than silently mis-decomposed.

## The `load` versus `from_weights` wiring decision

`src/model_metadata.rs:185` registers two entry points for this family, and the `WeightLoadRoute::ConfigBacked` arm at `src/loading/mod.rs:673` reaches `from_weights` without going through `load`, so a sanitizer placed only in `load` does not cover it. I checked what the siblings actually do for their own weight route before choosing, and the answer is not uniform:

- `KimiLinear` and `LongcatFlash` / `LongcatFlashNgram` are `WeightLoadRoute::Special`, and that route **does** sanitize: `src/loading/special.rs:241-262` takes an owned copy through `copy_weight_map` and runs the family sanitizer before `from_weights`.
- `Youtu-VL` is a VLM with `adapter: Some(...)`, so `load_model_with_adapter` rejects it before any weight route runs. Not applicable.
- `DeepSeekV3` and `DeepSeekV32` are `WeightLoadRoute::ConfigBacked`, the same route as this family, and both **share the gap**: `try_load_config_backed_model_from_weights` is macro-generated (`src/loading/config_backed.rs:50-68`) and calls `$weight_builder(weights, &args)` with no hook where a sanitizer could go.

So the gap is not a property of MLA families, it is a property of the `ConfigBacked` route: the hand-written `Special` route has a place to put the sanitizer and the macro-generated one does not. It affects exactly the three `ConfigBacked` MLA families, and `load_model_from_weights` is called from one place only (`src/loading/mod.rs:636`), so the blast radius is LoRA adapter loading, not ordinary model loading.

**Decision: sanitize in `load` only, matching `DeepSeekV3` and `DeepSeekV32` exactly.** Closing the gap unilaterally for this one family means either moving it to the `Special` route or adding a per-family hook to a macro that drives around sixty registrations, and the second of those fixes the siblings, which this PR was explicitly scoped not to do. Sanitizing inside `from_weights` was rejected on a separate ground: it would need an owned `copy_weight_map`, and the `load` path already owns its map, so the dir route would copy the whole weight map a second time. That is a real peak-memory regression on a large MoE in exchange for a route this family is not yet used on.

**The sibling gap deserves its own issue.** It is a genuine pre-existing bug, not an accepted design: LoRA adapter loading is already broken for `DeepSeekV3` and `DeepSeekV32` on the canonical checkpoint layout today, failing with the same `Weight not found: ...embed_q.weight` this PR fixes for the dir route. The asymmetry with the `Special` route is the evidence that it was an oversight. The fix wants to be one hook on the `ConfigBacked` registration, applied to all three families at once with its own tests, not three copies.

## On extracting a shared helper for the six decomposition blocks

PR #1027 declined this for three recorded reasons. Checked against the tree, all three hold but two are weaker than they look:

- **Only Youtu cross-checks the `w_full` shape.** True, and this PR makes it two of six. This is the one real behavioral difference, and it is a difference the other four should lose, not one worth preserving.
- **The slice and transpose helpers differ.** Kimi uses raw `mlxcel_core::slice` with explicit stops plus `swap_axes`; the rest use `slice_axis` plus `transpose_axes`. This is incidental, not semantic: `slice_axis` treats `end == -1` as "to the end of the axis" (`src/lib/mlxcel-core/src/utils.rs:52-61`), which is exactly what Kimi's explicit stop computes, and its in-code note about `stop=-1` is about the raw `slice`, not about `slice_axis`.
- **Kimi does not copy its slices contiguous.** True, and it is the odd one out rather than a considered choice: the other five all copy so `MultiLinear`'s matmul sees well-formed strides regardless of backend.

What genuinely varies per family is the prefix and the layer predicate: four use `model.layers.{l}.self_attn`, LongCat carries a sub-attention index (`self_attn.0` / `self_attn.1`), and Kimi skips its linear-attention layers. Both are naturally parameters, not obstacles. A `decompose_mla_kv_b_proj(&mut weights, prefix, layer_label, geometry) -> Result<(), String>` next to `infer_mla_quantization_params` in `mlxcel_core::layers` would be roughly sixty lines and would delete something like two hundred and fifty across five files.

**Conclusion: the extraction is now justified, and it should not ride in this PR.** It changes behavior for four shipped families in three ways at once (they gain the shape cross-check, Kimi gains contiguity, Kimi changes slice helper), which needs a per-family test matrix and its own bisect point. Bundling it here would also make a fix that restores a family's basic loadability impossible to revert on its own. PR #1027 declined once on the record, so overturning that call belongs in an issue where the three reasons can be answered, not in a paragraph attached to an unrelated fix. Recommend filing it as a follow-up.

## Test plan

Five tests in `src/models/glm4_moe_lite_sanitize_tests.rs`, all driving the real `sanitize_weights` and the real `Glm4MoeLiteModel::from_weights` with synthetic weight maps built from `mlxcel_core::from_slice_f32`, all asserting on the returned `Result`. None runs a forward pass: a load that produced a malformed `embed_q` reaches MLX through the cxx bridge as `UniquePtr<MlxArray>` rather than `Result`, so a throw there aborts the whole test binary instead of failing one test.

- `sanitize_synthesizes_the_mla_pair_no_checkpoint_ships`: asserts the unsanitized checkpoint fails with exactly `Weight not found: model.layers.0.self_attn.embed_q.weight` (the failure the issue reports, taken from the real loader rather than restated), then that the sanitized one loads and carries `embed_q` at `[heads, kv_lora_rank, qk_nope]` and `unembed_out` at `[heads, v_head, kv_lora_rank]`.
- `sanitize_dequantizes_kv_b_proj_before_the_per_head_split`: an honest affine 4-bit plane (`packed_in * 32 == bits * num_groups * group_size`, UINT32 packed so `dequantize` does not throw on the positive control) decomposes to the same shapes, consumes all three source planes, and leaves both halves dense.
- `sanitize_rejects_scales_with_no_biases`: positive control first, then a block-float plane is refused naming `model.layers.0.self_attn.kv_b_proj.biases` in PR #1027's wording.
- `sanitize_leaves_an_already_decomposed_checkpoint_alone`: a checkpoint shipping the pair plus a stale `kv_b_proj` keeps its `kv_b_proj.weight`, which is the observable proof the `continue` fired rather than the split running.
- `sanitize_rejects_a_kv_b_proj_that_disagrees_with_the_config`: a tensor carrying an extra head is refused before the reshape, naming the shape the config describes.

Commands actually run, all from a clean run on this branch:

- [x] `cargo test --lib models::glm4_moe_lite` (6 passed, 0 failed)
- [x] `cargo test --lib models::longcat_flash_ngram` (2 passed, 0 failed)
- [x] `cargo test --lib models::youtu_vl` (4 passed, 0 failed)
- [x] `cargo clippy --lib --tests -- -D warnings` (exit 0)
- [x] `cargo fmt --all -- --check` (exit 0)
- [x] `cargo check --lib --tests` (clean)

Not run here: the full-workspace clippy and test sweep, and any load against a real `glm4_moe_lite` checkpoint. No `glm4_moe_lite` weights are present on this machine, and the three public repos are tiny random fixtures rather than a released model, so the fix is verified against the published tensor layout and not against a production checkpoint.

## Review round 2

Two findings from implementation review, fixed in `0069c6c7`.

**The pipeline stage-executor route never sanitized.** `Glm4MoeLiteStageExecutor::load` is a second registered load path for this family (`StageFamily::Glm4MoeLite`), and it delegates to the shared `load_glm4_family_stage_model`, which went from `load_text_weights` straight to `filter_weight_map` with no sanitize step. `models::glm4_moe_lite::TransformerBlock::from_weights` reads `embed_q` unconditionally, so the canonical layout still failed there with the same `Weight not found: model.layers.N.self_attn.embed_q.weight`. `DeepSeekV3StageExecutor::load` (`src/distributed/pipeline/stage_executor/deepseek_v3.rs:84`) and `GlmMoeDsaStageExecutor::load` (`src/distributed/pipeline/stage_executor/glm_moe_dsa.rs:42`) both sanitize the full weight map before the filter. The generic now takes a `Sanitize: Fn(WeightMap, &A) -> Result<WeightMap, String>` hook called in that position; `Glm4MoeLiteStageExecutor` passes `sanitize_weights` and the two non-MLA GLM4 families pass a `no_sanitize` passthrough. This is distinct from the `ConfigBacked` gap discussed above, which stays open and cross-family.

**The tests could not tell the two halves apart.** The fixture set `qk_nope_head_dim` and `v_head_dim` both to 4, which leaves `[HEADS, KV_LORA_RANK, QK_NOPE]` and `[HEADS, V_HEAD, KV_LORA_RANK]` both valid with the nope and v halves swapped, and every fixture tensor was zero-filled, so no assertion could observe element order at all. A wrong half, a wrong reshape axis order or a missing transpose would all have passed. `v_head_dim` is now 6, and a sixth test decomposes a `0, 1, 2, ...` ramp and asserts the exact element identities against the reference layout: `embed_q[h][r][c] == kv_b[(h * head_dim + c) * kv_lora_rank + r]` for the transposed nope half, and `unembed_out[h][d][r] == kv_b[(h * head_dim + qk_nope + d) * kv_lora_rank + r]` for the v half as stored. It passes, so the decomposition is now pinned at the element level rather than by shape alone.

Re-verified after both: `cargo test --lib models::glm4_moe_lite` (7 passed, 0 failed), `cargo test --lib distributed::pipeline` (317 passed, 0 failed), `cargo clippy --lib --tests -- -D warnings` (exit 0), `cargo fmt --all -- --check` (exit 0).

Closes #1029