### PR TITLE
chore(deps): bump the MLX pin to 2c46b953 and re-derive three overlays

### DIFF
--- a/src/lib/mlx-cpp/CMakeLists.txt
+++ b/src/lib/mlx-cpp/CMakeLists.txt
@@ -92,7 +92,7 @@ else()
   FetchContent_Declare(
     mlx
     GIT_REPOSITORY "https://github.com/ml-explore/mlx.git"
-    GIT_TAG b7c3dd6d27f45b5365b08a840310187dc503f1db)
+    GIT_TAG 2c46b953db88965c4270cc7306eda6887a3247f2)
 
   # Use FetchContent_Populate + add_subdirectory so we can apply source
   # overlays before the MLX build system processes the files.

--- a/src/lib/mlx-cpp/patches-cuda/ops.cpp
+++ b/src/lib/mlx-cpp/patches-cuda/ops.cpp
@@ -94,11 +94,26 @@ array bf16_mixed_astype(
 }
 
 array indices_or_default(
-    std::optional<array> indices,
+    std::string_view tag,
+    const std::optional<array>& indices,
     const array& x,
     StreamOrDevice s) {
+  if (x.ndim() < 2) {
+    std::ostringstream msg;
+    msg << tag
+        << " Input must have at least two dimensions but got input with shape "
+        << x.shape() << ".";
+    throw std::invalid_argument(msg.str());
+  }
+
   if (indices.has_value()) {
-    return indices.value();
+    if (!issubdtype(indices->dtype(), integer)) {
+      std::ostringstream msg;
+      msg << tag
+          << " Got indices with invalid dtype. Indices must be integral.";
+      throw std::invalid_argument(msg.str());
+    }
+    return astype(indices.value(), uint32);
   }
 
   Shape shape(x.shape().begin(), x.shape().end() - 2);
@@ -389,10 +404,15 @@ array ones_like(const array& a, StreamOrDevice s /* = {} */) {
 }
 
 array eye(int n, int m, int k, Dtype dtype, StreamOrDevice s /* = {} */) {
-  if (n <= 0 || m <= 0) {
+  if (n < 0 || m < 0) {
     throw std::invalid_argument("[eye] N and M must be positive integers.");
   }
   array result = zeros({n, m}, dtype, s);
+
+  if (n == 0 || m == 0) {
+    return result;
+  }
+
   if (k >= m || -k >= n) {
     return result;
   }
@@ -2426,7 +2446,7 @@ array prod(
     out_type = int32;
   }
   auto out = (is_noop)
-      ? a
+      ? astype(a, out_type, s)
       : array(
             std::move(out_shape),
             out_type,
@@ -3387,9 +3407,14 @@ array matmul(
   }
 
   // We can batch the multiplication by reshaping a
-  if (in_a.ndim() > 2 && in_b.ndim() <= 2) {
+  bool flattened_a = false;
+
+  // Avoid flatten/unflatten during dynamic tracing because unflatten stores the
+  // trace-time shape, which breaks shapeless replay with dynamic batch sizes.
+  if (in_a.ndim() > 2 && in_b.ndim() <= 2 && !detail::in_dynamic_tracing()) {
     a = flatten(a, 0, -2, s);
-  } else if (in_b.ndim() > 2) {
+    flattened_a = true;
+  } else if (in_a.ndim() > 2 || in_b.ndim() > 2) {
     std::tie(a, b) = broadcast_arrays(a, b, {-2, -1}, s);
   }
 
@@ -3401,7 +3426,8 @@ array matmul(
       out_type,
       std::make_shared<Matmul>(to_stream(s)),
       {a, b});
-  if (in_a.ndim() > 2 && in_b.ndim() <= 2) {
+
+  if (flattened_a) {
     auto orig_shape = in_a.shape();
     orig_shape.pop_back();
     out = unflatten(out, 0, std::move(orig_shape), s);
@@ -4661,10 +4687,10 @@ void validate_global_scale(
 }
 
 array quantized_matmul(
-    array x,
-    array w,
-    array scales,
-    std::optional<array> biases /* = std::nullopt */,
+    const array& x,
+    const array& w,
+    const array& scales,
+    const std::optional<array>& biases /* = std::nullopt */,
     bool transpose /* = true */,
     std::optional<int> group_size_ /* = std::nullopt */,
     std::optional<int> bits_ /* = std::nullopt */,
@@ -4713,13 +4739,13 @@ array quantized_matmul(
 }
 
 void validate_qqmm_inputs(
-    array x,
-    array w,
-    std::optional<array> scales_w,
+    const array& x,
+    const array& w,
+    const std::optional<array>& scales_w,
     int group_size,
     int bits,
-    std::optional<array> global_scale_x,
-    std::optional<array> global_scale_w,
+    const std::optional<array>& global_scale_x,
+    const std::optional<array>& global_scale_w,
     QuantizationMode qmode) {
   // check 2D (for now)
   if (x.ndim() > 2 || w.ndim() > 2) {
@@ -4773,9 +4799,9 @@ void validate_qqmm_inputs(
 }
 
 std::pair<int, int> extract_qqmm_dims(
-    array x,
-    array w,
-    std::optional<array> scales_w,
+    const array& x,
+    const array& w,
+    const std::optional<array>& scales_w,
     int group_size,
     int bits) {
   if (w.dtype() != uint32) {
@@ -4803,24 +4829,17 @@ std::pair<int, int> extract_qqmm_dims(
 }
 
 array qqmm(
-    array in_x,
-    array w,
-    std::optional<array> scales_w,
+    const array& in_x,
+    const array& w,
+    const std::optional<array>& scales_w,
     std::optional<int> group_size_ /* = std::nullopt */,
     std::optional<int> bits_ /* = std::nullopt */,
     const std::string& mode /* = "nvfp4" */,
-    const std::optional<array> global_scale_x /* = std::nullopt */,
-    const std::optional<array> global_scale_w /* = std::nullopt */,
+    const std::optional<array>& global_scale_x /* = std::nullopt */,
+    const std::optional<array>& global_scale_w /* = std::nullopt */,
     StreamOrDevice s /* = {} */) {
   auto stream = to_stream(s);
   auto qmode = string_to_quantization_mode(mode, "qqmm");
-  // cuBLAS block scaled matmul only supports nvfp4 and mxfp8
-  if (qmode != QuantizationMode::Nvfp4 && qmode != QuantizationMode::Mxfp8) {
-    std::ostringstream msg;
-    msg << "[qqmm] Only 'nvfp4' and 'mxfp8' quantization modes are supported but '"
-        << mode << "' was provided.";
-    throw std::invalid_argument(msg.str());
-  }
   // we need to check 2 cases:
   // 1. w is quantized, scales is provided
   // 2. w is not quantized, scales is not provided
@@ -5123,12 +5142,6 @@ std::vector<array> quantize(
         << " matrix has shape " << w.shape();
     throw std::invalid_argument(msg.str());
   }
-  if (to_stream(s).device == Device::gpu && metal::is_available() &&
-      global_scale.has_value()) {
-    std::ostringstream msg;
-    msg << "[quantize] Global scale is not supported on the Metal backend.";
-    throw std::invalid_argument(msg.str());
-  }
   validate_global_scale("quantize", qmode, global_scale);
   if (qmode == QuantizationMode::Affine) {
     return affine_quantize(w, group_size, bits, s);
@@ -5388,13 +5401,6 @@ array dequantize(
         << "but it has only " << w.ndim() << ".";
     throw std::invalid_argument(msg.str());
   }
-  if (global_scale.has_value()) {
-    if (to_stream(s).device == Device::gpu && metal::is_available()) {
-      std::ostringstream msg;
-      msg << "[dequantize] Global scale is not supported on the Metal backend.";
-      throw std::invalid_argument(msg.str());
-    }
-  }
   validate_global_scale("dequantize", qmode, global_scale);
 
   if (qmode == QuantizationMode::Affine) {
@@ -5487,29 +5493,10 @@ array gather_qmm(
   }
 
   // Extract indices and broadcast them
-  array lhs_indices = indices_or_default(lhs_indices_, x, s);
-  array rhs_indices = indices_or_default(rhs_indices_, w, s);
+  array lhs_indices = indices_or_default("[gather_qmm]", lhs_indices_, x, s);
+  array rhs_indices = indices_or_default("[gather_qmm]", rhs_indices_, w, s);
   std::tie(lhs_indices, rhs_indices) =
       broadcast_arrays(lhs_indices, rhs_indices, s);
-
-  if (!issubdtype(lhs_indices.dtype(), integer)) {
-    throw std::invalid_argument(
-        "[gather_qmm] Got lhs_indices with invalid dtype. Indices must be integral.");
-  }
-
-  if (!issubdtype(rhs_indices.dtype(), integer)) {
-    throw std::invalid_argument(
-        "[gather_qmm] Got rhs_indices with invalid dtype. Indices must be integral.");
-  }
-  if (x.ndim() < 2) {
-    std::ostringstream msg;
-    msg << "[gather_qmm] Non-quantized input must have at least two"
-        << " dimensions but got input with shape " << x.shape() << ".";
-    throw std::invalid_argument(msg.str());
-  }
-
-  lhs_indices = astype(lhs_indices, uint32, s);
-  rhs_indices = astype(rhs_indices, uint32, s);
 
   // Compute the full output shape
   auto out_shape = lhs_indices.shape();
@@ -5543,6 +5530,56 @@ array gather_qmm(
           transpose,
           sorted_indices && !rhs_indices_,
           sorted_indices && !lhs_indices_),
+      std::move(inputs));
+}
+
+array gather_qqmm(
+    const array& x,
+    const array& w,
+    const std::optional<array>& scales_w,
+    const std::optional<array>& lhs_indices_,
+    const std::optional<array>& rhs_indices_,
+    std::optional<int> group_size_,
+    std::optional<int> bits_,
+    const std::string& mode,
+    const std::optional<array>& global_scale_x,
+    const std::optional<array>& global_scale_w,
+    bool sorted_indices,
+    StreamOrDevice s) {
+  auto stream = to_stream(s);
+  auto qmode = string_to_quantization_mode(mode, "gather_qqmm");
+  auto [group_size, bits] =
+      quantization_params_from_mode(qmode, group_size_, bits_);
+
+  // Extract indices and broadcast them
+  array lhs_indices = indices_or_default("[gather_qqmm]", lhs_indices_, x, s);
+  array rhs_indices = indices_or_default("[gather_qqmm]", rhs_indices_, w, s);
+  std::tie(lhs_indices, rhs_indices) =
+      broadcast_arrays(lhs_indices, rhs_indices, s);
+
+  std::vector<array> inputs = {
+      x,
+      w,
+      lhs_indices,
+      rhs_indices,
+  };
+  if (scales_w.has_value()) {
+    inputs.push_back(*scales_w);
+  }
+  if (global_scale_x.has_value() && global_scale_w.has_value()) {
+    inputs.push_back(*global_scale_x);
+    inputs.push_back(*global_scale_w);
+  }
+
+  auto [w_inner_dims, w_outer_dims] =
+      extract_qqmm_dims(x, w, scales_w, group_size, bits);
+  auto out_shape = lhs_indices.shape();
+  out_shape.push_back(x.shape(-2));
+  out_shape.push_back(w_outer_dims);
+  return array(
+      std::move(out_shape),
+      x.dtype(),
+      std::make_shared<GatherQQMM>(stream, group_size, bits, qmode),
       std::move(inputs));
 }
 
@@ -6044,27 +6081,13 @@ array gather_mm(
   b = astype(b, out_type, s);
 
   // Handle broadcasting
-  array lhs_indices = indices_or_default(lhs_indices_, a, s);
-  array rhs_indices = indices_or_default(rhs_indices_, b, s);
-
-  if (!issubdtype(lhs_indices.dtype(), integer)) {
-    throw std::invalid_argument(
-        "[gather_mm] Got lhs_indices with invalid dtype. Indices must be integral.");
-  }
-
-  if (!issubdtype(rhs_indices.dtype(), integer)) {
-    throw std::invalid_argument(
-        "[gather_mm] Got rhs_indices with invalid dtype. Indices must be integral.");
-  }
-
-  lhs_indices = astype(lhs_indices, uint32, s);
-  rhs_indices = astype(rhs_indices, uint32, s);
+  array lhs_indices = indices_or_default("[gather_mm]", lhs_indices_, a, s);
+  array rhs_indices = indices_or_default("[gather_mm]", rhs_indices_, b, s);
+  std::tie(lhs_indices, rhs_indices) =
+      broadcast_arrays(lhs_indices, rhs_indices, s);
 
   int M = a.shape(-2);
   int N = b.shape(-1);
-
-  std::tie(lhs_indices, rhs_indices) =
-      broadcast_arrays(lhs_indices, rhs_indices, s);
 
   auto out_shape = lhs_indices.shape();
   out_shape.push_back(M);

--- a/src/lib/mlx-cpp/patches/mlx/backend/cuda/quantized/quantized.cpp
+++ b/src/lib/mlx-cpp/patches/mlx/backend/cuda/quantized/quantized.cpp
@@ -5,10 +5,16 @@
 // exceeds the gridDim.y/z limit of 65535 and no `l = out.size()/(m*n)` int32
 // multiply overflows (see lablup/mlxcel#648); (3) route sorted M==1 GatherQMM
 // (MoE prefill) through dequant + CUTLASS grouped GEMM (lablup/mlxcel#629).
-// Synced to upstream e9463bb
-// (post-#3706/#3576 JIT qmm rework and #3723 qmv global scale; the dispatch
-// consumed here kept its public signatures, with qmv gaining an optional
-// global_scale that QuantizedMatmul passes as std::nullopt).
+// Synced to upstream 2c46b953 (lablup/mlxcel#1042). The only upstream change to
+// this file since the previous sync is #3757 (Add gather_qqmm), which inserted a
+// `const std::optional<array>& global_scale` parameter into qmm_naive at
+// position 5, right after `biases`. Both qmm_naive call sites below pass
+// std::nullopt there, matching upstream. Every other dispatch entry point
+// consumed here (qmm_sm90, qmm_sm80, qmv, gather_qmv, fp_qmv) kept its
+// signature: the full diff of quantized/qmm/qmm.h across that range is the one
+// global_scale line. Re-verify these call sites against qmm.h on the next pin
+// bump; an overlay that silently reverts an upstream change is how #830 / #831
+// happened.
 
 #include "mlx/backend/cuda/quantized/quantized.h"
 #include "mlx/backend/cuda/device.h"
@@ -187,6 +193,7 @@ void QuantizedMatmul::eval_gpu(const std::vector<array>& inputs, array& out) {
           w,
           scales,
           biases,
+          std::nullopt,
           std::nullopt,
           std::nullopt,
           oc,
@@ -428,6 +435,7 @@ void GatherQMM::eval_gpu(const std::vector<array>& inputs, array& out) {
               w,
               scales,
               biases,
+              std::nullopt,
               lc,
               rc,
               oc,

--- a/src/lib/mlx-cpp/patches/mlx/backend/metal/kernels/utils.h
+++ b/src/lib/mlx-cpp/patches/mlx/backend/metal/kernels/utils.h
@@ -76,14 +76,14 @@ struct Limits<bool> {
   static constexpr constant bool min = false;
 };
 
-template <>
-struct Limits<complex64_t> {
-  static constexpr constant complex64_t max = complex64_t(
-      metal::numeric_limits<float>::infinity(),
-      metal::numeric_limits<float>::infinity());
-  static constexpr constant complex64_t min = complex64_t(
-      -metal::numeric_limits<float>::infinity(),
-      -metal::numeric_limits<float>::infinity());
+template <typename T>
+struct Limits<complex_t<T>> {
+  inline static constexpr constant complex_t<T> max = complex_t<T>(
+      metal::numeric_limits<T>::infinity(),
+      metal::numeric_limits<T>::infinity());
+  inline static constexpr constant complex_t<T> min = complex_t<T>(
+      -metal::numeric_limits<T>::infinity(),
+      -metal::numeric_limits<T>::infinity());
 };
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -206,9 +206,9 @@ struct LoopedElemToLoc {
   OffsetT offset{0};
   int index{0};
 
-  LoopedElemToLoc(int dim) : dim(dim), inner_looper(dim - 1) {}
+  LoopedElemToLoc(int dim) thread : dim(dim), inner_looper(dim - 1) {}
 
-  void next(const constant int* shape, const constant int64_t* strides) {
+  void next(const constant int* shape, const constant int64_t* strides) thread {
     if (dim == 0) {
       return;
     }
@@ -221,7 +221,8 @@ struct LoopedElemToLoc {
     }
   }
 
-  void next(int n, const constant int* shape, const constant int64_t* strides) {
+  void next(int n, const constant int* shape, const constant int64_t* strides)
+      thread {
     if (dim == 0) {
       return;
     }
@@ -244,7 +245,7 @@ struct LoopedElemToLoc {
     }
   }
 
-  OffsetT location() {
+  OffsetT location() thread {
     return offset;
   }
 };
@@ -255,9 +256,9 @@ struct LoopedElemToLoc<1, OffsetT, true> {
   OffsetT offset{0};
   uint index{0};
 
-  LoopedElemToLoc(int dim) : dim(dim) {}
+  LoopedElemToLoc(int dim) thread : dim(dim) {}
 
-  void next(const constant int* shape, const constant int64_t* strides) {
+  void next(const constant int* shape, const constant int64_t* strides) thread {
     index++;
     if (dim > 1) {
       offset = elem_to_loc<OffsetT>(index, shape, strides, dim);
@@ -266,7 +267,8 @@ struct LoopedElemToLoc<1, OffsetT, true> {
     }
   }
 
-  void next(int n, const constant int* shape, const constant int64_t* strides) {
+  void next(int n, const constant int* shape, const constant int64_t* strides)
+      thread {
     index += n;
     if (dim > 1) {
       offset = elem_to_loc<OffsetT>(index, shape, strides, dim);
@@ -275,7 +277,7 @@ struct LoopedElemToLoc<1, OffsetT, true> {
     }
   }
 
-  OffsetT location() {
+  OffsetT location() thread {
     return offset;
   }
 };
@@ -284,17 +286,18 @@ template <typename OffsetT>
 struct LoopedElemToLoc<1, OffsetT, false> {
   OffsetT offset{0};
 
-  LoopedElemToLoc(int) {}
+  LoopedElemToLoc(int) thread {}
 
-  void next(const constant int*, const constant int64_t* strides) {
+  void next(const constant int*, const constant int64_t* strides) thread {
     offset += OffsetT(strides[0]);
   }
 
-  void next(int n, const constant int*, const constant int64_t* strides) {
+  void next(int n, const constant int*, const constant int64_t* strides)
+      thread {
     offset += n * OffsetT(strides[0]);
   }
 
-  OffsetT location() {
+  OffsetT location() thread {
     return offset;
   }
 };

--- a/src/lib/mlxcel-core/build.rs
+++ b/src/lib/mlxcel-core/build.rs
@@ -214,7 +214,7 @@ fn main() {
 }
 
 /// Expected MLX git commit — must match GIT_TAG in mlx-cpp/CMakeLists.txt.
-const MLX_EXPECTED_COMMIT: &str = "b7c3dd6d27f45b5365b08a840310187dc503f1db";
+const MLX_EXPECTED_COMMIT: &str = "2c46b953db88965c4270cc7306eda6887a3247f2";
 
 /// Purge stale cached MLX build artifacts before CMake runs.
 ///


### PR DESCRIPTION
## Summary

Bumps the MLX pin from `b7c3dd6d` (2026-07-17) to `2c46b953` (2026-08-05 upstream main), 58 commits, and re-derives the three source overlays that upstream touched in that window.

Closes #1042

## Why

Fixes in range that land on paths this repo ships:

| Upstream | What |
|---|---|
| #3854 | incorrect nvfp4 `quantized_matmul` through the split-K path (NVFP4 direct transcode is mlxcel's default on all builds) |
| #3893 | CUDA gemm conv unfold grid overflow past 65,535 output positions |
| #3934 | Metal NVFP4 scale reduction per 16-lane group |
| #3888 | Metal `gemv_wide` for few-row fp16/bf16 matmuls |
| #3943 | head dimension 96 in Metal full attention |
| #3898, #3813 | `prod` dtype promotion on a size-1 axis, shapeless matmul with dynamic batch dims |

## Overlay audit

mlxcel applies whole-file overlays via `configure_file(... COPYONLY)`, so an overlay whose upstream counterpart moved silently reverts that upstream change. That is how a broken RMSNorm kernel shipped in #824 / #829 and took until #830 / #831 to undo. All 21 overlays were diffed against the upstream range; three conflicted.

| Overlay | Upstream change | Resolution |
|---|---|---|
| `patches/mlx/backend/cuda/quantized/quantized.cpp` | #3757 inserted `const std::optional<array>& global_scale` into `qmm_naive` at position 5 | resolved by hand: mlxcel wraps both call sites in `run_row_chunked` / `run_batch_chunked`, which `git merge-file` cannot reconcile with an inline insertion. Both sites verified as 13 arguments in declaration order |
| `patches/mlx/backend/metal/kernels/utils.h` | #3970 templated complex scalar lanes, #3963 explicit `thread` address space for metal 4.1 | clean three-way merge, no overlap with mlxcel's delta |
| `patches-cuda/ops.cpp` | 189 lines | clean three-way merge, mlxcel's 57-line delta intact |

`quantized/qmm/qmm.h` also changed but is not overlaid, so mlxcel takes the new declaration. Its full diff across the range is the single `global_scale` line, so `qmm_sm90`, `qmm_sm80`, `qmv`, `gather_qmv` and `fp_qmv` are unaffected. The `qmm_sm80.cuh` race-fix overlay from #910 is untouched upstream and still required.

The stale `Synced to upstream e9463bb` header comment is updated to the real base, with an explicit instruction to re-verify these call sites on the next bump.

## The pin has two sources of truth

`GIT_TAG` in `src/lib/mlx-cpp/CMakeLists.txt:95` and `MLX_EXPECTED_COMMIT` in `src/lib/mlxcel-core/build.rs:217`. The latter drives `purge_stale_mlx_cache`. Updating only the CMakeLists leaves the cache marker matching `MLX_EXPECTED_COMMIT`, so `_deps/` is judged valid, never purged, and the build silently compiles the OLD MLX while looking bumped. Both moved together, verified three ways with no trace of the old SHA:

- binary embedded commit: `2c46b953…`
- `_deps/.mlx-build-commit` marker: `2c46b953…`
- fetched `_deps/mlx-src` HEAD: `2c46b953…`

Worth a follow-up to collapse this to one source of truth or add a build-time assert.

## Validation (GB10, sm_121)

- release CUDA build clean
- `cargo fmt --all -- --check` clean
- `fused_norm_parity` 8/8, `turbo_tests` 97/97
- greedy smoke on `llama-3.2-1b-4bit`, `qwen3-4b-4bit`, `deepseek-v2-lite-4bit`: coherent, and byte-identical run to run with a warm kernel cache. That determinism also confirms the `qmm_sm80` race-fix overlay still holds on the new base.

## Two pre-existing failures, separated by a control build

A control build at the old pin (`_deps` re-fetched to `b7c3dd6d`, verified) reproduces both, so neither is caused by this bump.

| Failure | New pin | Old pin (control) |
|---|---|---|
| `fused_rope_parity` 2 of 9 | offset 131069 rms 2.497e-3, offset 131071 rms 2.684e-3, tol 2.0e-3 | same digits, same 7 pass / 2 fail |
| full lib suite abort under graph capture | `cuGraphAddKernelNode` invalid argument, then `cudaStreamEndCapture` previous error during capture (site and message vary per run) | aborts the same way |

For the rope case the numbers match bit for bit, which also shows that path carries no exposure to this change. Upstream touched no rope file in the range. Both are left for separate issues rather than folded in here.
