### PR TITLE
fix: make autotune profiler tests deterministic

### DIFF
--- a/TECHNICAL_REPORTS/1096-deterministic-autotune-profiling-20260810.en.md
+++ b/TECHNICAL_REPORTS/1096-deterministic-autotune-profiling-20260810.en.md
@@ -1,0 +1,71 @@
+# Technical Report: PR #1096 - Deterministic Autotune Profiling Tests
+
+**Date**: 2026-08-10
+**Status**: Completed with platform qualification pending
+**Languages**: Rust
+**Risk Level**: Medium
+
+## Executive Summary
+
+PR #1096 removes host-scheduler timing jitter from autotune tests that assert candidate ordering. Production profiling continues to measure real `TunableOp::run` and `sync` latency with `Instant`, while tests exercise the same warmup, interleaving, selection, persistence, and memoization logic through an internal manual microsecond clock.
+
+Review also closed a production resource-bound gap: caller-supplied warmup repetitions are now capped by normalized `max_reps`, with CLI and API documentation updated to match.
+
+## 1. Problem Statement
+
+Two CPU-only autotune tests intermittently selected the wrong synthetic tactic under host load because `FakeOp` modeled costs with microsecond `thread::sleep` calls. Scheduler overshoot could exceed the 400-720 microsecond gaps being compared, so tests intended to verify deterministic selection instead measured operating-system wakeup behavior.
+
+The same test double powered other profile and resolve assertions, so fixing only the two observed failures would have left equivalent latent flakes elsewhere in the module.
+
+## 2. Technical Decisions
+
+### 2.1 Inject time at the profiler boundary
+
+An internal `ProfileTimer` abstraction supplies marks and elapsed microseconds to the existing profiling algorithm. `profile()` instantiates `RealTimer`, preserving the production path, while test-only helpers use `ManualTimer` and advance it by the selected tactic's declared cost. The seam remains internal and the public `TunableOp` contract is unchanged.
+
+### 2.2 Retain real sleep only for a one-candidate budget test
+
+`timed_repetitions_scale_inversely_with_launch_cost` still sleeps because its subject is adaptive wall-clock repetition budgeting. Each profile in that test has one candidate, so scheduler jitter can change the realized repetition count within documented bounds but cannot decide candidate ordering.
+
+### 2.3 Prove selection sensitivity and cap caller work
+
+The regression suite evaluates both cost directions: a faster tuned candidate must replace the default, while an inverted cost map must retain the faster default. A temporary wrong expectation was observed red before restoration. Separately, sanitized `warmup` is capped after `max_reps` is normalized above the timed repetition floor, preventing pathological CLI/API input from forcing an oversized warmup loop.
+
+## 3. Change Summary
+
+| Item | Value |
+|------|-------|
+| Files changed | 4 |
+| Lines added | 210 |
+| Lines deleted | 56 |
+| Focused tests | 57 passed |
+
+- Added internal real/manual timer implementations and routed the profiler's warmup and timed phases through them.
+- Migrated all ordering-sensitive fake-op profile and resolver tests to deterministic synthetic time.
+- Added inverted-cost and warmup-ceiling regression coverage.
+- Added a profiling closure seam for test-only resolver execution without changing public APIs.
+- Clarified `ProfileConfig` and `mlxcel tune` help/output to state that warmup is capped by `max_reps`.
+
+## 4. Review Findings
+
+| Finding | Severity | Resolution |
+|---------|----------|------------|
+| Caller-supplied `warmup` could exceed the documented `max_reps` ceiling | Medium | Clamp warmup after normalizing `max_reps`; add a seven-call regression proof |
+| Public and CLI wording still described warmup as an unconditional minimum after the cap | Low | Update profiler docs, CLI help, and tune summary output |
+
+No Critical or High findings remained. The timer abstraction is internal, production still uses `Instant`, and the deterministic resolver entry point is test-only.
+
+## 5. Validation
+
+- `cargo fmt --check -p mlxcel-core`: passed.
+- `cargo fmt --check -p mlxcel`: passed.
+- `cargo test --profile test-fast -p mlxcel-core --lib autotune:: -- --test-threads=1`: 57 passed, 0 failed, 1,355 filtered out.
+- Inverted synthetic-cost selection test: passed; a temporary wrong expectation failed as required before restoration.
+- Warmup-ceiling regression: passed, proving five capped warmups plus two timed repetitions.
+- Hosted change detection, crate-version, kernel-dtype-key, cross-repository-reference, cargo-fmt, cargo-deny, and CLA checks passed; MLX pin extraction was skipped because the pin did not change.
+- macOS `metal,accelerate` and loaded-host full-lib gates were unavailable and are not claimed. A current Linux full-lib attempt began 1,411 tests but aborted in an unrelated CUDA-backed cache test because no CUDA backend is exposed.
+
+## 6. Related Work
+
+- Issue #1079: sleep-accuracy flake and deterministic timing requirements.
+- Issue #997: separate concurrent-load flakes with a different mechanism and platform gate.

