### PR TITLE
fix: trim Gemma 4 server thought marker

### DIFF
--- a/TECHNICAL_REPORTS/1094-trim-gemma4-server-thought-marker-20260810.en.md
+++ b/TECHNICAL_REPORTS/1094-trim-gemma4-server-thought-marker-20260810.en.md
@@ -1,0 +1,64 @@
+# Technical Report: PR #1094 - Trim Gemma 4 Server Thought Marker
+
+**Date**: 2026-08-10
+**Status**: Completed
+**Languages**: Rust
+**Risk Level**: Medium
+
+## Executive Summary
+
+PR #1094 removes the Gemma 4 `thought` channel argument from server-side `reasoning_content` while preserving visible answer content and streaming/non-streaming parity. Review also corrected two position-accounting and malformed-stream edge cases exposed by consuming the longer `<|channel>thought` delimiter.
+
+## 1. Problem Statement
+
+The server stream filter previously entered reasoning mode after consuming only `<|channel>`, so the following `thought` argument was emitted as user-visible reasoning text. Simply replacing the delimiter with `<|channel>thought` exposed two adjacent risks: a decoded token split between delimiter bytes and emitted text could be counted twice in the parallel logprob queue, and a malformed bare `<|channel>` needed to remain suppressible without preempting the valid longer opener.
+
+## 2. Technical Decisions
+
+### 2.1 Prefer the full opener while retaining a deferred fallback
+
+The delimiter table keeps both `<|channel>thought` and `<|channel>`, but the shorter match is deferred while buffered bytes may still complete the longer opener. At end-of-stream the ambiguity is resolved because no additional fragment can arrive, preventing truncated channel markup from leaking through `flush()`.
+
+### 2.2 Track whether a fragment position was already counted
+
+Each buffered decoded fragment is represented by a span containing its remaining byte length and whether its token position still needs to be counted. When a delimiter consumes only part of a fragment, the remainder is marked as already counted; later reasoning or content emission therefore cannot drain the same logprob position twice.
+
+## 3. Change Summary
+
+| Item | Value |
+|------|-------|
+| Files changed | 2 |
+| Lines added | 167 |
+| Lines deleted | 33 |
+| Primary modules | `server::tool_calls::stream_filter`, `server::routes::chat` |
+
+- Server reasoning now consumes the full Gemma 4 channel opener and no longer emits `thought` in `reasoning_content`.
+- Streaming and non-streaming extraction reuse the same filter behavior; final visible content is unchanged.
+- Fragment-span bookkeeping preserves token/logprob alignment when a delimiter ends inside a decoded token.
+- Bare-channel fallback matching remains compatible with malformed output and is resolved safely during stream flush.
+- Regression coverage exercises whole and split openers, delimiter position counts, cross-family delimiter behavior, and end-of-stream fallback handling.
+
+## 4. Review Findings
+
+| Finding | Severity | Resolution |
+|---------|----------|------------|
+| A split `thought\n` fragment could count one token position twice | Medium | Fixed with counted fragment spans |
+| Removing the bare channel delimiter could expose malformed channel text | Medium | Fixed with deferred shorter-delimiter matching |
+| An exactly truncated bare channel could leak during `flush()` | Low | Fixed by final delimiter resolution at end-of-stream |
+
+No Critical or High findings remained after review. Delimiter matching remains bounded by the static delimiter table and the longest delimiter tail.
+
+## 5. Validation
+
+- `cargo test --lib server::tool_calls::stream_filter::tests`: 78 passed, 0 failed.
+- `cargo test --lib gemma4`: 225 passed, 0 failed, 30 existing hardware-dependent tests ignored.
+- `cargo test --lib reasoning_split_identical_whole_vs_chunked`: passed.
+- `cargo test --lib extract_reasoning_gemma4`: passed.
+- `cargo fmt --check`: passed.
+- Hosted PR checks passed; `MLX pin extraction` was skipped because the PR does not change the MLX pin.
+
+## 6. Related Work
+
+- Issue #890: server-side remainder of the Gemma 4 reasoning marker fix.
+- Issue #884: earlier CLI-side fix that established consuming `<|channel>thought` as one opener.
+

