### PR TITLE
docs(models): document the modelsize / modeltype / arch label taxonomy

### DIFF
--- a/docs/adding-models.md
+++ b/docs/adding-models.md
@@ -135,6 +135,49 @@ be possible at first, but the implementation should still prove that:
 If later a reference implementation appears, add a follow-up comparison against
 that implementation and tighten the tests or benchmark notes accordingly.
 
+## Labelling a Model Issue
+
+Model-support issues carry three orthogonal labels beyond the usual
+`type:` / `priority:` / `area:` set. They exist so that "what do we support, and
+what can we actually test here?" is a label query rather than an archaeology
+exercise.
+
+**`modelsize:`** is measured on the **smallest publicly available checkpoint at
+the lowest published quantization**, by on-disk size, which for MLX is close to
+resident memory. It describes the model, not the machine, so it does not need
+revisiting when the development hardware changes.
+
+| Label | Size | Meaning |
+|-------|------|---------|
+| `modelsize:small` | ≤ 10 GB | Fast iteration; safe to use in a smoke test |
+| `modelsize:medium` | 10 to 50 GB | Comfortable on a 128 GB box |
+| `modelsize:large` | 50 to 100 GB | Runs, but dominates the machine; serialize other work |
+| `modelsize:xlarge` | > 100 GB | Exceeds a 128 GB box; needs bigger hardware |
+
+`modelsize:large` is deliberately not a blocker: DBRX is 70 GB and was validated
+token-exact on the 128 GB development machine. When a model genuinely cannot be
+validated on available hardware, say so with `status:blocked` and record the
+reason in the issue body. Keeping the two apart means a hardware upgrade
+re-opens work by clearing `status:blocked`, without relabelling every model.
+
+**`modeltype:`** is the modality: `text`, `vlm`, `audio`, `omni`.
+
+**`arch:`** is the structural family, which is what actually predicts porting
+effort and code reuse:
+
+| Label | Covers |
+|-------|--------|
+| `arch:dense` | Dense transformer decoder |
+| `arch:moe` | Sparse mixture-of-experts decoder |
+| `arch:hybrid` | Mixed attention stack: linear/sliding/full interleave, or attention + SSM |
+| `arch:ssm` | State-space or recurrent (Mamba, RWKV) |
+
+`arch:hybrid` wins over `arch:moe` when a model is both, because the hybrid
+cache is the harder half of the port: it forces the
+`ModelOwnedSequenceState<Cache>` path rather than the simple `LanguageModel`
+cache path. AFMoE and MiMo v2 Flash are MoE models labelled `arch:hybrid` for
+exactly this reason.
+
 ## Text Model Checklist
 
 1. Add the implementation file under `src/models/`.


### PR DESCRIPTION
Adds a "Labelling a Model Issue" section to `docs/adding-models.md` describing the three label namespaces now applied to model-support issues, and the criteria behind each.

## Why three namespaces rather than one

The immediate motivation was needing to defer MiMo v2 Flash, whose only public checkpoint is 162 GB at 4-bit against a 128 GB development box. The obvious move is a single "too big" label, but that conflates two different facts:

- **How big the model is** is a property of the model. It does not change when the hardware changes.
- **Whether we can validate it here** is a property of the machine.

DBRX makes the difference concrete: it is 70 GB, comfortably in the "large" bucket, and was validated token-exact against the mlx-lm reference on the 128 GB machine. A scheme where "large" means "give up" would have wrongly deferred it.

So `modelsize:` is a pure size bucket, and `status:blocked` (already in the label set) carries feasibility. A hardware upgrade then re-opens work by clearing one label instead of relabelling every model.

## The labels

`modelsize:small` (≤10 GB) / `medium` (10-50) / `large` (50-100) / `xlarge` (>100), measured on the smallest publicly available checkpoint at the lowest published quantization, by on-disk size.

`modeltype:text` / `vlm` / `audio` / `omni` — modality.

`arch:dense` / `moe` / `hybrid` / `ssm` — structural family, which is what actually predicts porting effort. `arch:hybrid` wins over `arch:moe` when a model is both, because the hybrid cache forces the `ModelOwnedSequenceState<Cache>` path rather than the simple `LanguageModel` cache path.

## Applied

All twelve labels were created and applied across the nine model issues in the current chain (#835, #839, #840, #841, #842, #843, #844, #845, #846), including the three already merged, so the support view is complete rather than forward-only.

Docs-only change; no code touched.