### PR TITLE
fix(kernels): key every CUDA JIT launch on its input dtypes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -135,6 +135,27 @@ jobs:
       - name: Check every version-tracking crate carries the root version
         run: python3 scripts/ci/check_crate_versions.py
 
+  kernel-dtype-keys:
+    name: kernel dtype keys
+    # Deliberately not behind the `changes` filter, for the same reason as
+    # `crate-versions`: it needs no toolchain, runs in seconds, and the defect it
+    # guards against is silent. MLX's CUDA JIT memoises a compiled kernel under a
+    # name that does not carry the input dtypes, so a launch whose template args
+    # are all ints serves the first dtype's compiled module to every later dtype
+    # at the same geometry, reading buffers through the wrong pointer type.
+    # Issues #1053 and #1054 are two symptoms of exactly that. macOS never sees
+    # it, because Metal's key does carry the dtypes, so this job is the only
+    # place the omission is caught without CUDA hardware.
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          persist-credentials: false
+      - name: Check every CUDA JIT launch keys its cache on the input dtypes
+        run: python3 scripts/ci/check_kernel_dtype_keys.py
+
   mlx-pin:
     name: MLX pin extraction
     needs: changes

--- a/Makefile
+++ b/Makefile
@@ -579,6 +579,11 @@ verify-versions: ## Assert every version-tracking workspace crate carries the ro
 	@echo "$(CYAN)[verify] workspace crate versions...$(RESET)"
 	@python3 scripts/ci/check_crate_versions.py
 
+.PHONY: verify-kernel-dtype-keys
+verify-kernel-dtype-keys: ## Assert every CUDA JIT kernel launch keys its cache on the input dtypes (issues #1053, #1054)
+	@echo "$(CYAN)[verify] kernel dtype cache keys...$(RESET)"
+	@python3 scripts/ci/check_kernel_dtype_keys.py
+
 .PHONY: bump-version
 bump-version: ## Release: set every version-tracking crate to VERSION and sync Cargo.lock (make bump-version VERSION=0.5.0)
 	@test -n "$(VERSION)" || { echo "$(RED)usage: make bump-version VERSION=0.5.0$(RESET)"; exit 1; }
@@ -587,7 +592,7 @@ bump-version: ## Release: set every version-tracking crate to VERSION and sync C
 	@$(MAKE) --no-print-directory verify-versions
 
 .PHONY: verify
-verify: verify-versions verify-fmt verify-clippy verify-test ## Run the full CI-faithful gate locally (recommended before push)
+verify: verify-versions verify-kernel-dtype-keys verify-fmt verify-clippy verify-test ## Run the full CI-faithful gate locally (recommended before push)
 	@echo "$(GREEN)[verify] OK: matches the nightly-verify GitHub Actions job$(RESET)"
 
 .PHONY: verify-clean