--- a/TECHNICAL_REPORTS/1094-trim-gemma4-server-thought-marker-20260810.ko.md
+++ b/TECHNICAL_REPORTS/1094-trim-gemma4-server-thought-marker-20260810.ko.md
@@ -1,0 +1,64 @@
+# 기술 보고서: PR #1094 - Gemma 4 서버 thought 마커 제거
+
+**작성일**: 2026-08-10
+**상태**: 완료
+**언어**: Rust
+**위험도**: Medium
+
+## 요약
+
+PR #1094는 최종 답변 내용과 streaming/non-streaming 동등성을 유지하면서 Gemma 4의 `thought` channel 인자가 서버 `reasoning_content`에 남는 문제를 해결한다. 리뷰 과정에서는 더 긴 `<|channel>thought` delimiter를 소비하면서 드러난 token 위치 계산과 비정상 stream 처리 문제 두 가지도 함께 교정했다.
+
+## 1. 문제 정의
+
+기존 서버 stream filter는 `<|channel>`만 소비한 뒤 reasoning 상태로 전환했기 때문에 뒤따르는 `thought` 인자가 reasoning text로 노출되었다. Delimiter를 단순히 `<|channel>thought`로 바꾸면 인접한 두 위험이 생긴다. Delimiter byte와 출력 text에 걸친 decoded token이 병렬 logprob queue에서 두 번 계산될 수 있고, 올바른 긴 opener를 선점하지 않으면서도 비정상 bare `<|channel>`을 계속 억제해야 한다.
+
+## 2. 기술적 선택과 그 이유
+
+### 2.1 전체 opener를 우선하되 fallback을 지연 유지
+
+Delimiter table에는 `<|channel>thought`와 `<|channel>`을 모두 유지한다. 다만 현재 buffer가 긴 opener로 완성될 가능성이 있는 동안에는 짧은 match를 지연한다. End-of-stream에서는 추가 fragment가 올 수 없으므로 모호성을 해소하여 잘린 channel markup이 `flush()`를 통해 노출되지 않게 한다.
+
+### 2.2 Fragment 위치가 이미 계산되었는지 추적
+
+Buffer의 각 decoded fragment는 남은 byte 길이와 token 위치 계산 여부를 담은 span으로 표현한다. Delimiter가 fragment 일부만 소비하면 나머지를 이미 계산된 상태로 표시하여, 이후 reasoning 또는 content 출력 시 동일한 logprob 위치를 두 번 drain하지 않게 한다.
+
+## 3. 변경 요약
+
+| 항목 | 값 |
+|------|----|
+| 변경 파일 | 2 |
+| 추가 라인 | 167 |
+| 삭제 라인 | 33 |
+| 주요 모듈 | `server::tool_calls::stream_filter`, `server::routes::chat` |
+
+- 서버 reasoning이 Gemma 4 전체 channel opener를 소비하여 `reasoning_content`에 `thought`를 내보내지 않는다.
+- Streaming과 non-streaming 추출이 같은 filter 동작을 재사용하며 최종 visible content는 바뀌지 않는다.
+- Fragment-span bookkeeping으로 delimiter가 decoded token 중간에서 끝날 때도 token/logprob 정렬을 보존한다.
+- 비정상 출력 호환성을 위한 bare-channel fallback을 유지하고 stream flush 시 안전하게 해소한다.
+- Whole/split opener, delimiter 위치 계산, 다른 delimiter family 호환성, end-of-stream fallback을 회귀 테스트로 고정했다.
+
+## 4. 리뷰 발견 사항
+
+| 발견 사항 | 심각도 | 해결 |
+|-----------|--------|------|
+| 분할된 `thought\n` fragment가 한 token 위치를 두 번 계산할 수 있음 | Medium | 계산 여부를 가진 fragment span으로 수정 |
+| Bare channel delimiter 제거 시 비정상 channel text가 노출될 수 있음 | Medium | 짧은 delimiter match 지연으로 수정 |
+| 정확히 bare channel에서 잘린 stream이 `flush()` 중 노출될 수 있음 | Low | End-of-stream 최종 delimiter 해소로 수정 |
+
+리뷰 이후 남은 Critical 또는 High 발견 사항은 없다. Delimiter matching 비용은 정적 delimiter table과 최장 delimiter tail 길이로 제한된다.
+
+## 5. 검증
+
+- `cargo test --lib server::tool_calls::stream_filter::tests`: 78 passed, 0 failed.
+- `cargo test --lib gemma4`: 225 passed, 0 failed, 기존 hardware-dependent test 30개 ignored.
+- `cargo test --lib reasoning_split_identical_whole_vs_chunked`: 통과.
+- `cargo test --lib extract_reasoning_gemma4`: 통과.
+- `cargo fmt --check`: 통과.
+- Hosted PR check 통과. PR이 MLX pin을 변경하지 않아 `MLX pin extraction`은 skip되었다.
+
+## 6. 관련 작업
+
+- Issue #890: Gemma 4 reasoning marker 문제의 서버 측 후속 작업.
+- Issue #884: `<|channel>thought` 전체를 하나의 opener로 소비하도록 한 이전 CLI 수정.
+

