### PR TITLE
feat(models): Florence-2 processor, task prompts, and location tokens

### DIFF
--- a/src/models/florence2/checkpoint.rs
+++ b/src/models/florence2/checkpoint.rs
@@ -22,14 +22,14 @@
 //! Reference:
 //! https://github.com/Blaizzy/mlx-vlm/blob/main/mlx_vlm/models/florence2/florence2.py
 
-use anyhow::Result;
+use anyhow::{Result, anyhow};
 use serde_json::Value;
 
 use mlxcel_core::weights::WeightMap;
 
 use crate::vision::encoders::florence2_davit;
 
-use super::{Florence2TextConfig, Florence2VisionConfig};
+use super::Florence2VisionConfig;
 
 /// Weight-key prefix of the language model inside a Florence-2 checkpoint.
 pub(crate) const FLORENCE2_TEXT_PREFIX: &str = "language_model.";
@@ -106,4 +106,166 @@ pub fn sanitize(weights: WeightMap) -> WeightMap {
         }
     }
     out
+}
+
+/// Upper bound accepted for `encoder_layers` / `decoder_layers`. Real
+/// Florence-2 exports ship 6 (base) or 12 (large). The cap exists because
+/// [`encoder::Florence2Encoder::from_weights`] and
+/// [`decoder::Florence2Decoder::from_weights`] size a `Vec` from this field
+/// before they look up a single weight, so a negative value out of a hostile
+/// `config.json` becomes `usize::MAX` and aborts with a capacity overflow.
+const MAX_LAYERS: i32 = 256;
+
+/// Upper bound accepted for `max_position_embeddings`. Florence-2 ships 1024.
+///
+/// The field bounds two separate allocations: the position-table slice the
+/// encoder and decoder take (validated against the loaded table at load time)
+/// and the O(n^2) host buffer [`layers::additive_causal_mask`] fills for a
+/// multi-token decoder call. An unbounded value out of a hostile `config.json`
+/// is an out-of-memory abort rather than an error return.
+const MAX_POSITION_EMBEDDINGS: i32 = 65_536;
+
+/// BART encoder-decoder shape parameters, parsed from the `text_config`
+/// object of a Florence-2 `config.json` (`model_type: florence2_language`).
+#[derive(Debug, Clone)]
+pub struct Florence2TextConfig {
+    pub d_model: i32,
+    pub encoder_layers: i32,
+    pub decoder_layers: i32,
+    pub encoder_attention_heads: i32,
+    pub decoder_attention_heads: i32,
+    pub encoder_ffn_dim: i32,
+    pub decoder_ffn_dim: i32,
+    pub vocab_size: i32,
+    pub max_position_embeddings: i32,
+    pub scale_embedding: bool,
+    pub pad_token_id: i32,
+    pub bos_token_id: i32,
+    pub eos_token_id: i32,
+    pub decoder_start_token_id: i32,
+}
+
+fn config_i32(config: &Value, key: &str) -> Option<i32> {
+    config.get(key).and_then(Value::as_i64).map(|v| v as i32)
+}
+
+impl Florence2TextConfig {
+    /// Parse from the `text_config` sub-object itself.
+    pub fn from_text_config(config: &Value) -> Result<Self> {
+        let require = |key: &str| -> Result<i32> {
+            config_i32(config, key)
+                .ok_or_else(|| anyhow!("Florence-2 text_config missing field: {key}"))
+        };
+        let d_model = require("d_model")?;
+        let parsed = Self {
+            d_model,
+            encoder_layers: require("encoder_layers")?,
+            decoder_layers: require("decoder_layers")?,
+            encoder_attention_heads: require("encoder_attention_heads")?,
+            decoder_attention_heads: require("decoder_attention_heads")?,
+            encoder_ffn_dim: config_i32(config, "encoder_ffn_dim").unwrap_or(4 * d_model),
+            decoder_ffn_dim: config_i32(config, "decoder_ffn_dim").unwrap_or(4 * d_model),
+            vocab_size: require("vocab_size")?,
+            max_position_embeddings: config_i32(config, "max_position_embeddings").unwrap_or(1024),
+            scale_embedding: config
+                .get("scale_embedding")
+                .and_then(Value::as_bool)
+                .unwrap_or(false),
+            pad_token_id: config_i32(config, "pad_token_id").unwrap_or(1),
+            bos_token_id: config_i32(config, "bos_token_id").unwrap_or(0),
+            eos_token_id: config_i32(config, "eos_token_id").unwrap_or(2),
+            decoder_start_token_id: config_i32(config, "decoder_start_token_id").unwrap_or(2),
+        };
+        // Every field below becomes a shape, an index, a divisor, or a `Vec`
+        // capacity somewhere downstream. MLX throws on an out-of-range shape
+        // and the throw crosses an FFI boundary that cannot carry it, so a bad
+        // value aborts the process rather than surfacing as an error; these
+        // checks are what keep an untrusted `config.json` from getting that
+        // far. They also have to run *before* the divisibility check below,
+        // which would itself divide by zero on `encoder_attention_heads: 0`.
+        if parsed.d_model < 1 {
+            return Err(anyhow!(
+                "Florence-2 text_config d_model must be positive, got {}",
+                parsed.d_model
+            ));
+        }
+        if parsed.encoder_attention_heads < 1 || parsed.decoder_attention_heads < 1 {
+            return Err(anyhow!(
+                "Florence-2 text_config attention heads must be positive, got {} enc / {} dec",
+                parsed.encoder_attention_heads,
+                parsed.decoder_attention_heads
+            ));
+        }
+        if !(1..=MAX_LAYERS).contains(&parsed.encoder_layers)
+            || !(1..=MAX_LAYERS).contains(&parsed.decoder_layers)
+        {
+            return Err(anyhow!(
+                "Florence-2 text_config layer counts {} enc / {} dec outside 1..={MAX_LAYERS}",
+                parsed.encoder_layers,
+                parsed.decoder_layers
+            ));
+        }
+        if parsed.encoder_ffn_dim < 1 || parsed.decoder_ffn_dim < 1 {
+            return Err(anyhow!(
+                "Florence-2 text_config ffn dims must be positive, got {} enc / {} dec",
+                parsed.encoder_ffn_dim,
+                parsed.decoder_ffn_dim
+            ));
+        }
+        if parsed.vocab_size < 1 {
+            return Err(anyhow!(
+                "Florence-2 text_config vocab_size must be positive, got {}",
+                parsed.vocab_size
+            ));
+        }
+        if !(1..=MAX_POSITION_EMBEDDINGS).contains(&parsed.max_position_embeddings) {
+            return Err(anyhow!(
+                "Florence-2 text_config max_position_embeddings {} outside 1..={MAX_POSITION_EMBEDDINGS}",
+                parsed.max_position_embeddings
+            ));
+        }
+        // Both of these reach the shared embedding gather as literal token ids
+        // (`generate_greedy` seeds the decoder with `decoder_start_token_id`,
+        // `shift_tokens_right` substitutes `pad_token_id`), so an
+        // out-of-vocabulary or negative value is an out-of-range gather.
+        // `bos_token_id` and `eos_token_id` are deliberately left unchecked:
+        // they are only ever compared, never used as an index, and some
+        // exports legitimately carry sentinel values there.
+        if !(0..parsed.vocab_size).contains(&parsed.pad_token_id) {
+            return Err(anyhow!(
+                "Florence-2 text_config pad_token_id {} outside 0..vocab_size {}",
+                parsed.pad_token_id,
+                parsed.vocab_size
+            ));
+        }
+        if !(0..parsed.vocab_size).contains(&parsed.decoder_start_token_id) {
+            return Err(anyhow!(
+                "Florence-2 text_config decoder_start_token_id {} outside 0..vocab_size {}",
+                parsed.decoder_start_token_id,
+                parsed.vocab_size
+            ));
+        }
+        if parsed.d_model % parsed.encoder_attention_heads != 0
+            || parsed.d_model % parsed.decoder_attention_heads != 0
+        {
+            return Err(anyhow!(
+                "Florence-2 d_model {} not divisible by attention heads ({} enc / {} dec)",
+                parsed.d_model,
+                parsed.encoder_attention_heads,
+                parsed.decoder_attention_heads
+            ));
+        }
+        Ok(parsed)
+    }
+
+    /// Parse from a full Florence-2 `config.json` (`model_type: florence2`),
+    /// descending into its `text_config` sub-object. A bare text config (no
+    /// `text_config` key) is also accepted so the sub-object can be passed
+    /// directly.
+    pub fn from_model_config(config: &Value) -> Result<Self> {
+        match config.get("text_config") {
+            Some(text) => Self::from_text_config(text),
+            None => Self::from_text_config(config),
+        }
+    }
 }

--- a/src/models/florence2/checkpoint.rs
+++ b/src/models/florence2/checkpoint.rs
@@ -110,19 +110,20 @@ pub fn sanitize(weights: WeightMap) -> WeightMap {
 
 /// Upper bound accepted for `encoder_layers` / `decoder_layers`. Real
 /// Florence-2 exports ship 6 (base) or 12 (large). The cap exists because
-/// [`encoder::Florence2Encoder::from_weights`] and
-/// [`decoder::Florence2Decoder::from_weights`] size a `Vec` from this field
-/// before they look up a single weight, so a negative value out of a hostile
-/// `config.json` becomes `usize::MAX` and aborts with a capacity overflow.
+/// [`super::encoder::Florence2Encoder::from_weights`] and
+/// [`super::decoder::Florence2Decoder::from_weights`] size a `Vec` from this
+/// field before they look up a single weight, so a negative value out of a
+/// hostile `config.json` becomes `usize::MAX` and aborts with a capacity
+/// overflow.
 const MAX_LAYERS: i32 = 256;
 
 /// Upper bound accepted for `max_position_embeddings`. Florence-2 ships 1024.
 ///
 /// The field bounds two separate allocations: the position-table slice the
 /// encoder and decoder take (validated against the loaded table at load time)
-/// and the O(n^2) host buffer [`layers::additive_causal_mask`] fills for a
-/// multi-token decoder call. An unbounded value out of a hostile `config.json`
-/// is an out-of-memory abort rather than an error return.
+/// and the O(n^2) host buffer [`super::layers::additive_causal_mask`] fills
+/// for a multi-token decoder call. An unbounded value out of a hostile
+/// `config.json` is an out-of-memory abort rather than an error return.
 const MAX_POSITION_EMBEDDINGS: i32 = 65_536;
 
 /// BART encoder-decoder shape parameters, parsed from the `text_config`

--- a/src/models/florence2/coords.rs
+++ b/src/models/florence2/coords.rs
@@ -1,0 +1,209 @@
+// Copyright 2025-2026 Lablup Inc. and Jeongkyu Shin
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Florence-2 location tokens and the bin-to-pixel dequantizers.
+//!
+//! Florence-2 encodes every spatial answer as `<loc_N>` tokens. The vocabulary
+//! holds exactly 1000 of them, `<loc_0>` .. `<loc_999>`, occupying a
+//! contiguous id range, and each one names a bin index on a 1000-bin axis
+//! normalized to the *original* image extent. Turning a bin back into a pixel
+//! coordinate therefore needs the pre-resize image size, which is why the
+//! processor keeps it alongside the pixel tensor.
+//!
+//! Two dequantizers exist upstream and they are not interchangeable:
+//! [`dequantize_box`] handles an `(xmin, ymin, xmax, ymax)` 4-tuple and
+//! [`dequantize_coordinates`] handles an `(x, y)` point run. They happen to
+//! carry the same 1000/1000 bin counts and `floor` mode in every shipped
+//! config, so their arithmetic coincides, but the reachable tasks route to
+//! them separately and a future config could split the bin counts.
+//!
+//! Reference:
+//! https://github.com/Blaizzy/mlx-vlm/blob/main/mlx_vlm/models/florence2/processing_florence2.py
+//! (`BoxQuantizer`, `CoordinatesQuantizer`).
+
+/// Number of bins on each axis. `NUM_BBOX_{WIDTH,HEIGHT}_BINS` and
+/// `COORDINATES_{WIDTH,HEIGHT}_BINS` are all 1000 in the shipped default
+/// config, and the tokenizer only carries 1000 `<loc_*>` tokens, so a
+/// different value could not be expressed anyway.
+pub(crate) const LOC_BINS: i32 = 1000;
+
+/// Vocabulary id of `<loc_0>` in the Florence-2 tokenizer. The 1000 location
+/// tokens are contiguous from here, so `<loc_N>` is `FLORENCE2_LOC_TOKEN_BASE
+/// + N`, pinned against the checkpoint by
+/// `florence2_loc_tokens_are_contiguous`.
+///
+/// Post-processing works on decoded *text* rather than ids and does not need
+/// this; it is here for callers that want to inspect or constrain the id
+/// range directly.
+pub const FLORENCE2_LOC_TOKEN_BASE: u32 = 50269;
+
+/// Vocabulary id of `<loc_n>`, or `None` when `n` is outside `0..1000`.
+pub fn florence2_loc_token_id(n: u32) -> Option<u32> {
+    (n < LOC_BINS as u32).then(|| FLORENCE2_LOC_TOKEN_BASE + n)
+}
+
+/// Size of the image a Florence-2 answer's coordinates are relative to, in
+/// pixels.
+///
+/// Named fields on purpose. Upstream's `post_process_generation` docstring
+/// says its `image_size` argument is "height x width" but every call site
+/// unpacks it as `image_width, image_height = image_size`, so the docstring is
+/// wrong and a bare tuple is a coin flip at the call site.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct Florence2ImageSize {
+    pub width: u32,
+    pub height: u32,
+}
+
+impl Florence2ImageSize {
+    pub fn new(width: u32, height: u32) -> Self {
+        Self { width, height }
+    }
+
+    /// Pixels per bin on each axis, `(width, height)`.
+    ///
+    /// The division is done in f64 and the result narrowed to f32 because
+    /// upstream computes `size_w / bins_w` in Python (f64) and then hands the
+    /// result to torch as a scalar against an f32 tensor. Doing the whole
+    /// chain in f32 would round the quotient twice.
+    fn size_per_bin(self) -> (f32, f32) {
+        (
+            (f64::from(self.width) / f64::from(LOC_BINS)) as f32,
+            (f64::from(self.height) / f64::from(LOC_BINS)) as f32,
+        )
+    }
+}
+
+/// An axis-aligned box in original-image pixels, left-top-right-bottom.
+///
+/// Deliberately not `crate::vision::detection::rt_detr_v2::Detection`: that
+/// type carries a confidence score and a `label: usize` class index into a
+/// fixed COCO-style label set, and Florence-2 produces neither. Its labels are
+/// open-vocabulary strings decoded from the answer, and the model emits no
+/// per-box score at all, so reusing `Detection` would mean two fabricated
+/// fields on every box.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct Florence2BoundingBox {
+    pub xmin: f32,
+    pub ymin: f32,
+    pub xmax: f32,
+    pub ymax: f32,
+}
+
+impl Florence2BoundingBox {
+    /// Flat `[xmin, ymin, xmax, ymax]`, the layout upstream returns.
+    pub fn to_array(self) -> [f32; 4] {
+        [self.xmin, self.ymin, self.xmax, self.ymax]
+    }
+
+    /// Bin indices for this box, the inverse of [`dequantize_box`].
+    ///
+    /// `floor(pixel / size_per_bin)` clamped into `0..1000`, per upstream's
+    /// `BoxQuantizer.quantize` in `floor` mode. Not needed to read an answer;
+    /// it exists to *write* one, see [`Self::to_region_prompt`].
+    pub fn quantize(self, size: Florence2ImageSize) -> [i32; 4] {
+        let (spb_w, spb_h) = size.size_per_bin();
+        let bin = |value: f32, per_bin: f32| -> i32 {
+            if per_bin <= 0.0 {
+                return 0;
+            }
+            (value / per_bin).floor().clamp(0.0, (LOC_BINS - 1) as f32) as i32
+        };
+        [
+            bin(self.xmin, spb_w),
+            bin(self.ymin, spb_h),
+            bin(self.xmax, spb_w),
+            bin(self.ymax, spb_h),
+        ]
+    }
+
+    /// This box as the `<loc_a><loc_b><loc_c><loc_d>` string the
+    /// region-input tasks expect, for example
+    /// `"<loc_52><loc_332><loc_932><loc_774>"`.
+    ///
+    /// `<REGION_TO_CATEGORY>`, `<REGION_TO_DESCRIPTION>`, `<REGION_TO_OCR>`
+    /// and `<REGION_TO_SEGMENTATION>` all interpolate a region in this form
+    /// into their prompt, and the location tokens are real vocabulary entries,
+    /// so the string tokenizes to four ids rather than being spelled out.
+    pub fn to_region_prompt(self, size: Florence2ImageSize) -> String {
+        self.quantize(size)
+            .iter()
+            .map(|bin| format!("<loc_{bin}>"))
+            .collect()
+    }
+}
+
+/// An OCR region: four corner points in original-image pixels, flattened
+/// `[x0, y0, x1, y1, x2, y2, x3, y3]`.
+///
+/// Quad rather than a box because `<OCR_WITH_REGION>` predicts a rotated
+/// quadrilateral around each text line, which a left-top-right-bottom box
+/// cannot represent.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct Florence2QuadBox {
+    pub points: [f32; 8],
+}
+
+/// A closed polygon outline in original-image pixels, flattened
+/// `[x0, y0, x1, y1, ...]`.
+///
+/// Flat rather than `Vec<(f32, f32)>` to match the upstream shape exactly:
+/// the segmentation tasks emit an odd-length location run often enough that
+/// the parser has an explicit rule for it (drop the unpaired trailing bin),
+/// and keeping the flat layout makes that rule the only place pairing is
+/// decided.
+#[derive(Debug, Clone, PartialEq)]
+pub struct Florence2Polygon {
+    pub points: Vec<f32>,
+}
+
+/// Bin 4-tuple `(xmin, ymin, xmax, ymax)` to pixels.
+///
+/// `(bin + 0.5) * size_per_bin` per axis: the `+ 0.5` takes the bin center
+/// rather than its left edge, which is what makes dequantize-of-quantize a
+/// half-bin-accurate round trip instead of a systematically biased one.
+///
+/// Arithmetic is f32 throughout, matching upstream: `torch.tensor(bins)` is an
+/// int64 tensor, and adding a Python float to it promotes to torch's default
+/// dtype, f32.
+pub(crate) fn dequantize_box(bins: [i32; 4], size: Florence2ImageSize) -> Florence2BoundingBox {
+    let (spb_w, spb_h) = size.size_per_bin();
+    Florence2BoundingBox {
+        xmin: (bins[0] as f32 + 0.5) * spb_w,
+        ymin: (bins[1] as f32 + 0.5) * spb_h,
+        xmax: (bins[2] as f32 + 0.5) * spb_w,
+        ymax: (bins[3] as f32 + 0.5) * spb_h,
+    }
+}
+
+/// Bin run to pixels, read as consecutive `(x, y)` pairs.
+///
+/// `bins` must have even length; the callers that can produce an odd run drop
+/// the unpaired trailing element first, mirroring upstream's
+/// `if len(_polygon) % 2 == 1: _polygon = _polygon[:-1]`.
+pub(crate) fn dequantize_coordinates(bins: &[i32], size: Florence2ImageSize) -> Vec<f32> {
+    let (spb_w, spb_h) = size.size_per_bin();
+    bins.chunks_exact(2)
+        .flat_map(|pair| {
+            [
+                (pair[0] as f32 + 0.5) * spb_w,
+                (pair[1] as f32 + 0.5) * spb_h,
+            ]
+        })
+        .collect()
+}
+
+#[cfg(test)]
+#[path = "florence2_coords_tests.rs"]
+mod florence2_coords_tests;

--- a/src/models/florence2/florence2_coords_tests.rs
+++ b/src/models/florence2/florence2_coords_tests.rs
@@ -1,0 +1,123 @@
+// Copyright 2025-2026 Lablup Inc. and Jeongkyu Shin
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Location-token arithmetic. No checkpoint needed; the expected values are
+//! computed by hand from `(bin + 0.5) * size / 1000`.
+
+use super::*;
+
+/// Ids pinned against `models/Florence-2-base-ft-bf16/added_tokens.json`:
+/// 1000 location tokens occupying 50269..=51268 with no gaps.
+#[test]
+fn florence2_loc_tokens_are_contiguous() {
+    assert_eq!(florence2_loc_token_id(0), Some(50269));
+    assert_eq!(florence2_loc_token_id(1), Some(50270));
+    assert_eq!(florence2_loc_token_id(999), Some(51268));
+    // 1000 bins exactly: `<loc_1000>` is not a token.
+    assert_eq!(florence2_loc_token_id(1000), None);
+    assert_eq!(florence2_loc_token_id(u32::MAX), None);
+    for n in 0..LOC_BINS as u32 {
+        assert_eq!(
+            florence2_loc_token_id(n),
+            Some(FLORENCE2_LOC_TOKEN_BASE + n)
+        );
+    }
+}
+
+#[test]
+fn dequantize_box_uses_bin_centers() {
+    // 1000x1000 image: one pixel per bin, so bin n is centered at n + 0.5.
+    let size = Florence2ImageSize::new(1000, 1000);
+    let bbox = dequantize_box([0, 10, 500, 999], size);
+    assert_eq!(bbox.to_array(), [0.5, 10.5, 500.5, 999.5]);
+}
+
+#[test]
+fn dequantize_box_scales_axes_independently() {
+    // A non-square image is the case a single shared scale would get wrong:
+    // x must scale by 640/1000 and y by 480/1000.
+    let size = Florence2ImageSize::new(640, 480);
+    let bbox = dequantize_box([100, 100, 900, 900], size);
+    assert!((bbox.xmin - 64.32).abs() < 1e-4, "got {}", bbox.xmin);
+    assert!((bbox.ymin - 48.24).abs() < 1e-4, "got {}", bbox.ymin);
+    assert!((bbox.xmax - 576.32).abs() < 1e-3, "got {}", bbox.xmax);
+    assert!((bbox.ymax - 432.24).abs() < 1e-3, "got {}", bbox.ymax);
+}
+
+#[test]
+fn dequantize_coordinates_alternates_x_and_y() {
+    let size = Florence2ImageSize::new(1000, 2000);
+    // (0, 0), (10, 10): x keeps the 1x scale, y doubles.
+    let out = dequantize_coordinates(&[0, 0, 10, 10], size);
+    assert_eq!(out, vec![0.5, 1.0, 10.5, 21.0]);
+}
+
+/// An odd-length run is the caller's problem, so the dequantizer simply drops
+/// the unpaired tail rather than inventing a partner for it.
+#[test]
+fn dequantize_coordinates_drops_unpaired_tail() {
+    let size = Florence2ImageSize::new(1000, 1000);
+    assert_eq!(dequantize_coordinates(&[0, 0, 4], size), vec![0.5, 0.5]);
+    assert!(dequantize_coordinates(&[], size).is_empty());
+}
+
+#[test]
+fn quantize_is_the_inverse_of_dequantize() {
+    let size = Florence2ImageSize::new(640, 480);
+    for bins in [[0, 0, 999, 999], [52, 332, 932, 774], [1, 2, 3, 4]] {
+        let bbox = dequantize_box(bins, size);
+        assert_eq!(
+            bbox.quantize(size),
+            bins,
+            "dequantize then quantize must return the original bins"
+        );
+    }
+}
+
+#[test]
+fn quantize_clamps_out_of_range_pixels() {
+    let size = Florence2ImageSize::new(100, 100);
+    // Negative and past-the-edge coordinates land on the end bins rather than
+    // producing a token id that does not exist.
+    let bbox = Florence2BoundingBox {
+        xmin: -50.0,
+        ymin: -1.0,
+        xmax: 1000.0,
+        ymax: 100.0,
+    };
+    assert_eq!(bbox.quantize(size), [0, 0, 999, 999]);
+}
+
+#[test]
+fn region_prompt_is_four_location_tokens() {
+    let size = Florence2ImageSize::new(1000, 1000);
+    let bbox = dequantize_box([52, 332, 932, 774], size);
+    assert_eq!(
+        bbox.to_region_prompt(size),
+        "<loc_52><loc_332><loc_932><loc_774>"
+    );
+}
+
+/// A degenerate size must not divide by zero on the way to a bin index.
+#[test]
+fn quantize_survives_a_zero_size() {
+    let size = Florence2ImageSize::new(0, 0);
+    let bbox = Florence2BoundingBox {
+        xmin: 1.0,
+        ymin: 2.0,
+        xmax: 3.0,
+        ymax: 4.0,
+    };
+    assert_eq!(bbox.quantize(size), [0, 0, 0, 0]);
+}