--- a/TECHNICAL_REPORTS/1096-deterministic-autotune-profiling-20260810.ko.md
+++ b/TECHNICAL_REPORTS/1096-deterministic-autotune-profiling-20260810.ko.md
@@ -1,0 +1,71 @@
+# 기술 보고서: PR #1096 - 결정론적 Autotune Profiling 테스트
+
+**작성일**: 2026-08-10
+**상태**: 구현 완료, platform qualification 대기
+**언어**: Rust
+**위험도**: Medium
+
+## 요약
+
+PR #1096은 autotune candidate 순서를 검증하는 테스트에서 host scheduler timing jitter를 제거한다. Production profiling은 계속 `Instant`로 실제 `TunableOp::run` 및 `sync` latency를 측정하고, 테스트는 internal manual microsecond clock을 통해 동일한 warmup, interleaving, selection, persistence, memoization logic을 실행한다.
+
+리뷰 과정에서 production resource bound 문제도 함께 해결했다. 이제 caller가 지정한 warmup repetition은 정규화된 `max_reps`로 제한되며, CLI와 API 문서도 이 동작과 일치한다.
+
+## 1. 문제 정의
+
+CPU-only autotune 테스트 두 개는 `FakeOp` cost를 microsecond `thread::sleep`으로 모델링했기 때문에 host load에서 간헐적으로 잘못된 tactic을 선택했다. Scheduler overshoot가 비교 대상인 400-720 microsecond gap보다 커질 수 있어, 결정론적 selection을 검증해야 할 테스트가 operating-system wakeup 동작을 측정했다.
+
+같은 test double이 다른 profile 및 resolve assertion에도 사용되므로 관측된 두 테스트만 수정하면 동일한 잠재 flake가 module에 남는다.
+
+## 2. 기술적 선택과 그 이유
+
+### 2.1 Profiler 경계에 시간 주입
+
+Internal `ProfileTimer` abstraction이 기존 profiling algorithm에 mark와 elapsed microsecond를 제공한다. `profile()`은 `RealTimer`를 사용해 production 경로를 보존하고, test-only helper는 `ManualTimer`를 사용해 선택한 tactic의 선언된 cost만큼 시간을 전진시킨다. 이 seam은 internal로 유지되며 public `TunableOp` contract는 바뀌지 않는다.
+
+### 2.2 Single-candidate budget 테스트에만 real sleep 유지
+
+`timed_repetitions_scale_inversely_with_launch_cost`는 adaptive wall-clock repetition budgeting 자체를 검증하므로 sleep을 유지한다. 이 테스트의 각 profile에는 candidate가 하나뿐이어서 scheduler jitter가 문서화된 bound 안에서 repetition count를 바꿀 수는 있지만 candidate ordering을 결정할 수는 없다.
+
+### 2.3 Selection 민감도 증명 및 caller work 제한
+
+Regression suite는 양쪽 cost 방향을 모두 검증한다. Tuned candidate가 더 빠르면 default를 대체해야 하고, cost를 뒤집으면 더 빠른 default를 유지해야 한다. 임시로 잘못된 expectation을 넣었을 때 실제 red를 확인한 뒤 복원했다. 또한 `max_reps`를 timed repetition floor 이상으로 정규화한 다음 sanitized `warmup`을 그 값으로 제한하여 비정상 CLI/API input이 과도한 warmup loop를 강제하지 못하게 했다.
+
+## 3. 변경 요약
+
+| 항목 | 값 |
+|------|----|
+| 변경 파일 | 4 |
+| 추가 라인 | 210 |
+| 삭제 라인 | 56 |
+| Focused test | 57 passed |
+
+- Internal real/manual timer 구현을 추가하고 profiler의 warmup 및 timed phase를 이 경로로 연결했다.
+- Candidate ordering에 의존하는 모든 fake-op profile 및 resolver 테스트를 deterministic synthetic time으로 옮겼다.
+- Inverted-cost 및 warmup-ceiling 회귀 테스트를 추가했다.
+- Public API 변경 없이 test-only resolver 실행을 위한 profiling closure seam을 추가했다.
+- `ProfileConfig` 및 `mlxcel tune` help/output에 warmup이 `max_reps`로 제한됨을 명확히 기록했다.
+
+## 4. 리뷰 발견 사항
+
+| 발견 사항 | 심각도 | 해결 |
+|-----------|--------|------|
+| Caller-supplied `warmup`이 문서화된 `max_reps` ceiling을 넘을 수 있음 | Medium | `max_reps` 정규화 후 warmup을 제한하고 7-call 회귀 테스트 추가 |
+| Cap 추가 후에도 public 및 CLI 문구가 warmup을 무조건적인 minimum으로 설명함 | Low | Profiler 문서, CLI help, tune summary output 갱신 |
+
+남은 Critical 또는 High finding은 없다. Timer abstraction은 internal이며 production은 계속 `Instant`를 사용하고 deterministic resolver entry point는 test-only다.
+
+## 5. 검증
+
+- `cargo fmt --check -p mlxcel-core`: 통과.
+- `cargo fmt --check -p mlxcel`: 통과.
+- `cargo test --profile test-fast -p mlxcel-core --lib autotune:: -- --test-threads=1`: 57 passed, 0 failed, 1,355 filtered out.
+- Inverted synthetic-cost selection test: 통과. 복원 전 임시로 잘못된 expectation이 요구대로 실패함을 확인했다.
+- Warmup-ceiling regression: 통과. 제한된 warmup 5회와 timed repetition 2회를 증명했다.
+- Hosted change detection, crate-version, kernel-dtype-key, cross-repository-reference, cargo-fmt, cargo-deny, CLA check 통과. MLX pin을 변경하지 않아 extraction은 skip되었다.
+- macOS `metal,accelerate` 및 loaded-host full-lib gate는 사용할 수 없어 통과로 주장하지 않는다. 현재 Linux full-lib 실행은 1,411개 테스트를 시작했지만 CUDA backend가 없어 관련 없는 CUDA-backed cache test에서 abort되었다.
+
+## 6. 관련 작업
+
+- Issue #1079: sleep accuracy flake 및 deterministic timing 요구사항.
+- Issue #997: 다른 mechanism과 platform gate를 가진 별도 concurrent-load flake.