--- a/src/server/routes/chat.rs
+++ b/src/server/routes/chat.rs
@@ -1445,7 +1445,7 @@ mod tests {
         let raw = "<|channel>thought\ndeliberating<channel|>the answer";
         assert_eq!(
             extract_reasoning_content(raw, false),
-            Some("thought\ndeliberating".to_string())
+            Some("\ndeliberating".to_string())
         );
     }
 

--- a/src/server/tool_calls/stream_filter.rs
+++ b/src/server/tool_calls/stream_filter.rs
@@ -27,8 +27,9 @@
 //! - Qwen-style reasoning: `<think>` / `</think>` — Qwen3.x, Exaone4, Hunyuan, GLM4, etc.
 //! - Hermes-style tool calls: `<tool_call>` / `</tool_call>` — Qwen/DeepSeek tool call format
 //! - Mistral Nemo: `[TOOL_CALLS]` — one-shot start marker (rest of output is tool call JSON)
-//! - Gemma 4: `<|channel>thought` / `<channel|>`, `<|tool_call>` / `<tool_call|>`,
-//!   `<|think|>`, `<|turn>` / `<turn|>`
+//! - Gemma 4: `<|channel>thought` / `<channel|>` with a bare `<|channel>`
+//!   malformed-output fallback, `<|tool_call>` / `<tool_call|>`, `<|think|>`,
+//!   `<|turn>` / `<turn|>`
 //! - Function-calling Gemma: `<start_function_call>` / `<end_function_call>`,
 //!   a distinct marker family from Gemma 4, sharing only the inner
 //!   `call:name{...}` syntax