--- a/src/models/florence2/florence2_parse_tests.rs
+++ b/src/models/florence2/florence2_parse_tests.rs
@@ -1,0 +1,297 @@
+// Copyright 2025-2026 Lablup Inc. and Jeongkyu Shin
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Parser behavior against synthetic answers. No checkpoint required: these
+//! run on strings shaped like real Florence-2 output, so they cover the
+//! branches a single real image never would.
+
+use super::*;
+
+/// 1000x1000 makes bin n dequantize to n + 0.5, so expected coordinates stay
+/// readable and any axis mix-up still shows up in the ordering.
+fn unit_size() -> Florence2ImageSize {
+    Florence2ImageSize::new(1000, 1000)
+}
+
+fn locs(bins: &[i32]) -> String {
+    bins.iter().map(|b| format!("<loc_{b}>")).collect()
+}
+
+#[test]
+fn florence2_post_processing_patterns_compile() {
+    // The parsers degrade to "no instances" if a pattern fails to build, so
+    // this is the test that keeps that fallback unreachable.
+    assert!(CHUNK_WITH_PHRASE.is_some());
+    assert!(CHUNK_BARE.is_some());
+    assert!(CHUNK_POLY_WITH_PHRASE.is_some());
+    assert!(CHUNK_POLY_BARE.is_some());
+    assert!(OCR_RECORD.is_some());
+    assert!(POLY_INSTANCE.is_some());
+    assert!(POLY_RUN.is_some());
+}
+
+#[test]
+fn parse_boxes_reads_labelled_detections() {
+    let text = format!(
+        "<s>car{}person{}</s>",
+        locs(&[52, 332, 932, 774]),
+        locs(&[10, 20, 30, 40])
+    );
+    let instances = parse_boxes(&text, unit_size(), false);
+    assert_eq!(instances.len(), 2);
+    assert_eq!(instances[0].cat_name, "car");
+    assert_eq!(
+        instances[0].bbox.to_array(),
+        [52.5, 332.5, 932.5, 774.5],
+        "box must be dequantized from its own four bins"
+    );
+    assert_eq!(instances[1].cat_name, "person");
+    assert_eq!(instances[1].bbox.to_array(), [10.5, 20.5, 30.5, 40.5]);
+}
+
+/// A phrase carrying several boxes becomes one instance per box, all sharing
+/// the label. This is what makes `boxes` and `labels` index-aligned.
+#[test]
+fn parse_boxes_repeats_the_label_across_boxes() {
+    let text = format!("cat{}{}", locs(&[1, 2, 3, 4]), locs(&[5, 6, 7, 8]));
+    let instances = parse_boxes(&text, unit_size(), false);
+    assert_eq!(instances.len(), 2);
+    assert!(instances.iter().all(|i| i.cat_name == "cat"));
+    assert_eq!(instances[0].bbox.to_array(), [1.5, 2.5, 3.5, 4.5]);
+    assert_eq!(instances[1].bbox.to_array(), [5.5, 6.5, 7.5, 8.5]);
+}
+
+/// `<REGION_PROPOSAL>` answers carry no category names at all, so the chunker
+/// has to accept a bare location run.
+#[test]
+fn parse_boxes_allows_empty_phrases_for_region_proposal() {
+    let text = format!("<s>{}{}</s>", locs(&[1, 2, 3, 4]), locs(&[5, 6, 7, 8]));
+    let instances = parse_boxes(&text, unit_size(), true);
+    assert_eq!(instances.len(), 2);
+    assert!(instances.iter().all(|i| i.cat_name.is_empty()));
+    assert_eq!(instances[0].bbox.to_array(), [1.5, 2.5, 3.5, 4.5]);
+    assert_eq!(instances[1].bbox.to_array(), [5.5, 6.5, 7.5, 8.5]);
+}
+
+/// The same bare run read *without* the flag does not come back empty, and the
+/// reason is worth pinning: `[^<]+` can start one byte into `<loc_1>` and match
+/// the literal text `loc_1>`, leaving that as the label and consuming the first
+/// location token. So a bare run misparses into one box shifted by a token
+/// rather than into nothing.
+///
+/// This is upstream behavior, verified against the checkpoint's own
+/// `processing_florence2.py`, and it is exactly why `<REGION_PROPOSAL>` routes
+/// to the `allow_empty_phrase` parser instead of the default one.
+#[test]
+fn parse_boxes_misreads_a_bare_run_without_the_flag() {
+    let text = format!("<s>{}{}</s>", locs(&[1, 2, 3, 4]), locs(&[5, 6, 7, 8]));
+    let instances = parse_boxes(&text, unit_size(), false);
+    assert_eq!(instances.len(), 1);
+    assert_eq!(instances[0].cat_name, "loc_1>");
+    assert_eq!(instances[0].bbox.to_array(), [2.5, 3.5, 4.5, 5.5]);
+}
+
+/// Fewer than four location tokens is not a box, and a fifth trailing token
+/// does not create a second one.
+#[test]
+fn parse_boxes_ignores_short_runs() {
+    assert!(parse_boxes(&format!("car{}", locs(&[1, 2, 3])), unit_size(), false).is_empty());
+    let instances = parse_boxes(
+        &format!("car{}", locs(&[1, 2, 3, 4, 5])),
+        unit_size(),
+        false,
+    );
+    assert_eq!(instances.len(), 1);
+    assert_eq!(instances[0].bbox.to_array(), [1.5, 2.5, 3.5, 4.5]);
+}
+
+#[test]
+fn parse_boxes_drops_non_ascii_characters() {
+    // `encode('ascii', errors='ignore')` removes the character rather than
+    // replacing it, so "café" becomes "caf" and not "caf?".
+    let instances = parse_boxes(
+        &format!("caf\u{e9}{}", locs(&[1, 2, 3, 4])),
+        unit_size(),
+        false,
+    );
+    assert_eq!(instances.len(), 1);
+    assert_eq!(instances[0].cat_name, "caf");
+}
+
+#[test]
+fn parse_boxes_trims_surrounding_whitespace() {
+    let instances = parse_boxes(
+        &format!("  a dog  {}", locs(&[1, 2, 3, 4])),
+        unit_size(),
+        false,
+    );
+    assert_eq!(instances[0].cat_name, "a dog");
+}
+
+#[test]
+fn parse_ocr_reads_quadrilaterals() {
+    let text = format!(
+        "<s>HELLO{}WORLD{}",
+        locs(&[0; 8]),
+        locs(&[10, 20, 30, 40, 50, 60, 70, 80])
+    );
+    let instances = parse_ocr(&text, unit_size());
+    assert_eq!(instances.len(), 2);
+    assert_eq!(instances[0].text, "HELLO");
+    assert_eq!(instances[0].quad_box.points, [0.5; 8]);
+    assert_eq!(instances[1].text, "WORLD");
+    assert_eq!(
+        instances[1].quad_box.points,
+        [10.5, 20.5, 30.5, 40.5, 50.5, 60.5, 70.5, 80.5]
+    );
+}
+
+/// The quad's eight bins are (x, y) pairs, so a non-square image scales
+/// alternating entries by different factors. Getting this wrong is invisible
+/// on a square test image.
+#[test]
+fn parse_ocr_scales_x_and_y_separately() {
+    let text = format!("A{}", locs(&[0, 0, 999, 0, 999, 999, 0, 999]));
+    let instances = parse_ocr(&text, Florence2ImageSize::new(1000, 500));
+    assert_eq!(instances.len(), 1);
+    let p = instances[0].quad_box.points;
+    assert!((p[0] - 0.5).abs() < 1e-3, "x0 {}", p[0]);
+    assert!((p[1] - 0.25).abs() < 1e-3, "y0 {}", p[1]);
+    assert!((p[2] - 999.5).abs() < 1e-2, "x1 {}", p[2]);
+    assert!((p[5] - 499.75).abs() < 1e-2, "y2 {}", p[5]);
+}
+
+/// Exactly eight tokens make a record; seven is not an OCR line.
+#[test]
+fn parse_ocr_requires_eight_locations() {
+    assert!(parse_ocr(&format!("A{}", locs(&[0; 7])), unit_size()).is_empty());
+}
+
+#[test]
+fn parse_phrase_grounding_groups_boxes_per_phrase() {
+    let text = format!(
+        "<s>A green car{}{}parked next to a house{}</s>",
+        locs(&[1, 2, 3, 4]),
+        locs(&[5, 6, 7, 8]),
+        locs(&[9, 10, 11, 12])
+    );
+    let instances = parse_phrase_grounding(&text, unit_size());
+    assert_eq!(instances.len(), 2);
+    assert_eq!(instances[0].cat_name, "A green car");
+    assert_eq!(instances[0].boxes.len(), 2, "both boxes stay on one phrase");
+    assert_eq!(instances[1].cat_name, "parked next to a house");
+    assert_eq!(instances[1].boxes.len(), 1);
+}
+
+/// `FILTER_BY_BLACK_LIST` is true in the shipped config, so stopword phrases
+/// really are dropped rather than returned with empty labels.
+#[test]
+fn parse_phrase_grounding_drops_blacklisted_phrases() {
+    let text = format!(
+        "the image{}a truck{}",
+        locs(&[1, 2, 3, 4]),
+        locs(&[5, 6, 7, 8])
+    );
+    let instances = parse_phrase_grounding(&text, unit_size());
+    assert_eq!(instances.len(), 1);
+    assert_eq!(instances[0].cat_name, "a truck");
+
+    // Case sensitive, matching the Python `in` test against a set of
+    // lowercase strings plus the bare "I".
+    let cased = format!("The Image{}", locs(&[1, 2, 3, 4]));
+    assert_eq!(parse_phrase_grounding(&cased, unit_size()).len(), 1);
+}
+
+#[test]
+fn parse_polygons_reads_a_single_outline() {
+    let text = format!("<s>{}</s>", locs(&[1, 2, 3, 4, 5, 6]));
+    let instances = parse_polygons(&text, unit_size(), true);
+    assert_eq!(instances.len(), 1);
+    assert_eq!(instances[0].cat_name, "");
+    assert_eq!(instances[0].polygons.len(), 1);
+    assert_eq!(
+        instances[0].polygons[0].points,
+        vec![1.5, 2.5, 3.5, 4.5, 5.5, 6.5]
+    );
+}
+
+/// `<sep>` splits one instance into several outlines, which is how a
+/// disconnected object is expressed.
+#[test]
+fn parse_polygons_splits_outlines_on_sep() {
+    let text = format!("{}<sep>{}", locs(&[1, 2, 3, 4]), locs(&[5, 6, 7, 8]));
+    let instances = parse_polygons(&text, unit_size(), true);
+    assert_eq!(instances.len(), 1);
+    assert_eq!(instances[0].polygons.len(), 2);
+    assert_eq!(instances[0].polygons[0].points, vec![1.5, 2.5, 3.5, 4.5]);
+    assert_eq!(instances[0].polygons[1].points, vec![5.5, 6.5, 7.5, 8.5]);
+}
+
+/// `<poly>` ... `</poly>` delimits separate instances inside one chunk.
+#[test]
+fn parse_polygons_splits_instances_on_poly_markers() {
+    let text = format!(
+        "car<poly>{}</poly><poly>{}</poly>",
+        locs(&[1, 2, 3, 4]),
+        locs(&[5, 6, 7, 8])
+    );
+    let instances = parse_polygons(&text, unit_size(), false);
+    assert_eq!(instances.len(), 2);
+    assert!(instances.iter().all(|i| i.cat_name == "car"));
+    assert_eq!(instances[0].polygons[0].points, vec![1.5, 2.5, 3.5, 4.5]);
+    assert_eq!(instances[1].polygons[0].points, vec![5.5, 6.5, 7.5, 8.5]);
+}
+
+/// An outline is a flat (x, y) run, so an odd token count loses its tail
+/// instead of pairing a coordinate with nothing.
+#[test]
+fn parse_polygons_drops_an_unpaired_trailing_bin() {
+    let text = locs(&[1, 2, 3, 4, 5]);
+    let instances = parse_polygons(&text, unit_size(), true);
+    assert_eq!(instances.len(), 1);
+    assert_eq!(instances[0].polygons[0].points, vec![1.5, 2.5, 3.5, 4.5]);
+}
+
+/// The polygon phrase scan stops at `<poly>` as well as `<loc_`, unlike the
+/// box scan. Without that extra stop the label would swallow the marker.
+#[test]
+fn parse_polygons_stops_the_phrase_at_the_poly_marker() {
+    let text = format!("a wheel<poly>{}</poly>", locs(&[1, 2, 3, 4]));
+    let instances = parse_polygons(&text, unit_size(), false);
+    assert_eq!(instances.len(), 1);
+    assert_eq!(instances[0].cat_name, "a wheel");
+}
+
+#[test]
+fn multibyte_phrases_do_not_split_a_character() {
+    // A UTF-8 phrase must not be sliced mid-character on the way to the
+    // ASCII filter.
+    let text = format!("\u{d55c}\u{ae00}car{}", locs(&[1, 2, 3, 4]));
+    let instances = parse_boxes(&text, unit_size(), false);
+    assert_eq!(instances.len(), 1);
+    assert_eq!(instances[0].cat_name, "car");
+}
+
+#[test]
+fn empty_and_marker_only_answers_produce_nothing() {
+    for text in ["", "<s></s>", "<s><pad></s>", "just a caption"] {
+        assert!(parse_boxes(text, unit_size(), false).is_empty(), "{text}");
+        assert!(parse_ocr(text, unit_size()).is_empty(), "{text}");
+        assert!(parse_polygons(text, unit_size(), true).is_empty(), "{text}");
+        assert!(
+            parse_phrase_grounding(text, unit_size()).is_empty(),
+            "{text}"
+        );
+    }
+}

--- a/src/models/florence2/florence2_parse_tests.rs
+++ b/src/models/florence2/florence2_parse_tests.rs
@@ -295,3 +295,67 @@ fn empty_and_marker_only_answers_produce_nothing() {
         );
     }
 }
+
+/// Every parser runs over decoder output, which in a served deployment is
+/// attacker influenced through the image and the task input, so malformed and
+/// non-ASCII answers have to come back as "no instances" rather than as a
+/// process-killing panic.
+///
+/// The scanners in [`super::scan`] walk byte offsets rather than characters,
+/// so the cases below place multi-byte characters against every boundary those
+/// scanners take a slice at: the leading-whitespace cut, the stop-marker
+/// lookahead, the `<loc_` digit run, and the bare `loc_N>` prefix strip. The
+/// malformed-token cases pin the scanner's advance rule, which is what keeps
+/// [`super::scan::location_bins`] from looping on input it cannot consume.
+#[test]
+fn adversarial_answers_do_not_panic() {
+    let wide_digits = format!("<loc_{}>", "9".repeat(64));
+    let deep_prefix = "<loc_".repeat(512);
+    let long_run = locs(&[7i32; 4096]);
+    let cases: Vec<String> = vec![
+        // Multi-byte characters against each slicing boundary.
+        format!("\u{a0}\u{d55c}car{}", locs(&[1, 2, 3, 4])),
+        format!("\u{1f600}{}", locs(&[1, 2, 3, 4])),
+        format!("car\u{1f600}{}", locs(&[1, 2, 3, 4])),
+        format!("{}\u{1f600}", locs(&[1, 2, 3, 4])),
+        format!("<poly>\u{d55c}{}</poly>", locs(&[1, 2, 3, 4])),
+        format!("a\u{1f600}<sep>{}", locs(&[1, 2, 3, 4])),
+        "loc_\u{1f600}>car".to_string(),
+        format!("loc_12>\u{d55c}{}", locs(&[1, 2, 3, 4])),
+        // Malformed location tokens: no digits, no terminator, nested opens.
+        format!("car<loc_>{}", locs(&[1, 2, 3])),
+        format!("car<loc_12{}", locs(&[1, 2, 3])),
+        deep_prefix.clone(),
+        format!("car{deep_prefix}{}", locs(&[1, 2, 3, 4])),
+        // A digit run far wider than i32, which saturates rather than
+        // realigning the four-at-a-time grouping.
+        format!("car{}{}", wide_digits.repeat(4), locs(&[1, 2, 3, 4])),
+        // Unbalanced polygon and separator markers.
+        format!("car<poly>{}", locs(&[1, 2, 3, 4])),
+        format!("car</poly>{}<sep>", locs(&[1, 2, 3, 4])),
+        format!("car<sep><sep><sep>{}", locs(&[1, 2, 3, 4])),
+        // Sequence markers wedged between a phrase and its coordinates.
+        format!("car<s></s><pad>{}", locs(&[1, 2, 3, 4])),
+        // Newline before the first stop position, which drops the chunk.
+        format!("car\n{}", locs(&[1, 2, 3, 4])),
+        // Whitespace-only and marker-only phrases.
+        format!("   {}", locs(&[1, 2, 3, 4])),
+        format!("\u{a0}{}", locs(&[1, 2, 3, 4])),
+        // Long repetition, to keep the scanners' linear advance honest.
+        long_run.clone(),
+        format!("car{long_run}"),
+        format!("car{}", "<loc_1><sep>".repeat(2048)),
+    ];
+
+    for text in &cases {
+        for allow_empty in [false, true] {
+            let _ = parse_boxes(text, unit_size(), allow_empty);
+            let _ = parse_polygons(text, unit_size(), allow_empty);
+        }
+        let _ = parse_ocr(text, unit_size());
+        let _ = parse_phrase_grounding(text, unit_size());
+        for task in super::super::tasks::Florence2Task::ALL {
+            let _ = super::super::postprocess::post_process(text, task, unit_size());
+        }
+    }
+}

--- a/src/models/florence2/florence2_postprocess_tests.rs
+++ b/src/models/florence2/florence2_postprocess_tests.rs
@@ -1,0 +1,223 @@
+// Copyright 2025-2026 Lablup Inc. and Jeongkyu Shin
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Task-to-result routing: the shape each task produces, and the reshaping
+//! from parser instances into parallel arrays.
+
+use super::*;
+use crate::models::florence2::tasks::Florence2Task::*;
+
+fn unit_size() -> Florence2ImageSize {
+    Florence2ImageSize::new(1000, 1000)
+}
+
+fn locs(bins: &[i32]) -> String {
+    bins.iter().map(|b| format!("<loc_{b}>")).collect()
+}
+
+#[test]
+fn pure_text_strips_only_the_sequence_markers() {
+    let result = post_process("<s>A green car on a street.</s>", Caption, unit_size());
+    assert_eq!(
+        result,
+        Florence2TaskResult::Text("A green car on a street.".to_string())
+    );
+}
+
+/// `<REGION_TO_CATEGORY>` answers a region question with a plain word, so it
+/// must not be routed through a coordinate parser.
+#[test]
+fn region_questions_return_text() {
+    let result = post_process("<s>car</s>", RegionToCategory, unit_size());
+    assert_eq!(result, Florence2TaskResult::Text("car".to_string()));
+}
+
+#[test]
+fn object_detection_returns_aligned_boxes_and_labels() {
+    let text = format!(
+        "<s>car{}person{}</s>",
+        locs(&[52, 332, 932, 774]),
+        locs(&[10, 20, 30, 40])
+    );
+    let Florence2TaskResult::Boxes { boxes, labels } =
+        post_process(&text, ObjectDetection, unit_size())
+    else {
+        panic!("expected boxes");
+    };
+    assert_eq!(labels, vec!["car".to_string(), "person".to_string()]);
+    assert_eq!(boxes.len(), labels.len());
+    assert_eq!(boxes[0].to_array(), [52.5, 332.5, 932.5, 774.5]);
+    assert_eq!(boxes[1].to_array(), [10.5, 20.5, 30.5, 40.5]);
+}
+
+#[test]
+fn region_proposal_returns_unlabelled_boxes() {
+    let text = format!("<s>{}{}</s>", locs(&[1, 2, 3, 4]), locs(&[5, 6, 7, 8]));
+    let Florence2TaskResult::Boxes { boxes, labels } =
+        post_process(&text, RegionProposal, unit_size())
+    else {
+        panic!("expected boxes");
+    };
+    assert_eq!(boxes.len(), 2);
+    assert_eq!(labels, vec![String::new(), String::new()]);
+}
+
+/// Phrase grounding is flattened one label per box, so a phrase grounded by
+/// two boxes contributes its label twice and the arrays stay index-aligned.
+#[test]
+fn phrase_grounding_flattens_one_label_per_box() {
+    let text = format!(
+        "<s>A green car{}{}a house{}</s>",
+        locs(&[1, 2, 3, 4]),
+        locs(&[5, 6, 7, 8]),
+        locs(&[9, 10, 11, 12])
+    );
+    let Florence2TaskResult::Boxes { boxes, labels } =
+        post_process(&text, CaptionToPhraseGrounding, unit_size())
+    else {
+        panic!("expected boxes");
+    };
+    assert_eq!(boxes.len(), 3);
+    assert_eq!(
+        labels,
+        vec![
+            "A green car".to_string(),
+            "A green car".to_string(),
+            "a house".to_string()
+        ]
+    );
+}
+
+#[test]
+fn ocr_with_region_returns_quad_boxes() {
+    let text = format!("<s>HELLO{}", locs(&[1, 2, 3, 4, 5, 6, 7, 8]));
+    let Florence2TaskResult::QuadBoxes { quad_boxes, labels } =
+        post_process(&text, OcrWithRegion, unit_size())
+    else {
+        panic!("expected quad boxes");
+    };
+    assert_eq!(labels, vec!["HELLO".to_string()]);
+    assert_eq!(
+        quad_boxes[0].points,
+        [1.5, 2.5, 3.5, 4.5, 5.5, 6.5, 7.5, 8.5]
+    );
+}
+
+/// Plain `<OCR>` is text, `<OCR_WITH_REGION>` is quads. Routing these to the
+/// same parser would silently drop every coordinate.
+#[test]
+fn plain_ocr_and_ocr_with_region_diverge() {
+    let text = format!("<s>HELLO{}", locs(&[1, 2, 3, 4, 5, 6, 7, 8]));
+    assert!(matches!(
+        post_process(&text, Ocr, unit_size()),
+        Florence2TaskResult::Text(_)
+    ));
+    assert!(matches!(
+        post_process(&text, OcrWithRegion, unit_size()),
+        Florence2TaskResult::QuadBoxes { .. }
+    ));
+}
+
+#[test]
+fn segmentation_returns_polygons_grouped_per_instance() {
+    let text = format!("<s>{}<sep>{}</s>", locs(&[1, 2, 3, 4]), locs(&[5, 6, 7, 8]));
+    let Florence2TaskResult::Polygons { polygons, labels } =
+        post_process(&text, ReferringExpressionSegmentation, unit_size())
+    else {
+        panic!("expected polygons");
+    };
+    assert_eq!(labels.len(), 1);
+    assert_eq!(polygons.len(), 1);
+    assert_eq!(polygons[0].len(), 2, "both outlines stay on one instance");
+}
+
+/// `<OPEN_VOCABULARY_DETECTION>` picks its branch on whether `<poly>` appears
+/// anywhere in the answer, so both arms have to be exercised.
+#[test]
+fn open_vocabulary_detection_switches_on_the_poly_marker() {
+    let boxed = format!("<s>car{}</s>", locs(&[1, 2, 3, 4]));
+    let Florence2TaskResult::BoxesOrPolygons {
+        boxes,
+        box_labels,
+        polygons,
+        polygon_labels,
+    } = post_process(&boxed, OpenVocabularyDetection, unit_size())
+    else {
+        panic!("expected the mixed variant");
+    };
+    assert_eq!(box_labels, vec!["car".to_string()]);
+    assert_eq!(boxes.len(), 1);
+    assert!(polygons.is_empty() && polygon_labels.is_empty());
+
+    let polyed = format!("<s>car<poly>{}</poly></s>", locs(&[1, 2, 3, 4]));
+    let Florence2TaskResult::BoxesOrPolygons {
+        boxes,
+        polygons,
+        polygon_labels,
+        ..
+    } = post_process(&polyed, OpenVocabularyDetection, unit_size())
+    else {
+        panic!("expected the mixed variant");
+    };
+    assert!(boxes.is_empty());
+    assert_eq!(polygon_labels, vec!["car".to_string()]);
+    assert_eq!(polygons.len(), 1);
+}
+
+/// Every task must produce the variant its post-processing type names, and
+/// none may panic on an answer that carries no coordinates at all.
+#[test]
+fn every_task_routes_to_its_declared_variant() {
+    use Florence2PostProcessingType as P;
+    for task in Florence2Task::ALL {
+        let result = post_process("<s>nothing here</s>", task, unit_size());
+        let matches = matches!(
+            (task.post_processing_type(), &result),
+            (P::PureText, Florence2TaskResult::Text(_))
+                | (P::Ocr, Florence2TaskResult::QuadBoxes { .. })
+                | (
+                    P::DescriptionWithBoxes | P::Boxes | P::PhraseGrounding,
+                    Florence2TaskResult::Boxes { .. }
+                )
+                | (P::Polygons, Florence2TaskResult::Polygons { .. })
+                | (
+                    P::DescriptionWithBoxesOrPolygons,
+                    Florence2TaskResult::BoxesOrPolygons { .. }
+                )
+        );
+        assert!(matches, "{task} produced {result:?}");
+    }
+}
+
+/// The image size is what turns bins into pixels, so passing the resized
+/// 768x768 extent instead of the original must visibly change the answer.
+/// This is the failure the named-field `Florence2ImageSize` exists to prevent.
+#[test]
+fn coordinates_scale_with_the_declared_image_size() {
+    let text = format!("car{}", locs(&[500, 500, 999, 999]));
+    let Florence2TaskResult::Boxes { boxes: small, .. } =
+        post_process(&text, ObjectDetection, Florence2ImageSize::new(100, 200))
+    else {
+        panic!("expected boxes");
+    };
+    let Florence2TaskResult::Boxes { boxes: large, .. } =
+        post_process(&text, ObjectDetection, Florence2ImageSize::new(1000, 2000))
+    else {
+        panic!("expected boxes");
+    };
+    assert!((small[0].xmin - 50.05).abs() < 1e-3, "{:?}", small[0]);
+    assert!((small[0].ymin - 100.1).abs() < 1e-2, "{:?}", small[0]);
+    assert!((large[0].xmin - 500.5).abs() < 1e-2, "{:?}", large[0]);
+    assert!((large[0].ymin - 1001.0).abs() < 1e-1, "{:?}", large[0]);
+}

