### PR TITLE
chore(build): make the MLX pin a single source of truth

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -71,6 +71,8 @@ jobs:
               - '.github/workflows/ci.yml'
             mlx_pin:
               - 'src/lib/mlx-cpp/CMakeLists.txt'
+              - 'src/lib/mlxcel-core/build_support/mlx_pin.rs'
+              - 'src/lib/mlxcel-mlx-pin/**'
               - 'scripts/ci/mlx_pinned_commit.sh'
               - 'scripts/ci/mlx_pinned_commit_test.sh'
               - '.github/workflows/ci.yml'
@@ -132,6 +134,19 @@ jobs:
       # therefore break every release build, and release.yml is the only other
       # place this script runs, so without this job the breakage would first
       # appear when a release is cut. Issue #1047.
+      #
+      # `mlxcel-mlx-pin` compiles in under a second (a leaf crate with no
+      # production role, only `std` plus a `tempfile` dev-dependency), so it
+      # runs first here rather than only in nightly-verify.yml's `make verify`.
+      # Its `tests/cross_parser.rs` shells out to mlx_pinned_commit.sh itself
+      # and asserts that whenever the shell parser accepts an input, the Rust
+      # parser resolves to the identical commit for that same input: the two
+      # unit-test files below each cover one parser in isolation and cannot
+      # catch a same-input value mismatch on their own.
+      - uses: dtolnay/rust-toolchain@1.93.1
+      - name: Run the Rust pin parser's unit and cross-parser tests
+        run: cargo test -p mlxcel-mlx-pin
+
       - name: Extract the pinned MLX commit
         run: scripts/ci/mlx_pinned_commit.sh
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -72,6 +72,7 @@ jobs:
             mlx_pin:
               - 'src/lib/mlx-cpp/CMakeLists.txt'
               - 'scripts/ci/mlx_pinned_commit.sh'
+              - 'scripts/ci/mlx_pinned_commit_test.sh'
               - '.github/workflows/ci.yml'
 
   deny:
@@ -133,6 +134,14 @@ jobs:
       # appear when a release is cut. Issue #1047.
       - name: Extract the pinned MLX commit
         run: scripts/ci/mlx_pinned_commit.sh
+
+      # The other half of the contract: the shell parser must also *reject*
+      # everything the Rust parser rejects. A value it accepts and the Rust
+      # parser refuses is not harmless, because release.yml purges every MLX
+      # build cache that does not match what this script prints and the build
+      # then fails on the same file the purge was justified by.
+      - name: Check the pinned MLX commit parser rejects malformed input
+        run: scripts/ci/mlx_pinned_commit_test.sh
 
   cross-repo-refs:
     name: cross-repo refs

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,6 +54,7 @@ jobs:
       pull-requests: read
     outputs:
       rust: ${{ steps.filter.outputs.rust }}
+      mlx_pin: ${{ steps.filter.outputs.mlx_pin }}
     steps:
       - uses: actions/checkout@v7
         with:
@@ -67,6 +68,10 @@ jobs:
               - '**/Cargo.toml'
               - 'Cargo.lock'
               - 'deny.toml'
+              - '.github/workflows/ci.yml'
+            mlx_pin:
+              - 'src/lib/mlx-cpp/CMakeLists.txt'
+              - 'scripts/ci/mlx_pinned_commit.sh'
               - '.github/workflows/ci.yml'
 
   deny:
@@ -103,6 +108,31 @@ jobs:
         with:
           components: rustfmt
       - run: cargo fmt --all -- --check
+
+  mlx-pin:
+    name: MLX pin extraction
+    needs: changes
+    if: needs.changes.outputs.mlx_pin == 'true'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          persist-credentials: false
+      # The pinned MLX commit has one home, GIT_TAG in
+      # src/lib/mlx-cpp/CMakeLists.txt, and two independent parsers read it:
+      # mlxcel-core's build.rs in Rust (build_support/mlx_pin.rs, unit-tested by
+      # mlxcel-mlx-pin) and this script in awk, for release.yml's "Validate MLX
+      # build cache" steps. The shell half accepts strictly less than the Rust
+      # half: it needs GIT_TAG as the first token of its own line, after the
+      # GIT_REPOSITORY line, with no closing parenthesis in between. A CMake
+      # reformat that leaves every local build and `make verify` green can
+      # therefore break every release build, and release.yml is the only other
+      # place this script runs, so without this job the breakage would first
+      # appear when a release is cut. Issue #1047.
+      - name: Extract the pinned MLX commit
+        run: scripts/ci/mlx_pinned_commit.sh
 
   cross-repo-refs:
     name: cross-repo refs

--- a/.github/workflows/nightly-verify.yml
+++ b/.github/workflows/nightly-verify.yml
@@ -48,14 +48,14 @@
 #
 # WHICH MEMBERS IT COVERS
 #
-# All four, as of #1007, because `verify-clippy` and `verify-test` now pass
-# `--workspace`. They did not before, and the omission was not a small one: the
-# workspace root is itself the `mlxcel` package, so a bare `cargo test` there
-# resolves to `-p mlxcel` and never builds mlxcel-core, mlxcel-surgery or
-# mlxcel-xla at all. This job was running 5238 of the 6992 tests in the
-# repository and calling that the suite. mlxcel-core held 1354 of the missing
-# ones and is the crate with the MLX `cxx` bridge, layers.rs, the KV cache and
-# the quantization loaders.
+# All five, as of #1007 and #1047, because `verify-clippy` and `verify-test`
+# now pass `--workspace`. They did not before, and the omission was not a small
+# one: the workspace root is itself the `mlxcel` package, so a bare `cargo test`
+# there resolves to `-p mlxcel` and never builds mlxcel-core, mlxcel-mlx-pin,
+# mlxcel-surgery or mlxcel-xla at all. This job was running 5238 of the 6992
+# tests in the repository and calling that the suite. mlxcel-core held 1354 of
+# the missing ones and is the crate with the MLX `cxx` bridge, layers.rs, the
+# KV cache and the quantization loaders.
 #
 # The clippy half was the subtler one. `--all-targets` without `--workspace`
 # does not compile a member's *test* target either, so test-only lint debt and
@@ -67,12 +67,15 @@
 #
 # Feature resolution across the members is not a complication here.
 # mlxcel-core resolves to metal + accelerate through the root package's
-# forwarding, so one build of it serves every member. mlxcel-surgery and
-# mlxcel-xla resolve to their empty defaults, which matters most for
-# mlxcel-xla: its `iree` feature stays off, its build script skips the native
-# shim, and this job therefore needs no IREE distribution. The code behind
-# `iree`, `diagnostics` and `micro-oracle` stays outside the gate for the same
-# reason.
+# forwarding, so one build of it serves every member. mlxcel-mlx-pin,
+# mlxcel-surgery and mlxcel-xla resolve to their empty defaults, which matters
+# most for mlxcel-xla: its `iree` feature stays off, its build script skips the
+# native shim, and this job therefore needs no IREE distribution. The code
+# behind `iree`, `diagnostics` and `micro-oracle` stays outside the gate for
+# the same reason. mlxcel-mlx-pin (#1047) adds nothing measurable to the
+# budget: it is a leaf with no build script that hosts the unit tests for the
+# MLX-pin logic in mlxcel-core/build_support/mlx_pin.rs, and it does not depend
+# on mlxcel-core, so it never triggers an MLX C++ build of its own.
 #
 # On the budget: the switch to `[profile.test-fast]` in #1000 took the
 # `cargo test` step from 2h54m34s to 48m54s (run 30871982545), and the scope

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -466,6 +466,15 @@ jobs:
           fi
 
       - name: Validate MLX build cache
+        # MLX_PIN_CMAKE_FILE redirects which file the pin is read from. It
+        # exists for the parser's own negative-path fixtures and has no place in
+        # a release build, so it is pinned empty here (the script's `:-` default
+        # treats empty as unset) rather than left to whatever the runner
+        # environment or an earlier step happens to have put in scope. These are
+        # persistent self-hosted runners and this is the value that decides
+        # which upstream source a shipped binary is built from.
+        env:
+          MLX_PIN_CMAKE_FILE: ""
         run: |
           # Derive the pin from its single source of truth (GIT_TAG in
           # src/lib/mlx-cpp/CMakeLists.txt), the same line mlxcel-core's
@@ -669,6 +678,15 @@ jobs:
           fi
 
       - name: Validate MLX build cache
+        # MLX_PIN_CMAKE_FILE redirects which file the pin is read from. It
+        # exists for the parser's own negative-path fixtures and has no place in
+        # a release build, so it is pinned empty here (the script's `:-` default
+        # treats empty as unset) rather than left to whatever the runner
+        # environment or an earlier step happens to have put in scope. These are
+        # persistent self-hosted runners and this is the value that decides
+        # which upstream source a shipped binary is built from.
+        env:
+          MLX_PIN_CMAKE_FILE: ""
         run: |
           # Derive the pin from its single source of truth (GIT_TAG in
           # src/lib/mlx-cpp/CMakeLists.txt), the same line mlxcel-core's

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,13 +23,13 @@ on:
 # Default-deny top-level permissions; each job grants only what it needs.
 permissions: {}
 
-# Pinned MLX C++ commit, shared by both Linux CUDA jobs for build-cache
-# validation. Must match GIT_TAG in src/lib/mlx-cpp/CMakeLists.txt and
-# MLX_EXPECTED_COMMIT in src/lib/mlxcel-core/build.rs (the three-place pin
-# documented in CLAUDE.md). Hoisted to workflow scope so a future bump
-# touches one literal here instead of one per job.
-env:
-  MLX_EXPECTED_COMMIT: "b7c3dd6d27f45b5365b08a840310187dc503f1db"
+# This workflow does not store the pinned MLX C++ commit. Both Linux CUDA jobs
+# derive it from its single source of truth, GIT_TAG in
+# src/lib/mlx-cpp/CMakeLists.txt, via scripts/ci/mlx_pinned_commit.sh. The
+# workflow used to keep its own literal at this scope and it had already drifted
+# a bump behind the CMake file, so every release build was purging and rebuilding
+# MLX from scratch while reporting a pin the tree no longer used (issue #1047).
+# The bump checklist is in CONTRIBUTING.md ("Bumping the MLX upstream pin").
 
 jobs:
   # ============================================================================
@@ -467,7 +467,18 @@ jobs:
 
       - name: Validate MLX build cache
         run: |
-          # MLX_EXPECTED_COMMIT is set at workflow scope (top of this file).
+          # Derive the pin from its single source of truth (GIT_TAG in
+          # src/lib/mlx-cpp/CMakeLists.txt), the same line mlxcel-core's
+          # build.rs parses, rather than restating it here. The script exits
+          # non-zero unless the pin resolves to exactly one 40-character
+          # lowercase hex SHA; an empty value must never reach the comparison
+          # below, because it would mark every cache stale and purge all of them.
+          MLX_EXPECTED_COMMIT="$(scripts/ci/mlx_pinned_commit.sh)" || exit 1
+          if [ -z "$MLX_EXPECTED_COMMIT" ]; then
+            echo "Refusing to validate build caches against an empty MLX pin" >&2
+            exit 1
+          fi
+          echo "Pinned MLX commit: $MLX_EXPECTED_COMMIT"
           # Check every _deps directory for a valid .mlx-build-commit marker.
           # If the marker is missing or doesn't match, purge that _deps/ entirely.
           # This ensures stale MLX source/objects never survive across MLX upgrades.
@@ -646,7 +657,18 @@ jobs:
 
       - name: Validate MLX build cache
         run: |
-          # MLX_EXPECTED_COMMIT is set at workflow scope (top of this file).
+          # Derive the pin from its single source of truth (GIT_TAG in
+          # src/lib/mlx-cpp/CMakeLists.txt), the same line mlxcel-core's
+          # build.rs parses, rather than restating it here. The script exits
+          # non-zero unless the pin resolves to exactly one 40-character
+          # lowercase hex SHA; an empty value must never reach the comparison
+          # below, because it would mark every cache stale and purge all of them.
+          MLX_EXPECTED_COMMIT="$(scripts/ci/mlx_pinned_commit.sh)" || exit 1
+          if [ -z "$MLX_EXPECTED_COMMIT" ]; then
+            echo "Refusing to validate build caches against an empty MLX pin" >&2
+            exit 1
+          fi
+          echo "Pinned MLX commit: $MLX_EXPECTED_COMMIT"
           # Check every _deps directory for a valid .mlx-build-commit marker.
           # If the marker is missing or doesn't match, purge that _deps/ entirely.
           FOUND=0
@@ -904,8 +926,8 @@ jobs:
           VERSION="${TAG#v}"
           # syft dir:. catalogs the Rust workspace via the committed Cargo.lock.
           # Note: it does NOT capture the MLX C++ dependency fetched at build time
-          # via FetchContent (pinned by MLX_EXPECTED_COMMIT at the top of this
-          # file); recording that native pin in the SBOM is out of scope here.
+          # via FetchContent (pinned by GIT_TAG in src/lib/mlx-cpp/CMakeLists.txt);
+          # recording that native pin in the SBOM is out of scope here.
           syft dir:. -o cyclonedx-json > sbom.cyclonedx.json
           gzip -9 sbom.cyclonedx.json
           SBOM_FILE="sbom-${VERSION}.cyclonedx.json.gz"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -495,7 +495,20 @@ jobs:
               PURGED=$((PURGED + 1))
             fi
           done