@@ -227,8 +228,13 @@ const CHAT_DELIMITERS: &[(&str, DelimiterAction)] = &[
     ("<tool_call|>", DelimiterAction::ExitToolCall),
     // Gemma 4 reasoning channel: consume the full `<|channel>thought` opener
     // as one delimiter so the `thought` channel argument never leaks into
-    // `delta.reasoning_content`.
+    // `delta.reasoning_content`. Keep a bare `<|channel>` fallback for
+    // malformed channel output, but `find_earliest_delimiter` defers it when
+    // the current buffer ends exactly at that shorter prefix; otherwise a
+    // token boundary after `<|channel>` would prematurely enter Thinking and
+    // leak `thought` as reasoning.
     ("<|channel>thought", DelimiterAction::EnterThinking),
+    ("<|channel>", DelimiterAction::EnterThinking),
     ("<channel|>", DelimiterAction::ExitThinking),
     ("<|think|>", DelimiterAction::Strip),
     ("<|turn>", DelimiterAction::Strip),
@@ -305,8 +311,9 @@ enum FilterState {
 ///
 /// Covers Qwen-style (`<think>` / `</think>`), Hermes-style
 /// (`<tool_call>` / `</tool_call>`), Mistral Nemo (`[TOOL_CALLS]`), and
-/// Gemma 4 (`<|channel>thought` / `<channel|>`) reasoning families, plus Gemma 4
-/// tool-call and turn markers.
+/// Gemma 4 (`<|channel>thought` / `<channel|>`, with a malformed bare
+/// `<|channel>` fallback) reasoning families, plus Gemma 4 tool-call and turn
+/// markers.
 ///
 /// Feed decoded text fragments via [`feed()`](StreamFilter::feed).  The
 /// filter returns only the content that should be emitted to the client.
@@ -318,18 +325,24 @@ pub struct StreamFilter {
     /// Per-feed byte-length queue used to count how many token positions
     /// (i.e. `feed()` calls) contributed to the bytes currently in `buffer`.
     ///
-    /// Each `feed(fragment)` call appends `fragment.len()` to this queue.
+    /// Each `feed(fragment)` call appends a span for `fragment.len()` bytes.
     /// When `drain_buffer()` consumes bytes from the front of `buffer` (via
-    /// `buffer.drain(..N)`), it pops fragment-length entries from the front
-    /// of this queue until `N` bytes are accounted for. The number of entries
-    /// popped is the number of token positions whose text spanned that byte
-    /// range — used as `suppressed_positions` for delimiter matches.
+    /// `buffer.drain(..N)`), it pops spans from the front of this queue until
+    /// `N` bytes are accounted for. The number of uncounted spans popped is the
+    /// number of token positions whose text spanned that byte range — used as
+    /// `suppressed_positions` for delimiter matches.
     ///
-    /// Invariant: `fragment_lengths.iter().sum::<usize>() == buffer.len()`
+    /// Invariant: `fragment_lengths.iter().map(|s| s.remaining_bytes).sum::<usize>() == buffer.len()`
     /// before and after every `feed()` / `drain_buffer()` call.
-    fragment_lengths: std::collections::VecDeque<usize>,
+    fragment_lengths: std::collections::VecDeque<FragmentSpan>,
     /// Length of the longest delimiter (for partial-match buffering).
     max_delim_len: usize,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct FragmentSpan {
+    remaining_bytes: usize,
+    count_on_drain: bool,
 }
 
 impl Default for StreamFilter {
@@ -395,7 +408,10 @@ impl StreamFilter {
         }
 
         // Record the number of bytes this token contributes to the buffer.
-        self.fragment_lengths.push_back(fragment.len());
+        self.fragment_lengths.push_back(FragmentSpan {
+            remaining_bytes: fragment.len(),
+            count_on_drain: true,
+        });
         self.buffer.push_str(fragment);
         self.drain_buffer()
     }
@@ -445,15 +461,26 @@ impl StreamFilter {
         while n > 0 {
             match self.fragment_lengths.pop_front() {
                 Some(frag_len) => {
-                    count += 1;
-                    if frag_len <= n {
-                        n -= frag_len;
+                    if frag_len.remaining_bytes <= n {
+                        if frag_len.count_on_drain {
+                            count += 1;
+                        }
+                        n -= frag_len.remaining_bytes;
                     } else {
                         // This fragment straddles the boundary: `n` bytes were
-                        // consumed from it but `frag_len - n` bytes remain.
-                        // Push back the remainder so the invariant holds.
-                        let remainder = frag_len - n;
-                        self.fragment_lengths.push_front(remainder);
+                        // consumed from it but `remaining_bytes - n` bytes
+                        // remain. The token position has already been counted
+                        // for this drain, so the remainder must not count as a
+                        // second token position when it is emitted or
+                        // suppressed later.
+                        if frag_len.count_on_drain {
+                            count += 1;
+                        }
+                        let remainder = frag_len.remaining_bytes - n;
+                        self.fragment_lengths.push_front(FragmentSpan {
+                            remaining_bytes: remainder,
+                            count_on_drain: false,
+                        });
                         n = 0;
                     }
                 }
@@ -560,6 +587,9 @@ impl StreamFilter {
 
         for &(delim, action) in CHAT_DELIMITERS {
             if let Some(pos) = self.buffer.find(delim) {
+                if self.complete_prefix_is_still_ambiguous(pos, delim) {
+                    continue;
+                }
                 match earliest {
                     Some((best_pos, best_len, _)) => {
                         // Pick earliest position; on tie, pick longest delimiter
@@ -575,6 +605,16 @@ impl StreamFilter {
         }
 
         earliest
+    }
+
+    fn complete_prefix_is_still_ambiguous(&self, pos: usize, delim: &str) -> bool {
+        let suffix_from_match = &self.buffer[pos..];
+        CHAT_DELIMITERS.iter().any(|(other, _)| {
+            other.len() > delim.len()
+                && other.starts_with(delim)
+                && suffix_from_match.len() < other.len()
+                && other.starts_with(suffix_from_match)
+        })
     }
 
     /// Find how many bytes at the start of the buffer are safe to emit,
@@ -1054,6 +1094,10 @@ mod tests {
         let mut content = String::new();
         for frag in fragments {
             let out = f.feed(frag);
+            assert!(
+                out.consumed_positions <= 1 || out.suppressed_positions == out.consumed_positions,
+                "a token tail emitted after a delimiter must not be counted as a second position: {out:?}"
+            );
             if let Some(r) = out.reasoning {
                 reasoning.push_str(&r);
             }
@@ -1507,15 +1551,37 @@ mod tests {
         // suppressed_positions. This ensures position alignment is preserved
         // even when reasoning blocks appear before or between tool calls.
         let mut f = StreamFilter::new();
-        let out = f.feed("<think>reasoning</think>");
-        // The fragment contains TWO delimiters: <think> and </think>.
+        let open = f.feed("<think>");
+        let body = f.feed("reasoning");
+        let close = f.feed("</think>");
         assert_eq!(
-            out.suppressed_positions, 2,
+            open.suppressed_positions + close.suppressed_positions,
+            2,
             "<think>...</think> must produce suppressed_positions == 2 (one per delimiter match)"
         );
         // No content emitted from the markers; reasoning text goes to `reasoning`.
-        assert_eq!(out.content, None);
-        assert_eq!(out.reasoning.as_deref(), Some("reasoning"));
+        assert_eq!(open.content, None);
+        assert_eq!(close.content, None);
+        assert_eq!(body.content, None);
+        assert_eq!(body.reasoning.as_deref(), Some("reasoning"));
+    }
+
+    #[test]
+    fn delimiter_that_straddles_token_tail_counts_position_once() {
+        // The Gemma 4 opener commonly arrives as `<|channel>` followed by
+        // `thought\n`. The delimiter consumes `thought` but leaves `\n` as
+        // reasoning text from the same token; logprob position accounting must
+        // not count that token a second time when the newline is emitted.
+        let mut f = StreamFilter::new();
+        assert_eq!(f.feed("<|channel>").consumed_positions, 0);
+
+        let out = f.feed("thought\n");
+        assert_eq!(out.reasoning.as_deref(), Some("\n"));
+        assert_eq!(out.suppressed_positions, 2);
+        assert_eq!(
+            out.consumed_positions, 2,
+            "`thought\\n` must not be counted once for the delimiter and again for the newline"
+        );
     }
 
     // -- HIGH-1 regression: multi-fragment (multi-token) delimiter counting --

--- a/src/server/tool_calls/stream_filter.rs
+++ b/src/server/tool_calls/stream_filter.rs
@@ -428,13 +428,31 @@ impl StreamFilter {
             self.fragment_lengths.clear();
             return FilterOutput::default();
         }
+
+        // At end of stream, a complete delimiter that is also a prefix of a
+        // longer delimiter is no longer ambiguous: no future fragment can
+        // complete the longer form. Resolve those fallbacks before emitting
+        // the remaining tail so a truncated bare `<|channel>` cannot leak as
+        // visible content.
+        let mut output = self.drain_buffer_inner(true);
         let remaining = std::mem::take(&mut self.buffer);
         self.fragment_lengths.clear();
         match self.state {
-            FilterState::Content if !remaining.is_empty() => FilterOutput::content(remaining),
-            FilterState::Thinking if !remaining.is_empty() => FilterOutput::reasoning(remaining),
-            _ => FilterOutput::default(),
+            FilterState::Content if !remaining.is_empty() => {
+                output
+                    .content
+                    .get_or_insert_with(String::new)
+                    .push_str(&remaining);
+            }
+            FilterState::Thinking if !remaining.is_empty() => {
+                output
+                    .reasoning
+                    .get_or_insert_with(String::new)
+                    .push_str(&remaining);
+            }
+            _ => {}
         }
+        output
     }
 
     /// Drain `n` bytes from the front of `fragment_lengths`, returning the
@@ -507,6 +525,10 @@ impl StreamFilter {
     /// `tok.match` is one token ID (one position); here we count how many
     /// `feed()` positions contributed bytes to the matched span.
     fn drain_buffer(&mut self) -> FilterOutput {
+        self.drain_buffer_inner(false)
+    }
+
+    fn drain_buffer_inner(&mut self, end_of_stream: bool) -> FilterOutput {
         let mut content = String::new();
         let mut reasoning = String::new();
         let mut suppressed_positions: usize = 0;
@@ -517,7 +539,7 @@ impl StreamFilter {
                 break;
             }
 
-            match self.find_earliest_delimiter() {
+            match self.find_earliest_delimiter(end_of_stream) {
                 Some((pos, delim_len, action)) => {
                     // Text before the delimiter is attributed to the current
                     // state so thinking fragments surface as reasoning and
@@ -582,12 +604,15 @@ impl StreamFilter {
     /// Find the earliest complete delimiter in the buffer.
     ///
     /// Returns `(byte_position, delimiter_len, action)`.
-    fn find_earliest_delimiter(&self) -> Option<(usize, usize, DelimiterAction)> {
+    fn find_earliest_delimiter(
+        &self,
+        end_of_stream: bool,
+    ) -> Option<(usize, usize, DelimiterAction)> {
         let mut earliest: Option<(usize, usize, DelimiterAction)> = None;
 
         for &(delim, action) in CHAT_DELIMITERS {
             if let Some(pos) = self.buffer.find(delim) {
-                if self.complete_prefix_is_still_ambiguous(pos, delim) {
+                if !end_of_stream && self.complete_prefix_is_still_ambiguous(pos, delim) {
                     continue;
                 }
                 match earliest {
@@ -1582,6 +1607,18 @@ mod tests {
             out.consumed_positions, 2,
             "`thought\\n` must not be counted once for the delimiter and again for the newline"
         );
+    }
+
+    #[test]
+    fn flush_resolves_bare_channel_fallback_at_end_of_stream() {
+        let mut f = StreamFilter::new();
+        assert_eq!(f.feed("<|channel>").content, None);
+
+        let out = f.flush();
+        assert_eq!(out.content, None);
+        assert_eq!(out.reasoning, None);
+        assert_eq!(out.suppressed_positions, 1);
+        assert_eq!(out.consumed_positions, 1);
     }
 
     // -- HIGH-1 regression: multi-fragment (multi-token) delimiter counting --

--- a/src/server/tool_calls/stream_filter.rs
+++ b/src/server/tool_calls/stream_filter.rs
@@ -27,7 +27,7 @@
 //! - Qwen-style reasoning: `<think>` / `</think>` — Qwen3.x, Exaone4, Hunyuan, GLM4, etc.
 //! - Hermes-style tool calls: `<tool_call>` / `</tool_call>` — Qwen/DeepSeek tool call format
 //! - Mistral Nemo: `[TOOL_CALLS]` — one-shot start marker (rest of output is tool call JSON)
-//! - Gemma 4: `<|channel>` / `<channel|>`, `<|tool_call>` / `<tool_call|>`,
+//! - Gemma 4: `<|channel>thought` / `<channel|>`, `<|tool_call>` / `<tool_call|>`,
 //!   `<|think|>`, `<|turn>` / `<turn|>`
 //! - Function-calling Gemma: `<start_function_call>` / `<end_function_call>`,
 //!   a distinct marker family from Gemma 4, sharing only the inner
@@ -225,8 +225,10 @@ const CHAT_DELIMITERS: &[(&str, DelimiterAction)] = &[
     // a spurious Hermes hit on the Gemma 4 open tag.
     ("<|tool_call>", DelimiterAction::EnterToolCall),
     ("<tool_call|>", DelimiterAction::ExitToolCall),
-    // Gemma 4 reasoning channel and structural strip markers.
-    ("<|channel>", DelimiterAction::EnterThinking),
+    // Gemma 4 reasoning channel: consume the full `<|channel>thought` opener
+    // as one delimiter so the `thought` channel argument never leaks into
+    // `delta.reasoning_content`.
+    ("<|channel>thought", DelimiterAction::EnterThinking),
     ("<channel|>", DelimiterAction::ExitThinking),
     ("<|think|>", DelimiterAction::Strip),
     ("<|turn>", DelimiterAction::Strip),
@@ -303,7 +305,7 @@ enum FilterState {
 ///
 /// Covers Qwen-style (`<think>` / `</think>`), Hermes-style
 /// (`<tool_call>` / `</tool_call>`), Mistral Nemo (`[TOOL_CALLS]`), and
-/// Gemma 4 (`<|channel>` / `<channel|>`) reasoning families, plus Gemma 4
+/// Gemma 4 (`<|channel>thought` / `<channel|>`) reasoning families, plus Gemma 4
 /// tool-call and turn markers.
 ///
 /// Feed decoded text fragments via [`feed()`](StreamFilter::feed).  The
@@ -863,7 +865,7 @@ mod tests {
         // SSE chunks. Content after the close stays in `content`.
         let mut f = StreamFilter::new();
         let out = f.feed("<|channel>thought\nReasoning text<channel|>Answer text");
-        assert_eq!(out.reasoning.as_deref(), Some("thought\nReasoning text"));
+        assert_eq!(out.reasoning.as_deref(), Some("\nReasoning text"));
         assert_eq!(out.content.as_deref(), Some("Answer text"));
     }
 
@@ -1023,16 +1025,45 @@ mod tests {
 
     #[test]
     fn gemma4_regression_channel_reasoning_and_content() {
-        // Regression guard: Gemma 4 `<|channel>reasoning<channel|>content`
+        // Regression guard: Gemma 4 `<|channel>thought\nreasoning<channel|>content`
         // must still route correctly after the Qwen entries were added to
         // CHAT_DELIMITERS. Any change to the filter that silently breaks
         // Gemma 4 will be caught here.
         let mut f = StreamFilter::new();
         let out = f.feed("<|channel>thought\nReasoning text<channel|>Answer text");
-        assert_eq!(out.reasoning.as_deref(), Some("thought\nReasoning text"));
+        assert_eq!(out.reasoning.as_deref(), Some("\nReasoning text"));
         assert_eq!(out.content.as_deref(), Some("Answer text"));
         assert!(!out.content.as_deref().unwrap_or("").contains("<|channel>"));
         assert!(!out.content.as_deref().unwrap_or("").contains("<channel|>"));
+    }
+
+    #[test]
+    fn gemma4_streaming_delta_contract_only_drops_thought_residue() {
+        // Stream the Gemma 4 opener across token boundaries to prove the
+        // visible answer and reasoning delta framing stay identical to the old
+        // behavior except for removing the leaked `thought` residue.
+        let mut f = StreamFilter::new();
+        let fragments = [
+            "<|channel>",
+            "thought\n",
+            "first line",
+            "<channel|>",
+            "final answer",
+        ];
+        let mut reasoning = String::new();
+        let mut content = String::new();
+        for frag in fragments {
+            let out = f.feed(frag);
+            if let Some(r) = out.reasoning {
+                reasoning.push_str(&r);
+            }
+            if let Some(c) = out.content {
+                content.push_str(&c);
+            }
+        }
+
+        assert_eq!(reasoning, "\nfirst line");
+        assert_eq!(content, "final answer");
     }
 
     // -- Hermes / Qwen / DeepSeek tool-call markup suppression --


### PR DESCRIPTION
## Summary
Make the server reasoning splitter consume Gemma 4's full `<|channel>thought` opener so `reasoning_content` no longer starts with the leaked `thought` channel argument.

## What Changed
- update the server stream filter to enter Gemma 4 reasoning on `<|channel>thought` instead of bare `<|channel>`
- keep the visible answer path unchanged while trimming only the reasoning residue from streaming and non-streaming server extraction
- add a focused streaming regression assertion that exercises token-by-token Gemma 4 deltas and proves the answer/reasoning split is unchanged apart from dropping `thought`

## Test Plan
- [x] `cargo test --lib gemma4_streaming_delta_contract_only_drops_thought_residue`
- [x] `cargo test --lib extract_reasoning_gemma4`
- [x] `cargo test --lib gemma4_regression_channel_reasoning_and_content`
- [x] `cargo test --lib thinking_block_surfaces_as_reasoning_not_content`

Closes #890