--- a/src/models/florence2/florence2_processor_tests.rs
+++ b/src/models/florence2/florence2_processor_tests.rs
@@ -1,0 +1,131 @@
+// Copyright 2025-2026 Lablup Inc. and Jeongkyu Shin
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Processor wiring. The tokenizer half needs the real checkpoint and skips
+//! without it, following `tests/florence2_fusion_parity.rs`; everything else
+//! runs everywhere.
+
+use std::path::Path;
+
+use super::super::coords::florence2_loc_token_id;
+use super::*;
+
+const MODEL_DIR: &str = "models/Florence-2-base-ft-bf16";
+
+fn processor() -> Option<Florence2Processor> {
+    if !Path::new(MODEL_DIR).exists() {
+        eprintln!("skipping: {MODEL_DIR} not present");
+        return None;
+    }
+    Some(Florence2Processor::from_pretrained(Path::new(MODEL_DIR)).expect("load processor"))
+}
+
+/// The prompt the fusion parity test pins, reached through the task API
+/// instead of a hard-coded id list. `<CAPTION>` must expand, tokenize, and
+/// wrap in `<s>` / `</s>` to exactly those eight ids.
+#[test]
+fn caption_prompt_tokenizes_to_the_pinned_ids() {
+    let Some(processor) = processor() else { return };
+    let ids = processor
+        .encode_prompt(Florence2Task::Caption, None)
+        .expect("encode prompt");
+    assert_eq!(ids, vec![0, 2264, 473, 5, 2274, 6190, 116, 2]);
+}
+
+/// Every task's prompt must survive the round trip through the tokenizer.
+/// `<s>` and `</s>` come from the checkpoint's `RobertaProcessing`
+/// post-processor, so their presence is what proves special tokens were added.
+#[test]
+fn every_task_prompt_round_trips_through_the_tokenizer() {
+    let Some(processor) = processor() else { return };
+    for task in Florence2Task::ALL {
+        let input = task
+            .takes_input()
+            .then_some("<loc_52><loc_332><loc_932><loc_774>");
+        let prompt = task.expand(input).expect("expand");
+        let ids = processor.encode_prompt(task, input).expect("encode");
+        assert_eq!(ids.first(), Some(&0), "{task} must start with <s>");
+        assert_eq!(ids.last(), Some(&2), "{task} must end with </s>");
+
+        let decoded = processor.decode_answer(&ids).expect("decode");
+        assert_eq!(
+            decoded,
+            format!("<s>{prompt}</s>"),
+            "{task} did not round trip"
+        );
+    }
+}
+
+/// Location tokens are single vocabulary entries, so a region input must cost
+/// four ids and come back verbatim. If they tokenized as plain text the
+/// coordinates would be spelled out character by character.
+#[test]
+fn region_inputs_tokenize_as_single_location_tokens() {
+    let Some(processor) = processor() else { return };
+    let region = "<loc_52><loc_332><loc_932><loc_774>";
+    let ids = processor
+        .encode_prompt(Florence2Task::RegionToCategory, Some(region))
+        .expect("encode");
+
+    let expected: Vec<i32> = [52u32, 332, 932, 774]
+        .iter()
+        .map(|bin| florence2_loc_token_id(*bin).expect("in range") as i32)
+        .collect();
+    let found = ids
+        .windows(expected.len())
+        .any(|window| window == expected.as_slice());
+    assert!(found, "expected {expected:?} inside {ids:?}");
+}
+
+/// Decoding with `skip_special_tokens = true` would delete every coordinate,
+/// leaving the spatial tasks silently empty. This pins the opposite.
+#[test]
+fn decoding_keeps_location_tokens() {
+    let Some(processor) = processor() else { return };
+    let ids: Vec<i32> = [0u32, 50269, 50369, 51268, 2]
+        .iter()
+        .map(|id| *id as i32)
+        .collect();
+    let decoded = processor.decode_answer(&ids).expect("decode");
+    assert!(decoded.contains("<loc_0>"), "{decoded}");
+    assert!(decoded.contains("<loc_100>"), "{decoded}");
+    assert!(decoded.contains("<loc_999>"), "{decoded}");
+}
+
+/// End to end without a model: the post-processing half of `run` must turn a
+/// decoded answer into coordinates against the original image size.
+#[test]
+fn post_process_reaches_the_parsers() {
+    let result = postprocess::post_process(
+        "<s>car<loc_52><loc_332><loc_932><loc_774></s>",
+        Florence2Task::ObjectDetection,
+        Florence2ImageSize::new(1000, 1000),
+    );
+    let Florence2TaskResult::Boxes { boxes, labels } = result else {
+        panic!("expected boxes");
+    };
+    assert_eq!(labels, vec!["car".to_string()]);
+    assert_eq!(boxes[0].to_array(), [52.5, 332.5, 932.5, 774.5]);
+}
+
+#[test]
+fn missing_checkpoint_directory_is_an_error() {
+    // `Florence2Processor` holds MLX-backed handles and is not `Debug`, so
+    // the error is inspected without going through `expect_err`.
+    let message = match Florence2Processor::from_pretrained(Path::new("models/no-such-florence2")) {
+        Ok(_) => panic!("loading a missing checkpoint must fail"),
+        Err(e) => format!("{e:#}"),
+    };
+    assert!(message.contains("Florence-2"), "{message}");
+}

--- a/src/models/florence2/florence2_scan_tests.rs
+++ b/src/models/florence2/florence2_scan_tests.rs
@@ -1,0 +1,78 @@
+// Copyright 2025-2026 Lablup Inc. and Jeongkyu Shin
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Scanner behavior: the literal string work the parsers are built on.
+//!
+//! Kept apart from the parser tests because these functions know nothing
+//! about tasks or coordinates; they are exercised directly on the strings
+//! that reach them.
+
+use super::*;
+
+#[test]
+fn blacklist_is_sorted_for_binary_search() {
+    assert!(
+        PHRASE_GROUNDING_BLACKLIST.windows(2).all(|w| w[0] < w[1]),
+        "blacklist must be sorted and deduplicated"
+    );
+    assert_eq!(PHRASE_GROUNDING_BLACKLIST.len(), 72);
+}
+
+#[test]
+fn location_bins_reads_every_token() {
+    assert_eq!(location_bins("<loc_0><loc_999><loc_52>"), vec![0, 999, 52]);
+    assert_eq!(location_bins("car<loc_1>dog<loc_2>"), vec![1, 2]);
+    assert!(location_bins("no locations here").is_empty());
+    // Malformed tokens must be skipped without swallowing the next one.
+    assert_eq!(location_bins("<loc_><loc_7>"), vec![7]);
+    assert_eq!(location_bins("<loc_12<loc_8>"), vec![8]);
+}
+
+#[test]
+fn leading_phrase_stops_at_the_first_stop_marker() {
+    assert_eq!(leading_phrase("car<loc_1>", PHRASE_STOPS), Some("car"));
+    assert_eq!(leading_phrase("  car <loc_1>", PHRASE_STOPS), Some("car"));
+    assert_eq!(leading_phrase("<loc_1>", PHRASE_STOPS), Some(""));
+    assert_eq!(leading_phrase("a<od>b<loc_1>", PHRASE_STOPS), Some("a"));
+    // No stop marker at all is upstream's `re.search` returning None.
+    assert_eq!(leading_phrase("no markers", PHRASE_STOPS), None);
+}
+
+/// Upstream's `.` does not match a newline and its `^` is not multi-line, so
+/// a newline before the first location token makes the whole chunk vanish.
+/// Reproducing that keeps a multi-line answer parsing identically.
+#[test]
+fn leading_phrase_fails_across_a_newline() {
+    assert_eq!(leading_phrase("a\nb<loc_1>", PHRASE_STOPS), None);
+    // Leading whitespace is consumed by `\s*` first, so a newline there is fine.
+    assert_eq!(leading_phrase("\n  a<loc_1>", PHRASE_STOPS), Some("a"));
+}
+
+/// `<sep>` is not in the stop list, so the phrase scan runs past it. This is
+/// the one place the two stop lists visibly differ from "first `<`".
+#[test]
+fn leading_phrase_runs_past_a_sep_marker() {
+    assert_eq!(
+        leading_phrase("a<sep>b<loc_1>", PHRASE_STOPS_POLY),
+        Some("a<sep>b")
+    );
+}
+
+#[test]
+fn bare_loc_prefix_is_stripped() {
+    assert_eq!(strip_bare_loc_prefix("loc_12>rest"), "rest");
+    assert_eq!(strip_bare_loc_prefix("<loc_12>rest"), "<loc_12>rest");
+    assert_eq!(strip_bare_loc_prefix("loc_>rest"), "loc_>rest");
+    assert_eq!(strip_bare_loc_prefix("plain"), "plain");
+}

--- a/src/models/florence2/florence2_scan_tests.rs
+++ b/src/models/florence2/florence2_scan_tests.rs
@@ -37,6 +37,18 @@ fn location_bins_reads_every_token() {
     // Malformed tokens must be skipped without swallowing the next one.
     assert_eq!(location_bins("<loc_><loc_7>"), vec![7]);
     assert_eq!(location_bins("<loc_12<loc_8>"), vec![8]);
+    // Leading zeros are ordinary digits, not an overflow.
+    assert_eq!(location_bins("<loc_0000000000000005>"), vec![5]);
+}
+
+/// A digit run too wide for `i32` saturates instead of vanishing. Upstream's
+/// `int()` has no width limit, and dropping the token would shift every bin
+/// after it into the wrong slot of the four-at-a-time grouping.
+#[test]
+fn location_bins_saturates_instead_of_dropping_a_wide_run() {
+    assert_eq!(location_bins("<loc_99999999999><loc_7>"), vec![i32::MAX, 7]);
+    assert_eq!(parse_bin("999"), 999);
+    assert_eq!(parse_bin("99999999999"), i32::MAX);
 }
 
 #[test]

--- a/src/models/florence2/florence2_tasks_tests.rs
+++ b/src/models/florence2/florence2_tasks_tests.rs
@@ -1,0 +1,204 @@
+// Copyright 2025-2026 Lablup Inc. and Jeongkyu Shin
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Task markers, prompt expansions, and post-processing routing.
+//!
+//! The expected strings are transcribed from the checkpoint's own
+//! `processing_florence2.py` and pinned here byte for byte: a prompt that
+//! drifts by a character is still a valid sentence, so nothing downstream
+//! would catch it, but the model was trained on the exact wording.
+
+use super::*;
+use Florence2PostProcessingType as P;
+
+/// The fifteen tasks and their exact expansions, as
+/// `task_prompts_without_inputs` and `task_prompts_with_input` declare them.
+const EXPECTED: &[(Florence2Task, &str, &str, P)] = &[
+    (Ocr, "<OCR>", "What is the text in the image?", P::PureText),
+    (
+        OcrWithRegion,
+        "<OCR_WITH_REGION>",
+        "What is the text in the image, with regions?",
+        P::Ocr,
+    ),
+    (
+        Caption,
+        "<CAPTION>",
+        "What does the image describe?",
+        P::PureText,
+    ),
+    (
+        DetailedCaption,
+        "<DETAILED_CAPTION>",
+        "Describe in detail what is shown in the image.",
+        P::PureText,
+    ),
+    (
+        MoreDetailedCaption,
+        "<MORE_DETAILED_CAPTION>",
+        "Describe with a paragraph what is shown in the image.",
+        P::PureText,
+    ),
+    (
+        ObjectDetection,
+        "<OD>",
+        "Locate the objects with category name in the image.",
+        P::DescriptionWithBoxes,
+    ),
+    (
+        DenseRegionCaption,
+        "<DENSE_REGION_CAPTION>",
+        "Locate the objects in the image, with their descriptions.",
+        P::DescriptionWithBoxes,
+    ),
+    (
+        RegionProposal,
+        "<REGION_PROPOSAL>",
+        "Locate the region proposals in the image.",
+        P::Boxes,
+    ),
+    (
+        CaptionToPhraseGrounding,
+        "<CAPTION_TO_PHRASE_GROUNDING>",
+        "Locate the phrases in the caption: {input}",
+        P::PhraseGrounding,
+    ),
+    (
+        ReferringExpressionSegmentation,
+        "<REFERRING_EXPRESSION_SEGMENTATION>",
+        "Locate {input} in the image with mask",
+        P::Polygons,
+    ),
+    (
+        RegionToSegmentation,
+        "<REGION_TO_SEGMENTATION>",
+        "What is the polygon mask of region {input}",
+        P::Polygons,
+    ),
+    (
+        OpenVocabularyDetection,
+        "<OPEN_VOCABULARY_DETECTION>",
+        "Locate {input} in the image.",
+        P::DescriptionWithBoxesOrPolygons,
+    ),
+    (
+        RegionToCategory,
+        "<REGION_TO_CATEGORY>",
+        "What is the region {input}?",
+        P::PureText,
+    ),
+    (
+        RegionToDescription,
+        "<REGION_TO_DESCRIPTION>",
+        "What does the region {input} describe?",
+        P::PureText,
+    ),
+    (
+        RegionToOcr,
+        "<REGION_TO_OCR>",
+        "What text is in the region {input}?",
+        P::PureText,
+    ),
+];
+
+#[test]
+fn every_task_is_covered_exactly_once() {
+    assert_eq!(EXPECTED.len(), Florence2Task::ALL.len());
+    for task in Florence2Task::ALL {
+        let hits = EXPECTED.iter().filter(|(t, ..)| *t == task).count();
+        assert_eq!(hits, 1, "{task} appears {hits} times in the expected table");
+    }
+}
+
+#[test]
+fn tokens_and_post_processing_types_match_the_checkpoint() {
+    for (task, token, _, post) in EXPECTED {
+        assert_eq!(task.token(), *token);
+        assert_eq!(task.to_string(), *token);
+        assert_eq!(task.post_processing_type(), *post, "{token}");
+    }
+}
+
+/// The round trip the acceptance criteria call for: marker in, prompt out.
+#[test]
+fn prompt_expansion_matches_the_checkpoint() {
+    for (task, token, template, _) in EXPECTED {
+        if task.takes_input() {
+            assert!(template.contains("{input}"), "{token}");
+            let expanded = task.expand(Some("a green car")).expect("expand with input");
+            assert_eq!(expanded, template.replace("{input}", "a green car"));
+            assert!(!expanded.contains("{input}"), "{token} left a placeholder");
+        } else {
+            assert!(!template.contains("{input}"), "{token}");
+            assert_eq!(task.expand(None).expect("expand"), *template);
+        }
+    }
+}
+
+/// Exactly seven tasks interpolate an input, matching
+/// `task_prompts_with_input`.
+#[test]
+fn seven_tasks_take_an_input() {
+    let with_input = Florence2Task::ALL
+        .iter()
+        .filter(|t| t.takes_input())
+        .count();
+    assert_eq!(with_input, 7);
+}
+
+/// Upstream would expand a missing input to a literal gap ("What is the region
+/// ?") and let the model answer nonsense. Both mismatches are errors here.
+#[test]
+fn input_arity_mismatches_are_rejected() {
+    assert!(RegionToCategory.expand(None).is_err());
+    assert!(Caption.expand(Some("something")).is_err());
+
+    let err = ObjectDetection.expand(Some("x")).expect_err("must reject");
+    assert!(err.contains("<OD>"), "{err}");
+    let err = RegionToOcr.expand(None).expect_err("must reject");
+    assert!(err.contains("<REGION_TO_OCR>"), "{err}");
+}
+
+/// A region input is itself location tokens, and it must survive expansion
+/// untouched so the tokenizer sees real vocabulary entries.
+#[test]
+fn region_inputs_pass_through_verbatim() {
+    let region = "<loc_52><loc_332><loc_932><loc_774>";
+    assert_eq!(
+        RegionToCategory.expand(Some(region)).expect("expand"),
+        format!("What is the region {region}?")
+    );
+}
+
+#[test]
+fn task_markers_parse_from_strings() {
+    for task in Florence2Task::ALL {
+        assert_eq!(task.token().parse::<Florence2Task>(), Ok(task));
+    }
+    // Bare names and mixed case, so a CLI flag need not quote angle brackets.
+    assert_eq!("OD".parse(), Ok(ObjectDetection));
+    assert_eq!("  <caption>  ".parse(), Ok(Caption));
+    assert_eq!("ocr_with_region".parse(), Ok(OcrWithRegion));
+
+    // `<CAPTION>` is a prefix of `<CAPTION_TO_PHRASE_GROUNDING>` up to the
+    // underscore; matching must be exact, not prefix based.
+    assert_eq!("<CAPTION>".parse(), Ok(Caption));
+    assert_eq!(
+        "<CAPTION_TO_PHRASE_GROUNDING>".parse(),
+        Ok(CaptionToPhraseGrounding)
+    );
+
+    assert!("<NOT_A_TASK>".parse::<Florence2Task>().is_err());
+    assert!("".parse::<Florence2Task>().is_err());
+}

--- a/src/models/florence2/mod.rs
+++ b/src/models/florence2/mod.rs
@@ -35,11 +35,17 @@
 //! - https://github.com/Blaizzy/mlx-vlm/blob/main/mlx_vlm/models/florence2/config.py
 
 mod checkpoint;
+mod coords;
 mod decoder;
 mod encoder;
 mod fusion;
 pub(crate) mod layers;
 mod model;
+mod parse;
+mod postprocess;
+mod processor;
+mod scan;
+mod tasks;
 
 /// DaViT vision backbone, re-exported from the shared vision-encoder tree so
 /// the Florence-2 family directory exposes both halves of the model.
@@ -47,8 +53,15 @@ pub use crate::vision::encoders::florence2_davit::{
     FLORENCE2_VISION_PREFIX, Florence2DaViT, Florence2VisionConfig,
 };
 
-pub use checkpoint::{Florence2Config, sanitize};
+pub use checkpoint::{Florence2Config, Florence2TextConfig, sanitize};
+pub use coords::{
+    FLORENCE2_LOC_TOKEN_BASE, Florence2BoundingBox, Florence2ImageSize, Florence2Polygon,
+    Florence2QuadBox, florence2_loc_token_id,
+};
 pub use model::Florence2Model;
+pub use postprocess::{Florence2PostProcessingType, Florence2TaskResult};
+pub use processor::{Florence2Output, Florence2Processor};
+pub use tasks::Florence2Task;
 
 use std::path::Path;
 
@@ -62,168 +75,6 @@ use mlxcel_core::{MlxArray, UniquePtr};
 use decoder::Florence2Decoder;
 use encoder::Florence2Encoder;
 use layers::Florence2LayerCache;