--- a/src/commands/tune.rs
+++ b/src/commands/tune.rs
@@ -112,13 +112,13 @@ pub(crate) struct TuneArgs {
     #[arg(long, default_value = "1024,4096,16384")]
     pub(crate) context_lengths: String,
 
-    /// Minimum untimed warmup repetitions per candidate.
+    /// Minimum untimed warmup repetitions per candidate, capped by `--max-reps`.
     #[arg(long, default_value_t = DEFAULT_WARMUP)]
     pub(crate) warmup: usize,
 
     /// Wall-clock warmup per candidate, milliseconds. Warmup runs past
-    /// `--warmup` until this elapses, which is what brings the GPU to a steady
-    /// clock before anything is recorded.
+    /// `--warmup` until this elapses or `--max-reps` is reached, which is what
+    /// brings the GPU to a steady clock before anything is recorded.
     #[arg(long, default_value_t = DEFAULT_WARMUP_BUDGET_US / 1000.0)]
     pub(crate) warmup_ms: f64,
 
@@ -462,8 +462,9 @@ pub(crate) fn run_tune(args: TuneArgs) -> Result<()> {
     }
     let cfg = args.profile_config();
     println!(
-        "profile: warmup>={} ({:.0}ms) reps {}..{} ({:.0}ms budget) min_improvement={:.3} (+ measured spread)",
+        "profile: warmup>={} capped@{} ({:.0}ms) reps {}..{} ({:.0}ms budget) min_improvement={:.3} (+ measured spread)",
         cfg.warmup,
+        cfg.max_reps,
         cfg.warmup_budget_us / 1000.0,
         cfg.reps,
         cfg.max_reps,

--- a/src/lib/mlxcel-core/src/autotune/autotune_tests.rs
+++ b/src/lib/mlxcel-core/src/autotune/autotune_tests.rs
@@ -405,6 +405,25 @@ fn profile_config_sanitizes_degenerate_values() {
 }
 
 #[test]
+fn profile_config_bounds_warmup_by_the_rep_ceiling() {
+    let cfg = ProfileConfig {
+        warmup: 100,
+        warmup_budget_us: 0.0,
+        reps: 2,
+        max_reps: 5,
+        sample_budget_us: 0.0,
+        min_improvement: 0.02,
+    };
+    let op = FakeOp::new("fake_bounded_warmup", vec![(1, 1)]);
+    let _ = op.profile(cfg).expect("sweep produced a result");
+    assert_eq!(
+        op.calls(),
+        7,
+        "warmup is capped at 5 before the 2 timed reps run"
+    );
+}
+
+#[test]
 fn profile_runs_warmup_plus_reps_per_candidate() {
     // With both wall-clock budgets at zero the sampler falls back to the fixed
     // floors, which is what makes an exact call count assertable at all.

--- a/src/lib/mlxcel-core/src/autotune/autotune_tests.rs
+++ b/src/lib/mlxcel-core/src/autotune/autotune_tests.rs
@@ -15,13 +15,14 @@
 //! Unit tests for the shape-bucketed kernel autotuner (issue #906).
 //!
 //! Every test here is CPU-only: the [`FakeOp`] double implements
-//! [`TunableOp`] by sleeping for a per-tactic duration and overrides `sync` to
-//! a no-op, so the harness, the cache, and the precedence chain are exercised
-//! without a GPU. The GPU-backed consumers are validated by benchmark runs,
-//! not here.
+//! [`TunableOp`] with either a deterministic per-tactic timer or a bounded
+//! sleep and overrides `sync` to a no-op, so the harness, the cache, and the
+//! precedence chain are exercised without a GPU. The GPU-backed consumers are
+//! validated by benchmark runs, not here.
 
-use std::cell::RefCell;
+use std::cell::{Cell, RefCell};
 use std::path::PathBuf;
+use std::rc::Rc;
 use std::time::Duration;
 
 use super::bucket::{MAX_BUCKET_DIM, ShapeBucket, powers_of_two_up_to, round_up_pow2};
@@ -31,22 +32,51 @@ use super::ops::cuda_kernel_knobs::{
 };
 use super::ops::paged_decode_splits::split_candidates;
 use super::profile::{
-    Measurement, ProfileConfig, median, median_absolute_deviation, profile, samples_this_round,
-    select,
+    Measurement, ProfileConfig, ProfileResult, ProfileTimer, median, median_absolute_deviation,
+    profile, profile_with_timer, samples_this_round, select,
 };
 use super::store::{
     TACTIC_VERSION, TacticRecord, TacticStore, TuneKey, mlx_commit, mlxcel_version,
 };
 use super::tactic::{Tactic, TunableOp, TuneError};
-use super::{Mode, Resolution, Source, clear_memo, parse_mode, resolve_with_mode};
+use super::{
+    Mode, Resolution, Source, clear_memo, parse_mode, resolve_with_mode,
+    resolve_with_mode_and_timer,
+};
 
 // ── Test double ──────────────────────────────────────────────────────────────
 
-/// A [`TunableOp`] whose "kernel" is a sleep of a per-tactic duration.
+#[derive(Clone, Default)]
+struct ManualTimer {
+    now_us: Rc<Cell<f64>>,
+}
+
+#[derive(Clone, Copy)]
+struct ManualMark(f64);
+
+impl ManualTimer {
+    fn advance_us(&self, micros: u64) {
+        self.now_us.set(self.now_us.get() + micros as f64);
+    }
+}
+
+impl ProfileTimer for ManualTimer {
+    type Mark = ManualMark;
+
+    fn now(&self) -> Self::Mark {
+        ManualMark(self.now_us.get())
+    }
+
+    fn elapsed_us(&self, start: Self::Mark) -> f64 {
+        self.now_us.get() - start.0
+    }
+}
+
+/// A [`TunableOp`] whose "kernel" costs the per-tactic duration in microseconds.
 ///
-/// Sleeping is what makes the min-latency selection observable without a
-/// backend. Durations are in the tens of microseconds so a full sweep stays
-/// well under a millisecond.
+/// Most tests run it against a manual timer so candidate ordering is exact and
+/// independent of host scheduling. Tests that verify real wall-clock budgets
+/// opt into sleeping explicitly.
 struct FakeOp {
     op: String,
     bucket: ShapeBucket,
@@ -58,6 +88,7 @@ struct FakeOp {
     /// Which tactics fail instead of running.
     failing: Vec<i64>,
     calls: RefCell<usize>,
+    timer: Option<ManualTimer>,
 }
 
 impl FakeOp {
@@ -72,6 +103,7 @@ impl FakeOp {
             lazy: true,
             failing: Vec::new(),
             calls: RefCell::new(0),
+            timer: Some(ManualTimer::default()),
         }
     }
 
@@ -95,8 +127,29 @@ impl FakeOp {
         self
     }
 
+    fn with_real_sleep(mut self) -> Self {
+        self.timer = None;
+        self
+    }
+
     fn calls(&self) -> usize {
         *self.calls.borrow()
+    }
+
+    fn profile(&self, cfg: ProfileConfig) -> Option<ProfileResult> {
+        if let Some(timer) = &self.timer {
+            profile_with_timer(self, cfg, timer)
+        } else {
+            profile(self, cfg)
+        }
+    }
+
+    fn resolve_with(&self, store: &TacticStore, mode: Mode) -> Resolution {
+        if let Some(timer) = &self.timer {
+            resolve_with_mode_and_timer(self, store, fast_cfg(), mode, timer)
+        } else {
+            resolve_with_mode(self, store, fast_cfg(), mode)
+        }
     }
 }
 
@@ -139,7 +192,11 @@ impl TunableOp for FakeOp {
             .iter()
             .find(|(pp, _)| *pp == p)
             .map_or(0, |(_, us)| *us);
-        std::thread::sleep(Duration::from_micros(micros));
+        if let Some(timer) = &self.timer {
+            timer.advance_us(micros);
+        } else {
+            std::thread::sleep(Duration::from_micros(micros));
+        }
         Ok(())
     }
     fn sync(&self) {
@@ -148,9 +205,8 @@ impl TunableOp for FakeOp {
 }
 
 /// Zero wall-clock budgets, so the adaptive sampler degenerates to exactly
-/// `reps` timed repetitions per candidate. These tests assert selection logic,
-/// not timing methodology, and a real budget would make their call counts
-/// depend on how accurately the host honors `thread::sleep`.
+/// `reps` timed repetitions per candidate. The deterministic fake timer keeps
+/// selection and call-count assertions independent of host scheduling.
 fn fast_cfg() -> ProfileConfig {
     ProfileConfig {
         warmup: 0,
@@ -267,7 +323,7 @@ fn median_handles_nan_without_panicking() {
 fn profile_picks_the_min_latency_candidate() {
     // Default (2) is slow; 8 is 10x faster, well past the noise margin.
     let op = FakeOp::new("fake_min_latency", vec![(2, 800), (4, 400), (8, 80)]);
-    let result = profile(&op, fast_cfg()).expect("sweep produced a result");
+    let result = op.profile(fast_cfg()).expect("sweep produced a result");
     assert_eq!(result.best, Tactic::scalar("p", 8));
     assert!(result.changed);
     assert_eq!(result.measurements.len(), 3);
@@ -277,18 +333,34 @@ fn profile_picks_the_min_latency_candidate() {
 }
 
 #[test]
+fn profile_selection_changes_when_synthetic_costs_are_inverted() {
+    let faster_tuned = FakeOp::new("fake_cost_order_tuned", vec![(2, 800), (8, 80)]);
+    let tuned_result = faster_tuned
+        .profile(fast_cfg())
+        .expect("sweep produced a result");
+    assert_eq!(tuned_result.best, Tactic::scalar("p", 8));
+    assert!(tuned_result.changed);
+
+    let faster_default = FakeOp::new("fake_cost_order_default", vec![(2, 80), (8, 800)]);
+    let default_result = faster_default
+        .profile(fast_cfg())
+        .expect("sweep produced a result");
+    assert_eq!(default_result.best, Tactic::scalar("p", 2));
+    assert!(!default_result.changed);
+}
+
+#[test]
 fn profile_keeps_the_default_inside_the_noise_band() {
     // Candidate 8 is genuinely ~2x faster, but the required margin here is 90%,
     // so the win does not clear it and the pre-tuner behavior must survive.
-    // This is the regression guard: a win inside the host's noise floor
-    // converges back to the default rather than to a coin flip. The margin is
-    // exaggerated so that `thread::sleep` jitter cannot decide the assertion.
+    // This is the regression guard: a win inside the measured noise floor
+    // converges back to the default rather than to a coin flip.
     let cfg = ProfileConfig {
         min_improvement: 0.9,
         ..fast_cfg()
     };
     let op = FakeOp::new("fake_noise_band", vec![(2, 400), (4, 300), (8, 200)]);
-    let result = profile(&op, cfg).expect("sweep produced a result");
+    let result = op.profile(cfg).expect("sweep produced a result");
     assert_eq!(result.best, Tactic::scalar("p", 2));
     assert!(!result.changed);
 }
@@ -296,7 +368,7 @@ fn profile_keeps_the_default_inside_the_noise_band() {
 #[test]
 fn profile_drops_failing_candidates_without_aborting() {
     let op = FakeOp::new("fake_failing", vec![(2, 800), (4, 80), (8, 400)]).failing(&[4]);
-    let result = profile(&op, fast_cfg()).expect("sweep survived the failure");
+    let result = op.profile(fast_cfg()).expect("sweep survived the failure");
     // 4 was the fastest but is infeasible, so 8 wins.
     assert_eq!(result.best, Tactic::scalar("p", 8));
     assert_eq!(result.measurements.len(), 2);
@@ -305,13 +377,13 @@ fn profile_drops_failing_candidates_without_aborting() {
 #[test]
 fn profile_returns_none_when_every_candidate_fails() {
     let op = FakeOp::new("fake_all_fail", vec![(2, 10), (4, 10)]).failing(&[2, 4]);
-    assert!(profile(&op, fast_cfg()).is_none());
+    assert!(op.profile(fast_cfg()).is_none());
 }
 
 #[test]
 fn profile_returns_none_without_candidates() {
     let op = FakeOp::new("fake_no_candidates", vec![]);
-    assert!(profile(&op, fast_cfg()).is_none());
+    assert!(op.profile(fast_cfg()).is_none());
 }
 
 #[test]
@@ -341,7 +413,7 @@ fn profile_runs_warmup_plus_reps_per_candidate() {
         ..fast_cfg()
     };
     let op = FakeOp::new("fake_call_count", vec![(1, 1), (2, 1)]);
-    let _ = profile(&op, cfg).expect("sweep produced a result");
+    let _ = op.profile(cfg).expect("sweep produced a result");
     assert_eq!(op.calls(), 2 * (2 + 5));
 }
 
@@ -368,7 +440,7 @@ fn timed_repetitions_scale_inversely_with_launch_cost() {
     // pass in isolation and fail under full-suite parallelism, where 1200+
     // tests contend; the property under test is that effort scales inversely
     // with launch cost, not that a cheap launch lands on one particular number.
-    let cheap = FakeOp::new("fake_cheap_launch", vec![(1, 100)]);
+    let cheap = FakeOp::new("fake_cheap_launch", vec![(1, 100)]).with_real_sleep();
     let cheap_result = profile(&cheap, cfg).expect("cheap sweep produced a result");
     assert!(
         cheap_result.reps >= 4 * cfg.reps,
@@ -386,7 +458,7 @@ fn timed_repetitions_scale_inversely_with_launch_cost() {
     // The costly direction is robust to load in a way the cheap one is not:
     // overshooting a 20ms sleep only exhausts the budget sooner, so the floor
     // is reached under any amount of contention.
-    let costly = FakeOp::new("fake_costly_launch", vec![(1, 20_000)]);
+    let costly = FakeOp::new("fake_costly_launch", vec![(1, 20_000)]).with_real_sleep();
     let costly_result = profile(&costly, cfg).expect("costly sweep produced a result");
     assert_eq!(
         costly_result.reps, cfg.reps,
@@ -526,7 +598,7 @@ fn select_falls_back_to_the_default_when_the_pick_is_not_actually_faster() {
 #[test]
 fn profile_records_the_spread_behind_every_measurement() {
     let op = FakeOp::new("fake_spread", vec![(2, 400), (4, 200)]);
-    let result = profile(&op, fast_cfg()).expect("sweep produced a result");
+    let result = op.profile(fast_cfg()).expect("sweep produced a result");
     assert!(result.default_spread.is_some());
     assert!(result.best_spread.is_finite() && result.best_spread >= 0.0);
     assert!(result.required_improvement >= fast_cfg().min_improvement);
@@ -696,9 +768,9 @@ fn mode_rejects_an_unrecognized_value() {
 
 // ── Resolution precedence ────────────────────────────────────────────────────
 
-fn resolve(op: &dyn TunableOp, store: &TacticStore, mode: Mode) -> Resolution {
+fn resolve(op: &FakeOp, store: &TacticStore, mode: Mode) -> Resolution {
     clear_memo();
-    resolve_with_mode(op, store, fast_cfg(), mode)
+    op.resolve_with(store, mode)
 }
 
 #[test]
@@ -830,9 +902,9 @@ fn resolve_memoizes_so_a_hot_path_reads_the_cache_once() {
     let store = tmp_store(&dir);
     let op = FakeOp::new("fake_memo", vec![(2, 400), (8, 40)]);
     clear_memo();
-    let first = resolve_with_mode(&op, &store, fast_cfg(), Mode::Tune);
+    let first = op.resolve_with(&store, Mode::Tune);
     let calls_after_first = op.calls();
-    let second = resolve_with_mode(&op, &store, fast_cfg(), Mode::Tune);
+    let second = op.resolve_with(&store, Mode::Tune);
     assert_eq!(first, second);
     assert_eq!(
         op.calls(),

--- a/src/lib/mlxcel-core/src/autotune/mod.rs
+++ b/src/lib/mlxcel-core/src/autotune/mod.rs
@@ -286,6 +286,32 @@ pub fn resolve_with_mode(
     cfg: ProfileConfig,
     mode: Mode,
 ) -> Resolution {
+    resolve_with_mode_profiled(op, store, cfg, mode, profile)
+}
+
+#[cfg(test)]
+fn resolve_with_mode_and_timer<T: profile::ProfileTimer>(
+    op: &dyn TunableOp,
+    store: &TacticStore,
+    cfg: ProfileConfig,
+    mode: Mode,
+    timer: &T,
+) -> Resolution {
+    resolve_with_mode_profiled(op, store, cfg, mode, |op, cfg| {
+        profile::profile_with_timer(op, cfg, timer)
+    })
+}
+
+fn resolve_with_mode_profiled<F>(
+    op: &dyn TunableOp,
+    store: &TacticStore,
+    cfg: ProfileConfig,
+    mode: Mode,
+    profile_fn: F,
+) -> Resolution
+where
+    F: FnOnce(&dyn TunableOp, ProfileConfig) -> Option<ProfileResult>,
+{
     let bucket = op.bucket();
     let default = op.default_tactic(&bucket);
 
@@ -313,7 +339,7 @@ pub fn resolve_with_mode(
         return hit.clone();
     }
 
-    let resolution = resolve_uncached(op, store, cfg, mode, &key, &bucket, &default);
+    let resolution = resolve_uncached(op, store, cfg, mode, &key, &bucket, &default, profile_fn);
     if let Ok(mut guard) = memo().lock() {
         guard.insert(key, resolution.clone());
     }
@@ -329,6 +355,7 @@ fn resolve_uncached(
     key: &TuneKey,
     bucket: &ShapeBucket,
     default: &Tactic,
+    profile_fn: impl FnOnce(&dyn TunableOp, ProfileConfig) -> Option<ProfileResult>,
 ) -> Resolution {
     let candidates = op.candidates(bucket);
     if bucket.is_saturated() || candidates.is_empty() {
@@ -371,7 +398,7 @@ fn resolve_uncached(
         return Resolution::new(default.clone(), Source::Default);
     }
 
-    let Some(result) = profile(op, cfg) else {
+    let Some(result) = profile_fn(op, cfg) else {
         tracing::debug!(
             "autotune: {} bucket {bucket} produced no usable measurement; using default {default}",
             op.op_name()

--- a/src/lib/mlxcel-core/src/autotune/profile.rs
+++ b/src/lib/mlxcel-core/src/autotune/profile.rs
@@ -34,9 +34,10 @@
 //!
 //! 1. **Warm up by wall clock, not by iteration count.** Warmup runs until
 //!    [`ProfileConfig::warmup_budget_us`] has elapsed (with
-//!    [`ProfileConfig::warmup`] as a floor), so a cheap launch gets thousands
-//!    of iterations and an expensive one gets a handful. Both end up on a
-//!    ramped clock; a fixed count only does that for expensive launches.
+//!    [`ProfileConfig::warmup`] as a floor capped by
+//!    [`ProfileConfig::max_reps`]), so a cheap launch gets thousands of
+//!    iterations and an expensive one gets a handful. Both end up on a ramped
+//!    clock; a fixed count only does that for expensive launches.
 //! 2. **Scale repetitions by measured cost.** The warmup doubles as a cost
 //!    probe, and each candidate then targets
 //!    [`ProfileConfig::sample_budget_us`] of timed work, clamped to
@@ -117,7 +118,8 @@ pub const MAD_TO_SIGMA: f64 = 1.4826;
 /// Knobs for one profiling sweep.
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub struct ProfileConfig {
-    /// Minimum untimed repetitions before measuring.
+    /// Minimum untimed repetitions before measuring, capped by `max_reps`
+    /// during sanitization.
     pub warmup: usize,
     /// Wall-clock budget for the warmup phase of one candidate, microseconds.
     /// Warmup keeps going past `warmup` until this elapses.
@@ -160,8 +162,9 @@ fn sane_budget(value: f64, fallback: f64) -> f64 {
 
 impl ProfileConfig {
     /// Clamp to at least one timed repetition, a rep ceiling no lower than the
-    /// floor, and finite non-negative budgets and margins, so a caller-supplied
-    /// config can never produce an empty sample set or a nonsense threshold.
+    /// floor, warmup no higher than that ceiling, and finite non-negative
+    /// budgets and margins, so a caller-supplied config can never produce an
+    /// empty sample set or a nonsense threshold.
     #[must_use]
     pub fn sanitized(self) -> Self {
         let reps = self.reps.max(1);

--- a/src/lib/mlxcel-core/src/autotune/profile.rs
+++ b/src/lib/mlxcel-core/src/autotune/profile.rs
@@ -165,11 +165,12 @@ impl ProfileConfig {
     #[must_use]
     pub fn sanitized(self) -> Self {
         let reps = self.reps.max(1);
+        let max_reps = self.max_reps.max(reps);
         Self {
-            warmup: self.warmup,
+            warmup: self.warmup.min(max_reps),
             warmup_budget_us: sane_budget(self.warmup_budget_us, DEFAULT_WARMUP_BUDGET_US),
             reps,
-            max_reps: self.max_reps.max(reps),
+            max_reps,
             sample_budget_us: sane_budget(self.sample_budget_us, DEFAULT_SAMPLE_BUDGET_US),
             min_improvement: sane_budget(self.min_improvement, DEFAULT_MIN_IMPROVEMENT),
         }

--- a/src/lib/mlxcel-core/src/autotune/profile.rs
+++ b/src/lib/mlxcel-core/src/autotune/profile.rs
@@ -308,8 +308,25 @@ pub fn median_absolute_deviation(samples: &[f64], center: f64) -> Option<f64> {
     median(&deviations)
 }
 
-fn elapsed_us(start: Instant) -> f64 {
-    start.elapsed().as_nanos() as f64 / 1000.0
+pub(super) trait ProfileTimer {
+    type Mark: Copy;
+
+    fn now(&self) -> Self::Mark;
+    fn elapsed_us(&self, start: Self::Mark) -> f64;
+}
+
+struct RealTimer;
+
+impl ProfileTimer for RealTimer {
+    type Mark = Instant;
+
+    fn now(&self) -> Self::Mark {
+        Instant::now()
+    }
+
+    fn elapsed_us(&self, start: Self::Mark) -> f64 {
+        start.elapsed().as_nanos() as f64 / 1000.0
+    }
 }
 
 /// Warm one candidate and probe its per-iteration cost.
@@ -321,13 +338,18 @@ fn elapsed_us(start: Instant) -> f64 {
 /// low-clock ramp at the start do not inflate it. `Ok(None)` means no warmup
 /// was configured and there is nothing to estimate from; `Err(())` means the
 /// candidate is infeasible and must be dropped.
-fn warm_up(op: &dyn TunableOp, tactic: &Tactic, cfg: &ProfileConfig) -> Result<Option<f64>, ()> {
+fn warm_up<T: ProfileTimer>(
+    op: &dyn TunableOp,
+    tactic: &Tactic,
+    cfg: &ProfileConfig,
+    timer: &T,
+) -> Result<Option<f64>, ()> {
     let mut samples_us: Vec<f64> = Vec::new();
-    let phase_start = Instant::now();
+    let phase_start = timer.now();
     while samples_us.len() < cfg.warmup
-        || (elapsed_us(phase_start) < cfg.warmup_budget_us && samples_us.len() < cfg.max_reps)
+        || (timer.elapsed_us(phase_start) < cfg.warmup_budget_us && samples_us.len() < cfg.max_reps)
     {
-        let start = Instant::now();
+        let start = timer.now();
         if let Err(e) = op.run(tactic) {
             tracing::debug!(
                 "autotune: dropping candidate {tactic} for {} during warmup: {e}",
@@ -336,7 +358,7 @@ fn warm_up(op: &dyn TunableOp, tactic: &Tactic, cfg: &ProfileConfig) -> Result<O
             return Err(());
         }
         op.sync();
-        samples_us.push(elapsed_us(start));
+        samples_us.push(timer.elapsed_us(start));
     }
     if samples_us.is_empty() {
         return Ok(None);
@@ -479,6 +501,15 @@ pub fn select(
 /// failed to run. Callers treat `None` as "use the default".
 #[must_use]
 pub fn profile(op: &dyn TunableOp, cfg: ProfileConfig) -> Option<ProfileResult> {
+    profile_with_timer(op, cfg, &RealTimer)
+}
+
+#[must_use]
+pub(super) fn profile_with_timer<T: ProfileTimer>(
+    op: &dyn TunableOp,
+    cfg: ProfileConfig,
+    timer: &T,
+) -> Option<ProfileResult> {
     let cfg = cfg.sanitized();
     let bucket = op.bucket();
     let candidates = op.candidates(&bucket);
@@ -491,7 +522,7 @@ pub fn profile(op: &dyn TunableOp, cfg: ProfileConfig) -> Option<ProfileResult> 
     // candidates drop out here, before they can perturb the timed phase.
     let mut targets: Vec<(usize, usize)> = Vec::with_capacity(candidates.len());
     for (i, tactic) in candidates.iter().enumerate() {
-        if let Ok(est_us) = warm_up(op, tactic, &cfg) {
+        if let Ok(est_us) = warm_up(op, tactic, &cfg, timer) {
             targets.push((i, target_reps(est_us, &cfg)));
         }
     }
@@ -513,7 +544,7 @@ pub fn profile(op: &dyn TunableOp, cfg: ProfileConfig) -> Option<ProfileResult> 
                 continue;
             }
             let tactic = &candidates[cand];
-            let start = Instant::now();
+            let start = timer.now();
             if let Err(e) = op.run(tactic) {
                 tracing::debug!(
                     "autotune: dropping candidate {tactic} for {}: {e}",
@@ -523,7 +554,7 @@ pub fn profile(op: &dyn TunableOp, cfg: ProfileConfig) -> Option<ProfileResult> 
                 continue;
             }
             op.sync();
-            samples[slot].push(elapsed_us(start));
+            samples[slot].push(timer.elapsed_us(start));
         }
     }
 


### PR DESCRIPTION
## Summary

Make autotune profiler ordering tests independent of host scheduler sleep accuracy by adding an internal deterministic timer seam for tests while leaving production profiling on real `Instant` timing.

## What changed

- Added an internal `ProfileTimer` path used by `profile()` with `RealTimer` in production and by test-only helpers with a manual microsecond clock.
- Routed ordering-sensitive fake-op profile and resolve tests through the manual timer, including failing-candidate, metadata/spread, persistence, retune, and memoization coverage.
- Kept the adaptive wall-clock budget test on real `thread::sleep` because it verifies repetition scaling, not candidate ordering, and added an inverted-cost selection proof.
- Bounded caller-supplied warmup repetitions by the normalized `max_reps` ceiling and clarified the public profiler and `mlxcel tune` descriptions of that cap.

## Test plan

- [x] `cargo fmt --check -p mlxcel-core`
- [x] `cargo fmt --check -p mlxcel`
- [x] `cargo test --profile test-fast -p mlxcel-core --lib autotune:: -- --test-threads=1` (57 passed / 1355 filtered out)
- [x] `cargo test --profile test-fast -p mlxcel-core --lib autotune::autotune_tests::profile_selection_changes_when_synthetic_costs_are_inverted -- --test-threads=1`
- [x] `cargo test --profile test-fast -p mlxcel-core --lib autotune::autotune_tests::profile_config_bounds_warmup_by_the_rep_ceiling -- --test-threads=1`
- [x] Temporary mutation proof: forcing the inverted-cost test to expect `p=8` for the faster-default case failed with `left: p=2`, then the assertion was restored and the test passed.
- [ ] `cargo test --profile test-fast --features metal,accelerate -p mlxcel-core --lib autotune:: -- --test-threads=1` and loaded-host full lib suite: unavailable on this Linux host; not claimed as passing. A current-host broad run reached 1,411 tests but aborted in an unrelated CUDA-backed cache test because no CUDA backend is exposed.

Closes #1079
