### PR TITLE
feat(models): Florence-2 vision-language fusion and full weight loading

### DIFF
--- a/src/models/florence2/checkpoint.rs
+++ b/src/models/florence2/checkpoint.rs
@@ -1,0 +1,109 @@
+// Copyright 2025-2026 Lablup Inc. and Jeongkyu Shin
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Florence-2 checkpoint plumbing: whole-model config parsing and the
+//! weight-key normalization that has to happen before either half of the
+//! model is built.
+//!
+//! Kept apart from `model.rs` because these two run once at load time and
+//! have nothing to do with the forward path.
+//!
+//! Reference:
+//! https://github.com/Blaizzy/mlx-vlm/blob/main/mlx_vlm/models/florence2/florence2.py
+
+use anyhow::Result;
+use serde_json::Value;
+
+use mlxcel_core::weights::WeightMap;
+
+use crate::vision::encoders::florence2_davit;
+
+use super::{Florence2TextConfig, Florence2VisionConfig};
+
+/// Weight-key prefix of the language model inside a Florence-2 checkpoint.
+pub(crate) const FLORENCE2_TEXT_PREFIX: &str = "language_model.";
+
+/// Both halves of a Florence-2 `config.json` plus the fusion-stage fields.
+#[derive(Debug, Clone)]
+pub struct Florence2Config {
+    pub text: Florence2TextConfig,
+    pub vision: Florence2VisionConfig,
+    /// Placeholder id the processor may emit for the image. Florence-2 does
+    /// not actually splice image features into placeholder slots, so any
+    /// occurrence is dropped before the prompt is embedded. Upstream defaults
+    /// this to the text vocabulary size (51289), one past the last real id.
+    pub image_token_id: i32,
+}
+
+impl Florence2Config {
+    /// Parse a full Florence-2 `config.json` (`model_type: florence2`).
+    pub fn from_model_config(config: &Value) -> Result<Self> {
+        let text = Florence2TextConfig::from_model_config(config)?;
+        let vision = Florence2VisionConfig::from_model_config(config)?;
+        let image_token_id = config
+            .get("image_token_id")
+            .or_else(|| config.get("image_token_index"))
+            .and_then(Value::as_i64)
+            .map(|v| v as i32)
+            .unwrap_or(text.vocab_size);
+        Ok(Self {
+            text,
+            vision,
+            image_token_id,
+        })
+    }
+}
+
+/// Normalize a full Florence-2 checkpoint's weight keys.
+///
+/// Three passes, in order:
+///
+/// 1. The DaViT conv channels-last remap and `position_ids` drop from
+///    [`florence2_davit::sanitize`]. Both of its key guards are specific
+///    enough (`convs`/`proj.weight`, `blocks`/`dw.weight`) that running them
+///    over the whole checkpoint leaves `language_model.*` untouched, and both
+///    are idempotent, so this is a no-op on the `mlx-community` exports that
+///    already ship channels-last conv weights.
+/// 2. Drop `final_logits_bias`. HuggingFace BART carries it as a registered
+///    buffer of zeros; it is not a parameter and there is no LM-head bias in
+///    this implementation.
+/// 3. BART shared-embedding naming. The encoder and decoder token tables are
+///    tied to `model.shared` and exports vary in which of the three they
+///    materialize, so fill `model.shared.weight` from an `embed_tokens` copy
+///    when only the latter is present.
+pub fn sanitize(weights: WeightMap) -> WeightMap {
+    let weights = florence2_davit::sanitize(weights);
+
+    let mut out = WeightMap::with_capacity(weights.len());
+    for (key, value) in weights {
+        if key.contains("final_logits_bias") {
+            continue;
+        }
+        out.insert(key, value);
+    }
+
+    let shared = format!("{FLORENCE2_TEXT_PREFIX}model.shared.weight");
+    if !out.contains_key(&shared) {
+        let source = [
+            format!("{FLORENCE2_TEXT_PREFIX}model.encoder.embed_tokens.weight"),
+            format!("{FLORENCE2_TEXT_PREFIX}model.decoder.embed_tokens.weight"),
+        ]
+        .into_iter()
+        .find_map(|key| out.get(&key).map(|w| mlxcel_core::copy(w)));
+        if let Some(tensor) = source {
+            out.insert(shared, tensor);
+        }
+    }
+    out
+}