-
-/// Upper bound accepted for `encoder_layers` / `decoder_layers`. Real
-/// Florence-2 exports ship 6 (base) or 12 (large). The cap exists because
-/// [`encoder::Florence2Encoder::from_weights`] and
-/// [`decoder::Florence2Decoder::from_weights`] size a `Vec` from this field
-/// before they look up a single weight, so a negative value out of a hostile
-/// `config.json` becomes `usize::MAX` and aborts with a capacity overflow.
-const MAX_LAYERS: i32 = 256;
-
-/// Upper bound accepted for `max_position_embeddings`. Florence-2 ships 1024.
-///
-/// The field bounds two separate allocations: the position-table slice the
-/// encoder and decoder take (validated against the loaded table at load time)
-/// and the O(n^2) host buffer [`layers::additive_causal_mask`] fills for a
-/// multi-token decoder call. An unbounded value out of a hostile `config.json`
-/// is an out-of-memory abort rather than an error return.
-const MAX_POSITION_EMBEDDINGS: i32 = 65_536;
-
-/// BART encoder-decoder shape parameters, parsed from the `text_config`
-/// object of a Florence-2 `config.json` (`model_type: florence2_language`).
-#[derive(Debug, Clone)]
-pub struct Florence2TextConfig {
-    pub d_model: i32,
-    pub encoder_layers: i32,
-    pub decoder_layers: i32,
-    pub encoder_attention_heads: i32,
-    pub decoder_attention_heads: i32,
-    pub encoder_ffn_dim: i32,
-    pub decoder_ffn_dim: i32,
-    pub vocab_size: i32,
-    pub max_position_embeddings: i32,
-    pub scale_embedding: bool,
-    pub pad_token_id: i32,
-    pub bos_token_id: i32,
-    pub eos_token_id: i32,
-    pub decoder_start_token_id: i32,
-}
-
-fn config_i32(config: &Value, key: &str) -> Option<i32> {
-    config.get(key).and_then(Value::as_i64).map(|v| v as i32)
-}
-
-impl Florence2TextConfig {
-    /// Parse from the `text_config` sub-object itself.
-    pub fn from_text_config(config: &Value) -> Result<Self> {
-        let require = |key: &str| -> Result<i32> {
-            config_i32(config, key)
-                .ok_or_else(|| anyhow!("Florence-2 text_config missing field: {key}"))
-        };
-        let d_model = require("d_model")?;
-        let parsed = Self {
-            d_model,
-            encoder_layers: require("encoder_layers")?,
-            decoder_layers: require("decoder_layers")?,
-            encoder_attention_heads: require("encoder_attention_heads")?,
-            decoder_attention_heads: require("decoder_attention_heads")?,
-            encoder_ffn_dim: config_i32(config, "encoder_ffn_dim").unwrap_or(4 * d_model),
-            decoder_ffn_dim: config_i32(config, "decoder_ffn_dim").unwrap_or(4 * d_model),
-            vocab_size: require("vocab_size")?,
-            max_position_embeddings: config_i32(config, "max_position_embeddings").unwrap_or(1024),
-            scale_embedding: config
-                .get("scale_embedding")
-                .and_then(Value::as_bool)
-                .unwrap_or(false),
-            pad_token_id: config_i32(config, "pad_token_id").unwrap_or(1),
-            bos_token_id: config_i32(config, "bos_token_id").unwrap_or(0),
-            eos_token_id: config_i32(config, "eos_token_id").unwrap_or(2),
-            decoder_start_token_id: config_i32(config, "decoder_start_token_id").unwrap_or(2),
-        };
-        // Every field below becomes a shape, an index, a divisor, or a `Vec`
-        // capacity somewhere downstream. MLX throws on an out-of-range shape
-        // and the throw crosses an FFI boundary that cannot carry it, so a bad
-        // value aborts the process rather than surfacing as an error; these
-        // checks are what keep an untrusted `config.json` from getting that
-        // far. They also have to run *before* the divisibility check below,
-        // which would itself divide by zero on `encoder_attention_heads: 0`.
-        if parsed.d_model < 1 {
-            return Err(anyhow!(
-                "Florence-2 text_config d_model must be positive, got {}",
-                parsed.d_model
-            ));
-        }
-        if parsed.encoder_attention_heads < 1 || parsed.decoder_attention_heads < 1 {
-            return Err(anyhow!(
-                "Florence-2 text_config attention heads must be positive, got {} enc / {} dec",
-                parsed.encoder_attention_heads,
-                parsed.decoder_attention_heads
-            ));
-        }
-        if !(1..=MAX_LAYERS).contains(&parsed.encoder_layers)
-            || !(1..=MAX_LAYERS).contains(&parsed.decoder_layers)
-        {
-            return Err(anyhow!(
-                "Florence-2 text_config layer counts {} enc / {} dec outside 1..={MAX_LAYERS}",
-                parsed.encoder_layers,
-                parsed.decoder_layers
-            ));
-        }
-        if parsed.encoder_ffn_dim < 1 || parsed.decoder_ffn_dim < 1 {
-            return Err(anyhow!(
-                "Florence-2 text_config ffn dims must be positive, got {} enc / {} dec",
-                parsed.encoder_ffn_dim,
-                parsed.decoder_ffn_dim
-            ));
-        }
-        if parsed.vocab_size < 1 {
-            return Err(anyhow!(
-                "Florence-2 text_config vocab_size must be positive, got {}",
-                parsed.vocab_size
-            ));
-        }
-        if !(1..=MAX_POSITION_EMBEDDINGS).contains(&parsed.max_position_embeddings) {
-            return Err(anyhow!(
-                "Florence-2 text_config max_position_embeddings {} outside 1..={MAX_POSITION_EMBEDDINGS}",
-                parsed.max_position_embeddings
-            ));
-        }
-        // Both of these reach the shared embedding gather as literal token ids
-        // (`generate_greedy` seeds the decoder with `decoder_start_token_id`,
-        // `shift_tokens_right` substitutes `pad_token_id`), so an
-        // out-of-vocabulary or negative value is an out-of-range gather.
-        // `bos_token_id` and `eos_token_id` are deliberately left unchecked:
-        // they are only ever compared, never used as an index, and some
-        // exports legitimately carry sentinel values there.
-        if !(0..parsed.vocab_size).contains(&parsed.pad_token_id) {
-            return Err(anyhow!(
-                "Florence-2 text_config pad_token_id {} outside 0..vocab_size {}",
-                parsed.pad_token_id,
-                parsed.vocab_size
-            ));
-        }
-        if !(0..parsed.vocab_size).contains(&parsed.decoder_start_token_id) {
-            return Err(anyhow!(
-                "Florence-2 text_config decoder_start_token_id {} outside 0..vocab_size {}",
-                parsed.decoder_start_token_id,
-                parsed.vocab_size
-            ));
-        }
-        if parsed.d_model % parsed.encoder_attention_heads != 0
-            || parsed.d_model % parsed.decoder_attention_heads != 0
-        {
-            return Err(anyhow!(
-                "Florence-2 d_model {} not divisible by attention heads ({} enc / {} dec)",
-                parsed.d_model,
-                parsed.encoder_attention_heads,
-                parsed.decoder_attention_heads
-            ));
-        }
-        Ok(parsed)
-    }
-
-    /// Parse from a full Florence-2 `config.json` (`model_type: florence2`),
-    /// descending into its `text_config` sub-object. A bare text config (no
-    /// `text_config` key) is also accepted so the sub-object can be passed
-    /// directly.
-    pub fn from_model_config(config: &Value) -> Result<Self> {
-        match config.get("text_config") {
-            Some(text) => Self::from_text_config(text),
-            None => Self::from_text_config(config),
-        }
-    }
-}
 
 /// Decode-loop state for one sequence: per-layer dual KV caches plus the
 /// running token offset (the absolute position of the next decoder token).

--- a/src/models/florence2/parse.rs
+++ b/src/models/florence2/parse.rs
@@ -1,0 +1,328 @@
+// Copyright 2025-2026 Lablup Inc. and Jeongkyu Shin
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Parsers that turn a decoded Florence-2 answer into typed instances.
+//!
+//! The model answers a spatial task with a flat string mixing plain words and
+//! `<loc_*>` tokens, for example
+//! `"car<loc_52><loc_332><loc_932><loc_774>person<loc_10><loc_20><loc_30><loc_40>"`.
+//! Each parser here splits that into phrase chunks, reads the location runs,
+//! and dequantizes them through [`super::coords`].
+//!
+//! Port of `Florence2PostProcesser`:
+//! https://github.com/Blaizzy/mlx-vlm/blob/main/mlx_vlm/models/florence2/processing_florence2.py
+//!
+//! Three upstream behaviors are deliberately **not** ported, because they are
+//! unreachable from `post_process_generation`:
+//!
+//! - `parse_od_from_text_and_spans` and the `PATTERN` config indirection. No
+//!   task routes to the `'od'` parse task, and its configured pattern is
+//!   `r'([a-zA-Z0-9 ]+)<loc_(\\d+)>...'`, whose doubled backslash inside a raw
+//!   string matches a literal `\` followed by `d` and so can never match model
+//!   output. Every other parser overwrites its `pattern` argument on its first
+//!   lines, so only the OCR pattern is ever read from config at all.
+//! - The OCR area filter. It is gated on `area_threshold > 0` and the shipped
+//!   `AREA_THRESHOLD` is `0.00`, so it never runs.
+//! - `with_box_at_start` in the polygon parser. Every reachable call site
+//!   leaves it false.
+//!
+//! Also inert upstream and skipped here: the `<ground>` / `<obj>` chunk
+//! prefixes stripped before the phrase search. Neither string is in the
+//! checkpoint's vocabulary, and the second assignment overwrites the first
+//! (it reads `pharse_text` rather than the result of the `<ground>` strip), so
+//! the pair cannot change any output.
+
+use std::sync::LazyLock;
+
+use fancy_regex::Regex;
+
+use super::coords::{
+    Florence2BoundingBox, Florence2ImageSize, Florence2Polygon, Florence2QuadBox, dequantize_box,
+    dequantize_coordinates,
+};
+use super::scan::{
+    PHRASE_GROUNDING_BLACKLIST, PHRASE_STOPS, PHRASE_STOPS_POLY, ascii_only, box_bins,
+    leading_phrase, location_bins, strip_bare_loc_prefix, strip_sequence_markers,
+};
+
+/// One detected box with its open-vocabulary label.
+#[derive(Debug, Clone, PartialEq)]
+pub(crate) struct BoxInstance {
+    pub bbox: Florence2BoundingBox,
+    pub cat_name: String,
+}
+
+/// One phrase from a caption together with every box grounding it.
+#[derive(Debug, Clone, PartialEq)]
+pub(crate) struct GroundedPhrase {
+    pub boxes: Vec<Florence2BoundingBox>,
+    pub cat_name: String,
+}
+
+/// One OCR text line and the quadrilateral around it.
+#[derive(Debug, Clone, PartialEq)]
+pub(crate) struct QuadInstance {
+    pub quad_box: Florence2QuadBox,
+    pub text: String,
+}
+
+/// One segmentation instance: a label and the outlines that make it up.
+#[derive(Debug, Clone, PartialEq)]
+pub(crate) struct PolygonInstance {
+    pub polygons: Vec<Florence2Polygon>,
+    pub cat_name: String,
+}
+
+/// Every pattern below is a literal, compiled once, and covered by
+/// `florence2_post_processing_patterns_compile`. `None` is therefore
+/// unreachable; the parsers still treat it as "no matches" rather than
+/// aborting, matching how the rest of the tree handles a static regex
+/// (`src/server/tool_calls/formats.rs`).
+type Pattern = LazyLock<Option<Regex>>;
+
+/// Chunk splitter for the box tasks: a run of plain text followed by at least
+/// four location tokens.
+static CHUNK_WITH_PHRASE: Pattern = LazyLock::new(|| Regex::new(r"([^<]+(?:<loc_\d+>){4,})").ok());
+
+/// Same, for `allow_empty_phrase`: bare location runs with no leading text.
+static CHUNK_BARE: Pattern = LazyLock::new(|| Regex::new(r"(?:(?:<loc_\d+>){4,})").ok());
+
+/// Chunk splitter for the polygon tasks. `<sep>`, `<poly>` and `</poly>`
+/// count toward the four-unit minimum alongside location tokens.
+static CHUNK_POLY_WITH_PHRASE: Pattern =
+    LazyLock::new(|| Regex::new(r"([^<]+(?:<loc_\d+>|<sep>|<poly>|</poly>){4,})").ok());
+
+static CHUNK_POLY_BARE: Pattern =
+    LazyLock::new(|| Regex::new(r"(?:(?:<loc_\d+>|<sep>|<poly>|</poly>){4,})").ok());
+
+/// One OCR record: a non-greedy text run followed by exactly eight location
+/// tokens, the four corners of the quadrilateral.
+static OCR_RECORD: Pattern = LazyLock::new(|| {
+    Regex::new(concat!(
+        r"(.+?)",
+        r"<loc_(\d+)><loc_(\d+)><loc_(\d+)><loc_(\d+)>",
+        r"<loc_(\d+)><loc_(\d+)><loc_(\d+)><loc_(\d+)>",
+    ))
+    .ok()
+});
+
+/// One polygon instance inside a chunk, delimited by `<poly>` / `</poly>`.
+static POLY_INSTANCE: Pattern = LazyLock::new(|| Regex::new(r"<poly>(.*?)</poly>").ok());
+
+/// A maximal run of adjacent location tokens, terminated by `<sep>` or by the
+/// end of the instance. One run is one polygon outline.
+///
+/// One knowingly accepted difference from Python: `$` here matches only at the
+/// very end of the string, while Python's `$` also matches just before a
+/// trailing newline. Location runs are emitted without trailing newlines, so
+/// the two agree on real output.
+static POLY_RUN: Pattern = LazyLock::new(|| Regex::new(r"((?:<loc_\d+>)+)(?:<sep>|$)").ok());
+
+/// Full-match iteration over a chunk pattern.
+///
+/// Every chunk pattern either has no capture group or wraps the whole match in
+/// one, so group 0 and `re.findall`'s result are the same string.
+fn chunks<'a>(re: &Regex, text: &'a str) -> Vec<&'a str> {
+    re.find_iter(text)
+        .filter_map(Result::ok)
+        .map(|m| m.as_str())
+        .collect()
+}
+
+/// `<OCR_WITH_REGION>`: text lines with a rotated quadrilateral each.
+///
+/// Only `<s>` is stripped here, not `</s>` or `<pad>`; that asymmetry is
+/// upstream's and it is harmless because the trailing markers cannot sit
+/// between a text run and its eight location tokens.
+pub(crate) fn parse_ocr(text: &str, size: Florence2ImageSize) -> Vec<QuadInstance> {
+    let Some(record) = OCR_RECORD.as_ref() else {
+        return Vec::new();
+    };
+    let text = text.replace("<s>", "");
+    let mut instances = Vec::new();
+    for captures in record.captures_iter(&text).filter_map(Result::ok) {
+        let Some(content) = captures.get(1) else {
+            continue;
+        };
+        let mut bins = [0i32; 8];
+        let mut complete = true;
+        for (slot, bin) in bins.iter_mut().enumerate() {
+            match captures.get(slot + 2).and_then(|g| g.as_str().parse().ok()) {
+                Some(value) => *bin = value,
+                None => complete = false,
+            }
+        }
+        if !complete {
+            continue;
+        }
+        let dequantized = dequantize_coordinates(&bins, size);
+        let mut points = [0.0f32; 8];
+        if dequantized.len() != points.len() {
+            continue;
+        }
+        points.copy_from_slice(&dequantized);
+        instances.push(QuadInstance {
+            quad_box: Florence2QuadBox { points },
+            text: content.as_str().to_string(),
+        });
+    }
+    instances
+}
+
+/// `<OD>`, `<DENSE_REGION_CAPTION>`, `<REGION_PROPOSAL>`: one instance per
+/// box, with the chunk's phrase repeated across every box it carries.
+///
+/// `allow_empty_phrase` selects the `<REGION_PROPOSAL>` behavior, where the
+/// answer is bare location runs with no category names and each instance gets
+/// an empty label.
+pub(crate) fn parse_boxes(
+    text: &str,
+    size: Florence2ImageSize,
+    allow_empty_phrase: bool,
+) -> Vec<BoxInstance> {
+    let text = strip_sequence_markers(text);
+    let cell = if allow_empty_phrase {
+        &CHUNK_BARE
+    } else {
+        &CHUNK_WITH_PHRASE
+    };
+    let Some(pattern) = cell.as_ref() else {
+        return Vec::new();
+    };
+
+    let mut instances = Vec::new();
+    for chunk in chunks(pattern, &text) {
+        let Some(phrase) = leading_phrase(chunk, PHRASE_STOPS) else {
+            continue;
+        };
+        let boxes = box_bins(chunk);
+        if boxes.is_empty() {
+            continue;
+        }
+        let cat_name = ascii_only(phrase);
+        for bins in boxes {
+            instances.push(BoxInstance {
+                bbox: dequantize_box(bins, size),
+                cat_name: cat_name.clone(),
+            });
+        }
+    }
+    instances
+}
+
+/// `<CAPTION_TO_PHRASE_GROUNDING>`: one instance per phrase, keeping all of
+/// that phrase's boxes together, with the stopword blacklist applied.
+///
+/// The blacklist is checked against the trimmed phrase *before* the non-ASCII
+/// filter runs, which is upstream's order and matters for a phrase whose only
+/// difference from a blacklisted entry is a non-ASCII character.
+pub(crate) fn parse_phrase_grounding(text: &str, size: Florence2ImageSize) -> Vec<GroundedPhrase> {
+    let text = strip_sequence_markers(text);
+    let Some(pattern) = CHUNK_WITH_PHRASE.as_ref() else {
+        return Vec::new();
+    };
+
+    let mut instances = Vec::new();
+    for chunk in chunks(pattern, &text) {
+        let Some(phrase) = leading_phrase(chunk, PHRASE_STOPS) else {
+            continue;
+        };
+        let boxes = box_bins(chunk);
+        if boxes.is_empty() {
+            continue;
+        }
+        if PHRASE_GROUNDING_BLACKLIST.binary_search(&phrase).is_ok() {
+            continue;
+        }
+        instances.push(GroundedPhrase {
+            boxes: boxes
+                .into_iter()
+                .map(|bins| dequantize_box(bins, size))
+                .collect(),
+            cat_name: ascii_only(phrase),
+        });
+    }
+    instances
+}
+
+/// `<REFERRING_EXPRESSION_SEGMENTATION>`, `<REGION_TO_SEGMENTATION>`, and the
+/// polygon branch of `<OPEN_VOCABULARY_DETECTION>`.
+///
+/// A chunk holds one or more instances. When it carries both `<poly>` and
+/// `</poly>` the instances are the delimited spans; otherwise the whole chunk
+/// is a single instance. Within an instance, each maximal run of adjacent
+/// location tokens is one outline, and `<sep>` separates runs.
+pub(crate) fn parse_polygons(
+    text: &str,
+    size: Florence2ImageSize,
+    allow_empty_phrase: bool,
+) -> Vec<PolygonInstance> {
+    let text = strip_sequence_markers(text);
+    let cell = if allow_empty_phrase {
+        &CHUNK_POLY_BARE
+    } else {
+        &CHUNK_POLY_WITH_PHRASE
+    };
+    let (Some(pattern), Some(instance_re), Some(run_re)) =
+        (cell.as_ref(), POLY_INSTANCE.as_ref(), POLY_RUN.as_ref())
+    else {
+        return Vec::new();
+    };
+
+    let mut instances = Vec::new();
+    for chunk in chunks(pattern, &text) {
+        let Some(phrase) = leading_phrase(strip_bare_loc_prefix(chunk), PHRASE_STOPS_POLY) else {
+            continue;
+        };
+        let phrase = phrase.to_string();
+
+        let spans: Vec<&str> = if chunk.contains("<poly>") && chunk.contains("</poly>") {
+            instance_re
+                .captures_iter(chunk)
+                .filter_map(Result::ok)
+                .filter_map(|c| c.get(1).map(|g| g.as_str()))
+                .collect()
+        } else {
+            vec![chunk]
+        };
+
+        for span in spans {
+            let mut polygons = Vec::new();
+            for run in run_re.captures_iter(span).filter_map(Result::ok) {
+                let Some(run) = run.get(1) else { continue };
+                let mut bins = location_bins(run.as_str());
+                // An outline is a flat (x, y) sequence, so a trailing
+                // unpaired bin is dropped rather than paired with nothing.
+                if bins.len() % 2 == 1 {
+                    bins.pop();
+                }
+                polygons.push(Florence2Polygon {
+                    points: dequantize_coordinates(&bins, size),
+                });
+            }
+            if polygons.is_empty() {
+                continue;
+            }
+            instances.push(PolygonInstance {
+                polygons,
+                cat_name: phrase.clone(),
+            });
+        }
+    }
+    instances
+}
+
+#[cfg(test)]
+#[path = "florence2_parse_tests.rs"]
+mod florence2_parse_tests;

--- a/src/models/florence2/parse.rs
+++ b/src/models/florence2/parse.rs
@@ -53,7 +53,7 @@ use super::coords::{
 };
 use super::scan::{
     PHRASE_GROUNDING_BLACKLIST, PHRASE_STOPS, PHRASE_STOPS_POLY, ascii_only, box_bins,
-    leading_phrase, location_bins, strip_bare_loc_prefix, strip_sequence_markers,
+    leading_phrase, location_bins, parse_bin, strip_bare_loc_prefix, strip_sequence_markers,
 };
 
 /// One detected box with its open-vocabulary label.
@@ -158,8 +158,8 @@ pub(crate) fn parse_ocr(text: &str, size: Florence2ImageSize) -> Vec<QuadInstanc
         let mut bins = [0i32; 8];
         let mut complete = true;
         for (slot, bin) in bins.iter_mut().enumerate() {
-            match captures.get(slot + 2).and_then(|g| g.as_str().parse().ok()) {
-                Some(value) => *bin = value,
+            match captures.get(slot + 2) {
+                Some(group) => *bin = parse_bin(group.as_str()),
                 None => complete = false,
             }
         }

--- a/src/models/florence2/postprocess.rs
+++ b/src/models/florence2/postprocess.rs
@@ -1,0 +1,210 @@
+// Copyright 2025-2026 Lablup Inc. and Jeongkyu Shin
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Turning a decoded Florence-2 answer into a typed result.
+//!
+//! This is the dispatch half of upstream's `post_process_generation`: it maps
+//! a task to its parse behavior, runs the matching parser from
+//! [`super::parse`], and reshapes the parser's instance list into the
+//! parallel-array form callers consume.
+//!
+//! Reference:
+//! https://github.com/Blaizzy/mlx-vlm/blob/main/mlx_vlm/models/florence2/processing_florence2.py
+//! (`Florence2Processor.post_process_generation`).
+
+use super::coords::{Florence2BoundingBox, Florence2ImageSize, Florence2Polygon, Florence2QuadBox};
+use super::parse;
+use super::tasks::Florence2Task;
+
+/// How a task's answer is parsed.
+///
+/// Upstream keys this off a string in `tasks_answer_post_processing_type`;
+/// here it is an enum so [`Florence2Task::post_processing_type`] is total.
+/// The `'od'` and `'description_with_polygons'` parse tasks upstream declares
+/// are absent because no task routes to either.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum Florence2PostProcessingType {
+    /// The answer is prose. Only the sequence markers are removed.
+    PureText,
+    /// `<OCR_WITH_REGION>`: text lines with quadrilaterals.
+    Ocr,
+    /// `<OD>`, `<DENSE_REGION_CAPTION>`: labelled boxes.
+    DescriptionWithBoxes,
+    /// `<REGION_PROPOSAL>`: boxes with no labels.
+    Boxes,
+    /// `<CAPTION_TO_PHRASE_GROUNDING>`: caption phrases with their boxes.
+    PhraseGrounding,
+    /// `<REFERRING_EXPRESSION_SEGMENTATION>`, `<REGION_TO_SEGMENTATION>`.
+    Polygons,
+    /// `<OPEN_VOCABULARY_DETECTION>`: boxes or polygons, whichever the model
+    /// chose to emit.
+    DescriptionWithBoxesOrPolygons,
+}
+
+/// A parsed Florence-2 answer.
+///
+/// `#[non_exhaustive]` because the variant set follows the task set, and
+/// upstream has grown parse tasks (`description_with_polygons`) that no
+/// released task routes to yet.
+#[derive(Debug, Clone, PartialEq)]
+#[non_exhaustive]
+pub enum Florence2TaskResult {
+    /// Prose answer, sequence markers removed.
+    Text(String),
+    /// Boxes with one label each. Labels are empty strings for
+    /// `<REGION_PROPOSAL>`, which predicts regions without naming them. For
+    /// `<CAPTION_TO_PHRASE_GROUNDING>` a phrase grounded by several boxes
+    /// appears once per box, so `boxes` and `labels` stay index-aligned.
+    Boxes {
+        boxes: Vec<Florence2BoundingBox>,
+        labels: Vec<String>,
+    },
+    /// OCR lines: one quadrilateral and one text string each.
+    QuadBoxes {
+        quad_boxes: Vec<Florence2QuadBox>,
+        labels: Vec<String>,
+    },
+    /// Segmentation: one label per instance, and one or more outlines per
+    /// instance (a disconnected object needs several).
+    Polygons {
+        polygons: Vec<Vec<Florence2Polygon>>,
+        labels: Vec<String>,
+    },
+    /// `<OPEN_VOCABULARY_DETECTION>`. Upstream returns all four arrays
+    /// unconditionally and leaves the unused pair empty, so both are kept
+    /// rather than collapsing to an either/or.
+    BoxesOrPolygons {
+        boxes: Vec<Florence2BoundingBox>,
+        box_labels: Vec<String>,
+        polygons: Vec<Vec<Florence2Polygon>>,
+        polygon_labels: Vec<String>,
+    },
+}
+
+impl Florence2TaskResult {
+    /// Parse `text`, the answer decoded with special tokens kept, into the
+    /// structured form for `task`.
+    ///
+    /// `size` is the size of the image **as it was handed to the processor**,
+    /// not the 768x768 resized tensor: location bins are relative to the
+    /// original extent, so passing the resized size silently scales every
+    /// coordinate.
+    ///
+    /// Free of any model or tokenizer state, so a caller holding an answer
+    /// from elsewhere can parse it without loading a checkpoint.
+    /// [`super::Florence2Processor::post_process`] is the same call reached
+    /// through a loaded processor.
+    pub fn parse(text: &str, task: Florence2Task, size: Florence2ImageSize) -> Self {
+        post_process(text, task, size)
+    }
+}
+
+pub(crate) fn post_process(
+    text: &str,
+    task: Florence2Task,
+    size: Florence2ImageSize,
+) -> Florence2TaskResult {
+    use Florence2PostProcessingType as P;
+    match task.post_processing_type() {
+        P::PureText => Florence2TaskResult::Text(strip_sequence_markers(text)),
+        P::Ocr => {
+            let instances = parse::parse_ocr(text, size);
+            let mut quad_boxes = Vec::with_capacity(instances.len());
+            let mut labels = Vec::with_capacity(instances.len());
+            for instance in instances {
+                quad_boxes.push(instance.quad_box);
+                labels.push(instance.text);
+            }
+            Florence2TaskResult::QuadBoxes { quad_boxes, labels }
+        }
+        P::DescriptionWithBoxes => boxes_result(parse::parse_boxes(text, size, false)),
+        P::Boxes => boxes_result(parse::parse_boxes(text, size, true)),
+        P::PhraseGrounding => {
+            let mut boxes = Vec::new();
+            let mut labels = Vec::new();
+            for phrase in parse::parse_phrase_grounding(text, size) {
+                for bbox in phrase.boxes {
+                    boxes.push(bbox);
+                    labels.push(phrase.cat_name.clone());
+                }
+            }
+            Florence2TaskResult::Boxes { boxes, labels }
+        }
+        P::Polygons => {
+            let instances = parse::parse_polygons(text, size, true);
+            let mut polygons = Vec::with_capacity(instances.len());
+            let mut labels = Vec::with_capacity(instances.len());
+            for instance in instances {
+                polygons.push(instance.polygons);
+                labels.push(instance.cat_name);
+            }
+            Florence2TaskResult::Polygons { polygons, labels }
+        }
+        // Upstream picks the branch on a bare `'<poly>' in text` check rather
+        // than on anything structural, so a single answer is read as entirely
+        // polygons or entirely boxes.
+        P::DescriptionWithBoxesOrPolygons => {
+            if text.contains("<poly>") {
+                let instances = parse::parse_polygons(text, size, false);
+                let mut polygons = Vec::with_capacity(instances.len());
+                let mut polygon_labels = Vec::with_capacity(instances.len());
+                for instance in instances {
+                    polygons.push(instance.polygons);
+                    polygon_labels.push(instance.cat_name);
+                }
+                Florence2TaskResult::BoxesOrPolygons {
+                    boxes: Vec::new(),
+                    box_labels: Vec::new(),
+                    polygons,
+                    polygon_labels,
+                }
+            } else {
+                let instances = parse::parse_boxes(text, size, false);
+                let mut boxes = Vec::with_capacity(instances.len());
+                let mut box_labels = Vec::with_capacity(instances.len());
+                for instance in instances {
+                    boxes.push(instance.bbox);
+                    box_labels.push(instance.cat_name);
+                }
+                Florence2TaskResult::BoxesOrPolygons {
+                    boxes,
+                    box_labels,
+                    polygons: Vec::new(),
+                    polygon_labels: Vec::new(),
+                }
+            }
+        }
+    }
+}
+
+fn boxes_result(instances: Vec<parse::BoxInstance>) -> Florence2TaskResult {
+    let mut boxes = Vec::with_capacity(instances.len());
+    let mut labels = Vec::with_capacity(instances.len());
+    for instance in instances {
+        boxes.push(instance.bbox);
+        labels.push(instance.cat_name);
+    }
+    Florence2TaskResult::Boxes { boxes, labels }
+}
+
+/// `pure_text` strips only `<s>` and `</s>`, not `<pad>`, which is what
+/// upstream's `final_answer.replace('<s>', '').replace('</s>', '')` does. The
+/// box parsers strip `<pad>` as well; the asymmetry is upstream's.
+fn strip_sequence_markers(text: &str) -> String {
+    text.replace("<s>", "").replace("</s>", "")
+}
+
+#[cfg(test)]
+#[path = "florence2_postprocess_tests.rs"]
+mod florence2_postprocess_tests;