-          # Also clean workspace target/ from any previous actions/cache restore
+          # Also clean workspace target/ from any previous actions/cache restore.
+          # This loop is UNCONDITIONAL by design and does not consult a marker:
+          # $CARGO_TARGET_DIR above is the persistent self-hosted cache and is
+          # the only authoritative one, so anything a cache restore dropped into
+          # the ephemeral workspace target/ is discarded outright rather than
+          # trusted. It is also written against the literal relative path
+          # `target`, so it ignores CARGO_TARGET_DIR entirely.
+          #
+          # Consequence, which is why this is spelled out: running this step's
+          # body by hand from a developer checkout deletes every _deps/ under
+          # that checkout's target/, whatever the pin says, and each one costs a
+          # full MLX C++ rebuild to recreate. Exercise the pin extraction with
+          # MLX_PIN_CMAKE_FILE against a scratch fixture instead of running the
+          # step.
           for deps_dir in $(find target -path "*/_deps" -type d 2>/dev/null); do
             rm -rf "$deps_dir"
             PURGED=$((PURGED + 1))
@@ -684,6 +697,13 @@ jobs:
               PURGED=$((PURGED + 1))
             fi
           done
+          # Same unconditional workspace sweep as the aarch64 job above, and the
+          # same caveat: it consults no marker and is written against the
+          # literal relative path `target`, so running this step's body by hand
+          # from a developer checkout deletes every _deps/ under that checkout's
+          # target/ whatever the pin says, at the cost of a full MLX C++ rebuild
+          # each. Exercise the pin extraction with MLX_PIN_CMAKE_FILE against a
+          # scratch fixture instead of running the step.
           for deps_dir in $(find target -path "*/_deps" -type d 2>/dev/null); do
             rm -rf "$deps_dir"
             PURGED=$((PURGED + 1))

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -50,9 +50,9 @@ Thank you for your interest in contributing to mlxcel! This document covers the 
 
    `make verify` runs exactly the three commands above, and the nightly invokes those same Makefile targets, so the local gate and CI cannot drift apart. Tests build under `[profile.test-fast]` rather than `--release`: `opt-level = 3` is kept so MLX numerics stay representative, while the fat LTO and single codegen unit that make a full `--release` test link take hours are dropped. `make test-fast` / `make test-fast-cuda` are the same profile with `--test-threads=1` and a `FILTER` hook for narrowing the run while you iterate. Reach for `cargo test --release --features metal,accelerate` by hand only when you suspect a defect specific to release codegen. See [`docs/installation.md`](docs/installation.md#fast-iteration-builds) for the measured comparison.
 
-   `--workspace` is not optional, and leaving it off is how the gate went blind before (#1007). This repository's workspace root is itself the `mlxcel` package, so a bare `cargo test` or `cargo clippy` resolves to `-p mlxcel` and never builds `mlxcel-core`, `mlxcel-surgery` or `mlxcel-xla` at all, let alone their test targets. That hid 1754 tests, 1354 of them in `mlxcel-core`, which is the crate holding the MLX `cxx` bridge, `layers.rs`, the KV cache and the quantization loaders. It also hid test-only lint debt, since `--all-targets` without `--workspace` does not compile a member's test target either. `cargo fmt --all` was already workspace-wide, which is why the fmt gate never had the hole. Each member builds at the feature set the root selects: `mlxcel-core` gets `metal` and `accelerate` through the root's forwarding, `mlxcel-surgery` and `mlxcel-xla` get their empty defaults. `mlxcel-xla`'s `iree` feature stays off, so the gate needs no IREE distribution and the code behind `iree`, `diagnostics` and `micro-oracle` remains ungated.
+   `--workspace` is not optional, and leaving it off is how the gate went blind before (#1007). This repository's workspace root is itself the `mlxcel` package, so a bare `cargo test` or `cargo clippy` resolves to `-p mlxcel` and never builds `mlxcel-core`, `mlxcel-mlx-pin`, `mlxcel-surgery` or `mlxcel-xla` at all, let alone their test targets. That hid 1754 tests, 1354 of them in `mlxcel-core`, which is the crate holding the MLX `cxx` bridge, `layers.rs`, the KV cache and the quantization loaders. It also hid test-only lint debt, since `--all-targets` without `--workspace` does not compile a member's test target either. `cargo fmt --all` was already workspace-wide, which is why the fmt gate never had the hole. Each member builds at the feature set the root selects: `mlxcel-core` gets `metal` and `accelerate` through the root's forwarding, `mlxcel-mlx-pin`, `mlxcel-surgery` and `mlxcel-xla` get their empty defaults. `mlxcel-xla`'s `iree` feature stays off, so the gate needs no IREE distribution and the code behind `iree`, `diagnostics` and `micro-oracle` remains ungated.
 
-   `--no-fail-fast` goes with it. Once the run covers four members, the first failing test binary would otherwise end it and hide the other three; cargo still exits non-zero, so the gate is no weaker. Cargo runs the test binaries one at a time, so the `mlxcel-core` suite never shares the Metal device with the root suite, which is the condition that corrupts results in #1008.
+   `--no-fail-fast` goes with it. Once the run covers five members, the first failing test binary would otherwise end it and hide the other four; cargo still exits non-zero, so the gate is no weaker. Cargo runs the test binaries one at a time, so the `mlxcel-core` suite never shares the Metal device with the root suite, which is the condition that corrupts results in #1008.
 5. For inference changes, validate against a real checkpoint. Synthetic or build-only validation is not enough: a shape-compatible change can compile, pass unit tests, and still produce wrong logits on an actual quantized checkpoint. Fetch one with `mlxcel download mlx-community/<model-id>`, and see [`docs/supported-models.md`](docs/supported-models.md) for the families each code path covers. A change to a shared component should be smoke-tested against at least two families.
 6. Commit with a conventional prefix (see below) and a clear message.
 7. Push to your fork and open a Pull Request. The PR template will prompt for a summary, test plan, and linked issues.
@@ -101,13 +101,18 @@ See [`docs/adding-models.md`](docs/adding-models.md) for the full checklist. The
 
 ### Bumping the MLX upstream pin
 
-The pinned MLX C++ commit lives in three files that must stay in sync. They control source fetching, build-cache validation (marker file `_deps/.mlx-build-commit`), and CI cache invalidation respectively; a mismatch produces stale build artifacts and CI breakage.
+Edit one line: `GIT_TAG` in the `FetchContent_Declare(mlx ...)` block of [`src/lib/mlx-cpp/CMakeLists.txt`](src/lib/mlx-cpp/CMakeLists.txt). That is the commit CMake fetches, and since #1047 it is the only place the value is written down. It must be a full 40-character lowercase hex SHA; a branch or tag name is rejected, because the build-cache marker and the fetched-HEAD check both compare against an exact commit.
 
-| File | Field |
-|------|-------|
-| `src/lib/mlx-cpp/CMakeLists.txt` | `GIT_TAG` in `FetchContent_Declare(mlx ...)` |
-| `src/lib/mlxcel-core/build.rs` | `MLX_EXPECTED_COMMIT` constant |
-| `.github/workflows/release.yml` | `MLX_EXPECTED_COMMIT` env in the "Validate MLX build cache" step |
+Everything else derives from it:
+
+| Consumer | How it reads the pin |
+|----------|----------------------|
+| `src/lib/mlxcel-core/build.rs` | Parses the `GIT_TAG` line at build time via `build_support/mlx_pin.rs`, then drives `_deps/` purging, the `_deps/.mlx-build-commit` marker, the post-build check that the fetched `_deps/mlx-src` HEAD really is that commit, and the `MLXCEL_MLX_COMMIT` value baked into the binary |
+| `.github/workflows/release.yml` | Runs [`scripts/ci/mlx_pinned_commit.sh`](scripts/ci/mlx_pinned_commit.sh) inside each "Validate MLX build cache" step |
+
+Both parsers scope themselves to the declaration whose `GIT_REPOSITORY` names the MLX repository, so a second `FetchContent_Declare` cannot supply the pin by accident, and both fail loudly rather than guess when the line is missing, duplicated, or malformed. The Rust half is unit-tested by `cargo test -p mlxcel-mlx-pin`, which runs in seconds because it does not compile `mlxcel-core`.
+
+This used to be three literals in three files with nothing checking that they agreed. A partial bump left `_deps/` looking valid, so `FetchContent` never re-ran and the build linked the previous MLX while reporting the new commit. The workflow's copy had in fact already fallen a bump behind by the time #1047 was filed.
 
 After bumping the pin, re-validate the in-tree fused Metal kernel launchers in `src/lib/mlx-cpp/turbo/`, which are runtime-JIT paths a breaking MLX API change can silently regress:
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1966,6 +1966,13 @@ dependencies = [
 ]
 
 [[package]]
+name = "mlxcel-mlx-pin"
+version = "0.4.3"
+dependencies = [
+ "tempfile",
+]
+
+[[package]]
 name = "mlxcel-surgery"
 version = "0.4.3"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,14 +5,26 @@
 # `cargo build --release --target aarch64-apple-darwin --locked` included, which
 # would start compiling the default-off `mlxcel-xla` into every release build.
 #
-# The consequence is that a command must say `--workspace` to see all four
+# The consequence is that a command must say `--workspace` to see all five
 # members, and until #1007 the quality gate did not: `make verify-test` and
 # `make verify-clippy` covered the root package only, leaving 1754 tests across
-# the other three (1354 of them mlxcel-core's) and the whole of their test-target
+# the others (1354 of them mlxcel-core's) and the whole of their test-target
 # lint surface ungated. Both targets now pass `--workspace` explicitly. If you
-# add a fifth member, they pick it up with no change here.
+# add a sixth member, they pick it up with no change here.
+#
+# `mlxcel-mlx-pin` is a leaf with no production role: it hosts the unit tests
+# for the MLX-pin logic in `mlxcel-core/build_support/mlx_pin.rs` so that logic
+# can be tested without compiling mlxcel-core (and therefore MLX C++). Nothing
+# depends on it; see its manifest for why it is a path include rather than a
+# build dependency.
 [workspace]
-members = [".", "src/lib/mlxcel-core", "src/lib/mlxcel-surgery", "src/lib/mlxcel-xla"]
+members = [
+    ".",
+    "src/lib/mlxcel-core",
+    "src/lib/mlxcel-mlx-pin",
+    "src/lib/mlxcel-surgery",
+    "src/lib/mlxcel-xla",
+]
 resolver = "2"
 
 [package]

--- a/Makefile
+++ b/Makefile
@@ -468,10 +468,11 @@ pre-commit: fmt clippy test ## Pre-commit checks
 #      reproduces only under fat LTO or single-unit codegen; use
 #      `cargo test --release --features metal,accelerate` by hand when you
 #      are chasing one.
-#   4. `--workspace`: all four members, not just the root package. The
+#   4. `--workspace`: all five members, not just the root package. The
 #      workspace root IS the `mlxcel` package, so a bare `cargo test` or
 #      `cargo clippy` resolves to `-p mlxcel` and never builds mlxcel-core,
-#      mlxcel-surgery or mlxcel-xla, let alone their test targets. 1754 tests
+#      mlxcel-mlx-pin, mlxcel-surgery or mlxcel-xla, let alone their test
+#      targets. 1754 tests
 #      were invisible on that basis, mlxcel-core's 1354 of them, and so was
 #      test-only lint debt: six clippy errors sat in mlxcel-xla's lib-test
 #      target while the root gate passed clean, and during #973 five
@@ -491,8 +492,12 @@ pre-commit: fmt clippy test ## Pre-commit checks
 #
 #      What `--workspace` covers is each member at the feature set the root
 #      selects: mlxcel-core resolves to metal + accelerate through the root's
-#      forwarding, while mlxcel-surgery and mlxcel-xla resolve to their (empty)
-#      defaults. mlxcel-xla's `iree` feature stays off, so its build script
+#      forwarding, while mlxcel-mlx-pin, mlxcel-surgery and mlxcel-xla resolve
+#      to their (empty) defaults. mlxcel-mlx-pin is a leaf with no production
+#      role: it hosts the unit tests for the MLX-pin logic in
+#      mlxcel-core/build_support/mlx_pin.rs, and it costs the gate almost
+#      nothing because it does not depend on mlxcel-core and so never triggers
+#      an MLX build. mlxcel-xla's `iree` feature stays off, so its build script
 #      skips the C shim and the gate needs no IREE distribution; the code
 #      behind `iree`, `diagnostics` and `micro-oracle` is still ungated here.
 #

--- a/docs/benchmark_results/model_tests.md
+++ b/docs/benchmark_results/model_tests.md
@@ -237,7 +237,8 @@ Invocations:
 
 - **Hardware**: Apple M1 Ultra, 128 GB unified memory.
 - **MLX upstream commit pin**: `84961223c02925bef6bef95d3a0a046779bde935`
-  (`src/lib/mlxcel-core/build.rs::MLX_EXPECTED_COMMIT` at the time of measurement).
+  (the `GIT_TAG` in `src/lib/mlx-cpp/CMakeLists.txt` at the time of measurement,
+  which is the single place the pin is written down).
 - Re-measure after each MLX pin bump so the perf table reflects the active runtime.
 
 ### Reachable pairings

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -353,16 +353,20 @@ that `release.yml` runs, which would start compiling the default-off
 
 Each member builds at the feature set the root selects. `mlxcel-core` resolves
 to `metal` and `accelerate` through the root package's forwarding, so there is
-one build of it shared by every member. `mlxcel-surgery` and `mlxcel-xla`
-resolve to their empty defaults; in particular `mlxcel-xla`'s `iree` feature
-stays off, so its build script skips the native shim and the gate needs no IREE
-distribution. The code behind `iree`, `diagnostics` and `micro-oracle` is still
-outside the gate for that reason, and needs a local IREE dist to check (see
-`scripts/iree/setup-macos.sh`).
+one build of it shared by every member. `mlxcel-mlx-pin`, `mlxcel-surgery` and
+`mlxcel-xla` resolve to their empty defaults; in particular `mlxcel-xla`'s
+`iree` feature stays off, so its build script skips the native shim and the gate
+needs no IREE distribution. The code behind `iree`, `diagnostics` and
+`micro-oracle` is still outside the gate for that reason, and needs a local IREE
+dist to check (see `scripts/iree/setup-macos.sh`). `mlxcel-mlx-pin` is a leaf
+with no production role, holding the unit tests for the MLX-pin logic in
+`mlxcel-core/build_support/mlx_pin.rs`; it deliberately does not depend on
+`mlxcel-core`, so `cargo test -p mlxcel-mlx-pin` runs in seconds instead of
+triggering an MLX C++ build.
 
 `make verify-test` also passes `--no-fail-fast`, which matters only now that
-the run covers four members: without it the first failing test binary ends the
-run and hides the other three behind whatever failed first. Cargo still exits
+the run covers five members: without it the first failing test binary ends the
+run and hides the other four behind whatever failed first. Cargo still exits
 non-zero, so the gate is no weaker for it.
 
 Widening the scope does not put the run into the concurrency hazard of #1008,

--- a/docs/upstream/mlx-cuda-graph-cache-lifetime-miss-abort.md
+++ b/docs/upstream/mlx-cuda-graph-cache-lifetime-miss-abort.md
@@ -1,6 +1,6 @@
 # MLX CUDA: LRUCache's thrashing check aborts long-lived processes on a lifetime miss count
 
-Upstream bug report draft for ml-explore/mlx. Observed in mlxcel (lablup/mlxcel#818) and mitigated there by raising the CUDA graph-cache default (commit `bac0fca`); tracked for upstream in lablup/mlxcel#821. Every file and line reference below was read at MLX commit `b7c3dd6d27f45b5365b08a840310187dc503f1db`, which is mlxcel's current pin.
+Upstream bug report draft for ml-explore/mlx. Observed in mlxcel (lablup/mlxcel#818) and mitigated there by raising the CUDA graph-cache default (commit `bac0fca`); tracked for upstream in lablup/mlxcel#821. Every file and line reference below was read at MLX commit `b7c3dd6d27f45b5365b08a840310187dc503f1db`, which was mlxcel's pin at the time this report was written. For the pin in effect today, see the `GIT_TAG` argument of the `FetchContent_Declare(mlx ...)` block in `src/lib/mlx-cpp/CMakeLists.txt`, the single source of truth per issue #1047; it has moved on since.
 
 ## Summary
 

--- a/docs/upstream/mlx-cuda-rmsnorm-small-axis-regression.md
+++ b/docs/upstream/mlx-cuda-rmsnorm-small-axis-regression.md
@@ -2,7 +2,7 @@
 
 Started as an upstream bug report draft for ml-explore/mlx, tracked in lablup/mlxcel#830 (follow-up to lablup/mlxcel#824 and lablup/mlxcel#829). Verifying the claim against real source inverted it, so there is nothing to file upstream. The kernel at mlxcel's MLX pin computes the correct normalizer on the axis in question; the kernel mlxcel overlays on top of it does not.
 
-Every upstream file and line reference below was read at MLX commit `b7c3dd6d27f45b5365b08a840310187dc503f1db`, which is mlxcel's current pin (`src/lib/mlx-cpp/CMakeLists.txt:95`) and is upstream PR #3850 itself. The two bisect-boundary commits were read at `1700b39a1dc05611dc6792f4453458d379997037` (parent, PR #3804) and `a5a684db596c117f13f7bacaea9902d0ad6d28a6` (PR #3792). All measurements were run on GB10 (DGX Spark, sm_121), CUDA 13.0, Linux 6.17.
+Every upstream file and line reference below was read at MLX commit `b7c3dd6d27f45b5365b08a840310187dc503f1db` (upstream PR #3850 itself), which was mlxcel's pin at the time this report was written. For the pin in effect today, see the `GIT_TAG` argument of the `FetchContent_Declare(mlx ...)` block in `src/lib/mlx-cpp/CMakeLists.txt`, the single source of truth per issue #1047; it has moved on since. The two bisect-boundary commits were read at `1700b39a1dc05611dc6792f4453458d379997037` (parent, PR #3804) and `a5a684db596c117f13f7bacaea9902d0ad6d28a6` (PR #3792). All measurements were run on GB10 (DGX Spark, sm_121), CUDA 13.0, Linux 6.17.
 
 ## Summary
 

--- a/scripts/ci/mlx_pinned_commit.sh
+++ b/scripts/ci/mlx_pinned_commit.sh
@@ -1,0 +1,72 @@
+#!/usr/bin/env bash
+# Print the pinned MLX upstream commit on stdout.
+#
+# The pin has a single source of truth: the GIT_TAG argument of the
+# FetchContent_Declare block naming the MLX repository in
+# src/lib/mlx-cpp/CMakeLists.txt. src/lib/mlxcel-core/build.rs parses that same
+# line in Rust (src/lib/mlxcel-core/build_support/mlx_pin.rs, unit-tested by
+# src/lib/mlxcel-mlx-pin). This script exists so release.yml's "Validate MLX
+# build cache" steps can compare the _deps/.mlx-build-commit markers against the
+# pin without keeping a second copy of the literal. Issue #1047: the workflow's
+# copy had already drifted a bump behind the CMake file, which silently turned
+# every release build into a full MLX rebuild.
+#
+# Exits non-zero with a message on stderr unless the pin resolves to exactly one
+# 40-character lowercase hex SHA. Callers must treat a failure as fatal and must
+# never fall back to an empty value: an empty pin makes every marker comparison
+# fail, which purges every build cache instead of validating it.
+#
+# MLX_PIN_CMAKE_FILE overrides the file to read; it exists for the negative-path
+# checks that exercise this script against synthetic inputs.
+
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cmake_file="${MLX_PIN_CMAKE_FILE:-$repo_root/src/lib/mlx-cpp/CMakeLists.txt}"
+
+if [ ! -f "$cmake_file" ]; then
+  echo "mlx_pinned_commit: $cmake_file not found" >&2
+  exit 1
+fi
+
+# Comments are stripped first so a commented-out declaration or a GIT_TAG
+# mentioned in prose cannot be read as the live pin, and the scan is scoped to
+# the declaration whose GIT_REPOSITORY names the MLX repository so a second
+# dependency's GIT_TAG can never be picked up. Intentionally free of regex
+# interval syntax, which is not portable across the awk implementations on the
+# GitHub-hosted Linux and self-hosted macOS runners; the SHA shape is validated
+# in the shell below instead.
+commits="$(
+  awk '
+    { line = $0; sub(/#.*/, "", line); $0 = line }
+    /FetchContent_Declare/ { in_block = 1; is_mlx = 0 }
+    in_block && index($0, "ml-explore/mlx") > 0 { is_mlx = 1 }
+    in_block && is_mlx && $1 == "GIT_TAG" {
+      value = $2
+      gsub(/^"/, "", value)
+      gsub(/[")]+$/, "", value)
+      print value
+    }
+    in_block && index($0, ")") > 0 { in_block = 0; is_mlx = 0 }
+  ' "$cmake_file"
+)"
+
+count="$(printf '%s' "$commits" | grep -c . || true)"
+if [ "$count" -ne 1 ]; then
+  echo "mlx_pinned_commit: expected exactly one GIT_TAG in the FetchContent_Declare block naming ml-explore/mlx in $cmake_file, found $count" >&2
+  exit 1
+fi
+
+case "$commits" in
+  *[!0-9a-f]*)
+    echo "mlx_pinned_commit: GIT_TAG in $cmake_file is '$commits', which is not lowercase hex. Pin a full commit SHA, not a branch or tag name." >&2
+    exit 1
+    ;;
+esac
+
+if [ "${#commits}" -ne 40 ]; then
+  echo "mlx_pinned_commit: GIT_TAG in $cmake_file is '$commits', which is ${#commits} characters. Pin a full 40-character commit SHA." >&2
+  exit 1
+fi
+
+printf '%s\n' "$commits"

--- a/scripts/ci/mlx_pinned_commit.sh
+++ b/scripts/ci/mlx_pinned_commit.sh
@@ -36,6 +36,29 @@ fi
 # interval syntax, which is not portable across the awk implementations on the
 # GitHub-hosted Linux and self-hosted macOS runners; the SHA shape is validated
 # in the shell below instead.
+#
+# Count the matching declarations before reading any tag out of them. Counting
+# tags alone is not the same check and is not sufficient: with two blocks naming
+# the MLX repository where only the second carries a GIT_TAG, the tag count is 1
+# and this script would return that second block's SHA without complaint, while
+# the Rust parser rejects the same file as ambiguous. Anything the two parsers
+# disagree about is exactly the divergence #1047 exists to remove, so the shape
+# they accept has to be the same one.
+mlx_declarations="$(
+  awk '
+    { line = $0; sub(/#.*/, "", line); $0 = line }
+    /FetchContent_Declare/ { in_block = 1; is_mlx = 0 }
+    in_block && !is_mlx && index($0, "ml-explore/mlx") > 0 { is_mlx = 1; found++ }
+    in_block && index($0, ")") > 0 { in_block = 0; is_mlx = 0 }
+    END { print found + 0 }
+  ' "$cmake_file"
+)"
+
+if [ "$mlx_declarations" -ne 1 ]; then
+  echo "mlx_pinned_commit: expected exactly one FetchContent_Declare block naming ml-explore/mlx in $cmake_file, found $mlx_declarations. Leave exactly one; the pin is its GIT_TAG argument." >&2
+  exit 1
+fi
+
 commits="$(
   awk '
     { line = $0; sub(/#.*/, "", line); $0 = line }

--- a/scripts/ci/mlx_pinned_commit_test.sh
+++ b/scripts/ci/mlx_pinned_commit_test.sh
@@ -1,0 +1,111 @@
+#!/usr/bin/env bash
+# Negative-path coverage for scripts/ci/mlx_pinned_commit.sh.
+#
+# The Rust half of the MLX-pin parser is unit-tested by mlxcel-mlx-pin. The awk
+# half had no automated coverage at all, and the two must accept the same shape:
+# release.yml purges every MLX build cache that does not match whatever this
+# script prints, so a value this script accepts and the Rust parser rejects
+# means a release run that purges its caches and then fails the build.
+#
+# Each case asserts what the script does with a synthetic CMakeLists, fed
+# through MLX_PIN_CMAKE_FILE. Fixtures are written to a mktemp directory that is
+# removed on exit; nothing is written inside the repository.
+
+set -euo pipefail
+
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+under_test="$script_dir/mlx_pinned_commit.sh"
+
+work="$(mktemp -d "${TMPDIR:-/tmp}/mlx-pin-test.XXXXXX")"
+trap 'rm -rf "$work"' EXIT
+
+GOOD=2c46b953db88965c4270cc7306eda6887a3247f2
+OTHER=b7c3dd6d27f45b5365b08a840310187dc503f1db
+
+failures=0
+
+# expect_ok <name> <expected-sha> <fixture-body>
+expect_ok() {
+  local name="$1" expected="$2" body="$3" actual status
+  printf '%s' "$body" > "$work/$name"
+  set +e
+  actual="$(MLX_PIN_CMAKE_FILE="$work/$name" "$under_test" 2>/dev/null)"
+  status=$?
+  set -e
+  if [ "$status" -ne 0 ] || [ "$actual" != "$expected" ]; then
+    echo "FAIL $name: expected exit 0 and '$expected', got exit $status and '$actual'" >&2
+    failures=$((failures + 1))
+  else
+    echo "ok   $name -> $actual"
+  fi
+}
+
+# expect_fail <name> <fixture-body>
+expect_fail() {
+  local name="$1" body="$2" actual status
+  printf '%s' "$body" > "$work/$name"
+  set +e
+  actual="$(MLX_PIN_CMAKE_FILE="$work/$name" "$under_test" 2>/dev/null)"
+  status=$?
+  set -e
+  if [ "$status" -eq 0 ]; then
+    echo "FAIL $name: expected a non-zero exit, got 0 and '$actual'" >&2
+    failures=$((failures + 1))
+  elif [ -n "$actual" ]; then
+    echo "FAIL $name: exited $status but still printed '$actual' on stdout" >&2
+    failures=$((failures + 1))
+  else
+    echo "ok   $name -> rejected"
+  fi
+}
+
+mlx_block() {
+  printf 'FetchContent_Declare(\n  mlx\n  GIT_REPOSITORY "https://github.com/ml-explore/mlx.git"\n  %s)\n' "$1"
+}
+
+# The shape the repository actually uses, including a comment between
+# GIT_REPOSITORY and GIT_TAG.
+expect_ok canonical "$GOOD" "$(mlx_block "GIT_TAG $GOOD")"
+expect_ok commented "$GOOD" "$(printf 'FetchContent_Declare(\n  mlx\n  GIT_REPOSITORY "https://github.com/ml-explore/mlx.git"\n  # single source of truth, issue #1047\n  GIT_TAG %s)\n' "$GOOD")"
+
+# An unrelated dependency's GIT_TAG must never be mistaken for the pin.
+expect_ok other_dependency "$GOOD" "$(printf 'FetchContent_Declare(\n  fmt\n  GIT_REPOSITORY "https://github.com/fmtlib/fmt.git"\n  GIT_TAG %s)\n%s' "$OTHER" "$(mlx_block "GIT_TAG $GOOD")")"
+
+# A commented-out declaration is not the live pin.
+expect_ok commented_out_declaration "$GOOD" "$(printf '# FetchContent_Declare(mlx GIT_REPOSITORY "https://github.com/ml-explore/mlx.git" GIT_TAG %s)\n%s' "$OTHER" "$(mlx_block "GIT_TAG $GOOD")")"
+
+# Two blocks naming the MLX repository: which one supplies the pin is not well
+# defined, and the Rust parser rejects it, so this must too. Regression guard:
+# when only the second block carried a GIT_TAG, the tag count was 1 and this
+# script returned that second block's SHA.
+expect_fail two_mlx_declarations "$(printf '%s%s' "$(mlx_block "GIT_TAG $GOOD")" "$(mlx_block "GIT_TAG $OTHER")")"
+expect_fail two_mlx_declarations_one_tag "$(printf 'FetchContent_Declare(\n  mlx\n  GIT_REPOSITORY "https://github.com/ml-explore/mlx.git"\n)\n%s' "$(mlx_block "GIT_TAG $OTHER")")"
+
+# A repository whose path merely contains the marker is still a second
+# declaration, not a licence to pick either one.
+expect_fail lookalike_repository "$(printf 'FetchContent_Declare(\n  evil\n  GIT_REPOSITORY "https://github.com/attacker/ml-explore/mlx.git"\n  GIT_TAG %s)\n%s' "$OTHER" "$(mlx_block "GIT_TAG $GOOD")")"
+
+# Nothing to resolve.
+expect_fail no_mlx_declaration "$(printf 'FetchContent_Declare(\n  fmt\n  GIT_REPOSITORY "https://github.com/fmtlib/fmt.git"\n  GIT_TAG %s)\n' "$OTHER")"
+expect_fail no_git_tag "$(printf 'FetchContent_Declare(\n  mlx\n  GIT_REPOSITORY "https://github.com/ml-explore/mlx.git"\n)\n')"
+
+# Only a full lowercase hex SHA is a pin. A moving ref would make the cache
+# marker and the fetched-HEAD check meaningless.
+expect_fail branch_name "$(mlx_block "GIT_TAG main")"
+expect_fail short_sha "$(mlx_block "GIT_TAG 2c46b95")"
+expect_fail uppercase_sha "$(mlx_block "GIT_TAG $(printf '%s' "$GOOD" | tr 'a-f' 'A-F')")"
+
+# A missing file must fail loudly rather than resolve to an empty pin, which
+# release.yml would read as "every cache is stale".
+if MLX_PIN_CMAKE_FILE="$work/does-not-exist" "$under_test" >/dev/null 2>&1; then
+  echo "FAIL missing_file: expected a non-zero exit" >&2
+  failures=$((failures + 1))
+else
+  echo "ok   missing_file -> rejected"
+fi
+
+if [ "$failures" -ne 0 ]; then
+  echo "$failures case(s) failed" >&2
+  exit 1
+fi
+echo "all cases passed"

--- a/src/lib/mlx-cpp/CMakeLists.txt
+++ b/src/lib/mlx-cpp/CMakeLists.txt
@@ -83,7 +83,9 @@ set(_mlx_cached_binary_dir "${CMAKE_BINARY_DIR}/_deps/mlx-build")
 # proceed without re-running FetchContent. This is especially useful when Cargo
 # changes the build hash but the developer already has a cached MLX checkout.
 # NOTE: Stale-cache validation is handled by build.rs (purge_stale_mlx_cache)
-# which runs *before* CMake, ensuring _deps/ is either valid or absent.
+# which runs *before* CMake, ensuring _deps/ is either valid or absent, and
+# build.rs re-checks the fetched checkout's HEAD afterwards so a tree seeded
+# out of band cannot slip through this reuse branch either.
 if(EXISTS "${_mlx_cached_source_dir}/CMakeLists.txt")
   set(mlx_SOURCE_DIR "${_mlx_cached_source_dir}")
   set(mlx_BINARY_DIR "${_mlx_cached_binary_dir}")
@@ -92,6 +94,15 @@ else()
   FetchContent_Declare(
     mlx
     GIT_REPOSITORY "https://github.com/ml-explore/mlx.git"
+    # SINGLE SOURCE OF TRUTH for the pinned MLX commit, issue #1047. No other
+    # file stores this value. Two parsers read this exact line, both scoped to
+    # this declaration by the GIT_REPOSITORY URL just above it:
+    #   src/lib/mlxcel-core/build_support/mlx_pin.rs, used by mlxcel-core's
+    #     build.rs for cache purging, the fetched-HEAD check and the
+    #     MLXCEL_MLX_COMMIT env baked into the binary
+    #   scripts/ci/mlx_pinned_commit.sh, used by release.yml
+    # Keep the literal shape `GIT_TAG <40-char lowercase hex sha>` on one line.
+    # Both parsers reject anything else and fail loudly rather than guess.
     GIT_TAG 2c46b953db88965c4270cc7306eda6887a3247f2)
 
   # Use FetchContent_Populate + add_subdirectory so we can apply source

--- a/src/lib/mlx-cpp/CMakeLists.txt
+++ b/src/lib/mlx-cpp/CMakeLists.txt
@@ -101,8 +101,19 @@ else()
     #     build.rs for cache purging, the fetched-HEAD check and the
     #     MLXCEL_MLX_COMMIT env baked into the binary
     #   scripts/ci/mlx_pinned_commit.sh, used by release.yml
-    # Keep the literal shape `GIT_TAG <40-char lowercase hex sha>` on one line.
-    # Both parsers reject anything else and fail loudly rather than guess.
+    # The awk scan in mlx_pinned_commit.sh is the stricter of the two parsers,
+    # so keeping its shape satisfies both:
+    #   * GIT_TAG must be the first token on its line (leading whitespace is
+    #     fine; nothing else may precede it), followed by a bare or quoted
+    #     40-character lowercase hex sha, e.g. `GIT_TAG 2c46b95...` or
+    #     `GIT_TAG "2c46b95..."`.
+    #   * That line must come after the GIT_REPOSITORY line above naming
+    #     ml-explore/mlx, inside this same FetchContent_Declare(...) call.
+    #   * No line containing a closing paren `)` may appear between the
+    #     GIT_REPOSITORY line and the GIT_TAG line; the awk scan treats any
+    #     `)` as ending the declaration, so one there would hide the tag
+    #     instead of being read past.
+    # Both parsers fail loudly rather than guess when the shape does not hold.
     GIT_TAG 2c46b953db88965c4270cc7306eda6887a3247f2)
 
   # Use FetchContent_Populate + add_subdirectory so we can apply source

--- a/src/lib/mlx-cpp/turbo/CMakeLists.txt
+++ b/src/lib/mlx-cpp/turbo/CMakeLists.txt
@@ -25,7 +25,7 @@
 # this dir, because the cxx-build path in `mlxcel-core/build.rs` compiles the
 # launcher .cpp files directly. The CMakeLists.txt below documents the build
 # contract so MLX upstream-commit upgrades treat this directory as in-scope.
-# See `CLAUDE.md` MLX upgrade checklist.
+# See "Bumping the MLX upstream pin" in CONTRIBUTING.md.
 
 cmake_minimum_required(VERSION 3.16)
 

--- a/src/lib/mlxcel-core/build.rs
+++ b/src/lib/mlxcel-core/build.rs
@@ -67,7 +67,8 @@ fn main() {
         .file("cpp/mlx_cxx_ext.cpp")
         // Fused Sparse-V SDPA kernel launcher. Lives under
         // `src/lib/mlx-cpp/turbo/` so the MLX-upstream-commit upgrade
-        // checklist (CLAUDE.md) treats this directory as in-scope.
+        // checklist ("Bumping the MLX upstream pin" in CONTRIBUTING.md)
+        // treats this directory as in-scope.
         .file("../mlx-cpp/turbo/sparse_v_sdpa.cpp")
         // Fused Turbo4Delegated cold-V weighted-sum kernel
         // launcher. Reads the packed cold V directly so the dequantised

--- a/src/lib/mlxcel-core/build.rs
+++ b/src/lib/mlxcel-core/build.rs
@@ -18,16 +18,39 @@
 use cmake::Config;
 use std::{env, path::PathBuf};
 
+// Single-source-of-truth resolution and verification of the pinned MLX commit.
+// Shared by path (not by dependency) with `mlxcel-mlx-pin`, which unit-tests it
+// without dragging in an MLX build; see that crate's manifest for the reason.
+#[path = "build_support/mlx_pin.rs"]
+mod mlx_pin;
+
 fn main() {
     let out_dir = PathBuf::from(env::var("OUT_DIR").unwrap());
+    let manifest_dir = PathBuf::from(env::var("CARGO_MANIFEST_DIR").unwrap());
+
+    // The pinned MLX commit has exactly one home: GIT_TAG in
+    // ../mlx-cpp/CMakeLists.txt, which is what CMake actually fetches. Resolve
+    // it once, here, before anything compares against it. Everything below
+    // (the _deps/ purge decision, the MLXCEL_MLX_COMMIT export, the post-build
+    // HEAD verification and the cache marker) consumes this one value, so they
+    // cannot disagree with each other or with the tag that was fetched (#1047).
+    let mlx_commit = match mlx_pin::read_pinned_commit(&manifest_dir) {
+        Ok(commit) => commit,
+        Err(err) => panic!("mlxcel-core: {err}"),
+    };
 
     // Expose the pinned MLX commit to the crate so the runtime can scope the
     // persistent CUDA PTX cache directory by it (see ensure_persistent_ptx_cache).
-    println!("cargo:rustc-env=MLXCEL_MLX_COMMIT={MLX_EXPECTED_COMMIT}");
+    println!("cargo:rustc-env=MLXCEL_MLX_COMMIT={mlx_commit}");
 
     // Build MLX using cmake
-    let mlx_dst = build_mlx();
-    mark_mlx_cache_valid(&out_dir);
+    let mlx_dst = build_mlx(&mlx_commit);
+    // Verify what actually landed on disk before blessing it. CMake reuses an
+    // already-populated _deps/mlx-src rather than re-running FetchContent, so a
+    // checkout restored from a CI cache or seeded by hand can disagree with the
+    // pin without anything upstream of here noticing.
+    verify_fetched_mlx_head(&out_dir, &mlx_commit);
+    mark_mlx_cache_valid(&out_dir, &mlx_commit);
     let mlx_include = mlx_dst.join("build/include");
     let mlx_lib = mlx_dst.join("build/lib");
 
@@ -213,9 +236,6 @@ fn main() {
     println!("cargo:rerun-if-env-changed=MLXCEL_CXX_MARCH");
 }
 
-/// Expected MLX git commit — must match GIT_TAG in mlx-cpp/CMakeLists.txt.
-const MLX_EXPECTED_COMMIT: &str = "2c46b953db88965c4270cc7306eda6887a3247f2";
-
 /// Purge stale cached MLX build artifacts before CMake runs.
 ///
 /// CI caches may restore `_deps/` from a previous build. Even when the git
@@ -226,38 +246,65 @@ const MLX_EXPECTED_COMMIT: &str = "2c46b953db88965c4270cc7306eda6887a3247f2";
 /// Instead of fragile git-based validation, we use a simple marker file:
 /// after a successful build, `_deps/.mlx-build-commit` records the commit.
 /// If the marker is missing or doesn't match, we purge the entire `_deps/`.
-fn purge_stale_mlx_cache(out_dir: &std::path::Path) {
+///
+/// `expected_commit` is the value resolved from `../mlx-cpp/CMakeLists.txt` in
+/// `main`, so this decision is made against the tag CMake would actually fetch.
+fn purge_stale_mlx_cache(out_dir: &std::path::Path, expected_commit: &str) {
     let deps_dir = out_dir.join("build/_deps");
     if !deps_dir.exists() {
         return;
     }
 
     let marker = deps_dir.join(".mlx-build-commit");
-    let cached_commit = std::fs::read_to_string(&marker)
-        .ok()
-        .map(|s| s.trim().to_string());
+    let marker_contents = std::fs::read_to_string(&marker).ok();
 
-    if cached_commit.as_deref() == Some(MLX_EXPECTED_COMMIT) {
-        return; // Cache is valid
+    match mlx_pin::cache_state(marker_contents.as_deref(), expected_commit) {
+        mlx_pin::CacheState::Valid => {}
+        mlx_pin::CacheState::Stale { cached } => {
+            eprintln!(
+                "mlxcel-core: MLX build cache stale (cached={}, expected={expected_commit}), purging _deps/",
+                cached.as_deref().unwrap_or("none")
+            );
+            let _ = std::fs::remove_dir_all(&deps_dir);
+        }
     }
+}
 
-    eprintln!(
-        "mlxcel-core: MLX build cache stale (cached={}, expected={}), purging _deps/",
-        cached_commit.as_deref().unwrap_or("none"),
-        MLX_EXPECTED_COMMIT
-    );
-    let _ = std::fs::remove_dir_all(&deps_dir);
+/// Fail the build when the MLX checkout CMake used is not the pinned commit.
+///
+/// Runs after the CMake build returns and before the cache marker is written,
+/// so a tree that fails verification is never blessed as valid. A source tree
+/// with no git metadata, or a host without `git`, warns and skips: vendored and
+/// offline checkouts are legitimate and prove nothing either way. Only a
+/// readable HEAD that disagrees is an error.
+fn verify_fetched_mlx_head(out_dir: &std::path::Path, expected_commit: &str) {
+    let mlx_src = out_dir.join("build/_deps/mlx-src");
+    match mlx_pin::check_fetched_head(&mlx_src, expected_commit) {
+        mlx_pin::HeadCheck::Match => {}
+        mlx_pin::HeadCheck::Unavailable { reason } => {
+            println!(
+                "cargo:warning=mlxcel-core: skipped the fetched-MLX-commit check against \
+                 {expected_commit} ({reason})"
+            );
+        }
+        mlx_pin::HeadCheck::Mismatch { found } => {
+            panic!(
+                "mlxcel-core: {}",
+                mlx_pin::head_mismatch_message(&mlx_src, expected_commit, &found)
+            );
+        }
+    }
 }
 
 /// Write a marker after successful MLX build so future runs can validate the cache.
-fn mark_mlx_cache_valid(out_dir: &std::path::Path) {
+fn mark_mlx_cache_valid(out_dir: &std::path::Path, expected_commit: &str) {
     let marker = out_dir.join("build/_deps/.mlx-build-commit");
-    let _ = std::fs::write(marker, MLX_EXPECTED_COMMIT);
+    let _ = std::fs::write(marker, expected_commit);
 }
 
-fn build_mlx() -> PathBuf {
+fn build_mlx(expected_commit: &str) -> PathBuf {
     let out_dir = PathBuf::from(env::var("OUT_DIR").unwrap());
-    purge_stale_mlx_cache(&out_dir);
+    purge_stale_mlx_cache(&out_dir, expected_commit);
 
     let mut config = Config::new("../mlx-cpp");
     config.very_verbose(true);

--- a/src/lib/mlxcel-core/build_support/mlx_pin.rs
+++ b/src/lib/mlxcel-core/build_support/mlx_pin.rs
@@ -245,6 +245,49 @@ pub fn cache_state(marker_contents: Option<&str>, expected_commit: &str) -> Cach
     }
 }
 
+/// Environment variables through which git's repository discovery can be
+/// redirected at a different repository than the one named on the command line.
+///
+/// They are cleared for the HEAD probe. The probe exists to read the HEAD of
+/// one specific directory, and any of these left in the ambient environment
+/// silently makes `git -C <dir> rev-parse HEAD` answer for something else:
+/// `GIT_DIR` alone is enough to turn a `Mismatch` into a `Match`, which would
+/// let `mark_mlx_cache_valid` bless a `_deps/mlx-src` that is not the pinned
+/// commit. This is not an exotic condition. Git exports `GIT_DIR` (and friends)
+/// into the child environment of every hook, of `git rebase -x`, and of
+/// `git bisect run`, so any `cargo build` reached through one of those inherits
+/// it. The `.git` probe above defends against discovery walking *up*; this
+/// defends against it being redirected *sideways*.
+const GIT_DISCOVERY_ENV: &[&str] = &[
+    "GIT_DIR",
+    "GIT_WORK_TREE",
+    "GIT_COMMON_DIR",
+    "GIT_OBJECT_DIRECTORY",
+    "GIT_ALTERNATE_OBJECT_DIRECTORIES",
+    "GIT_INDEX_FILE",
+    "GIT_NAMESPACE",
+    "GIT_CEILING_DIRECTORIES",
+    "GIT_DISCOVERY_ACROSS_FILESYSTEM",
+];
+
+/// Build the `git rev-parse HEAD` invocation the HEAD probe runs.
+///
+/// `mlx_src_dir` is passed as the argument of `-C`, which git consumes
+/// unconditionally, so a directory whose name begins with a dash is read as a
+/// path and never as an option. Nothing else on the command line is
+/// path-derived.
+fn head_command(mlx_src_dir: &Path) -> Command {
+    let mut command = Command::new("git");
+    for name in GIT_DISCOVERY_ENV {
+        command.env_remove(name);
+    }
+    command
+        .arg("-C")
+        .arg(mlx_src_dir)
+        .args(["rev-parse", "HEAD"]);
+    command
+}
+
 /// Compare the HEAD of a fetched MLX checkout against the pin.
 ///
 /// This is the half of the fix that `parse_pinned_commit` cannot cover: it
@@ -271,12 +314,7 @@ pub fn check_fetched_head(mlx_src_dir: &Path, expected_commit: &str) -> HeadChec
         };
     }
 
-    let output = match Command::new("git")
-        .arg("-C")
-        .arg(mlx_src_dir)
-        .args(["rev-parse", "HEAD"])
-        .output()
-    {
+    let output = match head_command(mlx_src_dir).output() {
         Ok(output) => output,
         Err(err) => {
             return HeadCheck::Unavailable {
@@ -807,6 +845,31 @@ mod tests {
         match check_fetched_head(&inner, PIN) {
             HeadCheck::Unavailable { .. } => {}
             other => panic!("expected Unavailable, got {other:?} (outer HEAD is {outer_head})"),
+        }
+    }
+
+    /// `GIT_DIR` in the ambient environment redirects `git -C <dir> rev-parse
+    /// HEAD` at another repository entirely, which reports a `Match` for a
+    /// `_deps/mlx-src` that is not the pinned commit and gets it blessed by the
+    /// cache marker. The probe therefore clears the discovery variables rather
+    /// than trusting the environment it was launched in.
+    ///
+    /// Asserted on the constructed command rather than by setting the variable
+    /// for real: libtest runs these in threads of one process, and mutating the
+    /// process environment would race the other `git`-spawning tests here.
+    #[test]
+    fn the_head_probe_clears_gits_repository_redirection_variables() {
+        let command = head_command(Path::new("/out/build/_deps/mlx-src"));
+        let cleared: Vec<String> = command
+            .get_envs()
+            .filter(|(_, value)| value.is_none())
+            .map(|(name, _)| name.to_string_lossy().into_owned())
+            .collect();
+        for name in GIT_DISCOVERY_ENV {
+            assert!(
+                cleared.iter().any(|entry| entry == name),
+                "{name} must be cleared for the HEAD probe, cleared: {cleared:?}"
+            );
         }
     }
 

--- a/src/lib/mlxcel-core/build_support/mlx_pin.rs
+++ b/src/lib/mlxcel-core/build_support/mlx_pin.rs
@@ -1,0 +1,821 @@
+// Copyright 2025-2026 Lablup Inc. and Jeongkyu Shin
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Resolution and verification of the pinned MLX upstream commit (issue #1047).
+//!
+//! The pin has exactly one home: the `GIT_TAG` argument of the
+//! `FetchContent_Declare(mlx ...)` block in `src/lib/mlx-cpp/CMakeLists.txt`.
+//! That is the value CMake actually fetches, so everything else derives from it
+//! rather than restating it. Before #1047 the same 40-character SHA was written
+//! out in three places (the CMake file, a `MLX_EXPECTED_COMMIT` constant in
+//! `build.rs`, and a workflow-scope `env` in `.github/workflows/release.yml`)
+//! with nothing checking that they agreed, and the third had already fallen a
+//! bump behind.
+//!
+//! Two files include this module:
+//!
+//! * `src/lib/mlxcel-core/build.rs` pulls it in with `#[path]` and calls it to
+//!   resolve the pin once, before the `_deps/` purge decision, the
+//!   `cargo:rustc-env=MLXCEL_MLX_COMMIT` export, the post-build HEAD
+//!   verification and the `_deps/.mlx-build-commit` marker write, so all four
+//!   consume the same resolved value.
+//! * `src/lib/mlxcel-mlx-pin` includes the very same file as a library so the
+//!   unit tests at the bottom run without compiling `mlxcel-core`, whose build
+//!   script builds MLX C++ from source.
+//!
+//! The logic here is deliberately dependency-free (`std` only): a build script
+//! that needs a crates.io dependency to read its own pin would be a worse
+//! trade than the hand-rolled scanning below.
+
+// `build.rs` includes this file as a private module and does not necessarily
+// call every helper, which would make `dead_code` fire there (and, under
+// `cargo clippy --workspace --all-targets -- -D warnings`, fail the gate) for
+// code the `mlxcel-mlx-pin` unit tests do cover. The library view of this same
+// file re-exports everything publicly, so nothing is hidden by this.
+#![allow(dead_code)]
+
+use std::fmt;
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+/// Location of the CMake file that owns the pin, relative to `mlxcel-core`'s
+/// `CARGO_MANIFEST_DIR`.
+///
+/// Resolved against the manifest directory rather than the process working
+/// directory: a build script's CWD is the package root today, but that is a
+/// Cargo implementation detail and not something a correctness check should
+/// rest on.
+pub const CMAKE_LISTS_RELATIVE_PATH: &str = "../mlx-cpp/CMakeLists.txt";
+
+/// The same file spelled from the repository root, for human-facing messages.
+/// Nothing resolves a path through this; it exists so a build failure points at
+/// something the reader can open without first working out where the build
+/// script was standing.
+pub const CMAKE_LISTS_REPO_PATH: &str = "src/lib/mlx-cpp/CMakeLists.txt";
+
+/// The MLX upstream repository, used to pick the right `FetchContent_Declare`
+/// block out of the CMake file.
+///
+/// Matching on the repository rather than taking the file's only `GIT_TAG`
+/// keeps a second declared dependency from silently supplying the pin. Today
+/// there is exactly one `GIT_TAG` in the file, so a whole-file scan would work
+/// and would break invisibly the day that stops being true, which is the same
+/// class of defect #1047 is about.
+pub const MLX_REPOSITORY_MARKER: &str = "ml-explore/mlx";
+
+/// A `FetchContent_Declare` call, the CMake command the pin lives in.
+const FETCH_CONTENT_DECLARE: &str = "FetchContent_Declare";
+
+/// The `GIT_TAG` keyword whose argument is the pin.
+const GIT_TAG_KEYWORD: &str = "GIT_TAG";
+
+/// Length of a full git object name in hex characters.
+const FULL_SHA_LEN: usize = 40;
+
+/// Why the pin could not be resolved from the CMake file.
+///
+/// Every variant carries the path so the build failure names the file the
+/// reader has to open, and enough of the offending value to act on.
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum PinError {
+    /// The CMake file could not be read at all.
+    Unreadable { path: PathBuf, message: String },
+    /// No `FetchContent_Declare` block naming the MLX repository was found.
+    NoMlxDeclaration { path: PathBuf },
+    /// More than one `FetchContent_Declare` block names the MLX repository, so
+    /// which one supplies the pin is not well defined.
+    AmbiguousMlxDeclaration { path: PathBuf, count: usize },
+    /// The MLX declaration carries no `GIT_TAG` argument.
+    MissingGitTag { path: PathBuf },
+    /// The MLX declaration carries more than one `GIT_TAG` argument.
+    AmbiguousGitTag { path: PathBuf, count: usize },
+    /// The `GIT_TAG` argument is not a full lowercase hex commit SHA.
+    NotAFullCommitSha { path: PathBuf, value: String },
+}
+
+impl fmt::Display for PinError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Unreadable { path, message } => write!(
+                f,
+                "cannot read the pinned MLX commit: {} could not be opened ({message})",
+                path.display()
+            ),
+            Self::NoMlxDeclaration { path } => write!(
+                f,
+                "cannot resolve the pinned MLX commit: {} has no FetchContent_Declare block whose GIT_REPOSITORY names {MLX_REPOSITORY_MARKER}. The pin is the GIT_TAG argument of that block and nothing else stores it.",
+                path.display()
+            ),
+            Self::AmbiguousMlxDeclaration { path, count } => write!(
+                f,
+                "cannot resolve the pinned MLX commit: {} has {count} FetchContent_Declare blocks naming {MLX_REPOSITORY_MARKER}, so the pin is ambiguous. Leave exactly one.",
+                path.display()
+            ),
+            Self::MissingGitTag { path } => write!(
+                f,
+                "cannot resolve the pinned MLX commit: the FetchContent_Declare block naming {MLX_REPOSITORY_MARKER} in {} has no {GIT_TAG_KEYWORD} argument.",
+                path.display()
+            ),
+            Self::AmbiguousGitTag { path, count } => write!(
+                f,
+                "cannot resolve the pinned MLX commit: the FetchContent_Declare block naming {MLX_REPOSITORY_MARKER} in {} has {count} {GIT_TAG_KEYWORD} arguments. Leave exactly one.",
+                path.display()
+            ),
+            Self::NotAFullCommitSha { path, value } => write!(
+                f,
+                "the pinned MLX commit in {} is {value:?}, which is not a {FULL_SHA_LEN}-character lowercase hex commit SHA. A branch or tag name cannot be used here: the build-cache marker and the fetched-HEAD check both compare against an exact commit, and a moving ref would make both meaningless. Pin a full commit SHA.",
+                path.display()
+            ),
+        }
+    }
+}
+
+impl std::error::Error for PinError {}
+
+/// Whether a cached `_deps/` tree may be reused.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum CacheState {
+    /// The marker records the pin currently in effect; the cache is reusable.
+    Valid,
+    /// The marker is absent or records a different commit; `_deps/` must go.
+    Stale { cached: Option<String> },
+}
+
+/// Result of comparing the fetched MLX checkout's HEAD against the pin.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum HeadCheck {
+    /// HEAD is the pinned commit.
+    Match,
+    /// HEAD is readable and is a different commit. Always a hard error.
+    Mismatch { found: String },
+    /// HEAD could not be read, so nothing is proven either way.
+    ///
+    /// Vendored, exported or offline source trees legitimately arrive without
+    /// `.git`, and `git` is not guaranteed to be on the build host's `PATH`.
+    /// Neither is evidence of a wrong checkout, so both warn rather than fail.
+    Unavailable { reason: String },
+}
+
+/// Read and validate the pinned MLX commit from `mlxcel-core`'s CMake file.
+///
+/// `manifest_dir` is `mlxcel-core`'s `CARGO_MANIFEST_DIR`.
+pub fn read_pinned_commit(manifest_dir: &Path) -> Result<String, PinError> {
+    let path = manifest_dir.join(CMAKE_LISTS_RELATIVE_PATH);
+    let source = std::fs::read_to_string(&path).map_err(|err| PinError::Unreadable {
+        path: path.clone(),
+        message: err.to_string(),
+    })?;
+    parse_pinned_commit(&source, &path)
+}
+
+/// Parse and validate the pinned MLX commit out of CMake source text.
+///
+/// `path` is only used to build error messages.
+pub fn parse_pinned_commit(source: &str, path: &Path) -> Result<String, PinError> {
+    let uncommented = strip_cmake_comments(source);
+    let mlx_blocks: Vec<String> = fetch_content_declare_blocks(&uncommented)
+        .into_iter()
+        .filter(|block| block.contains(MLX_REPOSITORY_MARKER))
+        .collect();
+
+    match mlx_blocks.len() {
+        0 => {
+            return Err(PinError::NoMlxDeclaration {
+                path: path.to_path_buf(),
+            });
+        }
+        1 => {}
+        count => {
+            return Err(PinError::AmbiguousMlxDeclaration {
+                path: path.to_path_buf(),
+                count,
+            });
+        }
+    }
+
+    let tags = git_tag_arguments(&mlx_blocks[0]);
+    let tag = match tags.len() {
+        0 => {
+            return Err(PinError::MissingGitTag {
+                path: path.to_path_buf(),
+            });
+        }
+        1 => &tags[0],
+        count => {
+            return Err(PinError::AmbiguousGitTag {
+                path: path.to_path_buf(),
+                count,
+            });
+        }
+    };
+
+    if !is_full_commit_sha(tag) {
+        return Err(PinError::NotAFullCommitSha {
+            path: path.to_path_buf(),
+            value: tag.clone(),
+        });
+    }
+
+    Ok(tag.clone())
+}
+
+/// Decide whether a `_deps/` tree carrying `marker_contents` matches the pin.
+///
+/// `marker_contents` is `None` when `_deps/.mlx-build-commit` is missing or
+/// unreadable, which is treated exactly like a wrong commit: nothing vouches
+/// for the tree, so it does not get reused.
+pub fn cache_state(marker_contents: Option<&str>, expected_commit: &str) -> CacheState {
+    let cached = marker_contents.map(|raw| raw.trim().to_string());
+    if cached.as_deref() == Some(expected_commit) {
+        CacheState::Valid
+    } else {
+        CacheState::Stale { cached }
+    }
+}
+
+/// Compare the HEAD of a fetched MLX checkout against the pin.
+///
+/// This is the half of the fix that `parse_pinned_commit` cannot cover: it
+/// checks what actually landed on disk, so a `_deps/` tree restored from a CI
+/// cache, seeded by hand, or left behind by a `FetchContent` that never re-ran
+/// is caught rather than compiled.
+pub fn check_fetched_head(mlx_src_dir: &Path, expected_commit: &str) -> HeadCheck {
+    if !mlx_src_dir.exists() {
+        return HeadCheck::Unavailable {
+            reason: format!("{} does not exist", mlx_src_dir.display()),
+        };
+    }
+
+    // The `.git` probe is load-bearing, not a fast path. `git -C <dir>` walks
+    // up to the nearest enclosing repository, and `_deps/` sits inside the
+    // mlxcel checkout, so without this a source tree with no git metadata
+    // would answer with *mlxcel's* HEAD and be reported as a pin mismatch.
+    if !mlx_src_dir.join(".git").exists() {
+        return HeadCheck::Unavailable {
+            reason: format!(
+                "{} has no .git metadata (vendored or exported source tree)",
+                mlx_src_dir.display()
+            ),
+        };
+    }
+
+    let output = match Command::new("git")
+        .arg("-C")
+        .arg(mlx_src_dir)
+        .args(["rev-parse", "HEAD"])
+        .output()
+    {
+        Ok(output) => output,
+        Err(err) => {
+            return HeadCheck::Unavailable {
+                reason: format!("could not run `git`: {err}"),
+            };
+        }
+    };
+
+    if !output.status.success() {
+        return HeadCheck::Unavailable {
+            reason: format!(
+                "`git rev-parse HEAD` failed in {}: {}",
+                mlx_src_dir.display(),
+                String::from_utf8_lossy(&output.stderr).trim()
+            ),
+        };
+    }
+
+    let found = String::from_utf8_lossy(&output.stdout).trim().to_string();
+    if found == expected_commit {
+        HeadCheck::Match
+    } else {
+        HeadCheck::Mismatch { found }
+    }
+}
+
+/// Build the failure message for a fetched checkout that disagrees with the pin.
+pub fn head_mismatch_message(mlx_src_dir: &Path, expected_commit: &str, found: &str) -> String {
+    format!(
+        "the fetched MLX checkout does not match the pin: {} is at {found}, but {CMAKE_LISTS_REPO_PATH} pins {expected_commit}. \
+         CMake reuses an already-populated mlx-src instead of re-running FetchContent, so this build would link the wrong MLX. \
+         Delete the enclosing _deps/ directory to force a refetch.",
+        mlx_src_dir.display(),
+    )
+}
+
+/// Remove `#`-to-end-of-line CMake comments, preserving line structure.
+///
+/// Done before any scanning so a commented-out declaration or a `GIT_TAG`
+/// mentioned in prose cannot be mistaken for the live pin. `#` inside a
+/// double-quoted argument is left alone. CMake's bracket comments (`#[[ ]]`)
+/// are not handled; they would leave extra text in place rather than remove
+/// live text, so they cannot turn a correct parse into a wrong one, only into
+/// a loud failure.
+fn strip_cmake_comments(source: &str) -> String {
+    let mut out = String::with_capacity(source.len());
+    let mut chars = source.chars();
+    let mut in_string = false;
+    while let Some(c) = chars.next() {
+        match c {
+            '\\' if in_string => {
+                out.push(c);
+                if let Some(escaped) = chars.next() {
+                    out.push(escaped);
+                }
+            }
+            '"' => {
+                in_string = !in_string;
+                out.push(c);
+            }
+            '#' if !in_string => {
+                for skipped in chars.by_ref() {
+                    if skipped == '\n' {
+                        out.push('\n');
+                        break;
+                    }
+                }
+            }
+            _ => out.push(c),
+        }
+    }
+    out
+}
+
+/// Return the argument text of every `FetchContent_Declare(...)` call, with the
+/// outermost parentheses removed.
+fn fetch_content_declare_blocks(source: &str) -> Vec<String> {
+    let bytes = source.as_bytes();
+    let mut blocks = Vec::new();
+    let mut cursor = 0usize;
+
+    while let Some(offset) = source[cursor..].find(FETCH_CONTENT_DECLARE) {
+        let start = cursor + offset;
+        let after_keyword = start + FETCH_CONTENT_DECLARE.len();
+        cursor = after_keyword;
+
+        // Reject a longer identifier that merely ends with the keyword.
+        if start > 0 && is_identifier_byte(bytes[start - 1]) {
+            continue;
+        }
+        // ... or one that merely starts with it.
+        if bytes
+            .get(after_keyword)
+            .is_some_and(|b| is_identifier_byte(*b))
+        {
+            continue;
+        }
+
+        let mut index = after_keyword;
+        while index < bytes.len() && bytes[index].is_ascii_whitespace() {
+            index += 1;
+        }
+        if bytes.get(index) != Some(&b'(') {
+            continue;
+        }
+
+        if let Some((body, end)) = balanced_paren_body(source, index) {
+            blocks.push(body);
+            cursor = end;
+        }
+    }
+
+    blocks
+}
+
+/// Read from the `(` at `open` to its matching `)`, returning the text between
+/// them and the index just past the closing parenthesis.
+///
+/// Returns `None` for an unbalanced call, which then contributes no block and
+/// surfaces as a "no MLX declaration" failure rather than a partial parse.
+fn balanced_paren_body(source: &str, open: usize) -> Option<(String, usize)> {
+    let bytes = source.as_bytes();
+    debug_assert_eq!(bytes.get(open), Some(&b'('));
+    let mut depth = 0usize;
+    let mut in_string = false;
+    let mut index = open;
+
+    while index < bytes.len() {
+        let byte = bytes[index];
+        match byte {
+            b'\\' if in_string => index += 1,
+            b'"' => in_string = !in_string,
+            b'(' if !in_string => depth += 1,
+            b')' if !in_string => {
+                depth -= 1;
+                if depth == 0 {
+                    return Some((source[open + 1..index].to_string(), index + 1));
+                }
+            }
+            _ => {}
+        }
+        index += 1;
+    }
+
+    None
+}
+
+/// Collect every `GIT_TAG` argument inside one declaration body.
+fn git_tag_arguments(block: &str) -> Vec<String> {
+    let bytes = block.as_bytes();
+    let mut values = Vec::new();
+    let mut cursor = 0usize;
+
+    while let Some(offset) = block[cursor..].find(GIT_TAG_KEYWORD) {
+        let start = cursor + offset;
+        let after_keyword = start + GIT_TAG_KEYWORD.len();
+        cursor = after_keyword;
+
+        if start > 0 && is_identifier_byte(bytes[start - 1]) {
+            continue;
+        }
+        if bytes
+            .get(after_keyword)
+            .is_some_and(|b| is_identifier_byte(*b))
+        {
+            continue;
+        }
+
+        let mut index = after_keyword;
+        while index < bytes.len() && bytes[index].is_ascii_whitespace() {
+            index += 1;
+        }
+        if index >= bytes.len() {
+            continue;
+        }
+
+        let quoted = bytes[index] == b'"';
+        if quoted {
+            index += 1;
+        }
+        let value_start = index;
+        while index < bytes.len() {
+            let byte = bytes[index];
+            let terminates = if quoted {
+                byte == b'"'
+            } else {
+                byte.is_ascii_whitespace() || byte == b'(' || byte == b')'
+            };
+            if terminates {
+                break;
+            }
+            index += 1;
+        }
+
+        values.push(block[value_start..index].to_string());
+        cursor = index;
+    }
+
+    values
+}
+
+fn is_identifier_byte(byte: u8) -> bool {
+    byte.is_ascii_alphanumeric() || byte == b'_'
+}
+
+/// A full git object name: exactly 40 lowercase hex characters.
+///
+/// Uppercase is rejected on purpose. `git rev-parse HEAD` prints lowercase and
+/// the `_deps/.mlx-build-commit` marker is compared byte for byte, so an
+/// uppercase pin would make every cache look stale forever.
+fn is_full_commit_sha(value: &str) -> bool {
+    value.len() == FULL_SHA_LEN
+        && value
+            .bytes()
+            .all(|b| matches!(b, b'0'..=b'9' | b'a'..=b'f'))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::TempDir;
+
+    const PIN: &str = "2c46b953db88965c4270cc7306eda6887a3247f2";
+    const OTHER_PIN: &str = "b7c3dd6d27f45b5365b08a840310187dc503f1db";
+
+    fn path() -> PathBuf {
+        PathBuf::from("/repo/src/lib/mlx-cpp/CMakeLists.txt")
+    }
+
+    fn mlx_declaration(tag_line: &str) -> String {
+        format!(
+            "FetchContent_Declare(\n  mlx\n  GIT_REPOSITORY \"https://github.com/ml-explore/mlx.git\"\n  {tag_line})\n"
+        )
+    }
+
+    // ---------------------------------------------------------------- parsing
+
+    /// The in-tree CMake file must parse. This deliberately asserts only that
+    /// the result is a well-formed SHA, never a literal: asserting the value
+    /// would put a second copy of the pin in the tree and recreate #1047 in the
+    /// test suite.
+    #[test]
+    fn the_real_cmakelists_resolves_to_a_full_sha() {
+        let core_manifest = Path::new(env!("CARGO_MANIFEST_DIR")).join("../mlxcel-core");
+        let commit = read_pinned_commit(&core_manifest).expect("in-tree CMakeLists must parse");
+        assert!(
+            is_full_commit_sha(&commit),
+            "resolved pin {commit:?} is not a full lowercase hex SHA"
+        );
+    }
+
+    #[test]
+    fn parses_the_pin_from_a_well_formed_declaration() {
+        let source = mlx_declaration(&format!("GIT_TAG {PIN}"));
+        assert_eq!(parse_pinned_commit(&source, &path()).unwrap(), PIN);
+    }
+
+    #[test]
+    fn parses_a_quoted_pin() {
+        let source = mlx_declaration(&format!("GIT_TAG \"{PIN}\""));
+        assert_eq!(parse_pinned_commit(&source, &path()).unwrap(), PIN);
+    }
+
+    #[test]
+    fn parses_a_pin_preceded_by_a_comment_inside_the_block() {
+        let source = mlx_declaration(&format!(
+            "# single source of truth, see build_support/mlx_pin.rs\n  GIT_TAG {PIN}"
+        ));
+        assert_eq!(parse_pinned_commit(&source, &path()).unwrap(), PIN);
+    }
+
+    #[test]
+    fn ignores_a_commented_out_declaration() {
+        let source = format!(
+            "# FetchContent_Declare(mlx GIT_REPOSITORY \"https://github.com/ml-explore/mlx.git\" GIT_TAG {OTHER_PIN})\n{}",
+            mlx_declaration(&format!("GIT_TAG {PIN}"))
+        );
+        assert_eq!(parse_pinned_commit(&source, &path()).unwrap(), PIN);
+    }
+
+    #[test]
+    fn missing_git_tag_is_an_error() {
+        let source = "FetchContent_Declare(\n  mlx\n  GIT_REPOSITORY \"https://github.com/ml-explore/mlx.git\")\n";
+        assert_eq!(
+            parse_pinned_commit(source, &path()),
+            Err(PinError::MissingGitTag { path: path() })
+        );
+    }
+
+    #[test]
+    fn a_branch_name_is_rejected() {
+        let source = mlx_declaration("GIT_TAG main");
+        assert_eq!(
+            parse_pinned_commit(&source, &path()),
+            Err(PinError::NotAFullCommitSha {
+                path: path(),
+                value: "main".to_string(),
+            })
+        );
+    }
+
+    #[test]
+    fn a_short_sha_is_rejected() {
+        let source = mlx_declaration("GIT_TAG 2c46b95");
+        assert!(matches!(
+            parse_pinned_commit(&source, &path()),
+            Err(PinError::NotAFullCommitSha { .. })
+        ));
+    }
+
+    #[test]
+    fn an_uppercase_sha_is_rejected() {
+        let upper = PIN.to_ascii_uppercase();
+        let source = mlx_declaration(&format!("GIT_TAG {upper}"));
+        assert!(matches!(
+            parse_pinned_commit(&source, &path()),
+            Err(PinError::NotAFullCommitSha { .. })
+        ));
+    }
+
+    #[test]
+    fn two_mlx_declarations_are_ambiguous() {
+        let source = format!(
+            "{}{}",
+            mlx_declaration(&format!("GIT_TAG {PIN}")),
+            mlx_declaration(&format!("GIT_TAG {OTHER_PIN}"))
+        );
+        assert_eq!(
+            parse_pinned_commit(&source, &path()),
+            Err(PinError::AmbiguousMlxDeclaration {
+                path: path(),
+                count: 2,
+            })
+        );
+    }
+
+    #[test]
+    fn two_git_tags_in_one_declaration_are_ambiguous() {
+        let source = mlx_declaration(&format!("GIT_TAG {PIN}\n  GIT_TAG {OTHER_PIN}"));
+        assert_eq!(
+            parse_pinned_commit(&source, &path()),
+            Err(PinError::AmbiguousGitTag {
+                path: path(),
+                count: 2,
+            })
+        );
+    }
+
+    /// The reason the parse is scoped to the MLX block rather than taking the
+    /// file's only `GIT_TAG`: an unrelated dependency must not supply the pin.
+    #[test]
+    fn another_dependency_with_its_own_git_tag_is_not_picked_up() {
+        let source = format!(
+            "FetchContent_Declare(\n  fmt\n  GIT_REPOSITORY \"https://github.com/fmtlib/fmt.git\"\n  GIT_TAG {OTHER_PIN})\n{}",
+            mlx_declaration(&format!("GIT_TAG {PIN}"))
+        );
+        assert_eq!(parse_pinned_commit(&source, &path()).unwrap(), PIN);
+    }
+
+    #[test]
+    fn a_file_without_an_mlx_declaration_is_an_error() {
+        let source = format!(
+            "FetchContent_Declare(\n  fmt\n  GIT_REPOSITORY \"https://github.com/fmtlib/fmt.git\"\n  GIT_TAG {OTHER_PIN})\n"
+        );
+        assert_eq!(
+            parse_pinned_commit(&source, &path()),
+            Err(PinError::NoMlxDeclaration { path: path() })
+        );
+    }
+
+    #[test]
+    fn an_unreadable_file_is_an_error() {
+        let dir = TempDir::new().unwrap();
+        let err = read_pinned_commit(dir.path()).unwrap_err();
+        assert!(matches!(err, PinError::Unreadable { .. }));
+        assert!(
+            err.to_string().contains("CMakeLists.txt"),
+            "message should name the file: {err}"
+        );
+    }
+
+    #[test]
+    fn error_messages_name_the_file_and_what_was_expected() {
+        let source = mlx_declaration("GIT_TAG main");
+        let message = parse_pinned_commit(&source, &path())
+            .unwrap_err()
+            .to_string();
+        assert!(
+            message.contains("/repo/src/lib/mlx-cpp/CMakeLists.txt"),
+            "{message}"
+        );
+        assert!(message.contains("40-character lowercase hex"), "{message}");
+    }
+
+    // ------------------------------------------------------------ cache state
+
+    #[test]
+    fn a_marker_equal_to_the_pin_keeps_the_cache() {
+        assert_eq!(cache_state(Some(PIN), PIN), CacheState::Valid);
+    }
+
+    #[test]
+    fn marker_whitespace_is_ignored() {
+        assert_eq!(
+            cache_state(Some(&format!("{PIN}\n")), PIN),
+            CacheState::Valid
+        );
+    }
+
+    #[test]
+    fn a_marker_from_another_pin_makes_the_cache_stale() {
+        assert_eq!(
+            cache_state(Some(OTHER_PIN), PIN),
+            CacheState::Stale {
+                cached: Some(OTHER_PIN.to_string()),
+            }
+        );
+    }
+
+    #[test]
+    fn an_absent_marker_makes_the_cache_stale() {
+        assert_eq!(cache_state(None, PIN), CacheState::Stale { cached: None });
+    }
+
+    // ---------------------------------------------------------- fetched HEAD
+
+    fn git_available() -> bool {
+        Command::new("git")
+            .arg("--version")
+            .output()
+            .is_ok_and(|out| out.status.success())
+    }
+
+    /// Create a real git repository with one empty commit and return its HEAD.
+    fn init_repo_with_one_commit(dir: &Path) -> String {
+        let run = |args: &[&str]| {
+            let out = Command::new("git")
+                .arg("-C")
+                .arg(dir)
+                .args(args)
+                .output()
+                .expect("git should run");
+            assert!(
+                out.status.success(),
+                "git {args:?} failed: {}",
+                String::from_utf8_lossy(&out.stderr)
+            );
+        };
+        run(&["init", "-q"]);
+        run(&[
+            "-c",
+            "user.name=mlxcel test",
+            "-c",
+            "user.email=test@example.invalid",
+            "-c",
+            "commit.gpgsign=false",
+            "commit",
+            "--allow-empty",
+            "-q",
+            "-m",
+            "pin fixture",
+        ]);
+        let out = Command::new("git")
+            .arg("-C")
+            .arg(dir)
+            .args(["rev-parse", "HEAD"])
+            .output()
+            .expect("git should run");
+        String::from_utf8_lossy(&out.stdout).trim().to_string()
+    }
+
+    #[test]
+    fn head_matching_the_pin_passes() {
+        if !git_available() {
+            eprintln!("skipping: git is not on PATH");
+            return;
+        }
+        let dir = TempDir::new().unwrap();
+        let head = init_repo_with_one_commit(dir.path());
+        assert_eq!(check_fetched_head(dir.path(), &head), HeadCheck::Match);
+    }
+
+    #[test]
+    fn head_differing_from_the_pin_is_a_mismatch() {
+        if !git_available() {
+            eprintln!("skipping: git is not on PATH");
+            return;
+        }
+        let dir = TempDir::new().unwrap();
+        let head = init_repo_with_one_commit(dir.path());
+        assert_eq!(
+            check_fetched_head(dir.path(), PIN),
+            HeadCheck::Mismatch { found: head }
+        );
+    }
+
+    #[test]
+    fn a_tree_without_git_metadata_is_unavailable_not_a_mismatch() {
+        let dir = TempDir::new().unwrap();
+        assert!(matches!(
+            check_fetched_head(dir.path(), PIN),
+            HeadCheck::Unavailable { .. }
+        ));
+    }
+
+    #[test]
+    fn a_missing_directory_is_unavailable() {
+        let dir = TempDir::new().unwrap();
+        assert!(matches!(
+            check_fetched_head(&dir.path().join("mlx-src"), PIN),
+            HeadCheck::Unavailable { .. }
+        ));
+    }
+
+    /// `_deps/` lives inside the mlxcel checkout, so a source tree with no git
+    /// metadata must not be answered with the enclosing repository's HEAD.
+    #[test]
+    fn the_check_does_not_walk_up_into_an_enclosing_repository() {
+        if !git_available() {
+            eprintln!("skipping: git is not on PATH");
+            return;
+        }
+        let outer = TempDir::new().unwrap();
+        let outer_head = init_repo_with_one_commit(outer.path());
+        let inner = outer.path().join("build/_deps/mlx-src");
+        std::fs::create_dir_all(&inner).unwrap();
+
+        match check_fetched_head(&inner, PIN) {
+            HeadCheck::Unavailable { .. } => {}
+            other => panic!("expected Unavailable, got {other:?} (outer HEAD is {outer_head})"),
+        }
+    }
+
+    #[test]
+    fn the_mismatch_message_says_how_to_recover() {
+        let message = head_mismatch_message(Path::new("/out/build/_deps/mlx-src"), PIN, OTHER_PIN);
+        assert!(message.contains(PIN), "{message}");
+        assert!(message.contains(OTHER_PIN), "{message}");
+        assert!(message.contains(CMAKE_LISTS_REPO_PATH), "{message}");
+        assert!(message.contains("_deps/"), "{message}");
+    }
+}

--- a/src/lib/mlxcel-mlx-pin/Cargo.toml
+++ b/src/lib/mlxcel-mlx-pin/Cargo.toml
@@ -1,0 +1,33 @@
+# Unit-test host for the MLX-pin logic that `mlxcel-core`'s build script runs.
+#
+# The logic itself lives in `src/lib/mlxcel-core/build_support/mlx_pin.rs`, next
+# to the build script that owns it; `mlxcel-core/build.rs` pulls that file in
+# with `#[path]`. This crate includes the very same file so its behaviour can be
+# unit-tested with `cargo test -p mlxcel-mlx-pin` in seconds, instead of only
+# through `mlxcel-core`, whose build script builds MLX C++ from source (roughly
+# 770 MB of artifacts and tens of minutes) for any feature/profile pair that is
+# not already warm.
+#
+# Deliberately NOT wired as a `[build-dependencies]` entry of `mlxcel-core`,
+# which would be the more conventional shape. A build dependency feeds the
+# build-script unit's metadata hash, and that hash names `mlxcel-core`'s
+# `OUT_DIR` (`target/<profile>/build/mlxcel-core-<hash>/out`). Changing it
+# strands every warm `_deps/` MLX checkout under the old hash and forces a
+# from-scratch MLX rebuild on every existing configuration. Including the source
+# by path leaves the hash untouched, which is what keeps this change a no-op for
+# caches that are already valid.
+[package]
+name = "mlxcel-mlx-pin"
+version = "0.4.3"
+edition = "2024"
+description = "Unit-test host for mlxcel-core's build-script MLX pin resolution"
+license = "Apache-2.0"
+publish = false
+
+[lib]
+path = "src/lib.rs"
+
+[dev-dependencies]
+# Real temporary directories for the fetched-HEAD tests, which run against
+# actual `git init` repositories rather than a mocked `git`.
+tempfile = "3"

--- a/src/lib/mlxcel-mlx-pin/src/lib.rs
+++ b/src/lib/mlxcel-mlx-pin/src/lib.rs
@@ -1,0 +1,29 @@
+// Copyright 2025-2026 Lablup Inc. and Jeongkyu Shin
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Unit-test host for `mlxcel-core`'s build-script MLX pin resolution (#1047).
+//!
+//! This crate has no production role and nothing depends on it. It exists so
+//! the pure logic behind the single-source-of-truth MLX pin (CMake `GIT_TAG`
+//! parsing, the `_deps/` staleness decision, and the fetched-HEAD comparison)
+//! can be covered by real unit tests without compiling `mlxcel-core`, whose
+//! build script builds MLX C++ from source.
+//!
+//! The module below is the same file `mlxcel-core/build.rs` includes, reached
+//! by path rather than copied, so the tested code and the built code cannot
+//! drift apart. See `src/lib/mlxcel-mlx-pin/Cargo.toml` for why this is a
+//! path include rather than a `[build-dependencies]` entry.
+
+#[path = "../../mlxcel-core/build_support/mlx_pin.rs"]
+pub mod mlx_pin;

--- a/src/lib/mlxcel-mlx-pin/tests/cross_parser.rs
+++ b/src/lib/mlxcel-mlx-pin/tests/cross_parser.rs
@@ -1,0 +1,172 @@
+// Copyright 2025-2026 Lablup Inc. and Jeongkyu Shin
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Cross-parser agreement between the Rust MLX-pin parser
+//! (`mlxcel_mlx_pin::mlx_pin`) and the awk-based shell parser
+//! (`scripts/ci/mlx_pinned_commit.sh`), for issue #1047.
+//!
+//! `mlx_pin.rs`'s own unit tests and `mlx_pinned_commit_test.sh`'s fixtures
+//! each cover one parser in isolation; nothing ran both parsers over the same
+//! input and compared the results. This file closes that gap by shelling out
+//! to the real script for a battery of inputs and checking each against the
+//! Rust parser's answer for the identical text.
+//!
+//! The property asserted is one-directional: whenever the shell parser
+//! accepts an input and prints a commit, the Rust parser must accept the same
+//! input and resolve to the identical commit. The reverse does not hold and
+//! is not asserted here. The shell parser is intentionally the stricter of
+//! the two (see the `mlx-pin` job in `.github/workflows/ci.yml` and the
+//! comment above `GIT_TAG` in `src/lib/mlx-cpp/CMakeLists.txt`): it requires
+//! `GIT_TAG` to be the first token on its own line, after the line naming the
+//! MLX repository, with no closing parenthesis in between, while the Rust
+//! parser scans the whole declaration body regardless of line order. An input
+//! only the Rust parser accepts is exercised below (`git_tag_before_git_repository`)
+//! to keep that asymmetry documented and deliberate rather than accidental.
+//!
+//! What this rules out is the dangerous case: two parsers that both succeed
+//! but disagree on the value. `release.yml`'s cache purge decision and the
+//! actual MLX fetch both ultimately trace back to whichever parser answered,
+//! so a same-input value mismatch would be silent exactly where #1047 needs
+//! it loudest. A shell rejection, by contrast, is a hard, visible CI failure
+//! (see the `mlx-pin` job), not a silent divergence.
+
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+use mlxcel_mlx_pin::mlx_pin;
+
+const PIN: &str = "2c46b953db88965c4270cc7306eda6887a3247f2";
+const OTHER_PIN: &str = "b7c3dd6d27f45b5365b08a840310187dc503f1db";
+
+/// Absolute path to the shell parser under test, resolved from this crate's
+/// manifest directory rather than the process working directory so the test
+/// does not depend on where `cargo test` was invoked from.
+fn shell_script_path() -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR")).join("../../../scripts/ci/mlx_pinned_commit.sh")
+}
+
+/// Run the shell parser against `body`. `Some(commit)` on a zero exit and a
+/// printed commit, `None` on any rejection (matching what a CI step sees).
+fn run_shell_parser(body: &str) -> Option<String> {
+    let dir = tempfile::TempDir::new().expect("create fixture dir");
+    let fixture = dir.path().join("CMakeLists.txt");
+    std::fs::write(&fixture, body).expect("write fixture");
+
+    let script = shell_script_path();
+    let output = Command::new(&script)
+        .env("MLX_PIN_CMAKE_FILE", &fixture)
+        .output()
+        .unwrap_or_else(|err| panic!("failed to run {}: {err}", script.display()));
+
+    if !output.status.success() {
+        return None;
+    }
+    Some(String::from_utf8_lossy(&output.stdout).trim().to_string())
+}
+
+fn mlx_declaration(tag_line: &str) -> String {
+    format!(
+        "FetchContent_Declare(\n  mlx\n  GIT_REPOSITORY \"https://github.com/ml-explore/mlx.git\"\n  {tag_line})\n"
+    )
+}
+
+/// Named fixtures. Several mirror the shapes in
+/// `scripts/ci/mlx_pinned_commit_test.sh` so the two suites are known to
+/// agree on the same inputs rather than drifting apart independently.
+fn fixtures() -> Vec<(&'static str, String)> {
+    vec![
+        ("canonical", mlx_declaration(&format!("GIT_TAG {PIN}"))),
+        ("quoted", mlx_declaration(&format!("GIT_TAG \"{PIN}\""))),
+        (
+            "commented",
+            format!(
+                "FetchContent_Declare(\n  mlx\n  GIT_REPOSITORY \"https://github.com/ml-explore/mlx.git\"\n  # single source of truth, issue #1047\n  GIT_TAG {PIN})\n"
+            ),
+        ),
+        (
+            "other_dependency_first",
+            format!(
+                "FetchContent_Declare(\n  fmt\n  GIT_REPOSITORY \"https://github.com/fmtlib/fmt.git\"\n  GIT_TAG {OTHER_PIN})\n{}",
+                mlx_declaration(&format!("GIT_TAG {PIN}"))
+            ),
+        ),
+        (
+            "commented_out_declaration",
+            format!(
+                "# FetchContent_Declare(mlx GIT_REPOSITORY \"https://github.com/ml-explore/mlx.git\" GIT_TAG {OTHER_PIN})\n{}",
+                mlx_declaration(&format!("GIT_TAG {PIN}"))
+            ),
+        ),
+        (
+            "missing_git_tag",
+            "FetchContent_Declare(\n  mlx\n  GIT_REPOSITORY \"https://github.com/ml-explore/mlx.git\")\n"
+                .to_string(),
+        ),
+        ("branch_name", mlx_declaration("GIT_TAG main")),
+        ("short_sha", mlx_declaration("GIT_TAG 2c46b95")),
+        (
+            "uppercase_sha",
+            mlx_declaration(&format!("GIT_TAG {}", PIN.to_ascii_uppercase())),
+        ),
+        (
+            "two_mlx_declarations",
+            format!(
+                "{}{}",
+                mlx_declaration(&format!("GIT_TAG {PIN}")),
+                mlx_declaration(&format!("GIT_TAG {OTHER_PIN}"))
+            ),
+        ),
+        (
+            "no_mlx_declaration",
+            format!(
+                "FetchContent_Declare(\n  fmt\n  GIT_REPOSITORY \"https://github.com/fmtlib/fmt.git\"\n  GIT_TAG {OTHER_PIN})\n"
+            ),
+        ),
+        // The documented asymmetry: the shell parser requires GIT_TAG after
+        // the GIT_REPOSITORY line, so it rejects this reordering (falls
+        // through to the `None` arm below, no assertion). The Rust parser
+        // scans the whole block and accepts it. This fixture exists so the
+        // asymmetry is verified on every run rather than only described in a
+        // comment; if a future edit makes the shell parser accept this too,
+        // the `Some` arm's equality assertion below still holds.
+        (
+            "git_tag_before_git_repository",
+            "FetchContent_Declare(\n  mlx\n  GIT_TAG 2c46b953db88965c4270cc7306eda6887a3247f2\n  GIT_REPOSITORY \"https://github.com/ml-explore/mlx.git\")\n"
+                .to_string(),
+        ),
+    ]
+}
+
+#[test]
+fn shell_acceptance_implies_rust_agreement_on_the_same_commit() {
+    if Command::new("bash").arg("--version").output().is_err() {
+        eprintln!("skipping: bash is not on PATH");
+        return;
+    }
+
+    for (name, body) in fixtures() {
+        let shell_result = run_shell_parser(&body);
+        let rust_result = mlx_pin::parse_pinned_commit(&body, Path::new("<fixture>")).ok();
+
+        if let Some(shell_commit) = shell_result {
+            assert_eq!(
+                rust_result.as_deref(),
+                Some(shell_commit.as_str()),
+                "fixture {name:?}: shell parser accepted {shell_commit:?} but the Rust parser did not resolve to the same commit (got {rust_result:?}); a same-input value mismatch is exactly the silent divergence issue #1047 exists to prevent"
+            );
+        }
+        // A `None` shell result is not checked against the Rust result: the
+        // shell parser accepting strictly less is documented and expected.
+    }
+}


### PR DESCRIPTION
## Summary

The pinned MLX commit was written out in three places with nothing checking that they agreed, so bumping one produced a build that looked bumped and compiled the old MLX. This makes `GIT_TAG` in `src/lib/mlx-cpp/CMakeLists.txt` the only place the value lives (the issue's option 1), adds a post-build check that the checkout which actually landed on disk is that commit (option 3), and removes the third location, which had already gone stale.

The pin value is unchanged at `2c46b953db88965c4270cc7306eda6887a3247f2`.

## The third location, and why it matters

The issue names two locations. There were three, and `.github/workflows/release.yml` was already a generation behind: it carried `b7c3dd6d27f45b5365b08a840310187dc503f1db` while the tree had moved to `2c46b953` in #1046, and the comment above it called this "the three-place pin" and pointed at a documentation file that does not exist in this repository (the checklist is in `CONTRIBUTING.md`). The effect there was fail-safe rather than silent, since the mismatched literal made every marker comparison fail, but the practical result was that every release build purged and rebuilt MLX from scratch while the workflow reported a commit the tree no longer used. So the silent-divergence failure the issue predicts had already happened once, in the fail-safe direction.

## What changed

- `src/lib/mlxcel-core/build.rs`: `MLX_EXPECTED_COMMIT` is deleted. `main()` resolves the pin once from `../mlx-cpp/CMakeLists.txt` before anything compares against it, and threads that one value through `build_mlx`, `purge_stale_mlx_cache`, the new `verify_fetched_mlx_head`, `mark_mlx_cache_valid` and the `cargo:rustc-env=MLXCEL_MLX_COMMIT` export. A parse failure panics with a message naming the file and what it expected. No duplicate `rerun-if-changed` was added; the existing one at what is now line 204 is unchanged.
- `src/lib/mlxcel-core/build_support/mlx_pin.rs` (new): the pure logic. Parsing strips CMake comments first, then scopes itself to the `FetchContent_Declare` block whose `GIT_REPOSITORY` names `ml-explore/mlx`, and treats zero blocks, two blocks, zero `GIT_TAG`s, two `GIT_TAG`s, and any value that is not a 40-character lowercase hex SHA as hard failures with distinct actionable messages. Uppercase is rejected too: `git rev-parse` prints lowercase and the marker is compared byte for byte, so an uppercase pin would make every cache look stale forever.
- Post-build HEAD verification: after CMake returns and **before** the marker is written, `_deps/mlx-src`'s HEAD is read and a disagreement fails the build, telling the reader to delete `_deps/` to force a refetch. Verifying before marking is the point: a tree that failed verification is never blessed as valid. A missing `.git` or a host without `git` emits a `cargo:warning` and skips, so vendored and offline trees still build. The `.git` existence probe is load-bearing rather than a fast path, because `git -C` walks up to the nearest enclosing repository and `_deps/` sits inside the mlxcel checkout, so without it a metadata-free tree would answer with mlxcel's own HEAD and be reported as a pin mismatch. There is a unit test for exactly that.
- `.github/workflows/release.yml`: the workflow-scope `env: MLX_EXPECTED_COMMIT` literal is gone. Both "Validate MLX build cache" steps derive the pin from the CMake file through the new `scripts/ci/mlx_pinned_commit.sh`, and refuse to run the comparison against an empty value, since an empty pin would mark every cache stale and purge all of them rather than validate any. Purge behaviour is otherwise byte-identical. The stale documentation pointer and the stale SBOM comment at the bottom of the file are fixed.
- `scripts/ci/mlx_pinned_commit.sh` (new): the shell half of the parser. Same scoping (comments stripped, matched on the MLX repository), exits non-zero unless exactly one 40-character lowercase hex SHA resolves. Deliberately free of regex interval syntax, which is not portable across the awk implementations on the GitHub-hosted Linux and self-hosted macOS runners; the SHA shape is validated in shell instead. `MLX_PIN_CMAKE_FILE` overrides the input file for testing.
- `src/lib/mlx-cpp/CMakeLists.txt`: a comment above `GIT_TAG` naming both parsers and stating that the literal `GIT_TAG <40-char lowercase hex sha>` shape must stay parseable. Verified that CMake accepts a comment inside the command invocation and drops it from `ARGN`.
- Docs: `CONTRIBUTING.md`'s "Bumping the MLX upstream pin" section is rewritten for the one-file reality (the Metal kernel re-validation checklist after it is kept verbatim), and `docs/benchmark_results/model_tests.md` now points at the CMake `GIT_TAG` instead of the deleted constant.

## Test mechanism, and why it is not a build-dependency

The logic lives in `mlxcel-core/build_support/mlx_pin.rs`, which `build.rs` includes with `#[path]` and a new leaf crate `mlxcel-mlx-pin` includes as a library. That crate has no production role and nothing depends on it; it exists purely so `cargo test -p mlxcel-mlx-pin` can cover the logic in about a second without compiling `mlxcel-core` and therefore without building MLX C++.

The more conventional shape, a `[build-dependencies]` entry, was rejected on purpose: a new build-dependency feeds the build-script unit's metadata hash, that hash names `mlxcel-core`'s `OUT_DIR` (`target/<profile>/build/mlxcel-core-<hash>/out`), and moving it strands every warm `_deps/` MLX checkout under the old hash. Including the source by path leaves the hash untouched. This is reasoning from Cargo's metadata model rather than an experiment; testing it would have required the rebuild it is meant to avoid.

Adding a fifth workspace member made four "four members" statements stale, in `Cargo.toml`, `Makefile`, `CONTRIBUTING.md` and `docs/installation.md`. Those are corrected in the same commit rather than left to rot, which is the same defect class as the issue itself.

## Test plan

25 unit tests, all passing, all runnable without an MLX build:

- [x] `cargo test -p mlxcel-mlx-pin` (25 passed): happy path, quoted value, comment inside the block, commented-out declaration, missing `GIT_TAG`, branch name, short SHA, uppercase SHA, two MLX declarations, two `GIT_TAG`s in one declaration, an unrelated dependency carrying its own `GIT_TAG` (the wrong-block case), no MLX declaration, unreadable file, error-message content, marker-matches, marker-matches-with-trailing-whitespace, marker-differs, marker-absent, HEAD-matches, HEAD-differs, no-git-metadata, missing directory, no-walk-up-into-enclosing-repository, and the recovery text of the mismatch message. The HEAD tests run against real `git init` repositories, not a mocked `git`.
- [x] One test parses the actual in-tree `CMakeLists.txt` and asserts the result is a well-formed SHA. It deliberately does **not** assert the literal, because doing so would put a second copy of the pin in the tree and recreate this issue inside the test suite.
- [x] `cargo clippy -p mlxcel-mlx-pin --all-targets -- -D warnings`: clean.
- [x] `cargo fmt --all -- --check`: clean.
- [x] `build.rs` type-checks and passes `clippy -D warnings` with and without the `cuda` feature. Checked by compiling it verbatim in an isolated scratch crate with `cmake` and `cxx-build` as ordinary dependencies, since checking it in place re-enters CMake. This also confirms the build.rs view is free of `dead_code`, which the `#![allow(dead_code)]` in the shared module exists to guarantee for helpers only the tests call.
- [x] `scripts/ci/mlx_pinned_commit.sh` exercised against the real file plus eight synthetic fixtures via `MLX_PIN_CMAKE_FILE`: correct SHA on the real file and on the other-dependency and commented-out cases, non-zero with a specific message on missing tag, branch name, short SHA, two MLX declarations, no MLX declaration and missing file.
- [x] Both parsers cross-checked: the Rust parser, the awk parser and the value committed on `main` all resolve to `2c46b953db88965c4270cc7306eda6887a3247f2`, so this change is value-preserving.
- [x] `release.yml` parses as YAML and both "Validate MLX build cache" steps still sit immediately after `Checkout code`, which is what makes the repo available to the extraction script.

## What is not verified here

- The full `cargo build --release --features cuda` is run separately, outside this PR's local verification, because every profile/feature pair that is not already warm rebuilds MLX from source.
- The issue's second acceptance criterion, bumping to a different commit and confirming the fetched `_deps/mlx-src` HEAD, the `.mlx-build-commit` marker and the embedded `MLXCEL_MLX_COMMIT` all move together, was not executed as a deliberate two-rebuild experiment. What supports it: the five caches present on the development host before this change spanned both pin generations (two at `2c46b953`, three at `b7c3dd6d`) with the marker and the `mlx-src` HEAD agreeing in every one, which is the invariant the new HEAD check enforces rather than assumes.
- A note on how the cold build became available: while validating this change I ran the `Validate MLX build cache` step body extracted from `release.yml` against a scratch `CARGO_TARGET_DIR`, from the repository root. The first loop honoured the scratch directory; the second loop is written against the literal relative path `target` and consults no marker, so it deleted all five `_deps/` trees under the real `target/` (about 3.8 GB) with `rm -rf`. They are unrecoverable. The upside is incidental, not planned: with `_deps/` absent, the verification build is a genuine cold fetch, so the fetched HEAD, the marker and the embedded `MLXCEL_MLX_COMMIT` are all observed being produced from the single source in one run. That is what turned the second criterion from prohibitively expensive into a by-product, at a cost nobody chose to pay.
- The second commit documents that unconditional loop in place. It is deliberate for CI, where the persistent self-hosted `$CARGO_TARGET_DIR` is the only authoritative cache and anything a cache restore leaves in the ephemeral workspace `target/` is discarded outright, so the behaviour is left alone and only the intent and the local-execution hazard are now written down.

Closes #1047