### PR TITLE
fix(paged): key the paged decode v2 JIT cache on input dtypes

### DIFF
--- a/src/lib/mlx-cpp/turbo/paged_attention_v2.cpp
+++ b/src/lib/mlx-cpp/turbo/paged_attention_v2.cpp
@@ -600,6 +600,28 @@ std::vector<mlx::core::array> paged_attention_decode_v2_partial(
     const bool use_cuda = !mlx::core::metal::is_available();
     auto& kernel = get_partial_kernel(use_cuda).get();
 
+    // `QType`/`KVType` are load-bearing even though the body never names them:
+    // they exist to put the input dtypes into the JIT cache key (issue #1053).
+    //
+    // Both backends generate the buffer parameter types from the *runtime*
+    // dtypes of `inputs`, but only Metal folds those dtypes into the cache key.
+    // `backend/common/metal_kernel.cpp` appends `get_type_string(arr.dtype())`
+    // per input to the kernel name; `backend/cuda/custom_kernel.cpp` builds its
+    // name as `"custom_kernel_" + name + template_arguments_hash(template_args)`
+    // and stops there, while `cu::get_jit_module` memoises the compiled module
+    // under exactly that name in a process-global map and only invokes the
+    // source builder on a miss. With int-only template args a `float` pool and
+    // an `f16` pool of the same geometry therefore hash to one name, and
+    // whichever dtype compiles first wins for the life of the process: the
+    // second one reads its buffer through the wrong pointer type and returns
+    // numbers unrelated to its inputs.
+    //
+    // `template_arguments_hash` does hash a `Dtype` arg, so naming the dtypes
+    // here restores the discrimination on CUDA. On Metal the key was already
+    // correct and this only adds an unused `typename` parameter. This mirrors
+    // the `{"T", T}` the fused decode-MoE kernels have always passed, which is
+    // why those kernels never had the defect. Do not drop these because the
+    // kernel body does not reference them.
     std::vector<std::pair<std::string, TemplateArg>> template_args = {
         {"Dim", dim},
         {"PageSize", page_size},
@@ -608,6 +630,9 @@ std::vector<mlx::core::array> paged_attention_decode_v2_partial(
         {"QGroups", q_groups},
         {"DimsPerThread", dims_per_thread},
         {"NumWarps", num_warps},
+        {"QType", q.dtype()},
+        {"KVType", k_pool.dtype()},
+        {"VType", v_pool.dtype()},
     };
 
     // Pack scale into a 1-element f32 array (metal_kernel inputs must be

--- a/src/lib/mlx-cpp/turbo/paged_attention_v2_merge.cpp
+++ b/src/lib/mlx-cpp/turbo/paged_attention_v2_merge.cpp
@@ -203,8 +203,15 @@ std::vector<mlx::core::array> paged_attention_merge_states(
     const bool use_cuda = !mlx::core::metal::is_available();
     auto& kernel = get_merge_kernel(use_cuda).get();
 
+    // `VType`/`LseType` key the JIT cache on the input dtypes; see the longer
+    // note on the same additions in `paged_attention_v2.cpp` (issue #1053).
+    // `Dim` alone is a far weaker key here than it is there, because head dims
+    // repeat across families, so two callers that differ only in partial dtype
+    // would otherwise share one compiled module on CUDA.
     std::vector<std::pair<std::string, TemplateArg>> template_args = {
         {"Dim", dim},
+        {"VType", v_in.dtype()},
+        {"LseType", lse_in.dtype()},
     };
 
     std::vector<mlx::core::array> inputs = {v_in, lse_in, o_indptr};

--- a/src/lib/mlxcel-core/src/paged_v2/launch_tests.rs
+++ b/src/lib/mlxcel-core/src/paged_v2/launch_tests.rs
@@ -415,6 +415,81 @@ fn f16_pools_match_the_gather_reference() {
 }
 
 #[test]
+fn two_pool_dtypes_at_one_geometry_do_not_share_a_compiled_kernel() {
+    // Issue #1053. Both backends generate the kernel's buffer parameter types
+    // from the runtime dtypes of the inputs, but only Metal folds those dtypes
+    // into the JIT cache key. On CUDA the key was
+    // `"custom_kernel_" + name + template_arguments_hash(template_args)` over
+    // int-only args, and `cu::get_jit_module` memoises per key in a
+    // process-global map, so an f32 pool and an f16 pool of the *same geometry*
+    // collided: whichever compiled first won for the life of the process and
+    // the other read its buffer through the wrong pointer type, returning
+    // numbers unrelated to its inputs (relative error ~1.0).
+    //
+    // The geometry is held fixed on purpose. Every int template arg (`Dim`,
+    // `PageSize`, `NRep`, `QHeads`, `QGroups`, `DimsPerThread`, `NumWarps`) is
+    // derived from it, so holding it fixed while moving only the pool dtype is
+    // precisely the case the old key could not tell apart.
+    //
+    // This guard cannot fail on Metal, whose key already carried the dtypes;
+    // it exists for the CUDA backend, where it reproduces the defect.
+    const PAGE_SIZE: usize = 32;
+    const HQ: i32 = 8;
+    const HKV: i32 = 2;
+    const DIM: i32 = 64;
+    const LENS: [usize; 2] = [200, 97];
+    const STARTS: [usize; 2] = [0, 0];
+    const SEED: u64 = 0x1053;
+
+    let f32_batch = Batch::new(
+        PAGE_SIZE,
+        HQ,
+        HKV,
+        DIM,
+        &LENS,
+        &STARTS,
+        dtype::FLOAT32,
+        SEED,
+    );
+    let f32_before = run_with_chunk(&f32_batch, 4);
+    let err = max_rel_error(&f32_before, &f32_batch.reference());
+    assert!(
+        err < 2e-3,
+        "f32 pool relative error {err} before the f16 run"
+    );
+
+    // Same geometry, same values, f16 storage. The reference is the f64 host
+    // attention over the pre-rounding values, so the tolerance is set by f16
+    // storage rounding alone; 3e-2 matches the sibling assertion in
+    // `sparse_tests::an_f16_cache_matches_the_reference_within_its_own_precision`.
+    let f16_batch = Batch::new(
+        PAGE_SIZE,
+        HQ,
+        HKV,
+        DIM,
+        &LENS,
+        &STARTS,
+        dtype::FLOAT16,
+        SEED,
+    );
+    let f16_out = run_with_chunk(&f16_batch, 4);
+    let err = max_rel_error(&f16_out, &f16_batch.reference());
+    assert!(
+        err < 3e-2,
+        "f16 pool relative error {err} at a geometry already compiled for f32"
+    );
+
+    // And the f32 launch still answers correctly afterwards, so the guard holds
+    // whichever dtype the process happened to compile first.
+    let f32_after = run_with_chunk(&f32_batch, 4);
+    let err = max_rel_error(&f32_after, &f32_batch.reference());
+    assert!(
+        err < 2e-3,
+        "f32 pool relative error {err} after the f16 run"
+    );
+}
+
+#[test]
 fn the_entry_point_declines_a_batch_with_no_visible_tokens() {
     let batch = Batch::new(16, 4, 2, 64, &[32], &[32], dtype::FLOAT32, 0x5);
     let q = batch.q_array(dtype::FLOAT32);


### PR DESCRIPTION
## Summary

The fused sparse decode was not computing the wrong answer. It was running a kernel compiled for a different dtype.

Both MLX backends generate a custom kernel's buffer parameter types from the runtime dtypes of `inputs`, but only Metal folds those dtypes into the JIT cache key. `mlx/backend/common/metal_kernel.cpp` appends one `get_type_string(arr.dtype())` per input to the kernel name, with the comment "The generated source depends on the dtypes of the inputs and outputs ... Include them in the kernel name so that a given name always maps to the same source." `mlx/backend/cuda/custom_kernel.cpp` builds its name as `"custom_kernel_" + name + template_arguments_hash(template_args)` and stops there, and `cu::get_jit_module` memoises the compiled module under exactly that name in a process-global map, invoking the source builder only on a miss.

`paged_attention_decode_v2_partial` passed int-only template args, all derived from geometry. So an f32 pool and an f16 pool at the same geometry hashed to one name: whichever compiled first won for the life of the process, and the other read its buffer through the wrong pointer type and returned numbers unrelated to its inputs. That is the reported relative error of ~1.0, and it explains why the preceding `outcome.is_fused()` assertion passes: the dispatch is right, the compiled module is not.

This is not confined to the test suite. Any process that runs the same v2 geometry at two pool dtypes gets a silently wrong answer on CUDA.

## Change

Name the dtypes in `template_args` so `template_arguments_hash` discriminates. `TemplateArg` already accepts a `Dtype`; Metal renders it as a `typename` template parameter and CUDA as a `using` alias, so one change serves both backends and neither kernel body needs to reference it. This mirrors the `{"T", T}` that the fused decode-MoE kernels have always passed, which is why those kernels never had this defect.

- `turbo/paged_attention_v2.cpp`: adds `QType`, `KVType`, `VType`.
- `turbo/paged_attention_v2_merge.cpp`: adds `VType`, `LseType`, whose only prior key was `Dim`. Head dims repeat across families, so `Dim` alone was an especially weak key there.

Both additions carry a comment explaining that they are load-bearing despite being unreferenced by the kernel body, so a later cleanup does not remove them.

On JIT cost: CUDA now compiles one module per (geometry, dtype) instead of one per geometry. That is the count Metal has always had, and a process serves one KV cache dtype, so the steady-state module count is unchanged; what changes is that a second dtype now compiles its own module instead of silently reusing the first one's. No kernel body was touched, so nothing about the emitted code changes for a given dtype.

Neither `QType`/`KVType`/`VType` nor `VType`/`LseType` collides with an identifier in the Metal or the CUDA source string for these kernels, checked by hand because the CUDA bodies are not compiled on a Metal host.

## Regression coverage

`two_pool_dtypes_at_one_geometry_do_not_share_a_compiled_kernel` holds one geometry fixed (every int template arg is derived from it) and moves only the pool dtype: f32, then f16, then f32 again in a single process, each checked against its own host reference. That is precisely the case the old key could not tell apart, and running f32 again at the end makes the guard independent of which dtype the process compiled first.

## Validation

Verified on Metal (M1 Ultra, macOS 26.5.2, `--features metal,accelerate`):

- `cargo test --profile test-fast --features metal,accelerate -p mlxcel-core --lib paged_v2 -- --test-threads=1`: 93 passed, 0 failed (92 before this PR, plus the new guard).
- Full `mlxcel-core` lib suite serialized on `main` before the change: 1415 passed, 0 failed in 92.23s. This is how the issue's "CUDA-only or also CPU" question was answered: `an_f16_cache_matches_the_reference_within_its_own_precision` and `chunk_size_does_not_change_the_answer` both pass on Metal, because the Metal cache key already carried the dtypes.
- `cargo fmt --all -- --check` and `cargo clippy --workspace --all-targets --features metal,accelerate -- -D warnings` clean.

## Verification gap

The issue's acceptance criterion `cargo test --release --features cuda -p mlxcel-core --lib paged_v2 -- --test-threads=1` passes **is not met by this PR and could not be met in the session that wrote it**. There is no `nvcc` on this host and no CUDA node is reachable (re-verified 2026-08-07). The fix is reasoned from the MLX sources quoted above and validated to the extent a Metal host allows: it compiles, the Metal suite stays green, and passing a `Dtype` template arg through `cuda_kernel` is already exercised on CUDA today by `turbo/fused_norm.cpp` and `turbo/fused_rope_append.cpp`, so it is not a new code path.

A GB10 session should run that command and confirm both the new guard and `sparse_tests::an_f16_cache_matches_the_reference_within_its_own_precision` pass.

## Scope note

Three more `cuda_kernel` call sites still pass int-only template args and carry the same defect: `turbo/paged_attention.cpp` (the v1 kernel), `turbo/sampling.cpp`, and `turbo/sampling_rejection.cpp`. They are left to #1054, which is the same mechanism reached through a different inducing predecessor. `turbo/fused_norm.cpp`, `turbo/fused_rope_append.cpp` and the fused decode-MoE kernels were audited and are already correct.

Closes #1053