--- a/src/models/florence2/processor.rs
+++ b/src/models/florence2/processor.rs
@@ -1,0 +1,154 @@
+// Copyright 2025-2026 Lablup Inc. and Jeongkyu Shin
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! The Florence-2 processor: task prompt and image in, structured result out.
+//!
+//! [`Florence2Processor::run`] is the whole request path in one call:
+//!
+//! 1. Expand the task marker into its English prompt ([`super::tasks`]).
+//! 2. Tokenize it with the checkpoint's BART tokenizer, adding `<s>` / `</s>`.
+//! 3. Preprocess the image to 768x768 NCHW, keeping its original size.
+//! 4. Drive [`Florence2Model::generate_greedy`], which fuses image features
+//!    in front of the prompt embeddings and decodes greedily.
+//! 5. Decode the generated ids **keeping special tokens**, because the answer
+//!    to a spatial task is mostly `<loc_*>` tokens and dropping them would
+//!    leave only the labels.
+//! 6. Parse the answer against the *original* image size ([`super::parse`]).
+//!
+//! Reference:
+//! https://github.com/Blaizzy/mlx-vlm/blob/main/mlx_vlm/models/florence2/processing_florence2.py
+
+use std::path::Path;
+
+use anyhow::{Context, Result, anyhow};
+use image::DynamicImage;
+
+use crate::tokenizer::{MlxcelTokenizer, load_tokenizer};
+use crate::vision::processors::florence2::Florence2ImageProcessor;
+
+use super::coords::Florence2ImageSize;
+use super::model::Florence2Model;
+use super::postprocess::{self, Florence2TaskResult};
+use super::tasks::Florence2Task;
+
+/// One task run: the answer as the model wrote it, and its parsed form.
+///
+/// The raw text is kept alongside the parsed result because it is the only
+/// way to tell "the model found nothing" from "the parser rejected what the
+/// model wrote", and the two need different fixes.
+#[derive(Debug, Clone, PartialEq)]
+pub struct Florence2Output {
+    /// Decoded answer with special tokens intact, for example
+    /// `"<s>car<loc_52><loc_332><loc_932><loc_774>"`.
+    pub raw_text: String,
+    /// The answer parsed for the requested task.
+    pub result: Florence2TaskResult,
+}
+
+/// Tokenizer and image preprocessing for a Florence-2 checkpoint.
+pub struct Florence2Processor {
+    tokenizer: MlxcelTokenizer,
+    image_processor: Florence2ImageProcessor,
+}
+
+impl Florence2Processor {
+    /// Load both halves from a checkpoint directory (`tokenizer.json` +
+    /// `preprocessor_config.json`).
+    pub fn from_pretrained(model_path: &Path) -> Result<Self> {
+        let tokenizer = load_tokenizer(model_path)
+            .with_context(|| format!("Florence-2: failed to load tokenizer from {model_path:?}"))?;
+        let image_processor =
+            Florence2ImageProcessor::from_pretrained(model_path).map_err(|e| anyhow!("{e}"))?;
+        Ok(Self {
+            tokenizer,
+            image_processor,
+        })
+    }
+
+    /// The tokenizer, for callers that need to decode partial output while
+    /// streaming.
+    pub fn tokenizer(&self) -> &MlxcelTokenizer {
+        &self.tokenizer
+    }
+
+    /// The image preprocessing configuration.
+    pub fn image_processor(&self) -> &Florence2ImageProcessor {
+        &self.image_processor
+    }
+
+    /// Expand a task into its prompt sentence and tokenize it.
+    ///
+    /// `add_special_tokens` is on, so the checkpoint's `RobertaProcessing`
+    /// post-processor wraps the ids in `<s>` ... `</s>`; that is the form the
+    /// encoder was trained on.
+    pub fn encode_prompt(&self, task: Florence2Task, input: Option<&str>) -> Result<Vec<i32>> {
+        let prompt = task.expand(input).map_err(|e| anyhow!("{e}"))?;
+        let ids = self
+            .tokenizer
+            .encode(&prompt, true)
+            .with_context(|| format!("Florence-2: failed to tokenize prompt {prompt:?}"))?;
+        Ok(ids.into_iter().map(|id| id as i32).collect())
+    }
+
+    /// Decode generated ids back to text, keeping special tokens.
+    ///
+    /// Location tokens are marked special in `tokenizer.json`, so skipping
+    /// special tokens here would silently delete every coordinate in the
+    /// answer and leave the spatial tasks returning empty results.
+    pub fn decode_answer(&self, ids: &[i32]) -> Result<String> {
+        let ids: Vec<u32> = ids.iter().map(|id| *id as u32).collect();
+        self.tokenizer
+            .decode(&ids, false)
+            .context("Florence-2: failed to decode generated ids")
+    }
+
+    /// Parse an answer for `task` against the original image size.
+    pub fn post_process(
+        &self,
+        text: &str,
+        task: Florence2Task,
+        size: Florence2ImageSize,
+    ) -> Florence2TaskResult {
+        postprocess::post_process(text, task, size)
+    }
+
+    /// Run one task end to end against a loaded model.
+    pub fn run(
+        &self,
+        model: &Florence2Model,
+        task: Florence2Task,
+        input: Option<&str>,
+        image: &DynamicImage,
+        max_new_tokens: usize,
+    ) -> Result<Florence2Output> {
+        let prompt_ids = self.encode_prompt(task, input)?;
+        let processed = self
+            .image_processor
+            .preprocess_with_sizes(std::slice::from_ref(image));
+        let (width, height) = *processed
+            .original_sizes
+            .first()
+            .ok_or_else(|| anyhow!("Florence-2: image preprocessing returned no images"))?;
+
+        let generated =
+            model.generate_greedy(&processed.pixel_values, &prompt_ids, max_new_tokens)?;
+        let raw_text = self.decode_answer(&generated)?;
+        let result = self.post_process(&raw_text, task, Florence2ImageSize::new(width, height));
+        Ok(Florence2Output { raw_text, result })
+    }
+}
+
+#[cfg(test)]
+#[path = "florence2_processor_tests.rs"]
+mod florence2_processor_tests;

--- a/src/models/florence2/scan.rs
+++ b/src/models/florence2/scan.rs
@@ -161,13 +161,25 @@ pub(super) fn leading_phrase<'a>(chunk: &'a str, stops: &[&str]) -> Option<&'a s
     None
 }
 
+/// Parse a `<loc_N>` digit run the way upstream's `int()` does.
+///
+/// Python integers are unbounded, so a digit run wider than `i32` still yields
+/// a value there. Saturating rather than discarding the token is what keeps
+/// the four-at-a-time grouping in [`box_bins`] and the eight-token OCR record
+/// aligned: dropping one bin would silently re-pair every bin after it in the
+/// same chunk. Unreachable on real output, because the vocabulary carries only
+/// `<loc_0>` .. `<loc_999>`.
+pub(super) fn parse_bin(digits: &str) -> i32 {
+    digits.parse::<i32>().unwrap_or(i32::MAX)
+}
+
 /// Read every `<loc_N>` bin in `text`, left to right.
 ///
 /// Hand-rolled rather than a regex because the pattern is a fixed literal with
-/// one digit run, and this is the innermost step of every parser. Values that
-/// overflow `i32` or exceed the 1000-bin range cannot occur in real output
-/// (the tokenizer has no token for them) but are accepted here rather than
-/// rejected, matching upstream's plain `int()`.
+/// one digit run, and this is the innermost step of every parser. Bins outside
+/// the 1000-bin range cannot occur in real output (the tokenizer has no token
+/// for them) but are accepted here rather than rejected, matching upstream's
+/// plain `int()`; see [`parse_bin`] for the width case.
 pub(super) fn location_bins(text: &str) -> Vec<i32> {
     let bytes = text.as_bytes();
     let mut out = Vec::new();
@@ -179,9 +191,7 @@ pub(super) fn location_bins(text: &str) -> Vec<i32> {
             cursor += 1;
         }
         if cursor > digits_start && bytes.get(cursor) == Some(&b'>') {
-            if let Ok(bin) = text[digits_start..cursor].parse::<i32>() {
-                out.push(bin);
-            }
+            out.push(parse_bin(&text[digits_start..cursor]));
             index = cursor + 1;
         } else {
             index = digits_start;

--- a/src/models/florence2/scan.rs
+++ b/src/models/florence2/scan.rs
@@ -1,0 +1,227 @@
+// Copyright 2025-2026 Lablup Inc. and Jeongkyu Shin
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Low-level text scanners shared by the Florence-2 answer parsers.
+//!
+//! These are the pieces of upstream's post-processing that are literal string
+//! work rather than pattern matching: stripping sequence markers, finding the
+//! leading phrase of a chunk, and reading `<loc_N>` runs. Two of them replace
+//! an upstream regex with a hand-rolled scan, and the equivalence argument is
+//! recorded on each.
+//!
+//! Reference:
+//! https://github.com/Blaizzy/mlx-vlm/blob/main/mlx_vlm/models/florence2/processing_florence2.py
+
+/// Phrases dropped from `<CAPTION_TO_PHRASE_GROUNDING>` output.
+///
+/// Verbatim from the checkpoint (`_create_black_list_of_phrase_grounding`),
+/// deduplicated and sorted so membership is a binary search. Upstream lists
+/// 100 entries with 28 repeats and stores them in a `set`, so the duplicates
+/// carry no meaning. `FILTER_BY_BLACK_LIST` is true in the shipped config, so
+/// unlike most of upstream's post-processing knobs this one is live and really
+/// does remove phrases from the output.
+pub(super) const PHRASE_GROUNDING_BLACKLIST: &[&str] = &[
+    "I",
+    "a",
+    "a group",
+    "a set",
+    "all",
+    "an",
+    "another",
+    "any",
+    "anybody",
+    "anyone",
+    "anything",
+    "each",
+    "each other",
+    "everybody",
+    "everyone",
+    "everything",
+    "few",
+    "he",
+    "her",
+    "hers",
+    "herself",
+    "him",
+    "himself",
+    "his",
+    "image",
+    "images",
+    "it",
+    "its",
+    "itself",
+    "lots",
+    "many",
+    "me",
+    "mine",
+    "myself",
+    "nobody",
+    "none",
+    "one",
+    "one another",
+    "oneself",
+    "other objects",
+    "our",
+    "ours",
+    "ourselves",
+    "several",
+    "she",
+    "some",
+    "somebody",
+    "someone",
+    "something",
+    "that",
+    "the",
+    "the image",
+    "their",
+    "theirs",
+    "them",
+    "themselves",
+    "these",
+    "they",
+    "this",
+    "those",
+    "us",
+    "we",
+    "what",
+    "which",
+    "who",
+    "whom",
+    "whose",
+    "you",
+    "your",
+    "yours",
+    "yourself",
+    "yourselves",
+];
+
+/// Positions the phrase-string scan stops at, from upstream's
+/// `(?=<od>|</od>|<box>|</box>|<bbox>|</bbox>|<loc_)`.
+pub(super) const PHRASE_STOPS: &[&str] = &[
+    "<od>", "</od>", "<box>", "</box>", "<bbox>", "</bbox>", "<loc_",
+];
+
+/// Same list with `<poly>` appended, which is what the polygon parser uses.
+pub(super) const PHRASE_STOPS_POLY: &[&str] = &[
+    "<od>", "</od>", "<box>", "</box>", "<bbox>", "</bbox>", "<loc_", "<poly>",
+];
+
+/// Drop the sequence markers before parsing, as every upstream parser does.
+pub(super) fn strip_sequence_markers(text: &str) -> String {
+    text.replace("<s>", "")
+        .replace("</s>", "")
+        .replace("<pad>", "")
+}
+
+/// Non-ASCII characters are dropped, not replaced: upstream round-trips the
+/// phrase through `encode('ascii', errors='ignore')`.
+pub(super) fn ascii_only(text: &str) -> String {
+    text.chars().filter(char::is_ascii).collect()
+}
+
+/// The leading phrase of a chunk, or `None` when upstream's phrase regex would
+/// have failed and skipped the chunk.
+///
+/// Upstream uses `^\s*(.*?)(?=<od>|...|<loc_)` and takes group 0, then strips
+/// it. Two properties of that regex drive this scanner, and both are load
+/// bearing:
+///
+/// - `.` does not match a newline, and `^` is not multi-line, so the search
+///   fails outright if a newline sits between the end of the leading
+///   whitespace run and the first stop position. The chunk is then dropped.
+/// - The scan stops at the first stop *position*, not at the first `<`. A
+///   `<sep>` in a polygon chunk is not in the stop list, so the phrase runs
+///   past it.
+///
+/// The returned slice is the trimmed text before that stop position.
+pub(super) fn leading_phrase<'a>(chunk: &'a str, stops: &[&str]) -> Option<&'a str> {
+    let whitespace_end = chunk.len() - chunk.trim_start().len();
+    for (offset, ch) in chunk.char_indices() {
+        if offset < whitespace_end {
+            continue;
+        }
+        if stops.iter().any(|stop| chunk[offset..].starts_with(stop)) {
+            return Some(chunk[..offset].trim());
+        }
+        if ch == '\n' {
+            return None;
+        }
+    }
+    None
+}
+
+/// Read every `<loc_N>` bin in `text`, left to right.
+///
+/// Hand-rolled rather than a regex because the pattern is a fixed literal with
+/// one digit run, and this is the innermost step of every parser. Values that
+/// overflow `i32` or exceed the 1000-bin range cannot occur in real output
+/// (the tokenizer has no token for them) but are accepted here rather than
+/// rejected, matching upstream's plain `int()`.
+pub(super) fn location_bins(text: &str) -> Vec<i32> {
+    let bytes = text.as_bytes();
+    let mut out = Vec::new();
+    let mut index = 0usize;
+    while let Some(found) = text[index..].find("<loc_") {
+        let digits_start = index + found + "<loc_".len();
+        let mut cursor = digits_start;
+        while cursor < bytes.len() && bytes[cursor].is_ascii_digit() {
+            cursor += 1;
+        }
+        if cursor > digits_start && bytes.get(cursor) == Some(&b'>') {
+            if let Ok(bin) = text[digits_start..cursor].parse::<i32>() {
+                out.push(bin);
+            }
+            index = cursor + 1;
+        } else {
+            index = digits_start;
+        }
+    }
+    out
+}
+
+/// Every group of four consecutive location tokens, non-overlapping, matching
+/// upstream's `finditer(r'<loc_(\d+)><loc_(\d+)><loc_(\d+)><loc_(\d+)>')`.
+///
+/// Because the tokens in a chunk are always adjacent, scanning the flat bin
+/// list in groups of four is equivalent to the regex, and a trailing partial
+/// group is discarded exactly as a failed regex match would be.
+pub(super) fn box_bins(chunk: &str) -> Vec<[i32; 4]> {
+    location_bins(chunk)
+        .chunks_exact(4)
+        .map(|c| [c[0], c[1], c[2], c[3]])
+        .collect()
+}
+
+/// Upstream's `re.sub(r'^loc_\d+>', '', phrase_text, count=1)`, applied before
+/// the polygon phrase search.
+///
+/// Unreachable in practice: a chunk either starts with `<` or with a plain
+/// text run, and a model would have to emit the literal characters `loc_12>`
+/// as prose to trigger it. Ported anyway because it costs a scan and removes a
+/// divergence that would otherwise only show up on adversarial input.
+pub(super) fn strip_bare_loc_prefix(chunk: &str) -> &str {
+    let Some(rest) = chunk.strip_prefix("loc_") else {
+        return chunk;
+    };
+    let digits = rest.bytes().take_while(u8::is_ascii_digit).count();
+    if digits > 0 && rest.as_bytes().get(digits) == Some(&b'>') {
+        &rest[digits + 1..]
+    } else {
+        chunk
+    }
+}
+
+#[cfg(test)]
+#[path = "florence2_scan_tests.rs"]
+mod florence2_scan_tests;

--- a/src/models/florence2/tasks.rs
+++ b/src/models/florence2/tasks.rs
@@ -1,0 +1,212 @@
+// Copyright 2025-2026 Lablup Inc. and Jeongkyu Shin
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Florence-2 task tokens and their prompt expansions.
+//!
+//! Florence-2 selects its behavior with a task marker such as `<OD>` or
+//! `<CAPTION>`. These markers are **not vocabulary entries**: the checkpoint's
+//! tokenizer has no id for any of them. The processor replaces the marker with
+//! a plain English sentence *before* tokenization, and it is that sentence the
+//! encoder sees. `<OD>` really means "Locate the objects with category name in
+//! the image."
+//!
+//! Seven of the fifteen tasks additionally interpolate a caller-supplied
+//! string into the prompt: a caption to ground, a phrase to segment, or a
+//! region expressed as four `<loc_*>` tokens.
+//!
+//! Reference:
+//! https://github.com/Blaizzy/mlx-vlm/blob/main/mlx_vlm/models/florence2/processing_florence2.py
+//! (`Florence2Processor.task_prompts_without_inputs`,
+//! `task_prompts_with_input`, `tasks_answer_post_processing_type`,
+//! `_construct_prompts`).
+
+use std::fmt;
+use std::str::FromStr;
+
+use super::postprocess::Florence2PostProcessingType;
+
+/// One of the fifteen Florence-2 task modes.
+///
+/// Not `#[non_exhaustive]`: the set is fixed by the released checkpoints'
+/// training recipe, and callers matching exhaustively over it is the point.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum Florence2Task {
+    Ocr,
+    OcrWithRegion,
+    Caption,
+    DetailedCaption,
+    MoreDetailedCaption,
+    ObjectDetection,
+    DenseRegionCaption,
+    RegionProposal,
+    CaptionToPhraseGrounding,
+    ReferringExpressionSegmentation,
+    RegionToSegmentation,
+    OpenVocabularyDetection,
+    RegionToCategory,
+    RegionToDescription,
+    RegionToOcr,
+}
+
+use Florence2Task::*;
+
+impl Florence2Task {
+    /// Every task, in the order upstream declares them.
+    pub const ALL: [Florence2Task; 15] = [
+        Ocr,
+        OcrWithRegion,
+        Caption,
+        DetailedCaption,
+        MoreDetailedCaption,
+        ObjectDetection,
+        DenseRegionCaption,
+        CaptionToPhraseGrounding,
+        ReferringExpressionSegmentation,
+        RegionToSegmentation,
+        OpenVocabularyDetection,
+        RegionToCategory,
+        RegionToDescription,
+        RegionToOcr,
+        RegionProposal,
+    ];
+
+    /// The task marker, for example `"<OD>"`. Callers pass this string form
+    /// through a CLI or an API; it never reaches the tokenizer.
+    pub fn token(self) -> &'static str {
+        match self {
+            Ocr => "<OCR>",
+            OcrWithRegion => "<OCR_WITH_REGION>",
+            Caption => "<CAPTION>",
+            DetailedCaption => "<DETAILED_CAPTION>",
+            MoreDetailedCaption => "<MORE_DETAILED_CAPTION>",
+            ObjectDetection => "<OD>",
+            DenseRegionCaption => "<DENSE_REGION_CAPTION>",
+            RegionProposal => "<REGION_PROPOSAL>",
+            CaptionToPhraseGrounding => "<CAPTION_TO_PHRASE_GROUNDING>",
+            ReferringExpressionSegmentation => "<REFERRING_EXPRESSION_SEGMENTATION>",
+            RegionToSegmentation => "<REGION_TO_SEGMENTATION>",
+            OpenVocabularyDetection => "<OPEN_VOCABULARY_DETECTION>",
+            RegionToCategory => "<REGION_TO_CATEGORY>",
+            RegionToDescription => "<REGION_TO_DESCRIPTION>",
+            RegionToOcr => "<REGION_TO_OCR>",
+        }
+    }
+
+    /// Whether this task interpolates a caller-supplied string into its
+    /// prompt.
+    pub fn takes_input(self) -> bool {
+        self.prompt_template().contains("{input}")
+    }
+
+    /// How the model's answer for this task must be parsed.
+    pub fn post_processing_type(self) -> Florence2PostProcessingType {
+        use Florence2PostProcessingType as P;
+        match self {
+            Ocr | Caption | DetailedCaption | MoreDetailedCaption | RegionToCategory
+            | RegionToDescription | RegionToOcr => P::PureText,
+            OcrWithRegion => P::Ocr,
+            ObjectDetection | DenseRegionCaption => P::DescriptionWithBoxes,
+            RegionProposal => P::Boxes,
+            CaptionToPhraseGrounding => P::PhraseGrounding,
+            ReferringExpressionSegmentation | RegionToSegmentation => P::Polygons,
+            OpenVocabularyDetection => P::DescriptionWithBoxesOrPolygons,
+        }
+    }
+
+    /// The raw prompt sentence, with `{input}` still in place for the tasks
+    /// that take one.
+    ///
+    /// Copied byte for byte from the checkpoint, including the inconsistencies
+    /// upstream carries: `<OCR_WITH_REGION>` has a comma before "with
+    /// regions", `<REFERRING_EXPRESSION_SEGMENTATION>` and
+    /// `<REGION_TO_SEGMENTATION>` end without a period while their neighbours
+    /// have one. These are part of the trained input distribution, so
+    /// "tidying" them changes what the model sees.
+    fn prompt_template(self) -> &'static str {
+        match self {
+            Ocr => "What is the text in the image?",
+            OcrWithRegion => "What is the text in the image, with regions?",
+            Caption => "What does the image describe?",
+            DetailedCaption => "Describe in detail what is shown in the image.",
+            MoreDetailedCaption => "Describe with a paragraph what is shown in the image.",
+            ObjectDetection => "Locate the objects with category name in the image.",
+            DenseRegionCaption => "Locate the objects in the image, with their descriptions.",
+            RegionProposal => "Locate the region proposals in the image.",
+            CaptionToPhraseGrounding => "Locate the phrases in the caption: {input}",
+            ReferringExpressionSegmentation => "Locate {input} in the image with mask",
+            RegionToSegmentation => "What is the polygon mask of region {input}",
+            OpenVocabularyDetection => "Locate {input} in the image.",
+            RegionToCategory => "What is the region {input}?",
+            RegionToDescription => "What does the region {input} describe?",
+            RegionToOcr => "What text is in the region {input}?",
+        }
+    }
+
+    /// Expand this task into the English sentence the tokenizer receives.
+    ///
+    /// Deviation from upstream, deliberate: a missing input on a task that
+    /// needs one, or an input supplied to a task that does not, is an error
+    /// here. Upstream's `_construct_prompts` scans for the task token inside a
+    /// free-form string, so `"<REGION_TO_CATEGORY>"` with nothing after it
+    /// silently expands to `"What is the region ?"` and the model answers
+    /// nonsense. There is no way to tell that apart from a real prompt after
+    /// the fact, so it is rejected at the boundary instead.
+    pub fn expand(self, input: Option<&str>) -> Result<String, String> {
+        let template = self.prompt_template();
+        match (self.takes_input(), input) {
+            (false, None) => Ok(template.to_string()),
+            (false, Some(_)) => Err(format!(
+                "Florence-2 task {} takes no input text",
+                self.token()
+            )),
+            (true, None) => Err(format!(
+                "Florence-2 task {} requires input text",
+                self.token()
+            )),
+            (true, Some(text)) => Ok(template.replace("{input}", text)),
+        }
+    }
+}
+
+impl fmt::Display for Florence2Task {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(self.token())
+    }
+}
+
+impl FromStr for Florence2Task {
+    type Err = String;
+
+    /// Parse a task marker. Accepts the bare name as well (`"OD"` for
+    /// `"<OD>"`) and is case insensitive, so a CLI flag does not have to fight
+    /// shell quoting to pass angle brackets.
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        let trimmed = s.trim();
+        let bare = trimmed
+            .strip_prefix('<')
+            .and_then(|rest| rest.strip_suffix('>'))
+            .unwrap_or(trimmed);
+        Self::ALL
+            .into_iter()
+            .find(|task| {
+                let token = task.token();
+                token[1..token.len() - 1].eq_ignore_ascii_case(bare)
+            })
+            .ok_or_else(|| format!("unknown Florence-2 task: {s:?}"))
+    }
+}
+
+#[cfg(test)]
+#[path = "florence2_tasks_tests.rs"]
+mod florence2_tasks_tests;

