### PR TITLE
chore(ci): bump the pinned Rust toolchain to 1.97.1

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -107,7 +107,7 @@ jobs:
       # track `rust-toolchain.toml`'s `channel` rather than be bumped on its own.
       # Dependabot reads the tag as an ordinary version and will try to raise it;
       # `.github/dependabot.yml` ignores this action for that reason.
-      - uses: dtolnay/rust-toolchain@1.93.1
+      - uses: dtolnay/rust-toolchain@1.97.1
         with:
           components: rustfmt
       - run: cargo fmt --all -- --check
@@ -187,7 +187,7 @@ jobs:
       # parser resolves to the identical commit for that same input: the two
       # unit-test files below each cover one parser in isolation and cannot
       # catch a same-input value mismatch on their own.
-      - uses: dtolnay/rust-toolchain@1.93.1
+      - uses: dtolnay/rust-toolchain@1.97.1
       - name: Run the Rust pin parser's unit and cross-parser tests
         run: cargo test -p mlxcel-mlx-pin
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## [Unreleased]
+
+### Changed
+
+- The pinned Rust toolchain moves from 1.93.1 (2026-02-11) to 1.97.1 (2026-07-14), and the `dtolnay/rust-toolchain` tag in `ci.yml` tracks it as the comment there requires. The workflows that install `@stable` are unaffected and were never building at a different version: that action runs `rustup default` and never exports `RUSTUP_TOOLCHAIN`, so `rust-toolchain.toml` overrode it per directory and every cargo invocation in the tree already resolved to the pin. `cargo fmt` produces no diff at the new version, so the bump reformats nothing, but six new clippy lints fire under `-D warnings` and are fixed here: `question_mark` in `memory_estimate.rs` and `sanitize.rs`, `collapsible_match` in `chat_request.rs`, `for_kv_map` and `unnecessary_cast` in two test modules, and `unneeded_wildcard_pattern` in `pipeline_remote_real_models.rs`. All six are mechanical and behavior-preserving.
+
 ## [v0.5.0-beta.1] - 2026-08-06
 
 ### Added

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -132,7 +132,7 @@ Detailed setup instructions are in [`docs/installation.md`](docs/installation.md
 
 Minimum:
 
-- Rust **1.93+** (project uses edition 2024)
+- Rust **1.97+** (project uses edition 2024)
 - macOS: Apple Silicon Mac on macOS Sonoma+; Xcode Command Line Tools
 - Linux: CUDA 13+ toolchain, OpenBLAS, LAPACK (see [`docs/installation.md`](docs/installation.md) for the package list)
 

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -7,5 +7,5 @@
 # letting `stable` float. Keep this version identical in mlxcel and the
 # internal development repo.
 [toolchain]
-channel = "1.93.1"
+channel = "1.97.1"
 components = ["rustfmt", "clippy"]

--- a/src/distributed/disaggregated/request_router_tests.rs
+++ b/src/distributed/disaggregated/request_router_tests.rs
@@ -650,7 +650,7 @@ fn handle_node_failure_distributes_rerouted_requests() {
     // Force all requests onto prefill-0 for the test.
     {
         let mut requests = router.requests.write().unwrap();
-        for (_, tracked) in requests.iter_mut() {
+        for tracked in requests.values_mut() {
             tracked.phase = RequestPhase::Prefilling {
                 node_id: "prefill-0".to_string(),
             };

--- a/src/execution/memory_estimate.rs
+++ b/src/execution/memory_estimate.rs
@@ -732,11 +732,9 @@ pub fn kv_cache_params_from_path(
     let explicit_head_dim = config_fields::get_u64(text_cfg, config_fields::HEAD_DIM_KEYS);
     let head_dim = if let Some(head_dim) = explicit_head_dim {
         head_dim
-    } else if let Some(hidden_size) = hidden_size {
-        // 64 is the historical fallback for malformed configs with zero heads.
-        hidden_size.checked_div(num_heads).unwrap_or(64)
     } else {
-        return None;
+        // 64 is the historical fallback for malformed configs with zero heads.
+        hidden_size?.checked_div(num_heads).unwrap_or(64)
     };
 
     Some(KvCacheParams {

--- a/src/models/dbrx_tests.rs
+++ b/src/models/dbrx_tests.rs
@@ -314,9 +314,7 @@ fn clip_qkv_actually_clamps_the_projection() {
     assert_eq!(unclipped.clip_qkv, None);
 
     // Large inputs push the fused projection well past +/-8.
-    let big: Vec<f32> = (0..(args.d_model as usize))
-        .map(|i| 40.0 + i as f32)
-        .collect();
+    let big: Vec<f32> = (0..args.d_model).map(|i| 40.0 + i as f32).collect();
     let x = mlxcel_core::from_slice_f32(&big, &[1, 1, args.d_model as i32]);
 
     let mut cache_a = KVCache::new();

--- a/src/models/sanitize.rs
+++ b/src/models/sanitize.rs
@@ -329,10 +329,11 @@ fn normalize_nvfp4_keys(weights: &mut mlxcel_core::weights::WeightMap) {
                 format!("vision_tower.{rest}")
             } else if let Some(rest) = k.strip_prefix("model.embed_vision.") {
                 format!("embed_vision.{rest}")
-            } else if let Some(rest) = k.strip_prefix("model.lm_head.") {
-                format!("lm_head.{rest}")
             } else {
-                return None; // No remapping needed
+                // Anything that is not one of these prefixes needs no remapping,
+                // and `?` drops it from the collected set.
+                let rest = k.strip_prefix("model.lm_head.")?;
+                format!("lm_head.{rest}")
             };
             Some((k.clone(), new_key))
         })

--- a/src/server/chat_request.rs
+++ b/src/server/chat_request.rs
@@ -286,16 +286,16 @@ fn validate_no_reserved_media_sentinels(request: &ChatCompletionRequest) -> Resu
             {
                 anyhow::bail!("message text contains a reserved ordered-media sentinel");
             }
-            MessageContent::Parts(parts) => {
+            MessageContent::Parts(parts)
                 if parts.iter().any(|part| {
                     matches!(
                         part,
                         ContentPart::Text { text }
                             if text.contains(super::types::request::ORDERED_MEDIA_PREFIX)
                     )
-                }) {
-                    anyhow::bail!("message text contains a reserved ordered-media sentinel");
-                }
+                }) =>
+            {
+                anyhow::bail!("message text contains a reserved ordered-media sentinel");
             }
             _ => {}
         }

--- a/tests/pipeline_remote_real_models.rs
+++ b/tests/pipeline_remote_real_models.rs
@@ -183,11 +183,7 @@ fn pipeline_remote_runtime_llama_real_model_parity_and_cleanup() {
     let active_states = runtime.probe_stages().unwrap();
     assert!(active_states.iter().all(|state| matches!(
         state,
-        RemoteStageResponse::State {
-            state,
-            pending_entry_replies: _,
-            ..
-        } if state.in_flight_requests == 1
+        RemoteStageResponse::State { state, .. } if state.in_flight_requests == 1
     )));
 
     let atol = 1e-4f64;


### PR DESCRIPTION
## Summary

The pin sat at 1.93.1 (2026-02-11), four releases behind stable 1.97.1 (2026-07-14). This bumps `rust-toolchain.toml` and moves the `dtolnay/rust-toolchain` tag in `ci.yml` with it, as the comment on that step requires.

## The `@stable` workflows were never on a different version

`release.yml`, `nightly-verify.yml` and `pipeline-parallel-ci.yml` install `dtolnay/rust-toolchain@stable`, which looks like it would build at a newer compiler than the pin. It does not. That action runs `rustup default <toolchain>` and never exports `RUSTUP_TOOLCHAIN`, and `rust-toolchain.toml` overrides `rustup default` per directory, so every cargo invocation in the tree already resolved to the pin. Reproduced locally: with the default toolchain set to `stable`, `rustc --version` reports 1.93.1 inside the repository and 1.97.1 outside it. `nightly-verify.yml` documents this deliberately at lines 271-275, so those three workflows are left alone.

## What changed

| File | Change |
|------|--------|
| `rust-toolchain.toml` | `channel` 1.93.1 to 1.97.1 |
| `.github/workflows/ci.yml` | `dtolnay/rust-toolchain` tag, two occurrences |
| `CONTRIBUTING.md` | stated minimum 1.93+ to 1.97+ |
| `CHANGELOG.md` | `[Unreleased]` entry |

`cargo fmt` produces no diff at 1.97.1, so the bump reformats nothing. Six new clippy lints fire under `-D warnings` and are fixed here, all mechanical and behavior-preserving:

| Lint | Site |
|------|------|
| `question_mark` | `src/execution/memory_estimate.rs`, `src/models/sanitize.rs` |
| `collapsible_match` | `src/server/chat_request.rs` |
| `for_kv_map` | `src/distributed/disaggregated/request_router_tests.rs` |
| `unnecessary_cast` | `src/models/dbrx_tests.rs` |
| `unneeded_wildcard_pattern` | `tests/pipeline_remote_real_models.rs` |

The `collapsible_match` fix is the only one that changes control-flow shape: the nested `if` inside the `MessageContent::Parts` arm becomes a match guard. When the guard does not hold the arm now falls to `_ => {}`, which is what the empty `if` did before, so behavior is identical.

## Validation

Run on Apple M5 Max, macOS 26.6, under 1.97.1:

| Gate | Result |
|------|--------|
| `make verify-versions` | pass |
| `make verify-kernel-dtype-keys` | pass, 13 files |
| `make verify-fmt` | pass |
| `make verify-clippy` (`--workspace --all-targets --features metal,accelerate -- -D warnings`) | pass |
| `make verify-test` (`--workspace --profile test-fast`) | 2264 passed, 5 failed, 177 ignored |

Clippy covers all five workspace members. `mlxcel-core` and `mlxcel-xla` compile rather than check because of their build scripts, but the lint driver runs on them and they are green.

### The five test failures are pre-existing and unrelated

They are not caused by this bump. Every one of them reproduces on `main` at 1.93.1 with byte-identical values:

| Test | main @ 1.93.1 | this branch @ 1.97.1 |
|------|---------------|----------------------|
| `layers::tests::chunked_causal_attention_matches_fast_causal` | FAILED | same |
| `layers::tests::chunked_query_attention_matches_unchunked_with_mask` | FAILED | same |
| `mla::decode::decode_tests::absorbed_attention_respects_an_additive_causal_mask` | FAILED, `drifted by 0.0014691837` | same value |
| `mla::decode::decode_tests::expand_latent_reproduces_the_up_projection` | FAILED, `0.30357933044433594 != 0.3037950135765861` | same values |
| `mllama_parity::sub_max_real_tiles_keep_the_legacy_real_rows_byte_identical` | FAILED, `5.9604645e-8` | same value |

All five are host dependent: they pass on the M1 Ultra nightly runner (last successful `nightly-verify.yml` run 30939291504 reports `... ok` for all five) and fail deterministically on M5 Max.

The first four are tracked in #1065: f32 matmul and single-query SDPA lose about fp16 precision on M5. The fifth is a byte-identity assertion whose observed difference is 0.5 ULP of the output scale, the same class as #939, and is fixed separately following the precedent of #953.

The test delta introduced by this PR is zero.