### PR TITLE
chore(reports): opt TECHNICAL_REPORTS into git tracking

### DIFF
--- a/TECHNICAL_REPORTS/.keep-reports
+++ b/TECHNICAL_REPORTS/.keep-reports
@@ -1,0 +1,10 @@
+# Presence of this file opts the repository into tracking TECHNICAL_REPORTS/ in git.
+#
+# TECHNICAL_REPORTS/ is listed in .gitignore, so reports stay local by default and
+# each one has to be force-added by hand. This marker flips that: the report
+# workflow may generate a report for a still-open PR, dates it today rather than by
+# mergedAt, and force-adds, commits and pushes it so the report lands inside the
+# squash merge instead of trailing behind it.
+#
+# Adopted after the #1053/#1054/#1045/#1040 chain (PR #1077), which tracked its
+# eight reports by hand and left the directory in a partially tracked state.


### PR DESCRIPTION
## Summary

Adds `TECHNICAL_REPORTS/.keep-reports`, the marker the report workflow already defines as the opt-in for tracking reports in git.

## Why now

`TECHNICAL_REPORTS/` is in `.gitignore`, so reports stayed local and each had to be force-added by hand. PR #1077 did that for eight reports and left the directory in a half-and-half state: eight files tracked out of seventy-seven, inside a directory the ignore rules still say to skip. Either the reports are tracked here or they are not, and the marker is how the workflow expects that to be declared.

## What changes

With the marker present, the report workflow:

- may generate a report for a still-open PR rather than only a merged one,
- dates it today instead of by `mergedAt`,
- force-adds, commits and pushes it, so the report is inside the squash merge rather than trailing behind it.

The marker force-adds itself, so the opt-in survives a fresh clone.

## What does not change

The sixty-nine reports predating #1077 stay untracked. Adding them is a separate decision and several belong to work whose reports were deliberately left local, so this PR does not sweep them in.

## Validation

One new file, no code, no build or test surface touched. The file is force-added by explicit path.