--- a/src/models/florence2/decoder.rs
+++ b/src/models/florence2/decoder.rs
@@ -51,6 +51,25 @@ impl Florence2Decoder {
             .ok_or_else(|| {
                 format!("Florence-2 weight not found: {prefix}.embed_positions.weight")
             })?;
+        // `Florence2Model` bounds both the fused encoder input length and the
+        // decode offset against `config.max_position_embeddings`, and those
+        // guards are only sound if the loaded table actually covers that
+        // bound. Without this check a `config.json` that inflates
+        // `max_position_embeddings` (or `d_model`) passes them and reaches MLX
+        // as an out-of-range slice, which throws across the cxx bridge and
+        // aborts the process instead of returning `Err`. Sum in i64 so the
+        // comparison cannot overflow on a hostile value.
+        let position_shape = mlxcel_core::array_shape(&embed_positions);
+        let required_rows = POSITION_OFFSET as i64 + config.max_position_embeddings as i64;
+        if position_shape.len() != 2
+            || position_shape[1] != config.d_model
+            || (position_shape[0] as i64) < required_rows
+        {
+            return Err(format!(
+                "Florence-2 {prefix}.embed_positions.weight: expected at least [{required_rows}, {}] (max_position_embeddings {} + POSITION_OFFSET {POSITION_OFFSET}), got {position_shape:?}",
+                config.d_model, config.max_position_embeddings
+            ));
+        }
         let layernorm_embedding = layer_norm(weights, &format!("{prefix}.layernorm_embedding"))?;
 
         let mut layers = Vec::with_capacity(config.decoder_layers as usize);

--- a/src/models/florence2/encoder.rs
+++ b/src/models/florence2/encoder.rs
@@ -77,7 +77,15 @@ impl Florence2Encoder {
 
     /// Encode `[batch, seq, d_model]` input embeddings into encoder hidden
     /// states of the same shape.
-    pub(crate) fn forward(&self, inputs_embeds: &MlxArray) -> UniquePtr<MlxArray> {
+    ///
+    /// `mask` is the additive attention mask (`[batch, 1, 1, seq]`, `0` for a
+    /// real key and `-inf` for a padded one) applied by every block's
+    /// self-attention. Unpadded input passes `None`.
+    pub(crate) fn forward(
+        &self,
+        inputs_embeds: &MlxArray,
+        mask: Option<&MlxArray>,
+    ) -> UniquePtr<MlxArray> {
         let seq = mlxcel_core::array_shape(inputs_embeds)[1];
         let pos = mlxcel_core::slice(
             &self.embed_positions,
@@ -87,7 +95,7 @@ impl Florence2Encoder {
         let x = mlxcel_core::add(inputs_embeds, &pos);
         let mut x = self.layernorm_embedding.forward(&x);
         for layer in &self.layers {
-            x = layer.forward(&x);
+            x = layer.forward(&x, mask);
         }
         x
     }

--- a/src/models/florence2/encoder.rs
+++ b/src/models/florence2/encoder.rs
@@ -56,6 +56,25 @@ impl Florence2Encoder {
             .ok_or_else(|| {
                 format!("Florence-2 weight not found: {prefix}.embed_positions.weight")
             })?;
+        // `Florence2Model` bounds both the fused encoder input length and the
+        // decode offset against `config.max_position_embeddings`, and those
+        // guards are only sound if the loaded table actually covers that
+        // bound. Without this check a `config.json` that inflates
+        // `max_position_embeddings` (or `d_model`) passes them and reaches MLX
+        // as an out-of-range slice, which throws across the cxx bridge and
+        // aborts the process instead of returning `Err`. Sum in i64 so the
+        // comparison cannot overflow on a hostile value.
+        let position_shape = mlxcel_core::array_shape(&embed_positions);
+        let required_rows = POSITION_OFFSET as i64 + config.max_position_embeddings as i64;
+        if position_shape.len() != 2
+            || position_shape[1] != config.d_model
+            || (position_shape[0] as i64) < required_rows
+        {
+            return Err(format!(
+                "Florence-2 {prefix}.embed_positions.weight: expected at least [{required_rows}, {}] (max_position_embeddings {} + POSITION_OFFSET {POSITION_OFFSET}), got {position_shape:?}",
+                config.d_model, config.max_position_embeddings
+            ));
+        }
         let layernorm_embedding = layer_norm(weights, &format!("{prefix}.layernorm_embedding"))?;
 
         let mut layers = Vec::with_capacity(config.encoder_layers as usize);

--- a/src/models/florence2/florence2_fusion_tests.rs
+++ b/src/models/florence2/florence2_fusion_tests.rs
@@ -602,6 +602,44 @@ fn from_weights_rejects_mismatched_image_projection() {
     assert!(err.contains("image_projection"), "unexpected error: {err}");
 }
 
+/// `image_projection` has no fallback (it is a bare tensor with no `Linear`
+/// wrapper to synthesize a default from), so a checkpoint that omits it
+/// entirely must fail with the key named, distinct from the
+/// shape-mismatch case above.
+#[test]
+fn from_weights_rejects_missing_image_projection() {
+    let mut map = tiny_weights();
+    map.remove("image_projection");
+    let err = expect_err(Florence2Model::from_weights(
+        &map,
+        tiny_config(&["spatial_avg_pool"]),
+    ));
+    assert!(err.contains("image_projection"), "unexpected error: {err}");
+}
+
+/// The fusion stage cannot run without a position-embedding spec: unlike the
+/// optional embedding *type* checks below, a missing `image_pos_embed` /
+/// `visual_temporal_embedding` key in `vision_config` has to fail load with
+/// the missing field named rather than defaulting to some embedding kind.
+#[test]
+fn from_weights_rejects_missing_position_embedding_configs() {
+    let mut config = tiny_config(&["spatial_avg_pool"]);
+    config.vision.image_pos_embed = None;
+    let err = expect_err(Florence2Model::from_weights(&tiny_weights(), config));
+    assert!(
+        err.contains("missing image_pos_embed"),
+        "unexpected error: {err}"
+    );
+
+    let mut config = tiny_config(&["spatial_avg_pool"]);
+    config.vision.visual_temporal_embedding = None;
+    let err = expect_err(Florence2Model::from_weights(&tiny_weights(), config));
+    assert!(
+        err.contains("missing visual_temporal_embedding"),
+        "unexpected error: {err}"
+    );
+}
+
 #[test]
 fn from_weights_rejects_unsupported_embedding_types() {
     let mut config = tiny_config(&["spatial_avg_pool"]);
@@ -779,6 +817,34 @@ fn encode_image_rejects_non_square_feature_maps() {
     );
 }
 
+/// A backbone whose last `dim_embed` disagrees with the feature width it
+/// actually emits (a mismatched tower/fusion pairing) has to be caught before
+/// the position-embedding add, which would otherwise broadcast against the
+/// wrong axis instead of failing cleanly.
+#[test]
+fn encode_image_rejects_feature_width_mismatch() {
+    let model = tiny_model(&["spatial_avg_pool"]);
+    let features = mlxcel_core::from_slice_f32(
+        &vec![0.0; (GRID_TOKENS * (IMAGE_DIM + 2)) as usize],
+        &[1, GRID_TOKENS, IMAGE_DIM + 2],
+    );
+    let err = expect_err(model.encode_image_features(&features));
+    assert!(err.contains("dim_embed[-1]"), "unexpected error: {err}");
+}
+
+/// `image_feature_source` entries outside the three known pooling recipes
+/// have to fail at the point they are used, not silently pass through as one
+/// of the known pools.
+#[test]
+fn encode_image_rejects_unsupported_feature_source() {
+    let model = tiny_model(&["bogus_pool"]);
+    let err = expect_err(model.encode_image(&pixels()));
+    assert!(
+        err.contains("bogus_pool") && err.contains("not supported"),
+        "unexpected error: {err}"
+    );
+}
+
 /// Florence-2 concatenates rather than scattering into placeholder slots, so
 /// both halves of the fused sequence must survive byte for byte.
 #[test]
@@ -823,6 +889,39 @@ fn merge_without_prompt_returns_image_features_alone() {
     // A prompt made only of image placeholder ids is the same case.
     assert!(model.embed_prompt(&[VOCAB, VOCAB]).is_none());
     assert!(model.embed_prompt(&[]).is_none());
+}
+
+/// The rank check on `image_features` is what keeps a caller-supplied
+/// two-image-batch tensor (or any other unexpected rank) from panicking on
+/// `shape[2]` inside library code.
+#[test]
+fn merge_rejects_non_3d_image_features() {
+    let model = tiny_model(&["spatial_avg_pool"]);
+    let features = mlxcel_core::from_slice_f32(&vec![0.0; D_MODEL as usize], &[D_MODEL]);
+    let err = expect_err(model.merge_input_ids_with_image_features(&features, None));
+    assert!(
+        err.contains("[batch, tokens, dim]"),
+        "unexpected error: {err}"
+    );
+}
+
+/// A prompt embedding whose batch or feature width disagrees with the image
+/// features it is being concatenated with has to fail before the
+/// concatenate, which would otherwise either panic or silently broadcast.
+#[test]
+fn merge_rejects_incompatible_prompt_shape() {
+    let model = tiny_model(&["spatial_avg_pool"]);
+    let features = model.encode_image(&pixels()).unwrap();
+
+    let wrong_batch =
+        mlxcel_core::from_slice_f32(&vec![0.0; 3 * D_MODEL as usize], &[2, 3, D_MODEL]);
+    let err = expect_err(model.merge_input_ids_with_image_features(&features, Some(&wrong_batch)));
+    assert!(err.contains("not compatible"), "unexpected error: {err}");
+
+    let wrong_width =
+        mlxcel_core::from_slice_f32(&vec![0.0; 3 * (D_MODEL + 1) as usize], &[1, 3, D_MODEL + 1]);
+    let err = expect_err(model.merge_input_ids_with_image_features(&features, Some(&wrong_width)));
+    assert!(err.contains("not compatible"), "unexpected error: {err}");
 }
 
 /// The integrated path must be exactly "fuse, then run the text encoder over
@@ -897,6 +996,20 @@ fn encode_rejects_sequences_past_max_position_embeddings() {
     let err = expect_err(model.encode(&pixels(), &prompt));
     assert!(
         err.contains("max_position_embeddings"),
+        "unexpected error: {err}"
+    );
+}
+
+/// [`Florence2Model::encode_fused`] is a `pub` entry point a caller can drive
+/// directly with a hand-built tensor, so its own rank check (rather than a
+/// downstream MLX panic) has to be what catches a wrong-rank input.
+#[test]
+fn encode_fused_rejects_wrong_rank_input() {
+    let model = tiny_model(&["spatial_avg_pool"]);
+    let flat = mlxcel_core::from_slice_f32(&vec![0.0; D_MODEL as usize], &[1, D_MODEL]);
+    let err = expect_err(model.encode_fused(&flat, None));
+    assert!(
+        err.contains("[batch, seq, d_model]"),
         "unexpected error: {err}"
     );
 }

--- a/src/models/florence2/florence2_fusion_tests.rs
+++ b/src/models/florence2/florence2_fusion_tests.rs
@@ -855,6 +855,41 @@ fn encode_matches_manual_fusion_then_text_encoder() {
     }
 }
 
+/// The integrated path skips the additive-mask conversion because the mask it
+/// builds is all ones. That is only sound if an all-ones mask really is the
+/// identity, and the conversion is only worth keeping if a mask with a zero
+/// really changes the answer. Pin both halves.
+#[test]
+fn encoder_mask_is_identity_when_all_ones_and_load_bearing_otherwise() {
+    let model = tiny_model(&["spatial_avg_pool", "temporal_avg_pool"]);
+    let prompt_ids = [3i32, 4, 5];
+
+    let features = model.encode_image(&pixels()).unwrap();
+    let prompt_embeds = model.embed_prompt(&prompt_ids).unwrap();
+    let (fused, mask) = model
+        .merge_input_ids_with_image_features(&features, Some(&prompt_embeds))
+        .unwrap();
+
+    let unmasked = to_vec_f32(&model.encode_fused(&fused, None).unwrap());
+    let all_ones = to_vec_f32(&model.encode_fused(&fused, Some(&mask)).unwrap());
+    assert_eq!(unmasked, all_ones, "an all-ones mask must be the identity");
+
+    // Drop the last prompt position out of the mask.
+    let seq = mlxcel_core::array_shape(&mask)[1];
+    let mut values = vec![1.0f32; seq as usize];
+    values[seq as usize - 1] = 0.0;
+    let padded = mlxcel_core::from_slice_f32(&values, &[1, seq]);
+    let masked = to_vec_f32(&model.encode_fused(&fused, Some(&padded)).unwrap());
+    assert_ne!(
+        unmasked, masked,
+        "masking a position out must change the encoder output"
+    );
+    assert!(
+        masked.iter().all(|v| v.is_finite()),
+        "masked encoder output must stay finite"
+    );
+}
+
 #[test]
 fn encode_rejects_sequences_past_max_position_embeddings() {
     let model = tiny_model(&["spatial_avg_pool", "temporal_avg_pool"]);

--- a/src/models/florence2/florence2_fusion_tests.rs
+++ b/src/models/florence2/florence2_fusion_tests.rs
@@ -20,7 +20,8 @@
 //! exercised without a checkpoint.
 
 use super::super::fusion::{
-    LearnedPositionEmbedding2D, PositionalEmbeddingCosine1D, additive_attention_mask,
+    LearnedPositionEmbedding2D, MAX_TEMPORAL_EMBEDDINGS, PositionalEmbeddingCosine1D,
+    additive_attention_mask,
 };
 use super::super::{Florence2TextConfig, Florence2VisionConfig};
 use super::*;
@@ -391,6 +392,25 @@ fn cosine_temporal_embedding_rejects_wrong_shape_and_range() {
     assert!(embed.forward(0).is_err());
 }
 
+/// `max_temporal_embeddings` is untrusted `config.json` input that sizes a
+/// host buffer whenever the checkpoint omits `pos_idx_to_embed`. It has to be
+/// rejected before the allocation, not after: the synthesis fallback would
+/// otherwise ask the allocator for the declared size and fill it with a nested
+/// transcendental loop.
+#[test]
+fn cosine_temporal_embedding_rejects_oversized_max_temporal() {
+    let err = expect_err(PositionalEmbeddingCosine1D::from_weights(
+        &WeightMap::new(),
+        "temporal",
+        IMAGE_DIM,
+        MAX_TEMPORAL_EMBEDDINGS + 1,
+    ));
+    assert!(
+        err.contains("max_temporal_embeddings"),
+        "unexpected error: {err}"
+    );
+}
+
 // ---------------------------------------------------------------------------
 // Joint attention mask
 // ---------------------------------------------------------------------------
@@ -398,13 +418,22 @@ fn cosine_temporal_embedding_rejects_wrong_shape_and_range() {
 #[test]
 fn additive_mask_maps_one_to_zero_and_zero_to_neg_inf() {
     let mask = mlxcel_core::from_slice_f32(&[1.0, 1.0, 0.0, 1.0], &[1, 4]);
-    let additive = additive_attention_mask(&mask, mlxcel_core::dtype::FLOAT32);
+    let additive = additive_attention_mask(&mask, mlxcel_core::dtype::FLOAT32).unwrap();
     assert_eq!(mlxcel_core::array_shape(&additive), vec![1, 1, 1, 4]);
     let values = to_vec_f32(&additive);
     assert_eq!(values[0], 0.0);
     assert_eq!(values[1], 0.0);
     assert!(values[2].is_infinite() && values[2].is_sign_negative());
     assert_eq!(values[3], 0.0);
+}
+
+/// The mask reshape reads two axes by index, so a wrong-rank mask has to
+/// surface as an error rather than a panic inside library code.
+#[test]
+fn additive_mask_rejects_non_2d_mask() {
+    let mask = mlxcel_core::from_slice_f32(&[1.0, 1.0, 1.0, 1.0], &[1, 2, 2]);
+    let err = expect_err(additive_attention_mask(&mask, mlxcel_core::dtype::FLOAT32));
+    assert!(err.contains("[batch, seq]"), "unexpected error: {err}");
 }
 
 // ---------------------------------------------------------------------------
@@ -586,6 +615,106 @@ fn from_weights_rejects_unsupported_embedding_types() {
     assert!(err.contains("COSINE"), "unexpected error: {err}");
 }
 
+/// `max_position_embeddings` is the bound both the fused-encoder length check
+/// and the decode-offset check are written against, but nothing forces the
+/// checkpoint's position table to actually cover it. A short table has to fail
+/// here, at load, with the shapes named: past those guards the slice reaches
+/// MLX out of range and aborts the process across the FFI boundary.
+#[test]
+fn from_weights_rejects_short_position_table() {
+    let mut map = tiny_weights();
+    // One row short of `POSITION_OFFSET + max_position_embeddings`.
+    synth(
+        &mut map,
+        "language_model.model.encoder.embed_positions.weight",
+        &[MAX_POSITIONS + 1, D_MODEL],
+    );
+    let err = expect_err(Florence2Model::from_weights(
+        &map,
+        tiny_config(&["spatial_avg_pool"]),
+    ));
+    assert!(
+        err.contains("embed_positions.weight") && err.contains("max_position_embeddings"),
+        "unexpected error: {err}"
+    );
+}
+
+/// A table whose width disagrees with `d_model` is the same hazard on the
+/// other axis: the slice takes `d_model` columns.
+#[test]
+fn from_weights_rejects_position_table_width_mismatch() {
+    let mut map = tiny_weights();
+    synth(
+        &mut map,
+        "language_model.model.decoder.embed_positions.weight",
+        &[MAX_POSITIONS + 2, D_MODEL + 1],
+    );
+    let err = expect_err(Florence2Model::from_weights(
+        &map,
+        tiny_config(&["spatial_avg_pool"]),
+    ));
+    assert!(
+        err.contains("embed_positions.weight"),
+        "unexpected error: {err}"
+    );
+}
+
+/// `encoder_attention_heads: 0` used to reach the divisibility check and
+/// panic there with a divide by zero, and a negative layer count reached
+/// `Vec::with_capacity` as `usize::MAX`. Both values come straight out of
+/// `config.json`, so both must return `Err`.
+#[test]
+fn text_config_rejects_degenerate_shape_fields() {
+    let zero_heads = json!({
+        "d_model": D_MODEL,
+        "encoder_layers": 1,
+        "decoder_layers": 1,
+        "encoder_attention_heads": 0,
+        "decoder_attention_heads": HEADS,
+        "vocab_size": VOCAB,
+    });
+    let err = Florence2TextConfig::from_model_config(&zero_heads)
+        .unwrap_err()
+        .to_string();
+    assert!(err.contains("attention heads"), "unexpected error: {err}");
+
+    let negative_layers = json!({
+        "d_model": D_MODEL,
+        "encoder_layers": -1,
+        "decoder_layers": 1,
+        "encoder_attention_heads": HEADS,
+        "decoder_attention_heads": HEADS,
+        "vocab_size": VOCAB,
+    });
+    let err = Florence2TextConfig::from_model_config(&negative_layers)
+        .unwrap_err()
+        .to_string();
+    assert!(err.contains("layer counts"), "unexpected error: {err}");
+}
+
+/// `pad_token_id` and `decoder_start_token_id` are used as literal gather
+/// indices into the shared embedding, so an out-of-vocabulary value is an
+/// out-of-range gather rather than a wrong-looking caption.
+#[test]
+fn text_config_rejects_out_of_vocabulary_token_ids() {
+    let base = json!({
+        "d_model": D_MODEL,
+        "encoder_layers": 1,
+        "decoder_layers": 1,
+        "encoder_attention_heads": HEADS,
+        "decoder_attention_heads": HEADS,
+        "vocab_size": VOCAB,
+    });
+
+    let mut oversized_start = base.clone();
+    oversized_start["decoder_start_token_id"] = json!(VOCAB);
+    assert!(Florence2TextConfig::from_model_config(&oversized_start).is_err());
+
+    let mut negative_pad = base;
+    negative_pad["pad_token_id"] = json!(-1);
+    assert!(Florence2TextConfig::from_model_config(&negative_pad).is_err());
+}
+
 #[test]
 fn from_weights_rejects_empty_image_feature_source() {
     let err = expect_err(Florence2Model::from_weights(
@@ -708,7 +837,7 @@ fn encode_matches_manual_fusion_then_text_encoder() {
     let (fused, mask) = model
         .merge_input_ids_with_image_features(&features, Some(&prompt_embeds))
         .unwrap();
-    let additive = additive_attention_mask(&mask, model.dtype());
+    let additive = additive_attention_mask(&mask, model.dtype()).unwrap();
     let manual = model
         .text_model()
         .encode_embeds_with_mask(&fused, Some(&additive));

--- a/src/models/florence2/florence2_fusion_tests.rs
+++ b/src/models/florence2/florence2_fusion_tests.rs
@@ -1,0 +1,722 @@
+// Copyright 2025-2026 Lablup Inc. and Jeongkyu Shin
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Unit tests for the Florence-2 fusion stage: the two image-side positional
+//! embeddings, the joint attention mask, checkpoint-key sanitization, and the
+//! assembled forward path driven end to end on a tiny synthetic model (one
+//! block-free DaViT stage plus a one-layer BART stack), so the whole
+//! `pixels -> features -> concat -> encoder -> decoder logits` chain is
+//! exercised without a checkpoint.
+
+use super::super::fusion::{
+    LearnedPositionEmbedding2D, PositionalEmbeddingCosine1D, additive_attention_mask,
+};
+use super::super::{Florence2TextConfig, Florence2VisionConfig};
+use super::*;
+use serde_json::json;
+
+const D_MODEL: i32 = 8;
+const IMAGE_DIM: i32 = 8;
+const HALF_DIM: i32 = IMAGE_DIM / 2;
+const MAX_POS_EMBEDDINGS: i32 = 8;
+const MAX_TEMPORAL: i32 = 4;
+const VOCAB: i32 = 16;
+const MAX_POSITIONS: i32 = 32;
+const FFN: i32 = 16;
+const HEADS: i32 = 2;
+const PIXEL_SIDE: i32 = 8;
+/// Stride-2 2x2 patch embedding over an 8x8 image: a 4x4 grid, 16 tokens.
+const GRID_SIDE: i32 = 4;
+const GRID_TOKENS: i32 = GRID_SIDE * GRID_SIDE;
+
+// ---------------------------------------------------------------------------
+// Synthetic weights
+// ---------------------------------------------------------------------------
+
+fn to_vec_f32(a: &MlxArray) -> Vec<f32> {
+    let a = mlxcel_core::astype(a, mlxcel_core::dtype::FLOAT32);
+    mlxcel_core::eval(&a);
+    mlxcel_core::array_to_raw_bytes(&a)
+        .chunks_exact(4)
+        .map(|c| f32::from_le_bytes([c[0], c[1], c[2], c[3]]))
+        .collect()
+}
+
+/// `Result::unwrap_err` needs `T: Debug`, which none of these MLX-backed
+/// types implement (and should not, since printing one would force the graph).
+fn expect_err<T>(result: Result<T, String>) -> String {
+    match result {
+        Ok(_) => panic!("expected an error"),
+        Err(e) => e,
+    }
+}
+
+fn put(map: &mut WeightMap, key: &str, shape: &[i32], data: Vec<f32>) {
+    map.insert(key.to_string(), mlxcel_core::from_slice_f32(&data, shape));
+}
+
+/// Deterministic small pseudo-random tensor, matching the seeding scheme in
+/// `florence2_tests.rs` so the synthetic stacks stay numerically tame.
+fn synth(map: &mut WeightMap, key: &str, shape: &[i32]) {
+    let n: i32 = shape.iter().product();
+    let seed: f32 = key.bytes().map(|b| b as f32).sum();
+    let data: Vec<f32> = (0..n)
+        .map(|i| 0.1 * ((seed + 0.7 * i as f32).sin()))
+        .collect();
+    put(map, key, shape, data);
+}
+
+fn synth_ln(map: &mut WeightMap, prefix: &str, dim: i32) {
+    put(
+        map,
+        &format!("{prefix}.weight"),
+        &[dim],
+        vec![1.0; dim as usize],
+    );
+    put(
+        map,
+        &format!("{prefix}.bias"),
+        &[dim],
+        vec![0.0; dim as usize],
+    );
+}
+
+fn synth_attn(map: &mut WeightMap, prefix: &str) {
+    for proj in ["q_proj", "k_proj", "v_proj", "out_proj"] {
+        synth(map, &format!("{prefix}.{proj}.weight"), &[D_MODEL, D_MODEL]);
+        synth(map, &format!("{prefix}.{proj}.bias"), &[D_MODEL]);
+    }
+}
+
+fn tiny_text_config() -> Florence2TextConfig {
+    Florence2TextConfig {
+        d_model: D_MODEL,
+        encoder_layers: 1,
+        decoder_layers: 1,
+        encoder_attention_heads: HEADS,
+        decoder_attention_heads: HEADS,
+        encoder_ffn_dim: FFN,
+        decoder_ffn_dim: FFN,
+        vocab_size: VOCAB,
+        max_position_embeddings: MAX_POSITIONS,
+        scale_embedding: false,
+        pad_token_id: 1,
+        bos_token_id: 0,
+        eos_token_id: 2,
+        decoder_start_token_id: 2,
+    }
+}
+
+fn tiny_vision_config(image_feature_source: &[&str]) -> Florence2VisionConfig {
+    Florence2VisionConfig {
+        depths: vec![0],
+        dim_embed: vec![IMAGE_DIM],
+        num_heads: vec![HEADS],
+        num_groups: vec![HEADS],
+        patch_size: vec![2],
+        patch_stride: vec![2],
+        patch_padding: vec![0],
+        patch_prenorm: vec![false],
+        window_size: 2,
+        in_chans: 3,
+        mlp_ratio: 4.0,
+        qkv_bias: true,
+        conv_at_attn: true,
+        conv_at_ffn: true,
+        drop_path_rate: 0.0,
+        projection_dim: D_MODEL,
+        image_pos_embed: Some(json!({
+            "type": "learned_abs_2d",
+            "max_pos_embeddings": MAX_POS_EMBEDDINGS,
+        })),
+        visual_temporal_embedding: Some(json!({
+            "type": "COSINE",
+            "max_temporal_embeddings": MAX_TEMPORAL,
+        })),
+        image_feature_source: image_feature_source.iter().map(|s| s.to_string()).collect(),
+    }
+}
+
+fn tiny_config(image_feature_source: &[&str]) -> Florence2Config {
+    Florence2Config {
+        text: tiny_text_config(),
+        vision: tiny_vision_config(image_feature_source),
+        image_token_id: VOCAB,
+    }
+}
+
+fn tiny_weights() -> WeightMap {
+    let mut map = WeightMap::new();
+
+    // One block-free DaViT stage: patch embedding only.
+    synth(
+        &mut map,
+        "vision_tower.convs.0.proj.weight",
+        &[IMAGE_DIM, 2, 2, 3],
+    );
+    synth(&mut map, "vision_tower.convs.0.proj.bias", &[IMAGE_DIM]);
+    synth_ln(&mut map, "vision_tower.convs.0.norm", IMAGE_DIM);
+
+    // Fusion stage.
+    synth(&mut map, "image_projection", &[IMAGE_DIM, D_MODEL]);
+    synth_ln(&mut map, "image_proj_norm", D_MODEL);
+    synth(
+        &mut map,
+        "image_pos_embed.row_embeddings.weight",
+        &[MAX_POS_EMBEDDINGS, HALF_DIM],
+    );
+    synth(
+        &mut map,
+        "image_pos_embed.column_embeddings.weight",
+        &[MAX_POS_EMBEDDINGS, HALF_DIM],
+    );
+
+    // BART stack.
+    synth(
+        &mut map,
+        "language_model.model.shared.weight",
+        &[VOCAB, D_MODEL],
+    );
+    for side in ["encoder", "decoder"] {
+        let base = format!("language_model.model.{side}");
+        synth(
+            &mut map,
+            &format!("{base}.embed_positions.weight"),
+            &[MAX_POSITIONS + 2, D_MODEL],
+        );
+        synth_ln(&mut map, &format!("{base}.layernorm_embedding"), D_MODEL);
+        let layer = format!("{base}.layers.0");
+        synth_attn(&mut map, &format!("{layer}.self_attn"));
+        synth_ln(&mut map, &format!("{layer}.self_attn_layer_norm"), D_MODEL);
+        if side == "decoder" {
+            synth_attn(&mut map, &format!("{layer}.encoder_attn"));
+            synth_ln(
+                &mut map,
+                &format!("{layer}.encoder_attn_layer_norm"),
+                D_MODEL,
+            );
+        }
+        synth(&mut map, &format!("{layer}.fc1.weight"), &[FFN, D_MODEL]);
+        synth(&mut map, &format!("{layer}.fc1.bias"), &[FFN]);
+        synth(&mut map, &format!("{layer}.fc2.weight"), &[D_MODEL, FFN]);
+        synth(&mut map, &format!("{layer}.fc2.bias"), &[D_MODEL]);
+        synth_ln(&mut map, &format!("{layer}.final_layer_norm"), D_MODEL);
+    }
+    // No `language_model.lm_head.weight`: exercises the tied-embedding fallback.
+    map
+}
+
+fn tiny_model(image_feature_source: &[&str]) -> Florence2Model {
+    Florence2Model::from_weights(&tiny_weights(), tiny_config(image_feature_source)).unwrap()
+}
+
+fn pixels() -> UniquePtr<MlxArray> {
+    let n = (3 * PIXEL_SIDE * PIXEL_SIDE) as usize;
+    let data: Vec<f32> = (0..n).map(|i| 0.05 * ((i as f32) * 0.37).sin()).collect();
+    mlxcel_core::from_slice_f32(&data, &[1, 3, PIXEL_SIDE, PIXEL_SIDE])
+}
+
+// ---------------------------------------------------------------------------
+// LearnedPositionEmbedding2D
+// ---------------------------------------------------------------------------
+
+/// Column embeddings occupy the first half of the feature width and row
+/// embeddings the second. Swapping them would still typecheck and still
+/// produce plausible activations, so pin the layout with tables whose halves
+/// are distinguishable by value.
+#[test]
+fn learned_position_embedding_puts_column_first_then_row() {
+    let mut map = WeightMap::new();
+    // row[y] = 100 + y in every channel, column[x] = x in every channel.
+    let rows: Vec<f32> = (0..MAX_POS_EMBEDDINGS)
+        .flat_map(|y| std::iter::repeat_n(100.0 + y as f32, HALF_DIM as usize))
+        .collect();
+    let cols: Vec<f32> = (0..MAX_POS_EMBEDDINGS)
+        .flat_map(|x| std::iter::repeat_n(x as f32, HALF_DIM as usize))
+        .collect();
+    put(
+        &mut map,
+        "pos.row_embeddings.weight",
+        &[MAX_POS_EMBEDDINGS, HALF_DIM],
+        rows,
+    );
+    put(
+        &mut map,
+        "pos.column_embeddings.weight",
+        &[MAX_POS_EMBEDDINGS, HALF_DIM],
+        cols,
+    );
+
+    let embed = LearnedPositionEmbedding2D::from_weights(&map, "pos", IMAGE_DIM).unwrap();
+    let out = embed.forward(3, 2).unwrap();
+    assert_eq!(mlxcel_core::array_shape(&out), vec![1, 3, 2, IMAGE_DIM]);
+
+    let values = to_vec_f32(&out);
+    for y in 0..3usize {
+        for x in 0..2usize {
+            let base = (y * 2 + x) * IMAGE_DIM as usize;
+            for c in 0..HALF_DIM as usize {
+                assert_eq!(values[base + c], x as f32, "column half at ({y},{x})");
+            }
+            for c in 0..HALF_DIM as usize {
+                assert_eq!(
+                    values[base + HALF_DIM as usize + c],
+                    100.0 + y as f32,
+                    "row half at ({y},{x})"
+                );
+            }
+        }
+    }
+}
+
+#[test]
+fn learned_position_embedding_rejects_oversized_grid() {
+    let map = tiny_weights();
+    let embed =
+        LearnedPositionEmbedding2D::from_weights(&map, "image_pos_embed", IMAGE_DIM).unwrap();
+    let err = expect_err(embed.forward(MAX_POS_EMBEDDINGS + 1, 2));
+    assert!(
+        err.contains("max_pos_embeddings"),
+        "unexpected error: {err}"
+    );
+    assert!(embed.forward(0, 2).is_err());
+}
+
+#[test]
+fn learned_position_embedding_rejects_width_mismatch() {
+    let map = tiny_weights();
+    let err = expect_err(LearnedPositionEmbedding2D::from_weights(
+        &map,
+        "image_pos_embed",
+        IMAGE_DIM + 2,
+    ));
+    assert!(
+        err.contains("image feature width"),
+        "unexpected error: {err}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// PositionalEmbeddingCosine1D
+// ---------------------------------------------------------------------------
+
+/// With no checkpoint buffer the table is synthesized, and row 0 is
+/// `sin(0), cos(0), ...` = `0, 1, 0, 1, ...`. That row is what a single-frame
+/// image actually adds, so "still images make the temporal embedding a no-op"
+/// is wrong and this pins it.
+#[test]
+fn cosine_temporal_embedding_row_zero_is_interleaved_zero_one() {
+    let embed = PositionalEmbeddingCosine1D::from_weights(
+        &WeightMap::new(),
+        "missing",
+        IMAGE_DIM,
+        MAX_TEMPORAL,
+    )
+    .unwrap();
+    let row0 = embed.forward(1).unwrap();
+    assert_eq!(mlxcel_core::array_shape(&row0), vec![1, 1, IMAGE_DIM]);
+    let values = to_vec_f32(&row0);
+    for (i, v) in values.iter().enumerate() {
+        let expected = if i % 2 == 0 { 0.0 } else { 1.0 };
+        assert!((v - expected).abs() < 1e-6, "row0[{i}] = {v}");
+    }
+
+    // Row 1 follows sin/cos of `t * exp(-ln(10000) * j / embed_dim)`.
+    let rows = embed.forward(2).unwrap();
+    let values = to_vec_f32(&rows);
+    for j in 0..(IMAGE_DIM / 2) as usize {
+        let denominator = (-(10000.0f64).ln() * j as f64 / IMAGE_DIM as f64).exp();
+        let base = IMAGE_DIM as usize;
+        assert!((values[base + 2 * j] as f64 - denominator.sin()).abs() < 1e-6);
+        assert!((values[base + 2 * j + 1] as f64 - denominator.cos()).abs() < 1e-6);
+    }
+}
+
+/// Upstream registers the precomputed table as a module parameter, so a real
+/// checkpoint ships it and the checkpoint copy must win over recomputation.
+#[test]
+fn cosine_temporal_embedding_prefers_checkpoint_table() {
+    let mut map = WeightMap::new();
+    let data: Vec<f32> = (0..MAX_TEMPORAL * IMAGE_DIM).map(|i| i as f32).collect();
+    put(
+        &mut map,
+        "temporal.pos_idx_to_embed",
+        &[MAX_TEMPORAL, IMAGE_DIM],
+        data,
+    );
+    let embed =
+        PositionalEmbeddingCosine1D::from_weights(&map, "temporal", IMAGE_DIM, MAX_TEMPORAL)
+            .unwrap();
+    let values = to_vec_f32(&embed.forward(2).unwrap());
+    assert_eq!(values[0], 0.0);
+    assert_eq!(values[IMAGE_DIM as usize], IMAGE_DIM as f32);
+}
+
+#[test]
+fn cosine_temporal_embedding_rejects_wrong_shape_and_range() {
+    let mut map = WeightMap::new();
+    put(
+        &mut map,
+        "temporal.pos_idx_to_embed",
+        &[MAX_TEMPORAL, IMAGE_DIM + 2],
+        vec![0.0; (MAX_TEMPORAL * (IMAGE_DIM + 2)) as usize],
+    );
+    let err = expect_err(PositionalEmbeddingCosine1D::from_weights(
+        &map,
+        "temporal",
+        IMAGE_DIM,
+        MAX_TEMPORAL,
+    ));
+    assert!(err.contains("expected shape"), "unexpected error: {err}");
+
+    let embed = PositionalEmbeddingCosine1D::from_weights(
+        &WeightMap::new(),
+        "missing",
+        IMAGE_DIM,
+        MAX_TEMPORAL,
+    )
+    .unwrap();
+    assert!(embed.forward(MAX_TEMPORAL + 1).is_err());
+    assert!(embed.forward(0).is_err());
+}
+
+// ---------------------------------------------------------------------------
+// Joint attention mask
+// ---------------------------------------------------------------------------
+
+#[test]
+fn additive_mask_maps_one_to_zero_and_zero_to_neg_inf() {
+    let mask = mlxcel_core::from_slice_f32(&[1.0, 1.0, 0.0, 1.0], &[1, 4]);
+    let additive = additive_attention_mask(&mask, mlxcel_core::dtype::FLOAT32);
+    assert_eq!(mlxcel_core::array_shape(&additive), vec![1, 1, 1, 4]);
+    let values = to_vec_f32(&additive);
+    assert_eq!(values[0], 0.0);
+    assert_eq!(values[1], 0.0);
+    assert!(values[2].is_infinite() && values[2].is_sign_negative());
+    assert_eq!(values[3], 0.0);
+}
+
+// ---------------------------------------------------------------------------
+// Checkpoint-key sanitization
+// ---------------------------------------------------------------------------
+
+#[test]
+fn sanitize_drops_final_logits_bias() {
+    let mut map = tiny_weights();
+    put(
+        &mut map,
+        "language_model.final_logits_bias",
+        &[1, VOCAB],
+        vec![0.0; VOCAB as usize],
+    );
+    let out = sanitize(map);
+    assert!(!out.contains_key("language_model.final_logits_bias"));
+    assert!(out.contains_key("language_model.model.shared.weight"));
+}
+
+/// BART ties `model.shared` to both `embed_tokens` tables and exports differ
+/// in which they materialize. A checkpoint carrying only `embed_tokens` must
+/// still produce a usable `model.shared`.
+#[test]
+fn sanitize_fills_shared_from_embed_tokens() {
+    let mut map = tiny_weights();
+    map.remove("language_model.model.shared.weight");
+    synth(
+        &mut map,
+        "language_model.model.encoder.embed_tokens.weight",
+        &[VOCAB, D_MODEL],
+    );
+    let out = sanitize(map);
+    let shared = out.get("language_model.model.shared.weight").unwrap();
+    assert_eq!(mlxcel_core::array_shape(shared), vec![VOCAB, D_MODEL]);
+}
+
+/// The `mlx-community` bf16 export already ships channels-last conv weights,
+/// so the DaViT remap must be a no-op there while still fixing a raw PyTorch
+/// export.
+#[test]
+fn sanitize_conv_remap_is_idempotent_and_fixes_pytorch_layout() {
+    let already_last = sanitize(tiny_weights());
+    assert_eq!(
+        mlxcel_core::array_shape(
+            already_last
+                .get("vision_tower.convs.0.proj.weight")
+                .unwrap()
+        ),
+        vec![IMAGE_DIM, 2, 2, 3]
+    );
+
+    let mut pytorch = WeightMap::new();
+    // `(out, in, kH, kW)` with out < kH: unambiguously PyTorch-ordered.
+    synth(
+        &mut pytorch,
+        "vision_tower.convs.0.proj.weight",
+        &[2, 3, 4, 4],
+    );
+    let remapped = sanitize(pytorch);
+    assert_eq!(
+        mlxcel_core::array_shape(remapped.get("vision_tower.convs.0.proj.weight").unwrap()),
+        vec![2, 4, 4, 3]
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Config
+// ---------------------------------------------------------------------------
+
+#[test]
+fn config_defaults_image_token_id_to_vocab_size() {
+    let raw = json!({
+        "model_type": "florence2",
+        "text_config": {
+            "d_model": D_MODEL,
+            "encoder_layers": 1,
+            "decoder_layers": 1,
+            "encoder_attention_heads": HEADS,
+            "decoder_attention_heads": HEADS,
+            "vocab_size": VOCAB,
+        },
+        "vision_config": {
+            "model_type": "",
+            "depths": [0],
+            "dim_embed": [IMAGE_DIM],
+            "num_heads": [HEADS],
+            "patch_size": [2],
+            "patch_stride": [2],
+            "patch_padding": [0],
+            "image_feature_source": ["spatial_avg_pool", "temporal_avg_pool"],
+        },
+    });
+    let config = Florence2Config::from_model_config(&raw).unwrap();
+    assert_eq!(config.image_token_id, VOCAB);
+
+    let mut with_id = raw.clone();
+    with_id["image_token_index"] = json!(1234);
+    assert_eq!(
+        Florence2Config::from_model_config(&with_id)
+            .unwrap()
+            .image_token_id,
+        1234
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Load-time validation
+// ---------------------------------------------------------------------------
+
+#[test]
+fn from_weights_rejects_mismatched_image_projection() {
+    let mut map = tiny_weights();
+    synth(&mut map, "image_projection", &[IMAGE_DIM, D_MODEL + 1]);
+    let err = expect_err(Florence2Model::from_weights(
+        &map,
+        tiny_config(&["spatial_avg_pool"]),
+    ));
+    assert!(err.contains("image_projection"), "unexpected error: {err}");
+}
+
+#[test]
+fn from_weights_rejects_unsupported_embedding_types() {
+    let mut config = tiny_config(&["spatial_avg_pool"]);
+    config.vision.image_pos_embed = Some(json!({"type": "sine_2d"}));
+    let err = expect_err(Florence2Model::from_weights(&tiny_weights(), config));
+    assert!(err.contains("learned_abs_2d"), "unexpected error: {err}");
+
+    let mut config = tiny_config(&["spatial_avg_pool"]);
+    config.vision.visual_temporal_embedding = Some(json!({"type": "LEARNED"}));
+    let err = expect_err(Florence2Model::from_weights(&tiny_weights(), config));
+    assert!(err.contains("COSINE"), "unexpected error: {err}");
+}
+
+#[test]
+fn from_weights_rejects_empty_image_feature_source() {
+    let err = expect_err(Florence2Model::from_weights(
+        &tiny_weights(),
+        tiny_config(&[]),
+    ));
+    assert!(
+        err.contains("image_feature_source"),
+        "unexpected error: {err}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Fused forward path
+// ---------------------------------------------------------------------------
+
+#[test]
+fn encode_image_pools_and_projects_to_text_width() {
+    let model = tiny_model(&["spatial_avg_pool", "temporal_avg_pool"]);
+    let features = model.encode_image(&pixels()).unwrap();
+    // 1 spatially averaged token + one token per grid position.
+    assert_eq!(
+        mlxcel_core::array_shape(&features),
+        vec![1, 1 + GRID_TOKENS, D_MODEL]
+    );
+
+    let temporal_only = tiny_model(&["temporal_avg_pool"]);
+    assert_eq!(
+        mlxcel_core::array_shape(&temporal_only.encode_image(&pixels()).unwrap()),
+        vec![1, GRID_TOKENS, D_MODEL]
+    );
+}
+
+/// `image_feature_source` is order-sensitive: it decides the layout of the
+/// concatenated feature sequence. Upstream's dataclass default lists the two
+/// pools in the opposite order from every real checkpoint, so this pins that
+/// mlxcel follows the config rather than a default.
+#[test]
+fn image_feature_source_order_controls_layout() {
+    let spatial_first = tiny_model(&["spatial_avg_pool", "temporal_avg_pool"]);
+    let temporal_first = tiny_model(&["temporal_avg_pool", "spatial_avg_pool"]);
+    let a = to_vec_f32(&spatial_first.encode_image(&pixels()).unwrap());
+    let b = to_vec_f32(&temporal_first.encode_image(&pixels()).unwrap());
+    assert_eq!(a.len(), b.len());
+
+    let width = D_MODEL as usize;
+    let grid = GRID_TOKENS as usize;
+    // Spatial-first puts the pooled token at index 0; temporal-first puts it last.
+    assert_eq!(&a[..width], &b[grid * width..]);
+    assert_eq!(&a[width..], &b[..grid * width]);
+}
+
+#[test]
+fn encode_image_rejects_non_square_feature_maps() {
+    let model = tiny_model(&["spatial_avg_pool"]);
+    let features =
+        mlxcel_core::from_slice_f32(&vec![0.0; (5 * IMAGE_DIM) as usize], &[1, 5, IMAGE_DIM]);
+    let err = expect_err(model.encode_image_features(&features));
+    assert!(
+        err.contains("square feature map"),
+        "unexpected error: {err}"
+    );
+}
+
+/// Florence-2 concatenates rather than scattering into placeholder slots, so
+/// both halves of the fused sequence must survive byte for byte.
+#[test]
+fn merge_concatenates_image_then_prompt() {
+    let model = tiny_model(&["spatial_avg_pool", "temporal_avg_pool"]);
+    let features = model.encode_image(&pixels()).unwrap();
+    let prompt_ids = [3i32, 4, 5];
+    let prompt_embeds = model.embed_prompt(&prompt_ids).unwrap();
+    let (fused, mask) = model
+        .merge_input_ids_with_image_features(&features, Some(&prompt_embeds))
+        .unwrap();
+
+    let image_len = 1 + GRID_TOKENS;
+    let total = image_len + prompt_ids.len() as i32;
+    assert_eq!(
+        mlxcel_core::array_shape(&fused),
+        vec![1, total, D_MODEL],
+        "fused sequence length"
+    );
+    assert_eq!(mlxcel_core::array_shape(&mask), vec![1, total]);
+    assert!(to_vec_f32(&mask).iter().all(|v| *v == 1.0));
+
+    let fused_values = to_vec_f32(&fused);
+    let split = (image_len * D_MODEL) as usize;
+    assert_eq!(&fused_values[..split], to_vec_f32(&features).as_slice());
+    assert_eq!(
+        &fused_values[split..],
+        to_vec_f32(&prompt_embeds).as_slice()
+    );
+}
+
+#[test]
+fn merge_without_prompt_returns_image_features_alone() {
+    let model = tiny_model(&["spatial_avg_pool"]);
+    let features = model.encode_image(&pixels()).unwrap();
+    let (fused, mask) = model
+        .merge_input_ids_with_image_features(&features, None)
+        .unwrap();
+    assert_eq!(mlxcel_core::array_shape(&fused), vec![1, 1, D_MODEL]);
+    assert_eq!(mlxcel_core::array_shape(&mask), vec![1, 1]);
+
+    // A prompt made only of image placeholder ids is the same case.
+    assert!(model.embed_prompt(&[VOCAB, VOCAB]).is_none());
+    assert!(model.embed_prompt(&[]).is_none());
+}
+
+/// The integrated path must be exactly "fuse, then run the text encoder over
+/// the fused embeddings with the joint mask", not a separate code path.
+#[test]
+fn encode_matches_manual_fusion_then_text_encoder() {
+    let model = tiny_model(&["spatial_avg_pool", "temporal_avg_pool"]);
+    let prompt_ids = [3i32, 4, 5];
+
+    let features = model.encode_image(&pixels()).unwrap();
+    let prompt_embeds = model.embed_prompt(&prompt_ids).unwrap();
+    let (fused, mask) = model
+        .merge_input_ids_with_image_features(&features, Some(&prompt_embeds))
+        .unwrap();
+    let additive = additive_attention_mask(&mask, model.dtype());
+    let manual = model
+        .text_model()
+        .encode_embeds_with_mask(&fused, Some(&additive));
+
+    let integrated = model.encode(&pixels(), &prompt_ids).unwrap();
+    assert_eq!(
+        mlxcel_core::array_shape(&integrated),
+        mlxcel_core::array_shape(&manual)
+    );
+    for (a, b) in to_vec_f32(&integrated)
+        .iter()
+        .zip(to_vec_f32(&manual).iter())
+    {
+        assert!((a - b).abs() < 1e-5, "{a} vs {b}");
+    }
+}
+
+#[test]
+fn encode_rejects_sequences_past_max_position_embeddings() {
+    let model = tiny_model(&["spatial_avg_pool", "temporal_avg_pool"]);
+    let prompt: Vec<i32> = (0..MAX_POSITIONS).map(|i| i % VOCAB).collect();
+    let err = expect_err(model.encode(&pixels(), &prompt));
+    assert!(
+        err.contains("max_position_embeddings"),
+        "unexpected error: {err}"
+    );
+}
+
+/// End-to-end: pixels and a prompt in, decoder token ids out, through the same
+/// dual-KV-cache decode loop the text engine uses.
+#[test]
+fn generate_greedy_runs_the_whole_fused_path() {
+    let model = tiny_model(&["spatial_avg_pool", "temporal_avg_pool"]);
+    let generated = model.generate_greedy(&pixels(), &[3, 4, 5], 6).unwrap();
+    assert!(generated.len() <= 6);
+    for token in &generated {
+        assert!(
+            (0..VOCAB).contains(token),
+            "token {token} outside vocabulary"
+        );
+        assert_ne!(*token, model.config().text.eos_token_id);
+    }
+
+    // The single-step decode against the same encoder output must agree with
+    // the first token of the greedy loop.
+    let encoder_hidden = model.encode(&pixels(), &[3, 4, 5]).unwrap();
+    let mut cache = model.make_cache();
+    let start = mlxcel_core::from_slice_i32(&[model.config().text.decoder_start_token_id], &[1, 1]);
+    let logits = model.decode(&start, &encoder_hidden, &mut cache);
+    assert_eq!(
+        mlxcel_core::array_shape(&logits),
+        vec![1, 1, VOCAB],
+        "decoder logits shape"
+    );
+    if let Some(first) = generated.first() {
+        assert_eq!(*first, argmax_last_position(&logits).unwrap());
+    }
+}

--- a/src/models/florence2/florence2_fusion_tests.rs
+++ b/src/models/florence2/florence2_fusion_tests.rs
@@ -511,6 +511,53 @@ fn config_defaults_image_token_id_to_vocab_size() {
     );
 }
 
+/// `Florence2Model::load` must reject a quantized checkpoint before it ever
+/// touches the weight files, since neither the BART text stack nor the DaViT
+/// tower has a quantized code path. A directory holding only `config.json`
+/// (no safetensors) is enough to exercise this: the check runs, and returns,
+/// before weight loading is attempted.
+#[test]
+fn load_rejects_quantized_checkpoint() {
+    let raw = json!({
+        "model_type": "florence2",
+        "quantization": { "group_size": 64, "bits": 4 },
+        "text_config": {
+            "d_model": D_MODEL,
+            "encoder_layers": 1,
+            "decoder_layers": 1,
+            "encoder_attention_heads": HEADS,
+            "decoder_attention_heads": HEADS,
+            "vocab_size": VOCAB,
+        },
+        "vision_config": {
+            "model_type": "",
+            "depths": [0],
+            "dim_embed": [IMAGE_DIM],
+            "num_heads": [HEADS],
+            "patch_size": [2],
+            "patch_stride": [2],
+            "patch_padding": [0],
+            "image_feature_source": ["spatial_avg_pool", "temporal_avg_pool"],
+        },
+    });
+
+    let dir = tempfile::tempdir().expect("tempdir");
+    std::fs::write(
+        dir.path().join("config.json"),
+        serde_json::to_string(&raw).unwrap(),
+    )
+    .expect("write config.json");
+
+    let err = match Florence2Model::load(dir.path()) {
+        Ok(_) => panic!("quantized checkpoint must be rejected"),
+        Err(e) => e.to_string(),
+    };
+    assert!(
+        err.to_lowercase().contains("quantized"),
+        "error should mention the quantized-checkpoint rejection, got: {err}"
+    );
+}
+
 // ---------------------------------------------------------------------------
 // Load-time validation
 // ---------------------------------------------------------------------------

--- a/src/models/florence2/fusion.rs
+++ b/src/models/florence2/fusion.rs
@@ -37,6 +37,20 @@ use mlxcel_core::layers::Embedding;
 use mlxcel_core::weights::WeightMap;
 use mlxcel_core::{MlxArray, UniquePtr};
 
+/// Upper bound accepted for `max_temporal_embeddings`. Real Florence-2 exports
+/// ship 100, so this leaves ample headroom.
+///
+/// The field is untrusted `config.json` input
+/// (`vision_config.visual_temporal_embedding.max_temporal_embeddings`) that
+/// sizes a *host* buffer: when a checkpoint omits
+/// `visual_temporal_embed.pos_idx_to_embed`, which is the documented synthesis
+/// fallback, [`PositionalEmbeddingCosine1D::compute`] eagerly allocates
+/// `max_seq_len * embed_dim` floats and fills them with a nested sin/cos loop.
+/// A declared 2e9 against a 1024-wide tower asks for roughly 8 TB and ~10^12
+/// transcendental evaluations, so an unbounded value is an out-of-memory abort
+/// or an indefinite hang driven by a data file.
+pub(crate) const MAX_TEMPORAL_EMBEDDINGS: i32 = 65_536;
+
 /// Learned 2-D absolute position embedding over a `H x W` feature grid.
 ///
 /// The row and column tables are each half of the feature width; a token at
@@ -161,9 +175,9 @@ impl PositionalEmbeddingCosine1D {
                 "Florence-2 {prefix}: temporal embedding width {embed_dim} must be a positive even number"
             ));
         }
-        if max_seq_len < 1 {
+        if !(1..=MAX_TEMPORAL_EMBEDDINGS).contains(&max_seq_len) {
             return Err(format!(
-                "Florence-2 {prefix}: max_temporal_embeddings {max_seq_len} must be positive"
+                "Florence-2 {prefix}: max_temporal_embeddings {max_seq_len} outside 1..={MAX_TEMPORAL_EMBEDDINGS}"
             ));
         }
         let key = format!("{prefix}.pos_idx_to_embed");
@@ -226,13 +240,21 @@ impl PositionalEmbeddingCosine1D {
 /// exact zero to every logit and a masked-out key is driven to zero weight by
 /// the softmax. The reshape puts the key axis last so the tensor broadcasts
 /// across batch, head, and query axes of the `[b, h, lq, lk]` logits.
+///
+/// The rank check is what keeps a caller-supplied mask of the wrong rank from
+/// panicking on `shape[1]` inside library code.
 pub(crate) fn additive_attention_mask(
     attention_mask: &MlxArray,
     dtype: i32,
-) -> UniquePtr<MlxArray> {
+) -> Result<UniquePtr<MlxArray>, String> {
     let shape = mlxcel_core::array_shape(attention_mask);
+    if shape.len() != 2 {
+        return Err(format!(
+            "Florence-2 attention mask must be [batch, seq], got {shape:?}"
+        ));
+    }
     let as_f32 = mlxcel_core::astype(attention_mask, mlxcel_core::dtype::FLOAT32);
     let additive = mlxcel_core::log(&as_f32);
     let additive = mlxcel_core::astype(&additive, dtype);
-    mlxcel_core::reshape(&additive, &[shape[0], 1, 1, shape[1]])
+    Ok(mlxcel_core::reshape(&additive, &[shape[0], 1, 1, shape[1]]))
 }

--- a/src/models/florence2/fusion.rs
+++ b/src/models/florence2/fusion.rs
@@ -1,0 +1,238 @@
+// Copyright 2025-2026 Lablup Inc. and Jeongkyu Shin
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Positional embeddings applied to DaViT image features before they are
+//! projected into the text embedding space.
+//!
+//! Both live between the vision tower and the BART encoder, and neither is
+//! part of either half: the backbone emits raw `[B, H*W, dim_embed[-1]]`
+//! tokens with no notion of where a token sat in the grid, and the text
+//! encoder adds its own 1-D BART position table on top of the fused
+//! sequence. These two supply the *image-side* geometry.
+//!
+//! - [`LearnedPositionEmbedding2D`] adds a learned row + column embedding to
+//!   each token of a square feature map (`image_pos_embed.*` in the
+//!   checkpoint, `{"type": "learned_abs_2d", "max_pos_embeddings": 50}`).
+//! - [`PositionalEmbeddingCosine1D`] adds a fixed sinusoidal embedding over
+//!   the *frame* axis (`visual_temporal_embed.pos_idx_to_embed`,
+//!   `{"type": "COSINE", "max_temporal_embeddings": 100}`). Still frames use
+//!   a single frame, so this contributes row 0 (`sin(0), cos(0), ...`), which
+//!   is not the zero vector and must be applied for parity.
+//!
+//! Reference:
+//! https://github.com/Blaizzy/mlx-vlm/blob/main/mlx_vlm/models/florence2/florence2.py
+
+use mlxcel_core::layers::Embedding;
+use mlxcel_core::weights::WeightMap;
+use mlxcel_core::{MlxArray, UniquePtr};
+
+/// Learned 2-D absolute position embedding over a `H x W` feature grid.
+///
+/// The row and column tables are each half of the feature width; a token at
+/// `(y, x)` gets `concat(column[x], row[y])`. Column comes first, matching
+/// the reference (and the HuggingFace `Florence2` implementation it was
+/// ported from), so swapping the halves would silently mis-place every
+/// image token.
+pub(crate) struct LearnedPositionEmbedding2D {
+    row_embeddings: Embedding,
+    column_embeddings: Embedding,
+    /// Rows in each table, i.e. the largest grid side that can be embedded.
+    num_pos: i32,
+    row_dim: i32,
+    column_dim: i32,
+}
+
+impl LearnedPositionEmbedding2D {
+    /// Load `{prefix}.row_embeddings.weight` and
+    /// `{prefix}.column_embeddings.weight`, checking that the two halves add
+    /// up to `embedding_dim` (the vision tower's output width).
+    pub(crate) fn from_weights(
+        weights: &WeightMap,
+        prefix: &str,
+        embedding_dim: i32,
+    ) -> Result<Self, String> {
+        let row_embeddings = Embedding::from_weights(weights, &format!("{prefix}.row_embeddings"))?;
+        let column_embeddings =
+            Embedding::from_weights(weights, &format!("{prefix}.column_embeddings"))?;
+        let row_shape = mlxcel_core::array_shape(&row_embeddings.weight);
+        let column_shape = mlxcel_core::array_shape(&column_embeddings.weight);
+        if row_shape.len() != 2 || column_shape.len() != 2 {
+            return Err(format!(
+                "Florence-2 {prefix}: position tables must be 2-D, got {row_shape:?} / {column_shape:?}"
+            ));
+        }
+        if row_shape[0] != column_shape[0] {
+            return Err(format!(
+                "Florence-2 {prefix}: row table has {} positions but column table has {}",
+                row_shape[0], column_shape[0]
+            ));
+        }
+        // Upstream splits as `embedding_dim // 2` rows and the remainder
+        // columns; both halves are 512 for the 1024-wide base-ft tower.
+        if row_shape[1] + column_shape[1] != embedding_dim {
+            return Err(format!(
+                "Florence-2 {prefix}: row width {} + column width {} != image feature width {embedding_dim}",
+                row_shape[1], column_shape[1]
+            ));
+        }
+        Ok(Self {
+            row_embeddings,
+            column_embeddings,
+            num_pos: row_shape[0],
+            row_dim: row_shape[1],
+            column_dim: column_shape[1],
+        })
+    }
+
+    /// Build the `[1, height, width, embedding_dim]` position tensor for a
+    /// grid of this size. Broadcasting over the batch axis is left to the
+    /// caller's `add`, which is what the reference's explicit
+    /// `broadcast_to(..., (batch, h, w, c))` amounts to.
+    pub(crate) fn forward(&self, height: i32, width: i32) -> Result<UniquePtr<MlxArray>, String> {
+        if height < 1 || width < 1 {
+            return Err(format!(
+                "Florence-2 image position embedding: grid {height}x{width} must be positive"
+            ));
+        }
+        if height > self.num_pos || width > self.num_pos {
+            return Err(format!(
+                "Florence-2 image position embedding: grid {height}x{width} exceeds max_pos_embeddings {}",
+                self.num_pos
+            ));
+        }
+
+        let column_pos = mlxcel_core::arange_i32(0, width, 1);
+        let row_pos = mlxcel_core::arange_i32(0, height, 1);
+        let x_emb = self.column_embeddings.forward(&column_pos);
+        let y_emb = self.row_embeddings.forward(&row_pos);
+
+        // column: [W, Dc] -> [1, W, Dc] -> [H, W, Dc]
+        let x_emb = mlxcel_core::reshape(&x_emb, &[1, width, self.column_dim]);
+        let x_emb = mlxcel_core::broadcast_to(&x_emb, &[height, width, self.column_dim]);
+        // row: [H, Dr] -> [H, 1, Dr] -> [H, W, Dr]
+        let y_emb = mlxcel_core::reshape(&y_emb, &[height, 1, self.row_dim]);
+        let y_emb = mlxcel_core::broadcast_to(&y_emb, &[height, width, self.row_dim]);
+
+        let pos = mlxcel_core::concatenate(&x_emb, &y_emb, 2);
+        Ok(mlxcel_core::reshape(
+            &pos,
+            &[1, height, width, self.row_dim + self.column_dim],
+        ))
+    }
+}
+
+/// Fixed sinusoidal position embedding over the temporal (frame) axis.
+///
+/// The table is a materialized checkpoint tensor
+/// (`visual_temporal_embed.pos_idx_to_embed`), because upstream registers the
+/// precomputed buffer as a module parameter and therefore loads it from the
+/// checkpoint rather than recomputing it. [`Self::compute`] reproduces the
+/// same closed form for exports that omit the buffer.
+pub(crate) struct PositionalEmbeddingCosine1D {
+    pos_idx_to_embed: UniquePtr<MlxArray>,
+    max_seq_len: i32,
+    embed_dim: i32,
+}
+
+impl PositionalEmbeddingCosine1D {
+    /// Use `{prefix}.pos_idx_to_embed` from the checkpoint when present,
+    /// otherwise synthesize it. Either way the result is validated against
+    /// `(max_seq_len, embed_dim)` so a mismatched export fails here with the
+    /// shapes named instead of inside MLX.
+    pub(crate) fn from_weights(
+        weights: &WeightMap,
+        prefix: &str,
+        embed_dim: i32,
+        max_seq_len: i32,
+    ) -> Result<Self, String> {
+        if embed_dim < 2 || embed_dim % 2 != 0 {
+            return Err(format!(
+                "Florence-2 {prefix}: temporal embedding width {embed_dim} must be a positive even number"
+            ));
+        }
+        if max_seq_len < 1 {
+            return Err(format!(
+                "Florence-2 {prefix}: max_temporal_embeddings {max_seq_len} must be positive"
+            ));
+        }
+        let key = format!("{prefix}.pos_idx_to_embed");
+        let pos_idx_to_embed = match weights.get(&key) {
+            Some(table) => {
+                let shape = mlxcel_core::array_shape(table);
+                if shape != vec![max_seq_len, embed_dim] {
+                    return Err(format!(
+                        "Florence-2 {key}: expected shape [{max_seq_len}, {embed_dim}], got {shape:?}"
+                    ));
+                }
+                mlxcel_core::copy(table)
+            }
+            None => Self::compute(embed_dim, max_seq_len),
+        };
+        Ok(Self {
+            pos_idx_to_embed,
+            max_seq_len,
+            embed_dim,
+        })
+    }
+
+    /// `embed[t, 2i] = sin(t * exp(-ln(10000) * i / embed_dim))`,
+    /// `embed[t, 2i+1] = cos(...)` (sin/cos interleaved, not concatenated).
+    fn compute(embed_dim: i32, max_seq_len: i32) -> UniquePtr<MlxArray> {
+        let half = (embed_dim / 2) as usize;
+        let rows = max_seq_len as usize;
+        let width = embed_dim as usize;
+        let factor = (10000.0f64).ln();
+        let mut data = vec![0.0f32; rows * width];
+        for (i, chunk) in data.chunks_exact_mut(width).enumerate() {
+            let t = i as f64;
+            for j in 0..half {
+                let denominator = (-factor * j as f64 / embed_dim as f64).exp();
+                let angle = t * denominator;
+                chunk[2 * j] = angle.sin() as f32;
+                chunk[2 * j + 1] = angle.cos() as f32;
+            }
+        }
+        mlxcel_core::from_slice_f32(&data, &[max_seq_len, embed_dim])
+    }
+
+    /// The first `seq_len` rows, shaped `[1, seq_len, embed_dim]`.
+    pub(crate) fn forward(&self, seq_len: i32) -> Result<UniquePtr<MlxArray>, String> {
+        if seq_len < 1 || seq_len > self.max_seq_len {
+            return Err(format!(
+                "Florence-2 temporal embedding: sequence length {seq_len} outside 1..={}",
+                self.max_seq_len
+            ));
+        }
+        let rows = mlxcel_core::slice(&self.pos_idx_to_embed, &[0, 0], &[seq_len, self.embed_dim]);
+        Ok(mlxcel_core::reshape(&rows, &[1, seq_len, self.embed_dim]))
+    }
+}
+
+/// Turn a `[batch, seq]` 0/1 attention mask into the `[batch, 1, 1, seq]`
+/// additive mask the encoder's attention adds to its logits.
+///
+/// `log(1) = 0` and `log(0) = -inf`, so a fully valid mask contributes an
+/// exact zero to every logit and a masked-out key is driven to zero weight by
+/// the softmax. The reshape puts the key axis last so the tensor broadcasts
+/// across batch, head, and query axes of the `[b, h, lq, lk]` logits.
+pub(crate) fn additive_attention_mask(
+    attention_mask: &MlxArray,
+    dtype: i32,
+) -> UniquePtr<MlxArray> {
+    let shape = mlxcel_core::array_shape(attention_mask);
+    let as_f32 = mlxcel_core::astype(attention_mask, mlxcel_core::dtype::FLOAT32);
+    let additive = mlxcel_core::log(&as_f32);
+    let additive = mlxcel_core::astype(&additive, dtype);
+    mlxcel_core::reshape(&additive, &[shape[0], 1, 1, shape[1]])
+}

--- a/src/models/florence2/layers.rs
+++ b/src/models/florence2/layers.rs
@@ -220,8 +220,12 @@ impl Florence2EncoderLayer {
         })
     }
 
-    pub(crate) fn forward(&self, x: &MlxArray) -> UniquePtr<MlxArray> {
-        let y = self.self_attn.self_attention(x, None, &mut None);
+    /// `mask`, when present, is the additive attention mask broadcast over
+    /// the `[batch, head, query, key]` logits (`0` for a real key, `-inf` for
+    /// a padded one). The fused vision + prompt path builds it from the joint
+    /// attention mask; a plain text encode passes `None`.
+    pub(crate) fn forward(&self, x: &MlxArray, mask: Option<&MlxArray>) -> UniquePtr<MlxArray> {
+        let y = self.self_attn.self_attention(x, mask, &mut None);
         let x = mlxcel_core::add(x, &y);
         let x = self.self_attn_layer_norm.forward(&x);
 

--- a/src/models/florence2/mod.rs
+++ b/src/models/florence2/mod.rs
@@ -63,6 +63,23 @@ use decoder::Florence2Decoder;
 use encoder::Florence2Encoder;
 use layers::Florence2LayerCache;
 
+/// Upper bound accepted for `encoder_layers` / `decoder_layers`. Real
+/// Florence-2 exports ship 6 (base) or 12 (large). The cap exists because
+/// [`encoder::Florence2Encoder::from_weights`] and
+/// [`decoder::Florence2Decoder::from_weights`] size a `Vec` from this field
+/// before they look up a single weight, so a negative value out of a hostile
+/// `config.json` becomes `usize::MAX` and aborts with a capacity overflow.
+const MAX_LAYERS: i32 = 256;
+
+/// Upper bound accepted for `max_position_embeddings`. Florence-2 ships 1024.
+///
+/// The field bounds two separate allocations: the position-table slice the
+/// encoder and decoder take (validated against the loaded table at load time)
+/// and the O(n^2) host buffer [`layers::additive_causal_mask`] fills for a
+/// multi-token decoder call. An unbounded value out of a hostile `config.json`
+/// is an out-of-memory abort rather than an error return.
+const MAX_POSITION_EMBEDDINGS: i32 = 65_536;
+
 /// BART encoder-decoder shape parameters, parsed from the `text_config`
 /// object of a Florence-2 `config.json` (`model_type: florence2_language`).
 #[derive(Debug, Clone)]
@@ -114,6 +131,75 @@ impl Florence2TextConfig {
             eos_token_id: config_i32(config, "eos_token_id").unwrap_or(2),
             decoder_start_token_id: config_i32(config, "decoder_start_token_id").unwrap_or(2),
         };
+        // Every field below becomes a shape, an index, a divisor, or a `Vec`
+        // capacity somewhere downstream. MLX throws on an out-of-range shape
+        // and the throw crosses an FFI boundary that cannot carry it, so a bad
+        // value aborts the process rather than surfacing as an error; these
+        // checks are what keep an untrusted `config.json` from getting that
+        // far. They also have to run *before* the divisibility check below,
+        // which would itself divide by zero on `encoder_attention_heads: 0`.
+        if parsed.d_model < 1 {
+            return Err(anyhow!(
+                "Florence-2 text_config d_model must be positive, got {}",
+                parsed.d_model
+            ));
+        }
+        if parsed.encoder_attention_heads < 1 || parsed.decoder_attention_heads < 1 {
+            return Err(anyhow!(
+                "Florence-2 text_config attention heads must be positive, got {} enc / {} dec",
+                parsed.encoder_attention_heads,
+                parsed.decoder_attention_heads
+            ));
+        }
+        if !(1..=MAX_LAYERS).contains(&parsed.encoder_layers)
+            || !(1..=MAX_LAYERS).contains(&parsed.decoder_layers)
+        {
+            return Err(anyhow!(
+                "Florence-2 text_config layer counts {} enc / {} dec outside 1..={MAX_LAYERS}",
+                parsed.encoder_layers,
+                parsed.decoder_layers
+            ));
+        }
+        if parsed.encoder_ffn_dim < 1 || parsed.decoder_ffn_dim < 1 {
+            return Err(anyhow!(
+                "Florence-2 text_config ffn dims must be positive, got {} enc / {} dec",
+                parsed.encoder_ffn_dim,
+                parsed.decoder_ffn_dim
+            ));
+        }
+        if parsed.vocab_size < 1 {
+            return Err(anyhow!(
+                "Florence-2 text_config vocab_size must be positive, got {}",
+                parsed.vocab_size
+            ));
+        }
+        if !(1..=MAX_POSITION_EMBEDDINGS).contains(&parsed.max_position_embeddings) {
+            return Err(anyhow!(
+                "Florence-2 text_config max_position_embeddings {} outside 1..={MAX_POSITION_EMBEDDINGS}",
+                parsed.max_position_embeddings
+            ));
+        }
+        // Both of these reach the shared embedding gather as literal token ids
+        // (`generate_greedy` seeds the decoder with `decoder_start_token_id`,
+        // `shift_tokens_right` substitutes `pad_token_id`), so an
+        // out-of-vocabulary or negative value is an out-of-range gather.
+        // `bos_token_id` and `eos_token_id` are deliberately left unchecked:
+        // they are only ever compared, never used as an index, and some
+        // exports legitimately carry sentinel values there.
+        if !(0..parsed.vocab_size).contains(&parsed.pad_token_id) {
+            return Err(anyhow!(
+                "Florence-2 text_config pad_token_id {} outside 0..vocab_size {}",
+                parsed.pad_token_id,
+                parsed.vocab_size
+            ));
+        }
+        if !(0..parsed.vocab_size).contains(&parsed.decoder_start_token_id) {
+            return Err(anyhow!(
+                "Florence-2 text_config decoder_start_token_id {} outside 0..vocab_size {}",
+                parsed.decoder_start_token_id,
+                parsed.vocab_size
+            ));
+        }
         if parsed.d_model % parsed.encoder_attention_heads != 0
             || parsed.d_model % parsed.decoder_attention_heads != 0
         {

--- a/src/models/florence2/mod.rs
+++ b/src/models/florence2/mod.rs
@@ -20,10 +20,11 @@
 //! cross-attention, and the dual KV cache (per-step self-attention history
 //! plus one-shot cross-attention K/V) that the decode loop needs.
 //!
-//! The vision tower, image-feature fusion, and the task-prompt processor
-//! build on this foundation in follow-up work; they drive the same
-//! [`Florence2TextModel`] API exposed here, with fused image + text
-//! embeddings entering through [`Florence2TextModel::encode_embeds`].
+//! [`Florence2Model`] is the assembled vision-language model: it drives the
+//! DaViT tower, projects its features into the text embedding space, and
+//! feeds the fused image + prompt sequence into the [`Florence2TextModel`]
+//! API exposed here through [`Florence2TextModel::encode_embeds_with_mask`].
+//! The task-prompt processor and runtime registration build on top of it.
 //!
 //! Structure mirrors `crate::models::whisper`, mlxcel's other
 //! encoder-decoder family, adapted from audio-to-text to token-to-token and
@@ -33,15 +34,21 @@
 //! - https://github.com/Blaizzy/mlx-vlm/blob/main/mlx_vlm/models/florence2/language.py
 //! - https://github.com/Blaizzy/mlx-vlm/blob/main/mlx_vlm/models/florence2/config.py
 
+mod checkpoint;
 mod decoder;
 mod encoder;
+mod fusion;
 pub(crate) mod layers;
+mod model;
 
 /// DaViT vision backbone, re-exported from the shared vision-encoder tree so
 /// the Florence-2 family directory exposes both halves of the model.
 pub use crate::vision::encoders::florence2_davit::{
     FLORENCE2_VISION_PREFIX, Florence2DaViT, Florence2VisionConfig,
 };
+
+pub use checkpoint::{Florence2Config, sanitize};
+pub use model::Florence2Model;
 
 use std::path::Path;
 
@@ -288,7 +295,7 @@ impl Florence2TextModel {
     /// this; callers embedding longer sequences must bound them first.
     pub fn encode_tokens(&self, input_ids: &MlxArray) -> UniquePtr<MlxArray> {
         let embeds = self.embed_tokens(input_ids);
-        self.encoder.forward(&embeds)
+        self.encoder.forward(&embeds, None)
     }
 
     /// Encode pre-computed `[batch, seq, d_model]` input embeddings. This is
@@ -299,7 +306,19 @@ impl Florence2TextModel {
     /// [`Florence2TextConfig::max_position_embeddings`], as in
     /// [`Self::encode_tokens`].
     pub fn encode_embeds(&self, inputs_embeds: &MlxArray) -> UniquePtr<MlxArray> {
-        self.encoder.forward(inputs_embeds)
+        self.encoder.forward(inputs_embeds, None)
+    }
+
+    /// [`Self::encode_embeds`] with an additive attention mask
+    /// (`[batch, 1, 1, seq]`, `0` for a real key and `-inf` for a padded
+    /// one). [`Florence2Model`] builds the mask from the joint image + prompt
+    /// attention mask; `None` is equivalent to [`Self::encode_embeds`].
+    pub fn encode_embeds_with_mask(
+        &self,
+        inputs_embeds: &MlxArray,
+        mask: Option<&MlxArray>,
+    ) -> UniquePtr<MlxArray> {
+        self.encoder.forward(inputs_embeds, mask)
     }
 
     /// Fresh decode-loop cache sized to the decoder depth.
@@ -380,7 +399,7 @@ impl Florence2TextModel {
 /// graph is forced, routed through the fallible [`mlxcel_core::try_eval`]
 /// boundary so an MLX failure surfaces as `Err` instead of aborting the
 /// process with an uncaught C++ exception.
-fn argmax_last_position(logits: &MlxArray) -> Result<i32> {
+pub(crate) fn argmax_last_position(logits: &MlxArray) -> Result<i32> {
     let shape = mlxcel_core::array_shape(logits);
     let last = mlxcel_core::slice(logits, &[0, shape[1] - 1, 0], &[1, shape[1], shape[2]]);
     let last = mlxcel_core::astype(&last, mlxcel_core::dtype::FLOAT32);

--- a/src/models/florence2/model.rs
+++ b/src/models/florence2/model.rs
@@ -415,7 +415,7 @@ impl Florence2Model {
             ));
         }
 
-        let additive = additive_attention_mask(&attention_mask, self.dtype);
+        let additive = additive_attention_mask(&attention_mask, self.dtype)?;
         Ok(self
             .text
             .encode_embeds_with_mask(&inputs_embeds, Some(&additive)))

--- a/src/models/florence2/model.rs
+++ b/src/models/florence2/model.rs
@@ -77,9 +77,9 @@ pub struct Florence2Model {
     image_pos_embed: LearnedPositionEmbedding2D,
     visual_temporal_embed: PositionalEmbeddingCosine1D,
     /// Activation dtype of the text stack. Image features are cast to it
-    /// before the concatenation so a mixed-precision checkpoint (bf16 vision
-    /// tower alongside a quantized text stack) does not silently promote the
-    /// fused sequence to f32.
+    /// before the concatenation so a checkpoint where the vision tower and
+    /// text stack ended up on different dense dtypes does not silently
+    /// promote the fused sequence to f32.
     dtype: i32,
     /// Activation dtype of the vision tower, taken from its first conv
     /// weight. Pixel input is cast to it for the same reason.
@@ -99,20 +99,23 @@ impl Florence2Model {
             .map_err(|e| anyhow!("Failed to parse Florence-2 config: {e}"))?;
         let parsed = Florence2Config::from_model_config(&config)?;
 
+        // Quantized Florence-2 checkpoints are rejected outright rather than
+        // half-loaded, and before spending time loading their weights: both
+        // halves of this family are built from dense `Linear` / `Embedding`,
+        // so a packed uint32 weight would reach MLX and abort the process
+        // instead of surfacing as an error here.
+        if crate::models::sanitize::config_has_quantization_metadata(&config) {
+            return Err(anyhow!(
+                "Florence-2 quantized checkpoints are not supported yet: the BART text stack and the DaViT tower are built from dense layers. Use a bf16 or f16 export, for example mlx-community/Florence-2-base-ft-bf16."
+            ));
+        }
+
         let weights = mlxcel_core::weights::load_weights_from_dir(model_path)
             .map_err(|e| anyhow!("Failed to load Florence-2 weights: {e}"))?;
         let mut weights = sanitize(weights);
 
-        // Precision policy, matching `load_vlm_weights`: promote bf16 to f16
-        // on Apple Silicon for the non-quantized case, and leave a quantized
-        // checkpoint alone so its bf16 scales/biases stay dtype-consistent
-        // with the bf16 activation path the quantized kernels expect. A
-        // Florence-2 quant is mixed by construction (the DaViT tower stays
-        // dense), which is exactly why the fused path pins its activation
-        // dtype from the text stack rather than assuming one.
-        if !crate::models::sanitize::config_has_quantization_metadata(&config) {
-            let _ = crate::models::convert_bf16_weights(&mut weights);
-        }
+        // Apple Silicon precision policy: bf16 to f16 for the dense case.
+        let _ = crate::models::convert_bf16_weights(&mut weights);
 
         Self::from_weights(&weights, parsed)
             .map_err(|e| anyhow!("Failed to build Florence-2 model: {e}"))
@@ -343,11 +346,14 @@ impl Florence2Model {
     /// the joint attention mask.
     ///
     /// Returns `(inputs_embeds [batch, image + prompt, d_model],
-    /// attention_mask [batch, image + prompt])`. The mask is all ones here
-    /// because both segments are real content; it exists so a padded batch
-    /// can carry zeros through the same path, and
-    /// [`Self::encode_with_image_features`] converts it to the additive form
-    /// the encoder's attention consumes.
+    /// attention_mask [batch, image + prompt])`. The mask is applied by the
+    /// BART encoder's self-attention, via the additive form that
+    /// [`Self::encode_with_image_features`] converts it to; it is all ones
+    /// here because this model drives a single image and a single prompt
+    /// with no padding. Supporting a genuinely padded batch would also need
+    /// the same mask threaded into decoder cross-attention, which is not
+    /// implemented: `Florence2Attention::cross_attention` currently passes
+    /// `None`.
     pub fn merge_input_ids_with_image_features(
         &self,
         image_features: &MlxArray,

--- a/src/models/florence2/model.rs
+++ b/src/models/florence2/model.rs
@@ -1,0 +1,470 @@
+// Copyright 2025-2026 Lablup Inc. and Jeongkyu Shin
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Florence-2 vision-language fusion: the assembled model that joins the
+//! DaViT tower to the BART seq2seq engine.
+//!
+//! Florence-2 does *not* scatter image features into placeholder slots the
+//! way Llava-style models do. It pools the vision tower output into a short
+//! feature sequence, projects it into the text embedding space, and
+//! **concatenates** it in front of the task-prompt embeddings. The result is
+//! the encoder input; the decoder then cross-attends to it. So the encoder
+//! sees `[image features | prompt embeddings]` and there is no image token in
+//! the prompt at all.
+//!
+//! Pipeline, in order:
+//!
+//! 1. [`Florence2Model::encode_image`] runs the tower, adds the learned 2-D
+//!    grid position embedding and the temporal embedding, pools according to
+//!    `image_feature_source`, then applies `image_projection` (1024 -> 768)
+//!    and `image_proj_norm`.
+//! 2. [`Florence2Model::merge_input_ids_with_image_features`] concatenates
+//!    those features with the embedded prompt and builds the joint attention
+//!    mask.
+//! 3. [`Florence2Model::encode`] feeds the fused sequence to the BART
+//!    encoder, and [`Florence2Model::generate_greedy`] runs the decode loop
+//!    against it.
+//!
+//! Reference:
+//! https://github.com/Blaizzy/mlx-vlm/blob/main/mlx_vlm/models/florence2/florence2.py
+
+use std::path::Path;
+
+use anyhow::{Result, anyhow};
+use serde_json::Value;
+
+use mlxcel_core::layers::LayerNorm;
+use mlxcel_core::weights::WeightMap;
+use mlxcel_core::{MlxArray, UniquePtr};
+
+use super::checkpoint::{FLORENCE2_TEXT_PREFIX, Florence2Config, sanitize};
+use super::fusion::{
+    LearnedPositionEmbedding2D, PositionalEmbeddingCosine1D, additive_attention_mask,
+};
+use super::layers::layer_norm;
+use super::{
+    FLORENCE2_VISION_PREFIX, Florence2DaViT, Florence2SeqCache, Florence2TextModel,
+    argmax_last_position,
+};
+
+/// Florence-2 processes one still frame per request. Video support upstream
+/// stacks frames on this axis; the pooling below is written in terms of it so
+/// the shapes stay readable, and the temporal embedding contributes row 0
+/// rather than nothing.
+const NUM_FRAMES: i32 = 1;
+
+/// The assembled Florence-2 vision-language model.
+///
+/// Holds MLX weight handles, so the owning provider serializes access.
+pub struct Florence2Model {
+    config: Florence2Config,
+    vision_tower: Florence2DaViT,
+    text: Florence2TextModel,
+    /// `[dim_embed[-1], d_model]`, applied as `features @ image_projection`.
+    image_projection: UniquePtr<MlxArray>,
+    image_proj_norm: LayerNorm,
+    image_pos_embed: LearnedPositionEmbedding2D,
+    visual_temporal_embed: PositionalEmbeddingCosine1D,
+    /// Activation dtype of the text stack. Image features are cast to it
+    /// before the concatenation so a mixed-precision checkpoint (bf16 vision
+    /// tower alongside a quantized text stack) does not silently promote the
+    /// fused sequence to f32.
+    dtype: i32,
+    /// Activation dtype of the vision tower, taken from its first conv
+    /// weight. Pixel input is cast to it for the same reason.
+    vision_dtype: i32,
+}
+
+impl Florence2Model {
+    /// Load the whole model from a checkpoint directory (`config.json` +
+    /// safetensors). The checkpoint is read once and both halves are built
+    /// from the same weight map.
+    pub fn load(model_path: &Path) -> Result<Self> {
+        let config_path = model_path.join("config.json");
+        let config_str = std::fs::read_to_string(&config_path)
+            .map_err(|e| anyhow!("Failed to read {config_path:?}: {e}"))?;
+        let config_str = crate::models::sanitize_config_json(&config_str);
+        let config: Value = serde_json::from_str(&config_str)
+            .map_err(|e| anyhow!("Failed to parse Florence-2 config: {e}"))?;
+        let parsed = Florence2Config::from_model_config(&config)?;
+
+        let weights = mlxcel_core::weights::load_weights_from_dir(model_path)
+            .map_err(|e| anyhow!("Failed to load Florence-2 weights: {e}"))?;
+        let mut weights = sanitize(weights);
+
+        // Precision policy, matching `load_vlm_weights`: promote bf16 to f16
+        // on Apple Silicon for the non-quantized case, and leave a quantized
+        // checkpoint alone so its bf16 scales/biases stay dtype-consistent
+        // with the bf16 activation path the quantized kernels expect. A
+        // Florence-2 quant is mixed by construction (the DaViT tower stays
+        // dense), which is exactly why the fused path pins its activation
+        // dtype from the text stack rather than assuming one.
+        if !crate::models::sanitize::config_has_quantization_metadata(&config) {
+            let _ = crate::models::convert_bf16_weights(&mut weights);
+        }
+
+        Self::from_weights(&weights, parsed)
+            .map_err(|e| anyhow!("Failed to build Florence-2 model: {e}"))
+    }
+
+    /// Build from an already-loaded and already-sanitized [`WeightMap`].
+    pub fn from_weights(weights: &WeightMap, config: Florence2Config) -> Result<Self, String> {
+        let vision_tower =
+            Florence2DaViT::from_weights(weights, &config.vision, FLORENCE2_VISION_PREFIX)?;
+        let text =
+            Florence2TextModel::from_weights(weights, config.text.clone(), FLORENCE2_TEXT_PREFIX)?;
+
+        let image_dim = config.vision.output_dim();
+        let d_model = config.text.d_model;
+
+        // `image_projection` is a bare tensor rather than a `Linear`: upstream
+        // registers it as a raw parameter and applies it as a right-hand
+        // matmul, so it is stored `[in, out]` with no bias and no transpose.
+        let image_projection = weights
+            .get("image_projection")
+            .map(|w| mlxcel_core::copy(w))
+            .ok_or_else(|| "Florence-2 weight not found: image_projection".to_string())?;
+        let projection_shape = mlxcel_core::array_shape(&image_projection);
+        if projection_shape != vec![image_dim, d_model] {
+            return Err(format!(
+                "Florence-2 image_projection: expected shape [{image_dim}, {d_model}], got {projection_shape:?}"
+            ));
+        }
+        let image_proj_norm = layer_norm(weights, "image_proj_norm")?;
+
+        let pos_spec = config
+            .vision
+            .image_pos_embed
+            .as_ref()
+            .ok_or_else(|| "Florence-2 config missing image_pos_embed".to_string())?;
+        let pos_kind = pos_spec.get("type").and_then(Value::as_str).unwrap_or("");
+        if pos_kind != "learned_abs_2d" {
+            return Err(format!(
+                "Florence-2 image_pos_embed type {pos_kind:?} not supported (expected learned_abs_2d)"
+            ));
+        }
+        let image_pos_embed =
+            LearnedPositionEmbedding2D::from_weights(weights, "image_pos_embed", image_dim)?;
+
+        let temporal_spec = config
+            .vision
+            .visual_temporal_embedding
+            .as_ref()
+            .ok_or_else(|| "Florence-2 config missing visual_temporal_embedding".to_string())?;
+        let temporal_kind = temporal_spec
+            .get("type")
+            .and_then(Value::as_str)
+            .unwrap_or("");
+        if temporal_kind != "COSINE" {
+            return Err(format!(
+                "Florence-2 visual_temporal_embedding type {temporal_kind:?} not supported (expected COSINE)"
+            ));
+        }
+        let max_temporal = temporal_spec
+            .get("max_temporal_embeddings")
+            .and_then(Value::as_i64)
+            .unwrap_or(100) as i32;
+        let visual_temporal_embed = PositionalEmbeddingCosine1D::from_weights(
+            weights,
+            "visual_temporal_embed",
+            image_dim,
+            max_temporal,
+        )?;
+
+        // The pooling recipe is order-sensitive (it decides the layout of the
+        // concatenated feature sequence) and upstream's dataclass default is
+        // in the opposite order from every real checkpoint, so refuse to
+        // guess it.
+        if config.vision.image_feature_source.is_empty() {
+            return Err("Florence-2 config missing image_feature_source".to_string());
+        }
+
+        let dtype = text.dtype();
+        let vision_dtype = weights
+            .get(&format!("{FLORENCE2_VISION_PREFIX}convs.0.proj.weight"))
+            .map(|w| mlxcel_core::array_dtype(w))
+            .unwrap_or(dtype);
+
+        Ok(Self {
+            config,
+            vision_tower,
+            text,
+            image_projection,
+            image_proj_norm,
+            image_pos_embed,
+            visual_temporal_embed,
+            dtype,
+            vision_dtype,
+        })
+    }
+
+    /// Parsed configuration for both halves.
+    pub fn config(&self) -> &Florence2Config {
+        &self.config
+    }
+
+    /// The BART text core, for callers that need the decode primitives
+    /// directly.
+    pub fn text_model(&self) -> &Florence2TextModel {
+        &self.text
+    }
+
+    /// The DaViT tower.
+    pub fn vision_tower(&self) -> &Florence2DaViT {
+        &self.vision_tower
+    }
+
+    /// Activation dtype of the fused path (that of the text stack).
+    pub fn dtype(&self) -> i32 {
+        self.dtype
+    }
+
+    /// Encode NCHW `pixel_values` into projected image features
+    /// `[batch, tokens, d_model]` ready to concatenate with prompt
+    /// embeddings.
+    pub fn encode_image(&self, pixel_values: &MlxArray) -> Result<UniquePtr<MlxArray>, String> {
+        let pixel_values = if mlxcel_core::array_dtype(pixel_values) == self.vision_dtype {
+            mlxcel_core::copy(pixel_values)
+        } else {
+            mlxcel_core::astype(pixel_values, self.vision_dtype)
+        };
+        let features = self.vision_tower.forward(&pixel_values);
+        self.encode_image_features(&features)
+    }
+
+    /// The fusion half of [`Self::encode_image`], starting from raw backbone
+    /// tokens `[batch, H*W, dim_embed[-1]]`. Split out so a caller holding
+    /// cached tower output (or a test pinning the tower separately) can drive
+    /// the projection without re-running the tower.
+    pub fn encode_image_features(
+        &self,
+        features: &MlxArray,
+    ) -> Result<UniquePtr<MlxArray>, String> {
+        let shape = mlxcel_core::array_shape(features);
+        if shape.len() != 3 {
+            return Err(format!(
+                "Florence-2 image features must be [batch, tokens, dim], got {shape:?}"
+            ));
+        }
+        let (batch, num_tokens, dim) = (shape[0], shape[1], shape[2]);
+        let image_dim = self.config.vision.output_dim();
+        if dim != image_dim {
+            return Err(format!(
+                "Florence-2 image features have width {dim}, expected dim_embed[-1] {image_dim}"
+            ));
+        }
+        let side = (num_tokens as f64).sqrt().round() as i32;
+        if side * side != num_tokens {
+            return Err(format!(
+                "Florence-2 image features have {num_tokens} tokens, which is not a square feature map"
+            ));
+        }
+
+        // Learned 2-D grid position embedding over [B*T, H, W, D].
+        let x = mlxcel_core::reshape(features, &[batch * NUM_FRAMES, side, side, dim]);
+        let pos = self.image_pos_embed.forward(side, side)?;
+        let x = mlxcel_core::add(&x, &pos);
+
+        // Temporal embedding over the frame axis: [B, T, H*W, D] + [1, T, 1, D].
+        let x = mlxcel_core::reshape(&x, &[batch, NUM_FRAMES, num_tokens, dim]);
+        let temporal = self.visual_temporal_embed.forward(NUM_FRAMES)?;
+        let temporal = mlxcel_core::reshape(&temporal, &[1, NUM_FRAMES, 1, dim]);
+        let x = mlxcel_core::add(&x, &temporal);
+
+        // Pool per `image_feature_source` and concatenate along the token
+        // axis. For the base-ft recipe this is one spatially averaged token
+        // followed by the 576 temporally averaged grid tokens: 577 in total.
+        let mut fused: Option<UniquePtr<MlxArray>> = None;
+        for source in &self.config.vision.image_feature_source {
+            let pooled = match source.as_str() {
+                "spatial_avg_pool" => mlxcel_core::mean_axis(&x, 2, false),
+                "temporal_avg_pool" => mlxcel_core::mean_axis(&x, 1, false),
+                "last_frame" => {
+                    let last = mlxcel_core::slice(
+                        &x,
+                        &[0, NUM_FRAMES - 1, 0, 0],
+                        &[batch, NUM_FRAMES, num_tokens, dim],
+                    );
+                    mlxcel_core::reshape(&last, &[batch, num_tokens, dim])
+                }
+                other => {
+                    return Err(format!(
+                        "Florence-2 image_feature_source {other:?} is not supported"
+                    ));
+                }
+            };
+            fused = Some(match fused {
+                Some(previous) => mlxcel_core::concatenate(&previous, &pooled, 1),
+                None => pooled,
+            });
+        }
+        // `image_feature_source` was checked non-empty at load time.
+        let fused = fused.ok_or_else(|| "Florence-2 image_feature_source is empty".to_string())?;
+
+        let projected = mlxcel_core::matmul(&fused, &self.image_projection);
+        let projected = self.image_proj_norm.forward(&projected);
+        Ok(if mlxcel_core::array_dtype(&projected) == self.dtype {
+            projected
+        } else {
+            mlxcel_core::astype(&projected, self.dtype)
+        })
+    }
+
+    /// Embed the task prompt, dropping any image placeholder id.
+    ///
+    /// Returns `None` for an empty (or entirely placeholder) prompt, which is
+    /// the image-only case: the encoder input is then the image features
+    /// alone.
+    pub fn embed_prompt(&self, prompt_ids: &[i32]) -> Option<UniquePtr<MlxArray>> {
+        let filtered: Vec<i32> = prompt_ids
+            .iter()
+            .copied()
+            .filter(|id| *id != self.config.image_token_id)
+            .collect();
+        if filtered.is_empty() {
+            return None;
+        }
+        let ids = mlxcel_core::from_slice_i32(&filtered, &[1, filtered.len() as i32]);
+        Some(self.text.embed_tokens(&ids))
+    }
+
+    /// Concatenate image features in front of the prompt embeddings and build
+    /// the joint attention mask.
+    ///
+    /// Returns `(inputs_embeds [batch, image + prompt, d_model],
+    /// attention_mask [batch, image + prompt])`. The mask is all ones here
+    /// because both segments are real content; it exists so a padded batch
+    /// can carry zeros through the same path, and
+    /// [`Self::encode_with_image_features`] converts it to the additive form
+    /// the encoder's attention consumes.
+    pub fn merge_input_ids_with_image_features(
+        &self,
+        image_features: &MlxArray,
+        inputs_embeds: Option<&MlxArray>,
+    ) -> Result<(UniquePtr<MlxArray>, UniquePtr<MlxArray>), String> {
+        let image_shape = mlxcel_core::array_shape(image_features);
+        if image_shape.len() != 3 {
+            return Err(format!(
+                "Florence-2 image features must be [batch, tokens, dim], got {image_shape:?}"
+            ));
+        }
+        let (batch, image_len, dim) = (image_shape[0], image_shape[1], image_shape[2]);
+
+        let Some(prompt_embeds) = inputs_embeds else {
+            return Ok((
+                mlxcel_core::copy(image_features),
+                mlxcel_core::ones(&[batch, image_len], self.dtype),
+            ));
+        };
+
+        let prompt_shape = mlxcel_core::array_shape(prompt_embeds);
+        if prompt_shape.len() != 3 || prompt_shape[0] != batch || prompt_shape[2] != dim {
+            return Err(format!(
+                "Florence-2 prompt embeddings {prompt_shape:?} are not compatible with image features {image_shape:?}"
+            ));
+        }
+
+        let merged = mlxcel_core::concatenate(image_features, prompt_embeds, 1);
+        let mask = mlxcel_core::ones(&[batch, image_len + prompt_shape[1]], self.dtype);
+        Ok((merged, mask))
+    }
+
+    /// Full encoder pass: tower -> fusion -> BART encoder. Returns encoder
+    /// hidden states `[batch, image + prompt, d_model]`.
+    pub fn encode(
+        &self,
+        pixel_values: &MlxArray,
+        prompt_ids: &[i32],
+    ) -> Result<UniquePtr<MlxArray>, String> {
+        let image_features = self.encode_image(pixel_values)?;
+        self.encode_with_image_features(&image_features, prompt_ids)
+    }
+
+    /// [`Self::encode`] starting from already-projected image features.
+    pub fn encode_with_image_features(
+        &self,
+        image_features: &MlxArray,
+        prompt_ids: &[i32],
+    ) -> Result<UniquePtr<MlxArray>, String> {
+        let prompt_embeds = self.embed_prompt(prompt_ids);
+        let (inputs_embeds, attention_mask) =
+            self.merge_input_ids_with_image_features(image_features, prompt_embeds.as_deref())?;
+
+        let seq = mlxcel_core::array_shape(&inputs_embeds)[1];
+        let max_positions = self.config.text.max_position_embeddings;
+        if seq > max_positions {
+            return Err(format!(
+                "Florence-2 fused encoder input length {seq} exceeds max_position_embeddings {max_positions}"
+            ));
+        }
+
+        let additive = additive_attention_mask(&attention_mask, self.dtype);
+        Ok(self
+            .text
+            .encode_embeds_with_mask(&inputs_embeds, Some(&additive)))
+    }
+
+    /// Fresh decode-loop cache sized to the decoder depth.
+    pub fn make_cache(&self) -> Florence2SeqCache {
+        self.text.make_cache()
+    }
+
+    /// Run the decoder one step (or several) against encoder hidden states.
+    /// Returns logits `[batch, seq, vocab_size]`.
+    pub fn decode(
+        &self,
+        decoder_input_ids: &MlxArray,
+        encoder_hidden_states: &MlxArray,
+        cache: &mut Florence2SeqCache,
+    ) -> UniquePtr<MlxArray> {
+        self.text
+            .decode(decoder_input_ids, encoder_hidden_states, cache)
+    }
+
+    /// Greedy caption / task generation: fuse image and prompt, then decode
+    /// from `decoder_start_token_id` until EOS or `max_new_tokens`. Returns
+    /// the generated ids (EOS excluded).
+    pub fn generate_greedy(
+        &self,
+        pixel_values: &MlxArray,
+        prompt_ids: &[i32],
+        max_new_tokens: usize,
+    ) -> Result<Vec<i32>> {
+        let encoder_hidden = self
+            .encode(pixel_values, prompt_ids)
+            .map_err(|e| anyhow!("{e}"))?;
+
+        let text_config = &self.config.text;
+        let mut cache = self.make_cache();
+        let mut generated = Vec::new();
+        let mut next = text_config.decoder_start_token_id;
+        for _ in 0..max_new_tokens {
+            if cache.offset() >= text_config.max_position_embeddings {
+                break;
+            }
+            let token = mlxcel_core::from_slice_i32(&[next], &[1, 1]);
+            let logits = self.decode(&token, &encoder_hidden, &mut cache);
+            next = argmax_last_position(&logits)?;
+            if next == text_config.eos_token_id {
+                break;
+            }
+            generated.push(next);
+        }
+        Ok(generated)
+    }
+}
+
+#[cfg(test)]
+#[path = "florence2_fusion_tests.rs"]
+mod florence2_fusion_tests;

--- a/src/models/florence2/model.rs
+++ b/src/models/florence2/model.rs
@@ -346,14 +346,14 @@ impl Florence2Model {
     /// the joint attention mask.
     ///
     /// Returns `(inputs_embeds [batch, image + prompt, d_model],
-    /// attention_mask [batch, image + prompt])`. The mask is applied by the
-    /// BART encoder's self-attention, via the additive form that
-    /// [`Self::encode_with_image_features`] converts it to; it is all ones
-    /// here because this model drives a single image and a single prompt
-    /// with no padding. Supporting a genuinely padded batch would also need
-    /// the same mask threaded into decoder cross-attention, which is not
-    /// implemented: `Florence2Attention::cross_attention` currently passes
-    /// `None`.
+    /// attention_mask [batch, image + prompt])`. Hand the mask to
+    /// [`Self::encode_fused`], which converts it to the additive form the
+    /// BART encoder's self-attention applies. It is all ones here because
+    /// this model drives a single image and a single prompt with no padding,
+    /// so [`Self::encode_with_image_features`] skips the conversion; a
+    /// genuinely padded batch would also need the same mask threaded into
+    /// decoder cross-attention, which is not implemented
+    /// (`Florence2Attention::cross_attention` currently passes `None`).
     pub fn merge_input_ids_with_image_features(
         &self,
         image_features: &MlxArray,
@@ -404,10 +404,37 @@ impl Florence2Model {
         prompt_ids: &[i32],
     ) -> Result<UniquePtr<MlxArray>, String> {
         let prompt_embeds = self.embed_prompt(prompt_ids);
-        let (inputs_embeds, attention_mask) =
+        let (inputs_embeds, _attention_mask) =
             self.merge_input_ids_with_image_features(image_features, prompt_embeds.as_deref())?;
+        // The mask this just built is all ones by construction: the image half
+        // is all feature tokens and the prompt half is all prompt tokens, so
+        // there is nothing to mask out. Passing it anyway would add a provably
+        // all-zero `[batch, 1, 1, seq]` tensor into every encoder layer's
+        // `[batch, heads, seq, seq]` logits, an arithmetic identity costing
+        // tens of millions of elementwise f16 adds per encode. Callers that do
+        // have padding go through [`Self::encode_fused`] with their own mask.
+        self.encode_fused(&inputs_embeds, None)
+    }
 
-        let seq = mlxcel_core::array_shape(&inputs_embeds)[1];
+    /// Run the BART encoder over an already-fused `[batch, seq, d_model]`
+    /// embedding sequence.
+    ///
+    /// `attention_mask` is the 0/1 mask over the fused sequence, in the shape
+    /// [`Self::merge_input_ids_with_image_features`] returns it; it is
+    /// converted to the additive form the attention adds to its logits. Pass
+    /// `None` when every position is a real token.
+    pub fn encode_fused(
+        &self,
+        inputs_embeds: &MlxArray,
+        attention_mask: Option<&MlxArray>,
+    ) -> Result<UniquePtr<MlxArray>, String> {
+        let shape = mlxcel_core::array_shape(inputs_embeds);
+        if shape.len() != 3 {
+            return Err(format!(
+                "Florence-2 fused encoder input must be [batch, seq, d_model], got {shape:?}"
+            ));
+        }
+        let seq = shape[1];
         let max_positions = self.config.text.max_position_embeddings;
         if seq > max_positions {
             return Err(format!(
@@ -415,10 +442,13 @@ impl Florence2Model {
             ));
         }
 
-        let additive = additive_attention_mask(&attention_mask, self.dtype)?;
+        let additive = match attention_mask {
+            Some(mask) => Some(additive_attention_mask(mask, self.dtype)?),
+            None => None,
+        };
         Ok(self
             .text
-            .encode_embeds_with_mask(&inputs_embeds, Some(&additive)))
+            .encode_embeds_with_mask(inputs_embeds, additive.as_deref()))
     }
 
     /// Fresh decode-loop cache sized to the decoder depth.

--- a/src/models/mod.rs
+++ b/src/models/mod.rs
@@ -177,8 +177,8 @@ pub use exaone_moe::ExaoneMoeModel;
 pub use exaone4::{ExaOne4Model, ExaOne4Wrapper};
 pub use falcon_h1::FalconH1Model;
 pub use florence2::{
-    FLORENCE2_VISION_PREFIX, Florence2DaViT, Florence2SeqCache, Florence2TextConfig,
-    Florence2TextModel, Florence2VisionConfig,
+    FLORENCE2_VISION_PREFIX, Florence2Config, Florence2DaViT, Florence2Model, Florence2SeqCache,
+    Florence2TextConfig, Florence2TextModel, Florence2VisionConfig,
 };
 pub use gemma::GemmaModel;
 pub use gemma2::Gemma2Model;

--- a/tests/florence2_fusion_parity.rs
+++ b/tests/florence2_fusion_parity.rs
@@ -42,8 +42,9 @@
 //! does.
 //!
 //! To regenerate the pins, in a virtualenv holding `mlx`, `numpy`, and
-//! `Pillow`, with `references/mlx-vlm` on `sys.path` (the `mlx_vlm` package
-//! entry can be stubbed so `transformers` is not required): build
+//! `Pillow`, with a local checkout of https://github.com/Blaizzy/mlx-vlm on
+//! `sys.path` (the `mlx_vlm` package entry can be stubbed so `transformers`
+//! is not required): build
 //! `ModelConfig` as described above, instantiate `florence2.Model`, load
 //! `models/Florence-2-base-ft-bf16/model.safetensors`, pass it through
 //! `VisionModel.sanitize` then `Model.sanitize`, cast every tensor to

--- a/tests/florence2_fusion_parity.rs
+++ b/tests/florence2_fusion_parity.rs
@@ -1,0 +1,363 @@
+// Copyright 2025-2026 Lablup Inc. and Jeongkyu Shin
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Florence-2 end-to-end vision-language parity against the mlx-vlm reference.
+//!
+//! Pins the whole fused path: DaViT tower -> learned 2-D image position
+//! embedding -> cosine temporal embedding -> `image_feature_source` pooling ->
+//! `image_projection` / `image_proj_norm` -> concatenation with the embedded
+//! task prompt -> BART encoder -> cross-attending decoder logits -> greedy
+//! token ids. The reference is the mlx-vlm florence2 `Model`
+//! (https://github.com/Blaizzy/mlx-vlm/blob/main/mlx_vlm/models/florence2/florence2.py)
+//! running the same `models/Florence-2-base-ft-bf16` checkpoint with weights
+//! cast bf16 -> f16, matching mlxcel's Apple Silicon precision policy. Skips
+//! when the checkpoint is absent (CI has no Metal and no weights).
+//!
+//! The input is the same deterministic synthetic pixel tensor the DaViT
+//! backbone parity test uses (`tests/florence2_vision_parity.rs`): Florence-2
+//! image preprocessing belongs to the processor sub-issue, and a closed-form
+//! tensor is the only way to guarantee both runtimes see bit-identical input
+//! today.
+//!
+//! One deliberate difference on the reference side: upstream's `ModelConfig`
+//! reads `image_feature_source`, `image_pos_embed`, and
+//! `visual_temporal_embedding` from the *top level* of `config.json`, but
+//! every real Florence-2 checkpoint stores them inside `vision_config`. Left
+//! alone, upstream therefore falls back to its dataclass defaults, whose
+//! `image_feature_source` is `["temporal_avg_pool", "spatial_avg_pool"]`, the
+//! reverse of what the checkpoint asks for. The reference run overrides those
+//! three fields from `vision_config` so both sides execute the checkpoint's
+//! own recipe, which is also what the HuggingFace Florence-2 implementation
+//! does.
+//!
+//! To regenerate the pins, in a virtualenv holding `mlx`, `numpy`, and
+//! `Pillow`, with `references/mlx-vlm` on `sys.path` (the `mlx_vlm` package
+//! entry can be stubbed so `transformers` is not required): build
+//! `ModelConfig` as described above, instantiate `florence2.Model`, load
+//! `models/Florence-2-base-ft-bf16/model.safetensors`, pass it through
+//! `VisionModel.sanitize` then `Model.sanitize`, cast every tensor to
+//! `mx.float16`, and `load_weights`. Then call `_encode_image` on the
+//! synthetic pixels, `_merge_input_ids_with_image_features` with
+//! `language_model.model.shared(prompt_ids)`, `language_model.model.encoder`,
+//! and finally `language_model(inputs=token, encoder_outputs=..., cache=...)`
+//! in a greedy loop. Print each tensor's shape, first 16 values, mean, and
+//! standard deviation.
+
+use std::path::Path;
+
+use mlxcel::models::Florence2Model;
+
+const MODEL_DIR: &str = "models/Florence-2-base-ft-bf16";
+const IMAGE_SIDE: i32 = 768;
+
+/// `<s>What does the image describe?</s>` under the checkpoint tokenizer, the
+/// task prompt Florence-2 uses for `<CAPTION>`-style captioning.
+const PROMPT_IDS: &[i32] = &[0, 2264, 473, 5, 2274, 6190, 116, 2];
+
+/// 1 spatially averaged token + 576 temporally averaged grid tokens.
+const IMAGE_TOKENS: i32 = 577;
+const D_MODEL: i32 = 768;
+
+// Reference activations from the mlx-vlm florence2 Model (f16 weights, f32
+// readout). The full digit strings are the exact f16-representable reference
+// values; truncating them would move the pins off what the reference produced.
+#[allow(clippy::excessive_precision)]
+const REF_IMAGE_FEATURES_FIRST16: &[f32] = &[
+    -0.681640625,
+    0.7470703125,
+    -0.0171966552734375,
+    -1.7763671875,
+    1.1005859375,
+    0.38134765625,
+    -0.1007080078125,
+    -0.57373046875,
+    0.09912109375,
+    -1.4189453125,
+    -0.71826171875,
+    -0.18505859375,
+    -0.36279296875,
+    0.1702880859375,
+    1.26953125,
+    -0.4267578125,
+];
+const REF_IMAGE_FEATURES_STATS: (f32, f32) = (-0.004598, 0.813462);
+
+#[allow(clippy::excessive_precision)]
+const REF_ENCODER_FIRST16: &[f32] = &[
+    5.3984375,
+    1.9208984375,
+    0.93701171875,
+    -5.44921875,
+    3.546875,
+    3.794921875,
+    1.384765625,
+    -0.7529296875,
+    -1.4326171875,
+    -1.91015625,
+    -1.5458984375,
+    -0.94091796875,
+    -5.51171875,
+    1.9794921875,
+    -1.451171875,
+    -0.517578125,
+];
+const REF_ENCODER_STATS: (f32, f32) = (0.064738, 3.541291);
+
+#[allow(clippy::excessive_precision)]
+const REF_STEP0_LOGITS_FIRST16: &[f32] = &[
+    21.1875,
+    -6.484375,
+    4.98828125,
+    -6.48828125,
+    -2.791015625,
+    -3.642578125,
+    -0.409423828125,
+    -0.9736328125,
+    -1.2841796875,
+    -0.8759765625,
+    -3.626953125,
+    -1.7275390625,
+    -1.4326171875,
+    -0.0731201171875,
+    -3.181640625,
+    -1.7861328125,
+];
+const REF_STEP0_LOGITS_STATS: (f32, f32) = (-4.34751, 1.661954);
+
+/// Greedy ids after the `decoder_start_token_id` seed, EOS excluded. These
+/// decode to `<s>unanswerable`, which is the sensible caption for a
+/// procedurally generated noise field.
+const REF_GENERATED: &[i32] = &[0, 879, 27740, 868];
+
+/// `x[0, c, h, w] = ((h * side + w) * 3 + c) % 251 / 251.0 - 0.5`, NCHW.
+///
+/// Identical to `tests/florence2_vision_parity.rs`; every operation is a
+/// single IEEE-754 f32 step over exactly represented integers, so the Python
+/// reference reproduces it bit for bit.
+fn synthetic_pixels(side: i32) -> Vec<f32> {
+    let mut out = vec![0.0f32; (3 * side * side) as usize];
+    for c in 0..3i64 {
+        for h in 0..side as i64 {
+            for w in 0..side as i64 {
+                let raw = ((h * side as i64 + w) * 3 + c) % 251;
+                let value = raw as f32 / 251.0f32 - 0.5f32;
+                out[(c * side as i64 * side as i64 + h * side as i64 + w) as usize] = value;
+            }
+        }
+    }
+    out
+}
+
+fn to_vec_f32(a: &mlxcel_core::MlxArray) -> Vec<f32> {
+    let a = mlxcel_core::astype(a, mlxcel_core::dtype::FLOAT32);
+    mlxcel_core::eval(&a);
+    mlxcel_core::array_to_raw_bytes(&a)
+        .chunks_exact(4)
+        .map(|c| f32::from_le_bytes([c[0], c[1], c[2], c[3]]))
+        .collect()
+}
+
+fn assert_close(got: &[f32], want: &[f32], tol: f32, what: &str) {
+    assert_eq!(got.len(), want.len(), "{what}: length mismatch");
+    let mut worst = 0.0f32;
+    let mut worst_at = 0usize;
+    for (i, (g, w)) in got.iter().zip(want).enumerate() {
+        let dev = (g - w).abs();
+        if dev > worst {
+            worst = dev;
+            worst_at = i;
+        }
+    }
+    eprintln!("{what}: max abs deviation {worst} at index {worst_at} (tol {tol})");
+    assert!(
+        worst <= tol,
+        "{what}[{worst_at}]: got {}, reference {} (deviation {worst}, tol {tol})",
+        got[worst_at],
+        want[worst_at]
+    );
+}
+
+fn assert_stats(values: &[f32], want: (f32, f32), tol: f32, what: &str) {
+    let n = values.len() as f64;
+    let mean = values.iter().map(|v| *v as f64).sum::<f64>() / n;
+    let var = values
+        .iter()
+        .map(|v| {
+            let d = *v as f64 - mean;
+            d * d
+        })
+        .sum::<f64>()
+        / n;
+    let std = var.sqrt();
+    let (ref_mean, ref_std) = want;
+    eprintln!("{what}: mean {mean:.6} (ref {ref_mean:.6}), std {std:.6} (ref {ref_std:.6})");
+    assert!(
+        (mean as f32 - ref_mean).abs() <= tol,
+        "{what} mean: got {mean}, reference {ref_mean} (tol {tol})"
+    );
+    assert!(
+        (std as f32 - ref_std).abs() <= tol,
+        "{what} std: got {std}, reference {ref_std} (tol {tol})"
+    );
+}
+
+#[test]
+fn florence2_fusion_matches_mlx_vlm_reference() {
+    if !Path::new(MODEL_DIR).exists() {
+        eprintln!("skipping florence2_fusion_parity: {MODEL_DIR} not present");
+        return;
+    }
+
+    let model = Florence2Model::load(Path::new(MODEL_DIR)).expect("load florence2 model");
+    let config = model.config();
+    assert_eq!(config.text.d_model, D_MODEL);
+    assert_eq!(config.text.encoder_attention_heads, 12);
+    assert_eq!(config.text.decoder_attention_heads, 12);
+    assert_eq!(config.vision.output_dim(), 1024);
+    assert_eq!(config.vision.projection_dim, D_MODEL);
+    assert_eq!(
+        config.vision.image_feature_source,
+        vec![
+            "spatial_avg_pool".to_string(),
+            "temporal_avg_pool".to_string()
+        ]
+    );
+
+    let pixels = synthetic_pixels(IMAGE_SIDE);
+    let pixel_values = mlxcel_core::from_slice_f32(&pixels, &[1, 3, IMAGE_SIDE, IMAGE_SIDE]);
+
+    // 1. Vision tower + fusion-stage projection.
+    let image_features = model.encode_image(&pixel_values).expect("encode image");
+    assert_eq!(
+        mlxcel_core::array_shape(&image_features),
+        vec![1, IMAGE_TOKENS, D_MODEL],
+        "image feature shape"
+    );
+    let image_values = to_vec_f32(&image_features);
+    // Both sides run f16 with different op ordering. absmax here is 8.6, one
+    // f16 ulp at that magnitude is 8e-3, and the observed deviation on Apple
+    // Silicon was 2.2e-3; the bound is a small multiple of that and 80x below
+    // the tensor's own standard deviation.
+    assert_close(
+        &image_values[..16],
+        REF_IMAGE_FEATURES_FIRST16,
+        1e-2,
+        "image_features first16",
+    );
+    assert_stats(
+        &image_values,
+        REF_IMAGE_FEATURES_STATS,
+        2e-3,
+        "image_features",
+    );
+
+    // 2. Concatenation with the embedded task prompt + joint attention mask.
+    let prompt_embeds = model.embed_prompt(PROMPT_IDS).expect("embed prompt");
+    let (fused, attention_mask) = model
+        .merge_input_ids_with_image_features(&image_features, Some(&prompt_embeds))
+        .expect("merge image features");
+    let fused_len = IMAGE_TOKENS + PROMPT_IDS.len() as i32;
+    assert_eq!(
+        mlxcel_core::array_shape(&fused),
+        vec![1, fused_len, D_MODEL],
+        "fused encoder input shape"
+    );
+    assert_eq!(
+        mlxcel_core::array_shape(&attention_mask),
+        vec![1, fused_len],
+        "joint attention mask shape"
+    );
+    // Concatenation, not scatter: the image half of the fused sequence must be
+    // the image features unchanged.
+    assert_close(
+        &to_vec_f32(&fused)[..16],
+        REF_IMAGE_FEATURES_FIRST16,
+        1e-2,
+        "fused first16 (image half)",
+    );
+    let mask_values = to_vec_f32(&attention_mask);
+    assert!(
+        mask_values.iter().all(|v| *v == 1.0),
+        "joint attention mask must be all ones for unpadded input"
+    );
+
+    // 3. BART encoder over the fused sequence.
+    let encoder_hidden = model
+        .encode(&pixel_values, PROMPT_IDS)
+        .expect("fused encode");
+    assert_eq!(
+        mlxcel_core::array_shape(&encoder_hidden),
+        vec![1, fused_len, D_MODEL],
+        "encoder hidden state shape"
+    );
+    let encoder_values = to_vec_f32(&encoder_hidden);
+    // absmax 45.8 here, so one f16 ulp is 3.1e-2. Observed deviation 1.5e-2.
+    assert_close(
+        &encoder_values[..16],
+        REF_ENCODER_FIRST16,
+        8e-2,
+        "encoder_hidden_states first16",
+    );
+    assert_stats(&encoder_values, REF_ENCODER_STATS, 5e-3, "encoder_hidden");
+
+    // 4. First decoder step against the fused encoder output.
+    let mut cache = model.make_cache();
+    let start = mlxcel_core::from_slice_i32(&[config.text.decoder_start_token_id], &[1, 1]);
+    let logits = model.decode(&start, &encoder_hidden, &mut cache);
+    assert_eq!(
+        mlxcel_core::array_shape(&logits),
+        vec![1, 1, config.text.vocab_size],
+        "decoder logits shape"
+    );
+    let logit_values = to_vec_f32(&logits);
+    // absmax 21.2, one f16 ulp 1.6e-2. Observed deviation 6.6e-3.
+    assert_close(
+        &logit_values[..16],
+        REF_STEP0_LOGITS_FIRST16,
+        5e-2,
+        "step0 logits first16",
+    );
+    assert_stats(&logit_values, REF_STEP0_LOGITS_STATS, 5e-3, "step0 logits");
+
+    // 5. Whole greedy loop.
+    let generated = model
+        .generate_greedy(&pixel_values, PROMPT_IDS, 8)
+        .expect("greedy generation");
+    assert_eq!(
+        generated, REF_GENERATED,
+        "greedy token ids must match the reference"
+    );
+}
+
+#[test]
+fn florence2_fusion_config_parses_real_checkpoint() {
+    if !Path::new(MODEL_DIR).exists() {
+        eprintln!("skipping florence2_fusion_parity config check: {MODEL_DIR} not present");
+        return;
+    }
+    let raw = std::fs::read_to_string(Path::new(MODEL_DIR).join("config.json"))
+        .expect("read florence2 config.json");
+    let value: serde_json::Value = serde_json::from_str(&raw).expect("parse florence2 config.json");
+    let config =
+        mlxcel::models::Florence2Config::from_model_config(&value).expect("parse florence2 config");
+
+    assert_eq!(config.text.vocab_size, 51289);
+    assert_eq!(config.text.decoder_start_token_id, 2);
+    assert_eq!(config.text.eos_token_id, 2);
+    assert!(!config.text.scale_embedding);
+    // No `image_token_id` in the checkpoint; upstream's default is one past
+    // the last real vocabulary id.
+    assert_eq!(config.image_token_id, config.text.vocab_size);
+    assert_eq!(config.vision.dim_embed, vec![128, 256, 512, 1024]);
+}


### PR DESCRIPTION
## Summary

Joins the DaViT vision tower (#1063) to the BART seq2seq engine (#1060) into `Florence2Model`, the assembled Florence-2 vision-language model, and completes weight loading for the whole checkpoint. Florence-2 concatenates rather than scattering: the tower output is pooled into a short feature sequence, projected into the text embedding space, and placed in front of the task-prompt embeddings to form the encoder input, with no image placeholder token in the prompt at all.

## What changed

- `src/models/florence2/fusion.rs` (new): `LearnedPositionEmbedding2D` (learned column half first, then row half, over a square feature grid) and `PositionalEmbeddingCosine1D` (the `visual_temporal_embed.pos_idx_to_embed` table, taken from the checkpoint when present and synthesized from the closed form otherwise), plus `additive_attention_mask`, which turns a 0/1 mask into the `[batch, 1, 1, seq]` additive form attention consumes.
- `src/models/florence2/checkpoint.rs` (new): `Florence2Config` (both halves plus `image_token_id`, defaulting to the text vocabulary size) and `sanitize`, which runs the DaViT conv channels-last remap over the whole weight map, drops the BART `final_logits_bias` buffer, and fills `model.shared.weight` from an `embed_tokens` copy for exports that materialize only the tied table.
- `src/models/florence2/model.rs` (new): `Florence2Model` with `encode_image` / `encode_image_features` (`_encode_image`: 2-D grid position embedding, temporal embedding, `image_feature_source` pooling, `image_projection` 1024 to 768, `image_proj_norm`), `embed_prompt`, `merge_input_ids_with_image_features`, `encode` / `encode_with_image_features` / `encode_fused`, `make_cache`, `decode`, and `generate_greedy`.
- `src/models/florence2/{encoder,layers}.rs`: the encoder and its blocks now take an optional additive attention mask, so the joint mask the fusion stage builds reaches the encoder's self-attention instead of being dropped. `encode_tokens` / `encode_embeds` pass `None`, leaving the text-only numerics unchanged; the new `Florence2TextModel::encode_embeds_with_mask` is what the fused path drives.
- `src/models/florence2/florence2_fusion_tests.rs` (new): 37 unit tests covering both positional embeddings, the additive mask, all three `sanitize` passes, config parsing, load-time validation, and the whole `pixels -> features -> concat -> encoder -> decoder logits` chain on a tiny synthetic model (one block-free DaViT stage plus a one-layer BART stack), so the integrated path is exercised without a checkpoint.
- `tests/florence2_fusion_parity.rs` (new): gated end-to-end parity against the mlx-vlm florence2 `Model` on `models/Florence-2-base-ft-bf16`, skipping cleanly when the checkpoint is absent.

## Precision and dtype handling

The fused path pins its activation dtype from the text stack and casts the projected image features to it, and casts pixel input to the vision tower's own dtype, so a checkpoint whose two halves land on different dense dtypes does not silently promote the fused sequence to f32. Weight loading applies the usual Apple Silicon policy of promoting bf16 to f16.

Quantized Florence-2 checkpoints are rejected at load with a named error rather than half-loaded. Neither half of this family has a quantized code path: the BART text stack and the DaViT tower are both built from dense `Linear` / `Embedding`, so a packed uint32 weight would reach MLX and abort the process instead of surfacing as an error. The check runs right after config parsing, before any weight file is read.

## Deviations and findings

- **Upstream `image_feature_source` order is wrong for real checkpoints.** mlx-vlm's `ModelConfig` reads `image_feature_source`, `image_pos_embed`, and `visual_temporal_embedding` from the *top level* of `config.json`, but every real Florence-2 checkpoint stores them inside `vision_config`. Upstream therefore falls back to its dataclass defaults, and its `image_feature_source` default is `["temporal_avg_pool", "spatial_avg_pool"]`, the reverse of the checkpoint's `["spatial_avg_pool", "temporal_avg_pool"]`. That would put the pooled token at the end of the 577-token feature sequence instead of the front. mlxcel reads the config (as the HuggingFace Florence-2 implementation does) and refuses to guess when the field is absent; the parity run passes the checkpoint's own values to the reference so both sides execute the same recipe. A unit test pins the ordering behavior.
- **The temporal embedding is not a no-op for still images.** With one frame it contributes row 0 of the cosine table, which is `sin(0), cos(0), ...` = `0, 1, 0, 1, ...`, not the zero vector. Skipping it would shift every odd channel by 1.0 before projection. Pinned by a unit test.
- **`image_projection` is a bare tensor, not a `Linear`.** Upstream registers it as a raw `[in, out]` parameter applied as a right-hand matmul, so it is loaded and applied without a transpose or bias.
- The issue text says `projection_dim: 768` is the fusion-stage width and the backbone emits `dim_embed[-1]`; the checkpoint config confirms both (1024 to 768). No correction needed there.
- The joint attention mask reaches the encoder's self-attention only. Decoder cross-attention still passes no mask, matching the fact that this path drives a single image and a single prompt with no padding; a genuinely padded batch would need the mask threaded through cross-attention as well, which is not implemented here. The doc comment on `merge_input_ids_with_image_features` states this.
- **The all-ones mask is skipped rather than applied.** `merge_input_ids_with_image_features` builds the mask the acceptance criteria ask for, but it is all ones by construction, and converting it would add a provably all-zero `[batch, 1, 1, seq]` tensor into every encoder layer's `[batch, heads, seq, seq]` logits (roughly 24M elementwise f16 adds per 585-token encode across 6 layers, all computing an identity). The general entry point is `encode_fused(inputs_embeds, attention_mask)`, which converts a caller-supplied mask; `encode_with_image_features` passes `None`. That removes provably redundant arithmetic rather than trading accuracy for speed, so no wall-clock figure is claimed and none was measured. `encoder_mask_is_identity_when_all_ones_and_load_bearing_otherwise` pins both directions: all-ones must equal `None`, and zeroing a position must change the output.
- **Untrusted `config.json` integers are range-checked before they reach MLX.** MLX throws C++ exceptions that cannot cross the `cxx` bridge, so an out-of-range shape aborts the process instead of returning `Err`. `max_temporal_embeddings` is bounded (it drives an eager host allocation on the synthesis fallback), the loaded `embed_positions` table is checked to actually cover `max_position_embeddings` on both encoder and decoder, and `Florence2TextConfig` now rejects non-positive `d_model` / head counts / layer counts and out-of-vocabulary `pad_token_id` / `decoder_start_token_id`. `additive_attention_mask` returns `Result` instead of indexing an unchecked rank.
- Runtime registration (`src/models/detection.rs`, `src/model_metadata.rs`, `docs/supported-models.md`, the `generate` / `generate_vlm` wiring, `mlxcel list`) is deliberately untouched: that is #856's scope.

## Test plan

- [x] `cargo test --profile test-fast --features metal,accelerate --lib models::florence2::`: 51 passed. 37 in the new `florence2_fusion_tests.rs`, and 14 in `florence2_tests.rs` (7 pre-existing text-engine tests still green after the encoder mask change, plus 7 new config-validation tests).
- [x] `cargo test --profile test-fast --features metal,accelerate --test florence2_fusion_parity`: 2 passed against the real `models/Florence-2-base-ft-bf16` checkpoint. Worst deviations vs the mlx-vlm reference: 2.2e-3 on image features (absmax 8.6), 1.5e-2 on encoder hidden states (absmax 45.8), 6.6e-3 on first-step logits (absmax 21.2). Mean and standard deviation agree to 1e-4 or better on all three, and the greedy token ids match exactly (`[0, 879, 27740, 868]`, decoding to `<s>unanswerable`, the sensible caption for a procedurally generated noise field).
- [x] `cargo test --profile test-fast --features metal,accelerate --test florence2_text_parity --test florence2_vision_parity`: 3 passed, confirming the #852 and #853 pins are unmoved.
- [x] `cargo clippy --profile test-fast --features metal,accelerate --lib --tests -- -D warnings`: clean.
- [x] `cargo fmt --check`: clean.
- [x] `python3 scripts/ci/check_cross_repo_refs.py`: OK.

Closes #854