--- a/docs/code-guidelines.md
+++ b/docs/code-guidelines.md
@@ -26,3 +26,26 @@ fn repeat_kv(keys: &MlxArray, values: &MlxArray, n_rep: i32) -> ... {
 - `src/lib/mlxcel-core/src/layers.rs` - KVCache, Attention, Normalization
 - `src/lib/mlxcel-core/src/utils.rs` - create_causal_mask, softcap, repeat_kv
 - Model-specific attention variants in `src/models/*.rs`
+
+## JIT Kernel Cache Keys
+
+Every `template_args` list passed to a `cuda_kernel` launch must name the dtype of each input whose dtype can vary:
+
+```cpp
+std::vector<std::pair<std::string, TemplateArg>> template_args = {
+    {"Dim", dim},
+    {"KVType", k_pool.dtype()},   // keys the cache, not read by the kernel body
+};
+```
+
+**Why this matters:**
+
+MLX generates a custom kernel's buffer parameter types from the runtime dtypes of its inputs, but only Metal folds those dtypes into the kernel name. CUDA names a kernel `"custom_kernel_" + name + template_arguments_hash(template_args)`, and `cu::get_jit_module` memoises the compiled module under exactly that name in a process-global map, invoking the source builder only on a cache miss.
+
+With int-only template args, the first dtype to compile is then served to every later dtype at the same geometry. That call reads its buffers through the wrong pointer type and returns numbers unrelated to its inputs. Nothing throws, and macOS never sees it. Issues #1053 and #1054 are two symptoms; the sampler was affected in production, because `gumbel_max_sample_accepts` admits f32, f16 and bf16 at one `NumSplits`.
+
+The entry may stay unreferenced by the kernel body. Its job is the cache key, so do not remove it as dead code.
+
+**Enforcement:**
+
+`make verify-kernel-dtype-keys` (part of `make verify`, and the `kernel dtype keys` CI job) runs [`scripts/ci/check_kernel_dtype_keys.py`](../scripts/ci/check_kernel_dtype_keys.py). The rule is scoped by the presence of `cuda_kernel(` in the file rather than by a hand-maintained list, so a Metal-only launcher is out of scope until someone adds a CUDA port to it, at which point the check starts applying on its own. Read the script rather than trusting this section.

--- a/scripts/ci/check_kernel_dtype_keys.py
+++ b/scripts/ci/check_kernel_dtype_keys.py
@@ -1,0 +1,131 @@
+#!/usr/bin/env python3
+"""Require every CUDA JIT kernel launch to key its cache on the input dtypes.
+
+Rationale
+---------
+MLX generates a custom kernel's buffer parameter types from the *runtime* dtypes
+of its inputs, but the two backends disagree on whether those dtypes belong in
+the JIT cache key.
+
+* Metal (``mlx/backend/common/metal_kernel.cpp``) appends one
+  ``get_type_string(arr.dtype())`` per input to the kernel name, with the
+  comment "The generated source depends on the dtypes of the inputs and outputs
+  ... Include them in the kernel name so that a given name always maps to the
+  same source."
+* CUDA (``mlx/backend/cuda/custom_kernel.cpp``) builds its name as
+  ``"custom_kernel_" + name + template_arguments_hash(template_args)`` and stops
+  there. ``cu::get_jit_module`` then memoises the compiled module under exactly
+  that name in a process-global map and invokes the source builder only on a
+  cache miss.
+
+So on CUDA a launch whose ``template_args`` are all ints hashes to one name for
+every input dtype. Whichever dtype compiles first wins for the life of the
+process, and every later call at a different dtype reads its buffers through the
+wrong pointer type and returns numbers unrelated to its inputs. Nothing throws.
+
+That produced issues #1053 (a sparse f16 decode off by a relative error of ~1.0)
+and #1054, and it silently affected the sampler, whose
+``gumbel_max_sample_accepts`` admits float32, float16 and bfloat16 at one
+``NumSplits``.
+
+``template_arguments_hash`` *does* hash a ``Dtype`` template arg, so naming the
+input dtypes in ``template_args`` restores the discrimination. This check
+enforces that.
+
+The rule
+--------
+Every ``std::vector<std::pair<std::string, TemplateArg>>`` initialiser in a file
+that also contains a ``cuda_kernel(`` call must name at least one input dtype,
+either inline (``{"KVType", k_pool.dtype()}``) or through a local bound from a
+``.dtype()`` earlier in the same file (``auto T = x.inner.dtype();`` then
+``{"T", T}``).
+
+There is deliberately no allowlist. Metal-only launchers are out of scope
+because Metal's key already carries the dtypes, and they are excluded by the
+absence of ``cuda_kernel(`` in the file rather than by a hand-maintained list
+that could go stale. Adding a CUDA port to a Metal-only launcher therefore
+brings it under the check automatically, which is the point: the failure mode
+this guards against is a *new* call site repeating the omission.
+
+Usage
+-----
+    scripts/ci/check_kernel_dtype_keys.py
+
+Exits non-zero and names every offending initialiser.
+"""
+import pathlib
+import re
+import sys
+
+# Directories holding the in-tree kernel launchers.
+SEARCH_DIRS = ("src/lib/mlx-cpp/turbo", "src/lib/mlxcel-core/cpp")
+
+TEMPLATE_ARGS_RE = re.compile(
+    r"std::vector<std::pair<std::string,\s*(?:mlx::core::fast::)?TemplateArg>>"
+    r"\s*(\w+)\s*=\s*\{(.*?)\n\s*\};",
+    re.S,
+)
+# `auto T = x.inner.dtype();`, `const auto input_type = a.dtype();`
+DTYPE_BINDING_RE = re.compile(r"\b(?:auto|Dtype)\s+(\w+)\s*=\s*[^;]*\.dtype\(\)")
+# The value half of a `{"Name", value}` entry.
+ENTRY_RE = re.compile(r'\{\s*"(\w+)"\s*,\s*([^}]+?)\s*\}')
+
+
+def repo_root() -> pathlib.Path:
+    return pathlib.Path(__file__).resolve().parents[2]
+
+
+def check_file(path: pathlib.Path) -> list[str]:
+    src = path.read_text()
+    if "cuda_kernel(" not in src:
+        return []  # Metal-only launcher: Metal's cache key already carries dtypes.
+
+    dtype_locals = set(DTYPE_BINDING_RE.findall(src))
+    failures = []
+    for match in TEMPLATE_ARGS_RE.finditer(src):
+        var, body = match.group(1), match.group(2)
+        line = src[: match.start()].count("\n") + 1
+        keys = []
+        keyed_on_dtype = False
+        for name, value in ENTRY_RE.findall(body):
+            keys.append(name)
+            if ".dtype()" in value or value.strip() in dtype_locals:
+                keyed_on_dtype = True
+        if not keyed_on_dtype:
+            rel = path.relative_to(repo_root())
+            failures.append(
+                f"{rel}:{line}: `{var}` names no input dtype; keys are "
+                f"{keys or '[]'}"
+            )
+    return failures
+
+
+def main() -> int:
+    root = repo_root()
+    failures = []
+    scanned = 0
+    for directory in SEARCH_DIRS:
+        for path in sorted((root / directory).glob("*.cpp")):
+            scanned += 1
+            failures.extend(check_file(path))
+
+    if failures:
+        print("kernel-dtype-keys: FAIL")
+        for failure in failures:
+            print(f"  {failure}")
+        print()
+        print(
+            "Every CUDA JIT launch must key its cache on the input dtypes, or a\n"
+            "second dtype at the same geometry silently reuses the first one's\n"
+            "compiled module. Add the varying inputs' dtypes to `template_args`,\n"
+            'e.g. `{"KVType", k_pool.dtype()}`. They may stay unreferenced by the\n'
+            "kernel body; their job is the cache key. See issues #1053 and #1054."
+        )
+        return 1
+
+    print(f"kernel-dtype-keys: OK — {scanned} source files scanned.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/lib/mlx-cpp/turbo/paged_attention.cpp
+++ b/src/lib/mlx-cpp/turbo/paged_attention.cpp
@@ -488,11 +488,23 @@ mlx::core::array paged_attention_decode(
         num_splits = num_splits_override;
     }
 
+    // `QType`/`KVType`/`VType` exist to key the JIT cache on the input dtypes
+    // and are deliberately unreferenced by the kernel body (issue #1054, same
+    // mechanism as #1053). CUDA names a custom kernel
+    // `"custom_kernel_" + name + template_arguments_hash(template_args)` and
+    // memoises the compiled module under that name process-wide, while the
+    // buffer parameter types are generated from the runtime input dtypes. With
+    // int-only args, two callers that share this geometry but differ in pool
+    // dtype get one compiled module and the later one reads through the wrong
+    // pointer type. Metal already folds the dtypes into its key.
     std::vector<std::pair<std::string, TemplateArg>> template_args = {
         {"Dim", dim},
         {"NRep", n_rep},
         {"DimsPerThread", dims_per_thread},
         {"NumSplits", num_splits},
+        {"QType", q.dtype()},
+        {"KVType", k_pool.dtype()},
+        {"VType", v_pool.dtype()},
     };
 
     // Pack scale into a 1-element f32 array (metal_kernel inputs must be

--- a/src/lib/mlx-cpp/turbo/sampling.cpp
+++ b/src/lib/mlx-cpp/turbo/sampling.cpp
@@ -420,9 +420,17 @@ mlx::core::array gumbel_max_sample(
     auto temp_arr =
         mlx::core::full(Shape{1}, temperature, mlx::core::float32);
 
+    // `LogitsType` keys the JIT cache on the logits dtype and is deliberately
+    // unreferenced by the kernel body (issue #1054). This one is reachable in
+    // production, not only from tests: `gumbel_max_sample_accepts` admits
+    // float32, float16 and bfloat16, while `NumSplits` depends only on
+    // (batch, vocab). Two models with the same vocabulary but different logits
+    // dtypes therefore hashed to one kernel name on CUDA, and the second one
+    // sampled from a buffer read through the wrong pointer type.
     std::vector<std::pair<std::string, TemplateArg>> template_args = {
         {"TgSize", GUMBEL_TG_SIZE},
         {"NumSplits", num_splits},
+        {"LogitsType", logits.dtype()},
     };
 
     std::vector<mlx::core::array> inputs = {logits, rng_key, temp_arr};

--- a/src/lib/mlx-cpp/turbo/sampling_rejection.cpp
+++ b/src/lib/mlx-cpp/turbo/sampling_rejection.cpp
@@ -749,9 +749,16 @@ RejectionSampleResult rejection_sample(
     // Philox key; the counter carries the (round, row) pair.
     auto rng_key = mlx::core::random::bits(Shape{2}, 4);
 
+    // `ProbsType`/`ParamsType` key the JIT cache on the input dtypes and are
+    // deliberately unreferenced by the kernel body (issue #1054). This is the
+    // widest exposure of the three sites fixed there: `rejection_sample_accepts`
+    // places no dtype restriction at all, so any float dtype reaches the kernel
+    // while `TgSize` is a constant and `MaxRounds` is a caller cap.
     std::vector<std::pair<std::string, TemplateArg>> template_args = {
         {"TgSize", REJECTION_TG_SIZE},
         {"MaxRounds", rounds},
+        {"ProbsType", probs.dtype()},
+        {"ParamsType", params.dtype()},
     };
 
     std::vector<mlx::core::array> inputs = {probs, params, rng_key};


### PR DESCRIPTION
## Summary

The leaked process-global state this issue was looking for is MLX's CUDA JIT module cache, and the key is too weak.

`mlx/backend/cuda/custom_kernel.cpp` names a kernel `"custom_kernel_" + name + template_arguments_hash(template_args)`, while `build_kernel` in the same file generates every buffer parameter's type from the runtime dtype of the corresponding input. `cu::get_jit_module` then memoises the compiled module under exactly that name in a process-global map and invokes the source builder only on a cache miss. A launch whose `template_args` are all ints therefore hashes to one name for every input dtype: the first dtype to compile wins for the life of the process, and every later call at a different dtype reads its buffers through the wrong pointer type. Nothing throws. Metal is unaffected because its key already carries the dtypes.

That is the same mechanism as #1053, which fixed the two paged decode v2 kernels. This PR covers the rest of the class and adds the guard that stops a new call site repeating it.

## Changes

Three more launches gain dtype template args, so `template_arguments_hash` can tell their variants apart:

- `turbo/paged_attention.cpp` (the v1 paged attention kernel): `QType`, `KVType`, `VType`.
- `turbo/sampling.cpp`: `LogitsType`.
- `turbo/sampling_rejection.cpp`: `ProbsType`, `ParamsType`.

**The sampler was affected in production, not only in tests.** `gumbel_max_sample_accepts` explicitly admits `float32`, `float16` and `bfloat16`, and `NumSplits` depends only on `(batch, vocab)`, so two models with the same vocabulary but different logits dtypes shared one compiled kernel on CUDA. `rejection_sample_accepts` is wider still: it places no dtype restriction at all.

Audited and already correct, so unchanged: `turbo/fused_norm.cpp` (`{"T", x.dtype()}`, `{"TW", weight.dtype()}`), `turbo/fused_rope_append.cpp` (`{"T", qkv.dtype()}`), and the fused decode-MoE kernels in `cpp/mlx_cxx_kernels.cpp` (`{"T", T}`). Out of scope: `turbo/sparse_v_sdpa.cpp` and the three launches in `turbo/turbo4_delegated_sdpa.cpp` are Metal-only launchers with no `cuda_kernel(` call.

## The guard

`scripts/ci/check_kernel_dtype_keys.py`, wired into `make verify` (new `verify-kernel-dtype-keys` target) and a new `kernel dtype keys` CI job. Every `template_args` initialiser in a file that also contains a `cuda_kernel(` call must name at least one input dtype, inline (`{"KVType", k_pool.dtype()}`) or through a local bound from a `.dtype()` earlier in the file (`auto T = x.inner.dtype();` then `{"T", T}`).

There is deliberately no allowlist. Metal-only launchers are excluded by the absence of `cuda_kernel(` in the file rather than by a hand-maintained list, so adding a CUDA port to one brings it under the check automatically, which is exactly the case that would otherwise reintroduce the defect. That is the same inverted-rule shape `scripts/ci/check_crate_versions.py` uses, chosen for the same reason CLAUDE.md gives there: a prose or list-based rule goes stale precisely when it matters.

The job is not behind the `changes` path filter, matching `crate-versions`: it needs no toolchain, runs in seconds, and guards a silent defect that no macOS runner can see.

The invariant is written up in `docs/code-guidelines.md`, next to the existing shared-function convention.

## Validation

- **Negative control on the guard**: removing `{"LogitsType", logits.dtype()}` makes `check_kernel_dtype_keys.py` exit 1 naming `src/lib/mlx-cpp/turbo/sampling.cpp:430`. Restoring it returns to OK over 13 scanned source files. A check that cannot fail is not a check.
- `make verify-kernel-dtype-keys` passes; `.github/workflows/ci.yml` parses.
- Metal (M1 Ultra, `--features metal,accelerate`): full `mlxcel-core` lib suite serialized, `cargo fmt --all -- --check`, and `cargo clippy --workspace --all-targets --features metal,accelerate -- -D warnings`. Results in the PR checks below.
- Neither `QType`/`KVType`/`VType` nor `LogitsType`/`ProbsType`/`ParamsType` collides with an identifier in the Metal or the CUDA source string of the kernels they were added to, checked by hand because the CUDA bodies are not compiled on a Metal host.

One run of the serialized `mlxcel-core` suite reported `autotune::autotune_tests::profile_drops_failing_candidates_without_aborting` and `resolve_profiles_and_persists_under_tune_mode` failing; an identical re-run passed 1416 / 0. Those two are host-load flakes, not a regression from this change: the module documents itself as "Every test here is CPU-only: the `FakeOp` double implements `TunableOp` by sleeping for a per-tactic duration and overrides `sync` to a no-op", so a C++ kernel template arg cannot reach them, they pass 55 / 0 in isolation, and their sleeps are `Duration::from_micros` at 800 versus 400 while the host was at a load average of 40. Worth a separate issue: an assertion resting on microsecond `thread::sleep` accuracy can flip on any loaded runner.

## What this PR does NOT deliver

The issue's first acceptance criterion asks for a **minimal ordered pair of tests** that reproduces the failure. That is not here, and it is not guessed at.

Bisecting requires running the suite on CUDA, and there is no `nvcc` on this host and no reachable CUDA node (re-verified 2026-08-07). Narrowing it analytically did not converge: within `mlxcel-core` the v2 partial kernel is reached only from `paged_v2` tests, whose template-arg tuples do not overlap across dtypes (`launch_tests` is `PageSize=32`, `sparse_tests` reshapes to `PageSize=1`, `cascade_launch_tests` is `Dim=16, PageSize=8`). The merge kernel was the promising lead, since `pages_per_chunk 1` is the first loop value and the only one that runs a merge at all, but its one caller outside `paged_v2` is MLA `split_kv`, whose test uses `DIM=5` and whose production path casts to f32 before merging. Refuted, not confirmed.

On Metal the question is invisible: the full suite is 1415 passed / 0 failed, `chunk_size_does_not_change_the_answer` included.

A GB10 session should run `cargo test --release --features cuda -p mlxcel-core --lib -- --test-threads=1` on `main` after this lands and report whether the failure is gone. #1053's fix plausibly removed it, since it re-keyed both the partial and the merge kernel, but without a run that stays a hypothesis.

Closes #1054