--- a/src/models/mod.rs
+++ b/src/models/mod.rs
@@ -177,8 +177,11 @@ pub use exaone_moe::ExaoneMoeModel;
 pub use exaone4::{ExaOne4Model, ExaOne4Wrapper};
 pub use falcon_h1::FalconH1Model;
 pub use florence2::{
-    FLORENCE2_VISION_PREFIX, Florence2Config, Florence2DaViT, Florence2Model, Florence2SeqCache,
-    Florence2TextConfig, Florence2TextModel, Florence2VisionConfig,
+    FLORENCE2_LOC_TOKEN_BASE, FLORENCE2_VISION_PREFIX, Florence2BoundingBox, Florence2Config,
+    Florence2DaViT, Florence2ImageSize, Florence2Model, Florence2Output, Florence2Polygon,
+    Florence2PostProcessingType, Florence2Processor, Florence2QuadBox, Florence2SeqCache,
+    Florence2Task, Florence2TaskResult, Florence2TextConfig, Florence2TextModel,
+    Florence2VisionConfig, florence2_loc_token_id,
 };
 pub use gemma::GemmaModel;
 pub use gemma2::Gemma2Model;

--- a/src/vision/processors/florence2.rs
+++ b/src/vision/processors/florence2.rs
@@ -1,0 +1,265 @@
+// Copyright 2025-2026 Lablup Inc. and Jeongkyu Shin
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Florence-2 image preprocessing.
+//!
+//! Florence-2 ships a stock `CLIPImageProcessor` configured for a fixed
+//! 768x768 square, so the pipeline is: resize straight to 768x768, rescale to
+//! [0, 1], normalize, emit NCHW.
+//!
+//! Two details are easy to get wrong and are the reason this is its own
+//! processor rather than a reuse of an existing one:
+//!
+//! - The mean and standard deviation are **ImageNet** values, not the CLIP
+//!   ones the class name suggests and not the SigLIP 0.5s. Reusing
+//!   `PIXTRAL_IMAGE_MEAN` / `PIXTRAL_IMAGE_STD` here would shift every channel.
+//! - `size` carries `height` and `width` rather than `shortest_edge`, and
+//!   `do_center_crop` is false, so the resize does **not** preserve aspect
+//!   ratio. A non-square image is squashed, not letterboxed or cropped, and
+//!   the original extent is carried separately because Florence-2's location
+//!   bins are relative to it.
+//!
+//! Reference:
+//! https://github.com/Blaizzy/mlx-vlm/blob/main/mlx_vlm/models/florence2/processing_florence2.py
+
+use std::path::Path;
+
+use image::DynamicImage;
+use image::imageops::FilterType;
+use mlxcel_core::{MlxArray, UniquePtr};
+use serde::Deserialize;
+
+use super::ImageProcessor;
+
+/// PIL's `Image.BICUBIC`, the only `resample` value Florence-2 ships.
+const PIL_BICUBIC: u32 = 3;
+
+/// Preprocessing settings read from `preprocessor_config.json`.
+///
+/// Every field is read from the file rather than hard-coded: the checkpoint is
+/// the authority, and a variant that retrains at a different resolution would
+/// otherwise be silently misprocessed.
+#[derive(Debug, Clone, PartialEq)]
+pub struct Florence2ImageProcessor {
+    pub height: usize,
+    pub width: usize,
+    pub do_resize: bool,
+    pub do_rescale: bool,
+    pub rescale_factor: f32,
+    pub do_normalize: bool,
+    pub image_mean: [f32; 3],
+    pub image_std: [f32; 3],
+}
+
+/// Preprocessed pixels plus the sizes needed to interpret the answer.
+pub struct Florence2PixelValues {
+    /// `[batch, 3, height, width]` f32, NCHW.
+    pub pixel_values: UniquePtr<MlxArray>,
+    /// `(width, height)` of each input image *before* the resize, in the same
+    /// order as the batch. Florence-2's `<loc_*>` bins are relative to this,
+    /// so post-processing needs it to produce pixel coordinates.
+    pub original_sizes: Vec<(u32, u32)>,
+}
+
+#[derive(Debug, Deserialize)]
+struct RawSize {
+    #[serde(default)]
+    height: Option<usize>,
+    #[serde(default)]
+    width: Option<usize>,
+    #[serde(default)]
+    shortest_edge: Option<usize>,
+}
+
+#[derive(Debug, Deserialize)]
+struct RawPreprocessor {
+    #[serde(default)]
+    size: Option<RawSize>,
+    #[serde(default)]
+    do_resize: Option<bool>,
+    #[serde(default)]
+    do_rescale: Option<bool>,
+    #[serde(default)]
+    rescale_factor: Option<f32>,
+    #[serde(default)]
+    do_normalize: Option<bool>,
+    #[serde(default)]
+    do_center_crop: Option<bool>,
+    #[serde(default)]
+    image_mean: Option<Vec<f32>>,
+    #[serde(default)]
+    image_std: Option<Vec<f32>>,
+    #[serde(default)]
+    resample: Option<u32>,
+}
+
+impl Florence2ImageProcessor {
+    /// Read `preprocessor_config.json` from a checkpoint directory.
+    ///
+    /// The file is required. Falling back to defaults would turn a missing or
+    /// truncated checkpoint into subtly wrong pixels instead of an error, and
+    /// there is no second source for the mean and standard deviation.
+    pub fn from_pretrained(model_path: &Path) -> Result<Self, String> {
+        let path = model_path.join("preprocessor_config.json");
+        let raw = std::fs::read_to_string(&path)
+            .map_err(|e| format!("Florence-2: failed to read {}: {e}", path.display()))?;
+        let parsed: RawPreprocessor = serde_json::from_str(&raw)
+            .map_err(|e| format!("Florence-2: failed to parse {}: {e}", path.display()))?;
+        Self::from_raw(parsed)
+    }
+
+    fn from_raw(parsed: RawPreprocessor) -> Result<Self, String> {
+        // Center cropping would change which part of the image the location
+        // bins refer to, so an unexpected `true` has to stop the load rather
+        // than be ignored.
+        if parsed.do_center_crop == Some(true) {
+            return Err(
+                "Florence-2 preprocessor_config.json sets do_center_crop: true, which this processor does not implement".to_string(),
+            );
+        }
+        if let Some(resample) = parsed.resample
+            && resample != PIL_BICUBIC
+        {
+            return Err(format!(
+                "Florence-2 preprocessor_config.json sets resample: {resample}, expected {PIL_BICUBIC} (bicubic)"
+            ));
+        }
+
+        let size = parsed
+            .size
+            .ok_or_else(|| "Florence-2 preprocessor_config.json has no size".to_string())?;
+        // `shortest_edge` is the aspect-preserving CLIP form. Florence-2 does
+        // not use it, and treating it as a square target would be wrong, so it
+        // is only accepted as a square shorthand when no explicit pair exists.
+        let (height, width) = match (size.height, size.width) {
+            (Some(h), Some(w)) => (h, w),
+            _ => {
+                let edge = size.shortest_edge.or(size.height).or(size.width).ok_or_else(|| {
+                    "Florence-2 preprocessor_config.json size has neither height/width nor shortest_edge".to_string()
+                })?;
+                (edge, edge)
+            }
+        };
+        if height == 0 || width == 0 {
+            return Err(format!(
+                "Florence-2 preprocessor_config.json size {width}x{height} must be positive"
+            ));
+        }
+
+        let image_mean = triple(parsed.image_mean, "image_mean")?.unwrap_or([0.485, 0.456, 0.406]);
+        let image_std = triple(parsed.image_std, "image_std")?.unwrap_or([0.229, 0.224, 0.225]);
+        if image_std.contains(&0.0) {
+            return Err(format!(
+                "Florence-2 preprocessor_config.json image_std {image_std:?} must be non-zero"
+            ));
+        }
+
+        Ok(Self {
+            height,
+            width,
+            do_resize: parsed.do_resize.unwrap_or(true),
+            do_rescale: parsed.do_rescale.unwrap_or(true),
+            rescale_factor: parsed.rescale_factor.unwrap_or(1.0 / 255.0),
+            do_normalize: parsed.do_normalize.unwrap_or(true),
+            image_mean,
+            image_std,
+        })
+    }
+
+    /// Preprocess a batch, keeping each image's original `(width, height)`.
+    ///
+    /// This is the entry point the Florence-2 processor uses;
+    /// [`ImageProcessor::preprocess`] discards the sizes and so cannot drive
+    /// the spatial tasks on its own.
+    pub fn preprocess_with_sizes(&self, images: &[DynamicImage]) -> Florence2PixelValues {
+        let channels = 3usize;
+        let (height, width) = (self.height, self.width);
+        let mut data = vec![0.0f32; images.len() * channels * height * width];
+        let mut original_sizes = Vec::with_capacity(images.len());
+
+        for (index, image) in images.iter().enumerate() {
+            original_sizes.push((image.width(), image.height()));
+            // `resize_exact` ignores aspect ratio, which is what
+            // CLIPImageProcessor does for an explicit height/width `size`.
+            // `CatmullRom` is the `image` crate's cubic filter and the closest
+            // analog of PIL's `BICUBIC` (both are the a = -0.5 cubic with
+            // support scaled by the resampling ratio).
+            let resized = if self.do_resize {
+                image.resize_exact(width as u32, height as u32, FilterType::CatmullRom)
+            } else {
+                image.clone()
+            };
+            let rgb = resized.to_rgb8();
+            // A `do_resize: false` config can hand back a differently sized
+            // buffer; clamp rather than index out of bounds.
+            let copy_h = height.min(rgb.height() as usize);
+            let copy_w = width.min(rgb.width() as usize);
+
+            let plane = height * width;
+            let base = index * channels * plane;
+            for y in 0..copy_h {
+                for x in 0..copy_w {
+                    let pixel = rgb.get_pixel(x as u32, y as u32);
+                    for (c, channel) in pixel.0.iter().take(channels).enumerate() {
+                        let mut value = f32::from(*channel);
+                        if self.do_rescale {
+                            value *= self.rescale_factor;
+                        }
+                        if self.do_normalize {
+                            value = (value - self.image_mean[c]) / self.image_std[c];
+                        }
+                        data[base + c * plane + y * width + x] = value;
+                    }
+                }
+            }
+        }
+
+        let pixel_values = mlxcel_core::from_slice_f32(
+            &data,
+            &[
+                images.len() as i32,
+                channels as i32,
+                height as i32,
+                width as i32,
+            ],
+        );
+        Florence2PixelValues {
+            pixel_values,
+            original_sizes,
+        }
+    }
+}
+
+fn triple(values: Option<Vec<f32>>, field: &str) -> Result<Option<[f32; 3]>, String> {
+    match values {
+        None => Ok(None),
+        Some(v) if v.len() == 3 => Ok(Some([v[0], v[1], v[2]])),
+        Some(v) => Err(format!(
+            "Florence-2 preprocessor_config.json {field} must have 3 entries, got {}",
+            v.len()
+        )),
+    }
+}
+
+impl ImageProcessor for Florence2ImageProcessor {
+    /// Emits f32 NCHW. The fused model casts to the vision tower's own dtype
+    /// in `Florence2Model::encode_image`, so no cast is applied here.
+    fn preprocess(&self, images: &[DynamicImage]) -> UniquePtr<MlxArray> {
+        self.preprocess_with_sizes(images).pixel_values
+    }
+}
+
+#[cfg(test)]
+#[path = "florence2_tests.rs"]
+mod florence2_tests;

--- a/src/vision/processors/florence2.rs
+++ b/src/vision/processors/florence2.rs
@@ -45,6 +45,20 @@ use super::ImageProcessor;
 /// PIL's `Image.BICUBIC`, the only `resample` value Florence-2 ships.
 const PIL_BICUBIC: u32 = 3;
 
+/// Upper bound accepted for either edge of the `size` target. Real Florence-2
+/// exports ship 768 on both axes.
+///
+/// The cap exists because `size` is the only field in this file that becomes an
+/// allocation: [`Florence2ImageProcessor::preprocess_with_sizes`] sizes its
+/// host buffer as `batch * 3 * height * width` f32 before it looks at a single
+/// pixel. An unbounded value out of a hostile `preprocessor_config.json` is a
+/// multi-gigabyte allocation and an out-of-memory abort rather than an error
+/// return, and a value past `usize::MAX / 12` wraps that product in a release
+/// build, leaving a short buffer for a write loop that still runs to the
+/// configured extent. Same reasoning, and the same shape, as `MAX_LAYERS` and
+/// `MAX_POSITION_EMBEDDINGS` in `src/models/florence2/checkpoint.rs`.
+const MAX_SIZE_EDGE: usize = 8192;
+
 /// Preprocessing settings read from `preprocessor_config.json`.
 ///
 /// Every field is read from the file rather than hard-coded: the checkpoint is
@@ -154,6 +168,11 @@ impl Florence2ImageProcessor {
         if height == 0 || width == 0 {
             return Err(format!(
                 "Florence-2 preprocessor_config.json size {width}x{height} must be positive"
+            ));
+        }
+        if height > MAX_SIZE_EDGE || width > MAX_SIZE_EDGE {
+            return Err(format!(
+                "Florence-2 preprocessor_config.json size {width}x{height} exceeds the {MAX_SIZE_EDGE} per-edge limit"
             ));
         }
 

--- a/src/vision/processors/florence2.rs
+++ b/src/vision/processors/florence2.rs
@@ -219,6 +219,18 @@ impl Florence2ImageProcessor {
             } else {
                 image.clone()
             };
+            // Divergence from upstream: `resized` is resized in its source color
+            // type (RGBA stays RGBA through `resize_exact`), and `to_rgb8` here
+            // then drops the alpha channel unconditionally. Florence-2's
+            // `preprocessor_config.json` ships `"do_convert_rgb": null`, so
+            // upstream's `convert_to_rgb` step is skipped entirely and a
+            // non-opaque RGBA source is resized and fed to the model with alpha
+            // still attached instead of being flattened
+            // (https://github.com/Blaizzy/mlx-vlm/blob/main/mlx_vlm/models/florence2/processing_florence2.py).
+            // We flatten unconditionally instead because this pipeline only
+            // consumes RGB pixel data downstream; that is the safer, deterministic
+            // choice, at the cost of not bit-matching upstream on RGBA inputs with
+            // partial transparency.
             let rgb = resized.to_rgb8();
             // A `do_resize: false` config can hand back a differently sized
             // buffer; clamp rather than index out of bounds.

--- a/src/vision/processors/florence2_tests.rs
+++ b/src/vision/processors/florence2_tests.rs
@@ -99,6 +99,26 @@ fn rejects_configurations_it_would_silently_mishandle() {
         "\"size\": {\"height\": 0, \"width\": 0}",
     );
     assert!(from_json(&zero_size).is_err());
+
+    // `size` is the only field here that becomes an allocation, so an
+    // oversized one has to be refused at parse time rather than turned into a
+    // multi-gigabyte host buffer, and a value large enough to wrap the
+    // `batch * 3 * height * width` product has to be refused for the same
+    // reason it would otherwise be dangerous: the write loop still runs to the
+    // configured extent.
+    let huge_size = REAL_CONFIG.replace(
+        "\"size\": {\"height\": 768, \"width\": 768}",
+        "\"size\": {\"height\": 65536, \"width\": 65536}",
+    );
+    assert!(from_json(&huge_size).is_err());
+    let wrapping_size = REAL_CONFIG.replace(
+        "\"size\": {\"height\": 768, \"width\": 768}",
+        "\"size\": {\"height\": 4294967296, \"width\": 4294967296}",
+    );
+    assert!(from_json(&wrapping_size).is_err());
+
+    // The shipped 768 stays inside the cap.
+    assert!(from_json(REAL_CONFIG).is_ok());
 }
 
 #[test]

--- a/src/vision/processors/florence2_tests.rs
+++ b/src/vision/processors/florence2_tests.rs
@@ -1,0 +1,235 @@
+// Copyright 2025-2026 Lablup Inc. and Jeongkyu Shin
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Florence-2 preprocessing configuration and pixel layout.
+
+use std::path::Path;
+
+use image::{DynamicImage, Rgb, RgbImage};
+
+use super::*;
+
+const MODEL_DIR: &str = "models/Florence-2-base-ft-bf16";
+
+/// The checkpoint's own `preprocessor_config.json`, verbatim.
+const REAL_CONFIG: &str = r#"{
+  "crop_size": {"height": 768, "width": 768},
+  "do_center_crop": false,
+  "do_convert_rgb": null,
+  "do_normalize": true,
+  "do_rescale": true,
+  "do_resize": true,
+  "image_mean": [0.485, 0.456, 0.406],
+  "image_processor_type": "CLIPImageProcessor",
+  "image_seq_length": 577,
+  "image_std": [0.229, 0.224, 0.225],
+  "resample": 3,
+  "rescale_factor": 0.00392156862745098,
+  "size": {"height": 768, "width": 768}
+}"#;
+
+fn from_json(json: &str) -> Result<Florence2ImageProcessor, String> {
+    let parsed: RawPreprocessor =
+        serde_json::from_str(json).map_err(|e| format!("parse error: {e}"))?;
+    Florence2ImageProcessor::from_raw(parsed)
+}
+
+fn solid(width: u32, height: u32, rgb: [u8; 3]) -> DynamicImage {
+    let mut image = RgbImage::new(width, height);
+    for pixel in image.pixels_mut() {
+        *pixel = Rgb(rgb);
+    }
+    DynamicImage::ImageRgb8(image)
+}
+
+#[test]
+fn parses_the_checkpoint_configuration() {
+    let processor = from_json(REAL_CONFIG).expect("parse");
+    assert_eq!((processor.width, processor.height), (768, 768));
+    assert!(processor.do_resize && processor.do_rescale && processor.do_normalize);
+    // ImageNet statistics, not CLIP's 0.481/0.457/0.408 and not SigLIP's 0.5s.
+    assert_eq!(processor.image_mean, [0.485, 0.456, 0.406]);
+    assert_eq!(processor.image_std, [0.229, 0.224, 0.225]);
+    assert!((processor.rescale_factor - 1.0 / 255.0).abs() < 1e-9);
+}
+
+/// The on-disk file must agree with the transcription above, so the pinned
+/// constants cannot drift from the checkpoint unnoticed.
+#[test]
+fn the_real_file_matches_the_pinned_configuration() {
+    if !Path::new(MODEL_DIR).exists() {
+        eprintln!("skipping: {MODEL_DIR} not present");
+        return;
+    }
+    let from_disk = Florence2ImageProcessor::from_pretrained(Path::new(MODEL_DIR)).expect("load");
+    assert_eq!(from_disk, from_json(REAL_CONFIG).expect("parse"));
+}
+
+#[test]
+fn rejects_configurations_it_would_silently_mishandle() {
+    // Center cropping would change which region the location bins address.
+    let cropping = REAL_CONFIG.replace("\"do_center_crop\": false", "\"do_center_crop\": true");
+    assert!(from_json(&cropping).is_err());
+
+    // A different resampling filter changes the pixels the tower sees.
+    let nearest = REAL_CONFIG.replace("\"resample\": 3", "\"resample\": 0");
+    assert!(from_json(&nearest).is_err());
+
+    // A zero standard deviation would divide every channel by zero.
+    let zero_std = REAL_CONFIG.replace("[0.229, 0.224, 0.225]", "[0.0, 0.224, 0.225]");
+    assert!(from_json(&zero_std).is_err());
+
+    // Wrong-length statistics, and no size at all.
+    let short_mean = REAL_CONFIG.replace("[0.485, 0.456, 0.406]", "[0.485, 0.456]");
+    assert!(from_json(&short_mean).is_err());
+    assert!(from_json(r#"{"do_normalize": true}"#).is_err());
+    let zero_size = REAL_CONFIG.replace(
+        "\"size\": {\"height\": 768, \"width\": 768}",
+        "\"size\": {\"height\": 0, \"width\": 0}",
+    );
+    assert!(from_json(&zero_size).is_err());
+}
+
+#[test]
+fn missing_file_is_an_error_rather_than_a_default() {
+    let err = Florence2ImageProcessor::from_pretrained(Path::new("models/no-such-florence2"))
+        .expect_err("must fail");
+    assert!(err.contains("preprocessor_config.json"), "{err}");
+}
+
+#[test]
+fn emits_nchw_at_the_configured_resolution() {
+    let processor = from_json(REAL_CONFIG).expect("parse");
+    let processed = processor.preprocess_with_sizes(&[solid(224, 224, [0, 0, 0])]);
+    assert_eq!(
+        mlxcel_core::array_shape(&processed.pixel_values),
+        vec![1, 3, 768, 768]
+    );
+    assert_eq!(
+        mlxcel_core::array_dtype(&processed.pixel_values),
+        mlxcel_core::dtype::FLOAT32
+    );
+}
+
+/// The original extent, not the resized one, is what the location bins are
+/// relative to, and it is `(width, height)` in that order.
+#[test]
+fn reports_the_original_size_before_resizing() {
+    let processor = from_json(REAL_CONFIG).expect("parse");
+    let processed =
+        processor.preprocess_with_sizes(&[solid(640, 480, [0, 0, 0]), solid(100, 200, [0, 0, 0])]);
+    assert_eq!(processed.original_sizes, vec![(640, 480), (100, 200)]);
+    assert_eq!(
+        mlxcel_core::array_shape(&processed.pixel_values),
+        vec![2, 3, 768, 768]
+    );
+}
+
+/// A solid image resamples to itself, so the normalization can be checked in
+/// closed form: `(value / 255 - mean) / std` per channel.
+#[test]
+fn normalizes_each_channel_with_its_own_statistics() {
+    let processor = from_json(REAL_CONFIG).expect("parse");
+    let processed = processor.preprocess_with_sizes(&[solid(64, 64, [255, 0, 128])]);
+    let values = to_vec_f32(&processed.pixel_values);
+
+    let plane = 768 * 768;
+    let expected = [
+        (1.0 - 0.485) / 0.229,
+        (0.0 - 0.456) / 0.224,
+        (128.0 / 255.0 - 0.406) / 0.225,
+    ];
+    for (channel, want) in expected.iter().enumerate() {
+        let got = values[channel * plane];
+        assert!(
+            (got - want).abs() < 1e-4,
+            "channel {channel}: got {got}, want {want}"
+        );
+    }
+}
+
+/// A red/green split image pins the CHW ordering: channel planes must be
+/// contiguous and rows must run before columns. A transposed layout would
+/// still produce plausible statistics.
+#[test]
+fn lays_out_channels_then_rows_then_columns() {
+    let mut image = RgbImage::new(2, 2);
+    image.put_pixel(0, 0, Rgb([255, 0, 0]));
+    image.put_pixel(1, 0, Rgb([0, 255, 0]));
+    image.put_pixel(0, 1, Rgb([0, 255, 0]));
+    image.put_pixel(1, 1, Rgb([0, 255, 0]));
+
+    let mut processor = from_json(REAL_CONFIG).expect("parse");
+    processor.height = 2;
+    processor.width = 2;
+    processor.do_normalize = false;
+    let processed = processor.preprocess_with_sizes(&[DynamicImage::ImageRgb8(image)]);
+    let values = to_vec_f32(&processed.pixel_values);
+    assert_eq!(values.len(), 12);
+
+    // Red plane first: only the top-left pixel is red.
+    assert!((values[0] - 1.0).abs() < 1e-5, "{values:?}");
+    assert!(
+        values[1] < 1e-5 && values[2] < 1e-5 && values[3] < 1e-5,
+        "{values:?}"
+    );
+    // Green plane next: the other three pixels.
+    assert!(values[4] < 1e-5, "{values:?}");
+    assert!((values[5] - 1.0).abs() < 1e-5, "{values:?}");
+    // Blue plane is empty throughout.
+    assert!(values[8..].iter().all(|v| *v < 1e-5), "{values:?}");
+}
+
+/// A non-square image is squashed to the square target rather than cropped or
+/// letterboxed, because `size` gives an explicit height and width.
+#[test]
+fn resizes_without_preserving_aspect_ratio() {
+    let mut processor = from_json(REAL_CONFIG).expect("parse");
+    processor.height = 8;
+    processor.width = 8;
+    processor.do_normalize = false;
+    // A wide image whose left half is white: after a squash the left half of
+    // the 8x8 output is white, which letterboxing would not produce.
+    let mut image = RgbImage::new(40, 10);
+    for y in 0..10 {
+        for x in 0..20 {
+            image.put_pixel(x, y, Rgb([255, 255, 255]));
+        }
+    }
+    let processed = processor.preprocess_with_sizes(&[DynamicImage::ImageRgb8(image)]);
+    let values = to_vec_f32(&processed.pixel_values);
+    // Row 4 of the red plane: columns 0..3 white, columns 4..7 black.
+    let row = 4 * 8;
+    assert!(values[row] > 0.9, "{}", values[row]);
+    assert!(values[row + 7] < 0.1, "{}", values[row + 7]);
+}
+
+#[test]
+fn an_empty_batch_produces_an_empty_tensor() {
+    let processor = from_json(REAL_CONFIG).expect("parse");
+    let processed = processor.preprocess_with_sizes(&[]);
+    assert_eq!(
+        mlxcel_core::array_shape(&processed.pixel_values),
+        vec![0, 3, 768, 768]
+    );
+    assert!(processed.original_sizes.is_empty());
+}
+
+fn to_vec_f32(array: &mlxcel_core::MlxArray) -> Vec<f32> {
+    mlxcel_core::eval(array);
+    mlxcel_core::array_to_raw_bytes(array)
+        .chunks_exact(4)
+        .map(|c| f32::from_le_bytes([c[0], c[1], c[2], c[3]]))
+        .collect()
+}

--- a/src/vision/processors/florence2_tests.rs
+++ b/src/vision/processors/florence2_tests.rs
@@ -235,6 +235,72 @@ fn resizes_without_preserving_aspect_ratio() {
     assert!(values[row + 7] < 0.1, "{}", values[row + 7]);
 }
 
+/// Regression coverage for the flat NCHW index `c*H*W + y*W + x`: every other
+/// test in this file either targets a square output (`height == width`) or
+/// checks a single axis, so a transposed `y`/`x` (or `H`/`W`) multiplier would
+/// not surface. Here the source image, the target resolution, and even the
+/// two axes of the target resolution are all pairwise distinct (80x40 source,
+/// 8x4 target), and the R channel marks the column half while the G channel
+/// marks the row half, so a swap on either axis flips a distinct assertion.
+#[test]
+fn preserves_nchw_offsets_for_a_non_square_target() {
+    let (src_width, src_height) = (80u32, 40u32);
+    let mut image = RgbImage::new(src_width, src_height);
+    for (x, y, pixel) in image.enumerate_pixels_mut() {
+        let r = if x < src_width / 2 { 255 } else { 0 };
+        let g = if y < src_height / 2 { 255 } else { 0 };
+        *pixel = Rgb([r, g, 0]);
+    }
+
+    let mut processor = from_json(REAL_CONFIG).expect("parse");
+    processor.height = 4;
+    processor.width = 8;
+    processor.do_normalize = false;
+    let processed = processor.preprocess_with_sizes(&[DynamicImage::ImageRgb8(image)]);
+
+    assert_eq!(
+        mlxcel_core::array_shape(&processed.pixel_values),
+        vec![1, 3, 4, 8]
+    );
+
+    let values = to_vec_f32(&processed.pixel_values);
+    assert_eq!(values.len(), 3 * 4 * 8);
+
+    let (height, width, plane) = (4usize, 8usize, 4usize * 8usize);
+    let offset = |channel: usize, y: usize, x: usize| channel * plane + y * width + x;
+
+    // Sample away from the resample-filter boundary on each axis: columns 1
+    // (left) and 6 (right) versus the width-8 midpoint at 4, rows 0 (top) and
+    // 3 (bottom) versus the height-4 midpoint at 2.
+    for &y in &[0usize, height - 1] {
+        // Red (channel 0) tracks the column half regardless of row.
+        assert!(
+            values[offset(0, y, 1)] > 0.9,
+            "left column should be red-high at row {y}: {values:?}"
+        );
+        assert!(
+            values[offset(0, y, 6)] < 0.1,
+            "right column should be red-low at row {y}: {values:?}"
+        );
+    }
+    for &x in &[1usize, 6usize] {
+        // Green (channel 1) tracks the row half regardless of column.
+        assert!(
+            values[offset(1, 0, x)] > 0.9,
+            "top row should be green-high at column {x}: {values:?}"
+        );
+        assert!(
+            values[offset(1, height - 1, x)] < 0.1,
+            "bottom row should be green-low at column {x}: {values:?}"
+        );
+    }
+    // Blue (channel 2) is never written, so the whole plane stays at zero.
+    assert!(
+        values[2 * plane..3 * plane].iter().all(|v| *v < 1e-5),
+        "{values:?}"
+    );
+}
+
 #[test]
 fn an_empty_batch_produces_an_empty_tensor() {
     let processor = from_json(REAL_CONFIG).expect("parse");

--- a/src/vision/processors/mod.rs
+++ b/src/vision/processors/mod.rs
@@ -22,6 +22,7 @@ pub mod deepseekocr;
 pub mod dots_ocr;
 pub mod ernie4_5_vl;
 pub mod fastvlm;
+pub mod florence2;
 pub mod gemma4;
 pub mod gemma4_unified;
 pub mod hunyuan_vl;

--- a/tests/florence2_postprocess_parity.rs
+++ b/tests/florence2_postprocess_parity.rs
@@ -1,0 +1,265 @@
+// Copyright 2025-2026 Lablup Inc. and Jeongkyu Shin
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Florence-2 answer post-processing, pinned against the upstream processor.
+//!
+//! Every expected value below was produced by importing the checkpoint's own
+//! `processing_florence2.py` unmodified and calling `Florence2PostProcesser`
+//! through the same dispatch `post_process_generation` uses, so these are real
+//! upstream results rather than a reimplementation agreeing with itself. The
+//! upstream file is published at
+//! https://github.com/Blaizzy/mlx-vlm/blob/main/mlx_vlm/models/florence2/processing_florence2.py
+//!
+//! Post-processing is pure string-to-struct work, so unlike the rest of the
+//! Florence-2 parity suite this file needs no checkpoint and always runs.
+//!
+//! To regenerate: in a virtualenv holding `transformers`, put the checkpoint
+//! directory on `sys.path`, build
+//! `Florence2PostProcesser(tokenizer=BartTokenizerFast.from_pretrained(dir))`,
+//! and for each case call it with `parse_tasks` set to the task's entry in
+//! `tasks_answer_post_processing_type`, then reshape the instance list exactly
+//! as `post_process_generation` does. `AutoTokenizer` cannot be used because
+//! it routes through `AutoConfig`, which does not know this checkpoint's
+//! custom `florence2_language` model type; the post-processor only reads
+//! `tokenizer.all_special_tokens`, so the choice does not affect the results.
+
+use mlxcel::models::Florence2Task::{self, *};
+use mlxcel::models::{Florence2ImageSize, Florence2TaskResult};
+
+/// Coordinates are deterministic f32 arithmetic on both sides, so the observed
+/// deviation is zero; the tolerance only guards against a literal in this file
+/// being rounded during transcription.
+const TOL: f32 = 1e-4;
+
+fn size(width: u32, height: u32) -> Florence2ImageSize {
+    Florence2ImageSize::new(width, height)
+}
+
+fn assert_coords(got: &[f32], want: &[f32], what: &str) {
+    assert_eq!(got.len(), want.len(), "{what}: length {got:?} vs {want:?}");
+    for (i, (g, w)) in got.iter().zip(want).enumerate() {
+        assert!(
+            (g - w).abs() <= TOL,
+            "{what}[{i}]: got {g}, reference {w} (tol {TOL})"
+        );
+    }
+}
+
+type Case<T> = (&'static str, &'static str, Florence2Task, (u32, u32), T);
+
+// ---------------------------------------------------------------- pure text
+
+#[rustfmt::skip]
+const TEXT_CASES: &[Case<&'static str>] = &[
+    ("caption_text", "<s>A green car on a street.</s>", Caption, (1000, 1000), "A green car on a street."),
+    ("region_to_category", "<s>car</s>", RegionToCategory, (1000, 1000), "car"),
+    // `<OCR>` is pure text even when the answer carries location tokens, so
+    // they survive verbatim instead of being parsed into coordinates.
+    ("plain_ocr", "<s>HELLO<loc_1><loc_2><loc_3><loc_4><loc_5><loc_6><loc_7><loc_8>", Ocr, (1000, 1000), "HELLO<loc_1><loc_2><loc_3><loc_4><loc_5><loc_6><loc_7><loc_8>"),
+];
+
+#[test]
+fn pure_text_matches_upstream() {
+    for (name, text, task, (w, h), want) in TEXT_CASES {
+        let result = Florence2TaskResult::parse(text, *task, size(*w, *h));
+        assert_eq!(
+            result,
+            Florence2TaskResult::Text((*want).to_string()),
+            "{name}"
+        );
+    }
+}
+
+// -------------------------------------------------------------------- boxes
+
+type BoxCase = Case<(&'static [[f32; 4]], &'static [&'static str])>;
+
+#[allow(clippy::excessive_precision)]
+#[rustfmt::skip]
+const BOX_CASES: &[BoxCase] = &[
+    ("od_two_objects", "<s>car<loc_52><loc_332><loc_932><loc_774>person<loc_10><loc_20><loc_30><loc_40></s>", ObjectDetection, (1000, 1000), (&[[52.5, 332.5, 932.5, 774.5], [10.5, 20.5, 30.5, 40.5]], &["car", "person"])),
+    ("od_shared_label", "cat<loc_1><loc_2><loc_3><loc_4><loc_5><loc_6><loc_7><loc_8>", ObjectDetection, (1000, 1000), (&[[1.5, 2.5, 3.5, 4.5], [5.5, 6.5, 7.5, 8.5]], &["cat", "cat"])),
+    // Non-square: x scales by 640/1000 and y by 480/1000, independently.
+    ("od_non_square", "car<loc_52><loc_332><loc_932><loc_774>", ObjectDetection, (640, 480), (&[[33.599998474121094, 159.59999084472656, 596.7999877929688, 371.7599792480469]], &["car"])),
+    // A bare location run read by the labelled parser: `[^<]+` starts one byte
+    // into the first token and captures the literal text `loc_1>` as the
+    // label, shifting the box by one bin. Upstream behavior, and the reason
+    // `<REGION_PROPOSAL>` routes to the empty-phrase parser instead.
+    ("od_bare_locs", "<s><loc_1><loc_2><loc_3><loc_4><loc_5><loc_6><loc_7><loc_8></s>", ObjectDetection, (1000, 1000), (&[[2.5, 3.5, 4.5, 5.5]], &["loc_1>"])),
+    ("od_short_run", "car<loc_1><loc_2><loc_3>", ObjectDetection, (1000, 1000), (&[], &[])),
+    ("od_five_locs", "car<loc_1><loc_2><loc_3><loc_4><loc_5>", ObjectDetection, (1000, 1000), (&[[1.5, 2.5, 3.5, 4.5]], &["car"])),
+    // Non-ASCII characters are dropped, not replaced.
+    ("od_non_ascii", "caf\u{e9}<loc_1><loc_2><loc_3><loc_4>", ObjectDetection, (1000, 1000), (&[[1.5, 2.5, 3.5, 4.5]], &["caf"])),
+    ("od_whitespace", "  a dog  <loc_1><loc_2><loc_3><loc_4>", ObjectDetection, (1000, 1000), (&[[1.5, 2.5, 3.5, 4.5]], &["a dog"])),
+    // A newline before the first location token makes upstream's phrase regex
+    // fail, dropping the whole chunk.
+    ("od_newline", "a\nb<loc_1><loc_2><loc_3><loc_4>", ObjectDetection, (1000, 1000), (&[], &[])),
+    ("od_multibyte", "\u{d55c}\u{ae00}car<loc_1><loc_2><loc_3><loc_4>", ObjectDetection, (1000, 1000), (&[[1.5, 2.5, 3.5, 4.5]], &["car"])),
+    ("region_proposal", "<s><loc_1><loc_2><loc_3><loc_4><loc_5><loc_6><loc_7><loc_8></s>", RegionProposal, (1000, 1000), (&[[1.5, 2.5, 3.5, 4.5], [5.5, 6.5, 7.5, 8.5]], &["", ""])),
+    // Phrase grounding flattens to one label per box.
+    ("grounding_groups", "<s>A green car<loc_1><loc_2><loc_3><loc_4><loc_5><loc_6><loc_7><loc_8>parked next to a house<loc_9><loc_10><loc_11><loc_12></s>", CaptionToPhraseGrounding, (1000, 1000), (&[[1.5, 2.5, 3.5, 4.5], [5.5, 6.5, 7.5, 8.5], [9.5, 10.5, 11.5, 12.5]], &["A green car", "A green car", "parked next to a house"])),
+    ("grounding_blacklist", "the image<loc_1><loc_2><loc_3><loc_4>a truck<loc_5><loc_6><loc_7><loc_8>", CaptionToPhraseGrounding, (1000, 1000), (&[[5.5, 6.5, 7.5, 8.5]], &["a truck"])),
+    // The blacklist is case sensitive, so "The Image" survives.
+    ("grounding_case", "The Image<loc_1><loc_2><loc_3><loc_4>", CaptionToPhraseGrounding, (1000, 1000), (&[[1.5, 2.5, 3.5, 4.5]], &["The Image"])),
+    ("empty", "", ObjectDetection, (1000, 1000), (&[], &[])),
+    ("markers_only", "<s></s>", ObjectDetection, (1000, 1000), (&[], &[])),
+    ("pad_only", "<s><pad></s>", ObjectDetection, (1000, 1000), (&[], &[])),
+    ("no_locs", "just a caption", ObjectDetection, (1000, 1000), (&[], &[])),
+];
+
+#[test]
+fn boxes_match_upstream() {
+    for (name, text, task, (w, h), (want_boxes, want_labels)) in BOX_CASES {
+        let Florence2TaskResult::Boxes { boxes, labels } =
+            Florence2TaskResult::parse(text, *task, size(*w, *h))
+        else {
+            panic!("{name}: expected the boxes variant");
+        };
+        assert_eq!(labels, *want_labels, "{name}: labels");
+        assert_eq!(boxes.len(), want_boxes.len(), "{name}: box count");
+        for (i, (got, want)) in boxes.iter().zip(*want_boxes).enumerate() {
+            assert_coords(&got.to_array(), want, &format!("{name} box {i}"));
+        }
+    }
+}
+
+// --------------------------------------------------------------- quad boxes
+
+type QuadCase = Case<(&'static [[f32; 8]], &'static [&'static str])>;
+
+#[allow(clippy::excessive_precision)]
+#[rustfmt::skip]
+const QUAD_CASES: &[QuadCase] = &[
+    ("ocr_two_lines", "<s>HELLO<loc_0><loc_0><loc_0><loc_0><loc_0><loc_0><loc_0><loc_0>WORLD<loc_10><loc_20><loc_30><loc_40><loc_50><loc_60><loc_70><loc_80>", OcrWithRegion, (1000, 1000), (&[[0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5], [10.5, 20.5, 30.5, 40.5, 50.5, 60.5, 70.5, 80.5]], &["HELLO", "WORLD"])),
+    // The eight bins are (x, y) pairs, so alternating entries take different
+    // scales on a non-square image.
+    ("ocr_non_square", "A<loc_0><loc_0><loc_999><loc_0><loc_999><loc_999><loc_0><loc_999>", OcrWithRegion, (1000, 500), (&[[0.5, 0.25, 999.5, 0.25, 999.5, 499.75, 0.5, 499.75]], &["A"])),
+    ("ocr_seven_locs", "A<loc_0><loc_0><loc_0><loc_0><loc_0><loc_0><loc_0>", OcrWithRegion, (1000, 1000), (&[], &[])),
+];
+
+#[test]
+fn quad_boxes_match_upstream() {
+    for (name, text, task, (w, h), (want_quads, want_labels)) in QUAD_CASES {
+        let Florence2TaskResult::QuadBoxes { quad_boxes, labels } =
+            Florence2TaskResult::parse(text, *task, size(*w, *h))
+        else {
+            panic!("{name}: expected the quad-boxes variant");
+        };
+        assert_eq!(labels, *want_labels, "{name}: labels");
+        assert_eq!(quad_boxes.len(), want_quads.len(), "{name}: quad count");
+        for (i, (got, want)) in quad_boxes.iter().zip(*want_quads).enumerate() {
+            assert_coords(&got.points, want, &format!("{name} quad {i}"));
+        }
+    }
+}
+
+// ----------------------------------------------------------------- polygons
+
+type PolygonCase = Case<(
+    &'static [&'static [&'static [f32]]],
+    &'static [&'static str],
+)>;
+
+#[rustfmt::skip]
+const POLYGON_CASES: &[PolygonCase] = &[
+    ("poly_single", "<s><loc_1><loc_2><loc_3><loc_4><loc_5><loc_6></s>", ReferringExpressionSegmentation, (1000, 1000), (&[&[&[1.5, 2.5, 3.5, 4.5, 5.5, 6.5]]], &[""])),
+    // `<sep>` splits outlines within one instance, not into two instances.
+    ("poly_sep", "<loc_1><loc_2><loc_3><loc_4><sep><loc_5><loc_6><loc_7><loc_8>", ReferringExpressionSegmentation, (1000, 1000), (&[&[&[1.5, 2.5, 3.5, 4.5], &[5.5, 6.5, 7.5, 8.5]]], &[""])),
+    // An odd bin count loses its unpaired tail.
+    ("poly_odd", "<loc_1><loc_2><loc_3><loc_4><loc_5>", ReferringExpressionSegmentation, (1000, 1000), (&[&[&[1.5, 2.5, 3.5, 4.5]]], &[""])),
+    ("poly_region_to_seg", "<s><loc_1><loc_2><loc_3><loc_4><sep><loc_5><loc_6><loc_7><loc_8></s>", RegionToSegmentation, (1000, 1000), (&[&[&[1.5, 2.5, 3.5, 4.5], &[5.5, 6.5, 7.5, 8.5]]], &[""])),
+];
+
+#[test]
+fn polygons_match_upstream() {
+    for (name, text, task, (w, h), (want_polys, want_labels)) in POLYGON_CASES {
+        let Florence2TaskResult::Polygons { polygons, labels } =
+            Florence2TaskResult::parse(text, *task, size(*w, *h))
+        else {
+            panic!("{name}: expected the polygons variant");
+        };
+        assert_eq!(labels, *want_labels, "{name}: labels");
+        assert_polygons(&polygons, want_polys, name);
+    }
+}
+
+// ---------------------------------------------- boxes or polygons (open vocab)
+
+type MixedCase = Case<(
+    &'static [[f32; 4]],
+    &'static [&'static str],
+    &'static [&'static [&'static [f32]]],
+    &'static [&'static str],
+)>;
+
+#[rustfmt::skip]
+const MIXED_CASES: &[MixedCase] = &[
+    ("ovd_boxes", "<s>car<loc_1><loc_2><loc_3><loc_4></s>", OpenVocabularyDetection, (1000, 1000), (&[[1.5, 2.5, 3.5, 4.5]], &["car"], &[], &[])),
+    ("ovd_polys", "<s>car<poly><loc_1><loc_2><loc_3><loc_4></poly></s>", OpenVocabularyDetection, (1000, 1000), (&[], &[], &[&[&[1.5, 2.5, 3.5, 4.5]]], &["car"])),
+    ("ovd_two_polys", "car<poly><loc_1><loc_2><loc_3><loc_4></poly><poly><loc_5><loc_6><loc_7><loc_8></poly>", OpenVocabularyDetection, (1000, 1000), (&[], &[], &[&[&[1.5, 2.5, 3.5, 4.5]], &[&[5.5, 6.5, 7.5, 8.5]]], &["car", "car"])),
+    ("ovd_poly_phrase", "a wheel<poly><loc_1><loc_2><loc_3><loc_4></poly>", OpenVocabularyDetection, (1000, 1000), (&[], &[], &[&[&[1.5, 2.5, 3.5, 4.5]]], &["a wheel"])),
+];
+
+#[test]
+fn open_vocabulary_detection_matches_upstream() {
+    for (name, text, task, (w, h), (want_boxes, want_box_labels, want_polys, want_poly_labels)) in
+        MIXED_CASES
+    {
+        let Florence2TaskResult::BoxesOrPolygons {
+            boxes,
+            box_labels,
+            polygons,
+            polygon_labels,
+        } = Florence2TaskResult::parse(text, *task, size(*w, *h))
+        else {
+            panic!("{name}: expected the mixed variant");
+        };
+        assert_eq!(box_labels, *want_box_labels, "{name}: box labels");
+        assert_eq!(polygon_labels, *want_poly_labels, "{name}: polygon labels");
+        assert_eq!(boxes.len(), want_boxes.len(), "{name}: box count");
+        for (i, (got, want)) in boxes.iter().zip(*want_boxes).enumerate() {
+            assert_coords(&got.to_array(), want, &format!("{name} box {i}"));
+        }
+        assert_polygons(&polygons, want_polys, name);
+    }
+}
+
+fn assert_polygons(got: &[Vec<mlxcel::models::Florence2Polygon>], want: &[&[&[f32]]], name: &str) {
+    assert_eq!(got.len(), want.len(), "{name}: instance count");
+    for (i, (instance, want_instance)) in got.iter().zip(want).enumerate() {
+        assert_eq!(
+            instance.len(),
+            want_instance.len(),
+            "{name} instance {i}: outline count"
+        );
+        for (j, (outline, want_outline)) in instance.iter().zip(*want_instance).enumerate() {
+            assert_coords(
+                &outline.points,
+                want_outline,
+                &format!("{name} instance {i} outline {j}"),
+            );
+        }
+    }
+}
+
+/// Every case above must have been exercised, so a table that silently loses
+/// rows during an edit fails rather than passing vacuously.
+#[test]
+fn the_parity_tables_cover_every_result_variant() {
+    assert_eq!(TEXT_CASES.len(), 3);
+    assert_eq!(BOX_CASES.len(), 18);
+    assert_eq!(QUAD_CASES.len(), 3);
+    assert_eq!(POLYGON_CASES.len(), 4);
+    assert_eq!(MIXED_CASES.len(), 4);
+}

--- a/tests/florence2_processor_parity.rs
+++ b/tests/florence2_processor_parity.rs
@@ -1,0 +1,342 @@
+// Copyright 2025-2026 Lablup Inc. and Jeongkyu Shin
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Florence-2 processor parity: preprocessing, tokenization, and the whole
+//! task path from a real image to structured coordinates.
+//!
+//! Where `tests/florence2_fusion_parity.rs` pins the fused model on a
+//! synthetic pixel tensor, this file closes the loop on a real image:
+//! `tests/fixtures/test_image.png` goes in as a task marker plus a picture,
+//! and boxes and quadrilaterals in original-image pixels come out.
+//!
+//! The reference is the same checkpoint driven through Python: image
+//! preprocessing by the checkpoint's own `CLIPImageProcessor` configuration,
+//! tokenization by its `BartTokenizerFast`, and generation by the upstream
+//! mlx-vlm florence2 `Model`
+//! (https://github.com/Blaizzy/mlx-vlm/blob/main/mlx_vlm/models/florence2/florence2.py)
+//! with weights cast bf16 -> f16 to match mlxcel's Apple Silicon precision
+//! policy. Skips when the checkpoint is absent (CI has no Metal and no
+//! weights).
+//!
+//! Two things are needed to reproduce the reference run, both of which cost
+//! real time to rediscover:
+//!
+//! - Upstream's `ModelConfig` reads `image_feature_source`, `image_pos_embed`
+//!   and `visual_temporal_embedding` from the top level of `config.json`, but
+//!   every real checkpoint stores them inside `vision_config`, and the
+//!   dataclass default for `image_feature_source` is the reverse order. They
+//!   have to be passed explicitly from `vision_config`.
+//! - mlx's `nn.Module` starts in training mode and upstream's DaViT
+//!   `DropPath` only short-circuits when `not self.training`, so without
+//!   `model.eval()` the vision tower applies stochastic depth at inference
+//!   and the output is not reproducible.
+
+use std::path::{Path, PathBuf};
+
+use mlxcel::models::{
+    Florence2ImageSize, Florence2Model, Florence2Processor, Florence2Task, Florence2TaskResult,
+};
+use mlxcel::vision::processors::florence2::Florence2ImageProcessor;
+
+const MODEL_DIR: &str = "models/Florence-2-base-ft-bf16";
+
+/// The committed fixture: 224x224 8-bit RGB. Upscaled to 768x768 by the
+/// processor, which is the interesting direction here because it is what makes
+/// the location bins land on a 224-pixel extent.
+const FIXTURE_SIZE: (u32, u32) = (224, 224);
+
+/// Reference pixels from the checkpoint's `CLIPImageProcessor`
+/// (`CLIPImageProcessorPil` backend, so PIL BICUBIC). All sixteen leading
+/// values are the same saturated red-channel corner:
+/// `(255/255 - 0.485) / 0.229`.
+#[allow(clippy::excessive_precision)]
+const REF_PIXELS_FIRST16: &[f32] = &[2.248908281326294; 16];
+
+/// Mean and standard deviation over all 1,769,472 values.
+#[allow(clippy::excessive_precision)]
+const REF_PIXELS_STATS: (f32, f32) = (0.343636691570282, 1.3729557991027832);
+
+/// Tokenized task prompts: `<s>` + the expanded English sentence + `</s>`.
+const REF_PROMPT_IDS: &[(Florence2Task, &[i32])] = &[
+    (
+        Florence2Task::Caption,
+        &[0, 2264, 473, 5, 2274, 6190, 116, 2],
+    ),
+    (
+        Florence2Task::ObjectDetection,
+        &[0, 574, 22486, 5, 8720, 19, 4120, 766, 11, 5, 2274, 4, 2],
+    ),
+    (
+        Florence2Task::OcrWithRegion,
+        &[0, 2264, 16, 5, 2788, 11, 5, 2274, 6, 19, 3806, 116, 2],
+    ),
+    (
+        Florence2Task::Ocr,
+        &[0, 2264, 16, 5, 2788, 11, 5, 2274, 116, 2],
+    ),
+    (
+        Florence2Task::DenseRegionCaption,
+        &[0, 574, 22486, 5, 8720, 11, 5, 2274, 6, 19, 49, 24173, 4, 2],
+    ),
+    (
+        Florence2Task::RegionProposal,
+        &[0, 574, 22486, 5, 976, 5327, 11, 5, 2274, 4, 2],
+    ),
+];
+
+/// Answers the reference produced for the fixture, decoded with special
+/// tokens kept. `<CAPTION>` says "unanswerable" and `<OCR>` reads a stray "0";
+/// those are the honest outputs for this small synthetic-looking image and the
+/// point is that both runtimes produce the same string, not that the string is
+/// impressive.
+const REF_ANSWERS: &[(Florence2Task, &str)] = &[
+    (Florence2Task::Caption, "<s>unanswerable"),
+    (
+        Florence2Task::ObjectDetection,
+        "<s>poster<loc_0><loc_0><loc_998><loc_998>",
+    ),
+    (
+        Florence2Task::OcrWithRegion,
+        "<s>0:00 PM<loc_0><loc_999><loc_76><loc_999><loc_76><loc_999><loc_0><loc_999>",
+    ),
+    (Florence2Task::Ocr, "<s>0"),
+    (Florence2Task::DenseRegionCaption, "<s>orange square"),
+    (
+        Florence2Task::RegionProposal,
+        "<s><loc_0><loc_0><loc_998><loc_998>",
+    ),
+];
+
+/// Bins dequantized against the fixture's own 224x224 extent, from upstream's
+/// `post_process_generation`. `<loc_998>` on a 224-pixel axis is
+/// `(998 + 0.5) * 0.224`.
+#[allow(clippy::excessive_precision)]
+const REF_OD_BOX: [f32; 4] = [
+    0.1120000034570694,
+    0.1120000034570694,
+    223.66400146484375,
+    223.66400146484375,
+];
+
+#[allow(clippy::excessive_precision)]
+const REF_OCR_QUAD: [f32; 8] = [
+    0.1120000034570694,
+    223.88800048828125,
+    17.13599967956543,
+    223.88800048828125,
+    17.13599967956543,
+    223.88800048828125,
+    0.1120000034570694,
+    223.88800048828125,
+];
+
+const MAX_NEW_TOKENS: usize = 96;
+
+fn skip() -> bool {
+    if Path::new(MODEL_DIR).exists() {
+        return false;
+    }
+    eprintln!("skipping florence2_processor_parity: {MODEL_DIR} not present");
+    true
+}
+
+fn fixture() -> image::DynamicImage {
+    let path = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("tests/fixtures/test_image.png");
+    image::open(&path).expect("load tests/fixtures/test_image.png")
+}
+
+fn to_vec_f32(a: &mlxcel_core::MlxArray) -> Vec<f32> {
+    let a = mlxcel_core::astype(a, mlxcel_core::dtype::FLOAT32);
+    mlxcel_core::eval(&a);
+    mlxcel_core::array_to_raw_bytes(&a)
+        .chunks_exact(4)
+        .map(|c| f32::from_le_bytes([c[0], c[1], c[2], c[3]]))
+        .collect()
+}
+
+fn assert_close(got: &[f32], want: &[f32], tol: f32, what: &str) {
+    assert_eq!(got.len(), want.len(), "{what}: length mismatch");
+    let mut worst = 0.0f32;
+    let mut worst_at = 0usize;
+    for (i, (g, w)) in got.iter().zip(want).enumerate() {
+        let dev = (g - w).abs();
+        if dev > worst {
+            worst = dev;
+            worst_at = i;
+        }
+    }
+    eprintln!("{what}: max abs deviation {worst} at index {worst_at} (tol {tol})");
+    assert!(
+        worst <= tol,
+        "{what}[{worst_at}]: got {}, reference {} (deviation {worst}, tol {tol})",
+        got[worst_at],
+        want[worst_at]
+    );
+}
+
+/// Preprocessing parity on the real fixture.
+///
+/// The tolerance is generous relative to what was measured: comparing all
+/// 1,769,472 values against the Python reference gave a maximum absolute
+/// deviation of exactly 0.0, so the `image` crate's `CatmullRom` filter and
+/// PIL's `BICUBIC` agree bit for bit on this 224 -> 768 upscale. The bound is
+/// kept loose anyway because that agreement is a property of two independent
+/// resampling implementations and is not guaranteed to survive a version bump
+/// on either side.
+#[test]
+fn preprocessing_matches_the_checkpoint_processor() {
+    if skip() {
+        return;
+    }
+    let processor =
+        Florence2ImageProcessor::from_pretrained(Path::new(MODEL_DIR)).expect("load processor");
+    assert_eq!((processor.width, processor.height), (768, 768));
+
+    let processed = processor.preprocess_with_sizes(std::slice::from_ref(&fixture()));
+    assert_eq!(
+        mlxcel_core::array_shape(&processed.pixel_values),
+        vec![1, 3, 768, 768],
+        "pixel tensor shape"
+    );
+    // The pre-resize extent, which is what the location bins are relative to.
+    assert_eq!(processed.original_sizes, vec![FIXTURE_SIZE]);
+
+    let values = to_vec_f32(&processed.pixel_values);
+    assert_eq!(values.len(), 3 * 768 * 768, "one image, three planes");
+    assert_close(
+        &values[..16],
+        REF_PIXELS_FIRST16,
+        1e-4,
+        "pixel_values first16",
+    );
+
+    let n = values.len() as f64;
+    let mean = values.iter().map(|v| *v as f64).sum::<f64>() / n;
+    let var = values
+        .iter()
+        .map(|v| {
+            let d = *v as f64 - mean;
+            d * d
+        })
+        .sum::<f64>()
+        / n;
+    let (ref_mean, ref_std) = REF_PIXELS_STATS;
+    eprintln!(
+        "pixel_values: mean {mean:.6} (ref {ref_mean:.6}), std {:.6} (ref {ref_std:.6})",
+        var.sqrt()
+    );
+    assert!((mean as f32 - ref_mean).abs() <= 1e-4, "pixel mean {mean}");
+    assert!(
+        (var.sqrt() as f32 - ref_std).abs() <= 1e-4,
+        "pixel std {}",
+        var.sqrt()
+    );
+}
+
+/// Tokenizer parity. Unlike the pixel comparison this one is exact: the same
+/// vocabulary and the same merges have to produce identical ids.
+#[test]
+fn task_prompts_tokenize_exactly_as_the_reference() {
+    if skip() {
+        return;
+    }
+    let processor = Florence2Processor::from_pretrained(Path::new(MODEL_DIR)).expect("load");
+    for (task, want) in REF_PROMPT_IDS {
+        let ids = processor.encode_prompt(*task, None).expect("encode prompt");
+        assert_eq!(ids, want.to_vec(), "{task} prompt ids");
+    }
+}
+
+/// The whole path the acceptance criteria describe: a task marker and an image
+/// go in, a structured result comes out, and both halves match the reference.
+///
+/// Loads the model once and drives every task against it, because loading the
+/// checkpoint dominates the runtime.
+#[test]
+fn task_runs_match_the_reference_end_to_end() {
+    if skip() {
+        return;
+    }
+    let model = Florence2Model::load(Path::new(MODEL_DIR)).expect("load model");
+    let processor = Florence2Processor::from_pretrained(Path::new(MODEL_DIR)).expect("load");
+    let image = fixture();
+
+    for (task, want_text) in REF_ANSWERS {
+        let output = processor
+            .run(&model, *task, None, &image, MAX_NEW_TOKENS)
+            .expect("run task");
+        eprintln!("{task}: {:?}", output.raw_text);
+        assert_eq!(&output.raw_text, want_text, "{task} answer text");
+    }
+}
+
+/// Detection and OCR parse into the coordinates upstream computes, in
+/// original-image pixels rather than in the 768x768 resized frame.
+#[test]
+fn detection_and_ocr_parse_into_reference_coordinates() {
+    if skip() {
+        return;
+    }
+    let model = Florence2Model::load(Path::new(MODEL_DIR)).expect("load model");
+    let processor = Florence2Processor::from_pretrained(Path::new(MODEL_DIR)).expect("load");
+    let image = fixture();
+
+    let od = processor
+        .run(
+            &model,
+            Florence2Task::ObjectDetection,
+            None,
+            &image,
+            MAX_NEW_TOKENS,
+        )
+        .expect("run <OD>");
+    let Florence2TaskResult::Boxes { boxes, labels } = od.result else {
+        panic!("<OD> must produce boxes, got {:?}", od.result);
+    };
+    assert_eq!(labels, vec!["poster".to_string()]);
+    assert_close(&boxes[0].to_array(), &REF_OD_BOX, 1e-4, "<OD> box");
+    // A box in the resized 768 frame would run to roughly 767, not 224.
+    assert!(
+        boxes[0].xmax <= FIXTURE_SIZE.0 as f32,
+        "box must be in original-image pixels, got {:?}",
+        boxes[0]
+    );
+
+    let ocr = processor
+        .run(
+            &model,
+            Florence2Task::OcrWithRegion,
+            None,
+            &image,
+            MAX_NEW_TOKENS,
+        )
+        .expect("run <OCR_WITH_REGION>");
+    let Florence2TaskResult::QuadBoxes { quad_boxes, labels } = ocr.result else {
+        panic!("<OCR_WITH_REGION> must produce quads, got {:?}", ocr.result);
+    };
+    assert_eq!(labels, vec!["0:00 PM".to_string()]);
+    assert_close(&quad_boxes[0].points, &REF_OCR_QUAD, 1e-4, "OCR quad");
+
+    // The same answer parsed against a different declared size must move,
+    // which is what proves the original extent is actually threaded through.
+    let scaled = Florence2TaskResult::parse(
+        &od.raw_text,
+        Florence2Task::ObjectDetection,
+        Florence2ImageSize::new(1000, 1000),
+    );
+    let Florence2TaskResult::Boxes { boxes: scaled, .. } = scaled else {
+        panic!("expected boxes");
+    };
+    assert!(scaled[0].xmax > 900.0, "got {:?}", scaled[0]);
+}


### PR DESCRIPTION
## Summary

Completes the Florence-2 request path on top of the fused model from #854. A task marker and an image go in; a structured result with coordinates in original-image pixels comes out.

Florence-2 selects its behavior with a marker such as `<OD>` or `<CAPTION>`, and **none of those markers is in the vocabulary**. The processor expands each one into the English sentence the model was actually trained on (`<OD>` becomes "Locate the objects with category name in the image."), tokenizes that, preprocesses the image to 768x768, generates, and parses the answer's `<loc_N>` tokens back into boxes, quadrilaterals, and polygons against the image's pre-resize extent.

The integration entry point is `Florence2Processor::run(&model, task, input, image, max_new_tokens) -> Florence2Output`, which is what #856 will reach from the CLI.

## What changed

**New, under `src/models/florence2/`**

- `tasks.rs`: the fifteen task markers, their prompt expansions copied byte for byte from the checkpoint, and routing to a post-processing kind. Seven tasks interpolate a caller-supplied input.
- `coords.rs`: `Florence2ImageSize`, `Florence2BoundingBox`, `Florence2QuadBox`, `Florence2Polygon`, the bin-to-pixel dequantizers, and the inverse so a caller can build the `<loc_a><loc_b><loc_c><loc_d>` region string the region-input tasks expect.
- `scan.rs`: literal string scanners (sequence-marker stripping, leading-phrase extraction, `<loc_N>` reading) plus the phrase-grounding stopword blacklist.
- `parse.rs`: the four reachable parsers over compiled-once patterns.
- `postprocess.rs`: `Florence2TaskResult` and the task dispatch. `Florence2TaskResult::parse` is model-free, so an answer obtained elsewhere parses without loading a checkpoint.
- `processor.rs`: `Florence2Processor`, tokenizer plus image processor plus the end-to-end `run`.

**New elsewhere**

- `src/vision/processors/florence2.rs`: `Florence2ImageProcessor`, reading `preprocessor_config.json` rather than hard-coding it, and refusing configurations it would silently mishandle (center cropping, a non-bicubic resample, a zero standard deviation, a zero size).
- `tests/florence2_postprocess_parity.rs`, `tests/florence2_processor_parity.rs`.
- Unit tests beside each new module.

**Moved**

- `Florence2TextConfig` from `src/models/florence2/mod.rs` to `src/models/florence2/checkpoint.rs`, next to the `Florence2Config` that contains it. Pure relocation, no behavior change; it keeps `mod.rs` under the 500-line limit now that the module list has grown.

## Design notes

`Florence2BoundingBox` is deliberately not a reuse of `rt_detr_v2::Detection`. That type carries a confidence score and a `label: usize` index into a fixed class list; Florence-2 emits no per-box score and its labels are open-vocabulary strings decoded from the answer, so reusing it would mean two fabricated fields on every box. There is no polygon or quadrilateral type anywhere in the tree to reuse.

`Florence2ImageSize` has named fields rather than being a `(u32, u32)` tuple because upstream's own docstring disagrees with its code about the order (see corrections below), and passing the 768x768 resized extent instead of the original silently scales every coordinate.

Two upstream regexes were replaced with hand-rolled scanners, each with its equivalence argument recorded in the code. The phrase-string pattern `^\s*(.*?)(?=<od>|...|<loc_)` becomes a forward scan for the first stop marker; the two behaviors that make it non-trivial (`.` not matching a newline, and `<sep>` not being in the stop list) are reproduced and tested. `<loc_(\d+)>` becomes a digit scan, since it is a fixed literal on the innermost path of every parser. Everything else uses `fancy-regex`, which matches Python's backtracking semantics.

## Corrections to the issue text

- The issue suggests using the dots_ocr and paddleocr modules as a partial reference for location-token to box conversion. **They contain no coordinate parsing at all.** Both are plain text-emitting VLMs. The only box type in the tree is `rt_detr_v2::Detection`, and there is no polygon type. Nothing was reusable.
- `<REGION_PROPOSAL>` routes to the `bboxes` post-processing kind, not `description_with_bboxes`. Same parser, but with `allow_empty_phrase` set, which matters: its answers carry no category names.

## Corrections to upstream

Verified against the checkpoint's own `processing_florence2.py` and the mlx-vlm sources.

- **`post_process_generation`'s docstring is wrong about coordinate order.** It documents `image_size` as "height x width", but every call site unpacks it as `image_width, image_height = image_size`. It is `(width, height)`. This is why the Rust type uses named fields.
- **The `od` parse task's configured PATTERN can never match.** It is `r'([a-zA-Z0-9 ]+)<loc_(\\d+)>...'`, and the doubled backslash inside a raw string matches a literal `\` followed by `d`. It is unreachable in practice: no task routes to `'od'`, and every parser except the OCR one overwrites its `pattern` argument on its first lines, so only the OCR pattern is ever read from config.
- **The OCR area filter never runs.** It is gated on `area_threshold > 0` and the shipped `AREA_THRESHOLD` is `0.00`.
- **`with_box_at_start` is false at every call site reachable from `post_process_generation`,** so that polygon branch is dead.
- **The `<ground>` / `<obj>` prefix strip is a no-op twice over.** The second assignment reads `pharse_text` rather than the result of the first, discarding the `<ground>` strip, and neither marker is in the checkpoint's vocabulary.
- **A newline in a phrase silently deletes the whole chunk.** `^\s*(.*?)(?=...)` is not multi-line and `.` does not match a newline, so if a newline sits between the leading whitespace and the first location token, `re.search` fails and the chunk is dropped. Reproduced deliberately and pinned by `od_newline`.
- **`[^<]+` can start one byte inside a `<loc_N>` token.** A bare location run fed to the labelled parser therefore yields the literal label `loc_1>` and a box shifted by one bin, rather than no result. Reproduced, pinned by `od_bare_locs`, and the reason `<REGION_PROPOSAL>` needs the empty-phrase parser.
- **mlx-vlm's florence2 model applies stochastic depth at inference unless you call `model.eval()`.** mlx's `nn.Module` starts in training mode and upstream's DaViT `DropPath` only short-circuits on `not self.training`. Without it the vision tower output is not reproducible. Recorded in the parity test's module docs so the next person does not lose an hour to it.
- **`AutoTokenizer.from_pretrained` fails on this checkpoint**, because it routes through `AutoConfig`, which does not know the custom `florence2_language` model type. `BartTokenizerFast` directly works.
- Re-confirmed from #854: upstream's `ModelConfig` reads `image_feature_source`, `image_pos_embed` and `visual_temporal_embedding` from the top level of `config.json`, but real checkpoints store them under `vision_config`, and the dataclass default for `image_feature_source` is the reverse order.

## Deliberately not implemented

Each is unreachable from `post_process_generation`, and each is documented in `parse.rs` with the reason rather than silently omitted: `parse_od_from_text_and_spans` and the PATTERN config indirection, the OCR area filter, the `with_box_at_start` polygon branch, and the `<ground>` / `<obj>` prefix strip. `decode_with_spans` is also not ported; its character spans exist only for score attribution, which no reachable task uses.

One intentional deviation: `Florence2Task::expand` rejects an input supplied to a task that takes none, and a missing input on a task that requires one. Upstream produces `"What is the region ?"` in the second case and lets the model answer nonsense, which is indistinguishable from a real prompt after the fact.

One knowingly accepted difference: `$` in the polygon-run pattern matches only at end of string, while Python's also matches just before a trailing newline. Location runs are not emitted with trailing newlines.

## Validation

Against the real checkpoint (`models/Florence-2-base-ft-bf16`) and the real upstream Python, in a scratch virtualenv with `torch`, `transformers`, `mlx`, `numpy` and `Pillow`. The post-processing reference imports the checkpoint's own `processing_florence2.py` **unmodified**, so it is upstream behavior rather than a reimplementation agreeing with itself.

- **Post-processing**: 32 cases across all five result shapes, all matching upstream exactly, including every edge case listed above.
- **Preprocessing**: `tests/fixtures/test_image.png` through the checkpoint's `CLIPImageProcessor` versus the Rust processor. Maximum absolute deviation **exactly 0.0** across all 1,769,472 values; the `image` crate's `CatmullRom` and PIL's `BICUBIC` agree bit for bit on this 224 to 768 upscale. The test tolerance is kept loose anyway, since that agreement is a property of two independent resampling implementations.
- **Tokenization**: exact id match on all six tested task prompts.
- **End to end**: upstream mlx-vlm florence2 with weights cast bf16 to f16. Byte-identical answers on all six tasks, including `<OD>` producing `poster<loc_0><loc_0><loc_998><loc_998>` and `<OCR_WITH_REGION>` producing a full eight-token quadrilateral, and identical parsed coordinates for both.

No unexplained Rust-versus-Python divergence was found anywhere in this work.

## Test plan

- [x] `cargo check --profile test-fast --features metal,accelerate --lib --tests`
- [x] `cargo clippy --profile test-fast --features metal,accelerate --lib --tests -- -D warnings` (zero warnings)
- [x] `cargo test --profile test-fast --features metal,accelerate -p mlxcel --lib florence2`
- [x] `cargo test --profile test-fast --features metal,accelerate -p mlxcel --test florence2_postprocess_parity`
- [x] `cargo test --profile test-fast --features metal,accelerate -p mlxcel --test florence2_processor_parity`
- [x] `cargo test --profile test-fast --features metal,accelerate -p mlxcel --test florence2_fusion_parity` (unchanged by the `Florence2TextConfig` move)
- [x] `cargo fmt --check`
- [x] `python3 scripts/ci/check_cross_repo_refs.py`

Closes #855
