### PR TITLE
fix(models): correct Molmo v1 image decoding seams

### DIFF
--- a/TECHNICAL_REPORTS/1099-molmo-v1-image-decoding-seams-20260811.en.md
+++ b/TECHNICAL_REPORTS/1099-molmo-v1-image-decoding-seams-20260811.en.md
@@ -1,0 +1,147 @@
+# Technical Report: PR #1099 - fix(models): correct Molmo v1 image decoding seams
+
+**Date**: 2026-08-10
+**Author**: mlxcel maintainers
+**Reviewer**: implementation, security, and finalizer review cycle
+**Status**: Completed for an open PR
+**Languages**: Rust, Markdown
+**Risk Level**: Medium
+
+---
+
+## Executive Summary
+
+PR #1099 fixes the Molmo v1 seams behind issue #1087: image-conditioned generation from `molmo-7b` was incoherent on a real COCO cats photo while `molmo2-4b` answered correctly on the same setup. The root cause was not the server path, BOS insertion, or feature scatter. It was two model-family seams in the Molmo v1 decode stack: flat configs that omit `rope_impl` were falling back to a stale local default that selected MLX traditional interleave RoPE instead of the checkpoint's effective LLaMA rotate-half layout, and the image preprocessor was deviating from reference behavior by padding in normalized space and collapsing fractional patch coverage to booleans.
+
+The PR fixes both seams in `src/models/molmo.rs` and `src/vision/processors/molmo.rs`, adds targeted regression coverage, and was validated on the real NVIDIA GB10 CUDA path that originally reproduced the bug. The pre-fix CLI run reproduced the reported garbage output byte-for-byte at `prompt_tokens=749`; the fixed CLI and the normal BatchScheduler-backed server path both returned the same coherent description of two cats sleeping on a red couch under a pink blanket. Two independent review passes reported no further findings, and the finalizer pass judged the PR merge-ready.
+
+---
+
+## 1. Problem Statement
+
+### 1.1 User-visible failure
+
+Issue #1087 reported that `molmo-7b` generated incoherent output on image prompts while `molmo2-4b` answered correctly on the same GB10 CUDA setup. The failure was reproduced on the real 640x480 COCO cats image and was already present on `main`, so it was a pre-existing Molmo v1 defect rather than a regression from adjacent work.
+
+### 1.2 Acceptance target
+
+The issue required three things:
+
+- coherent real-photo CLI output for Molmo v1,
+- a fix at the actual root-cause seam rather than a prompt-side workaround,
+- and verification on both `mlxcel` CLI and `mlxcel-server`.
+
+---
+
+## 2. Root Cause
+
+Two independent seams were confirmed.
+
+### 2.1 Omitted `rope_impl` selected the wrong RoPE layout
+
+Molmo v1 flat configs can omit `rope_impl`. The released checkpoint still effectively expects the LLaMA rotate-half layout, but the local dataclass default treated the omission as MLX traditional interleave RoPE. That mismatch corrupts positional rotation before any image-conditioned reasoning happens, so decoding becomes nonsensical even when the prompt, server path, and image features are otherwise correct.
+
+The fix makes omitted Molmo v1 `rope_impl` default to the checkpoint's effective LLaMA layout while preserving explicit `interleave` as the MLX traditional path.
+
+### 2.2 The image preprocessor was not reference-faithful
+
+`pad_and_partial_pad` had two reference mismatches:
+
+- it padded after normalization, so padded pixels became zero-valued normalized-space pixels instead of normalized black,
+- and it thresholded `image_masks` to booleans, losing the fractional border coverage values the reference path preserves.
+
+Those mistakes degrade the visual tokens that Molmo v1 consumes, especially on partial border patches. The fix pads raw black before normalization and preserves float mask coverage end to end.
+
+---
+
+## 3. Confirmed Non-Causes
+
+Several plausible suspects were checked and explicitly ruled out.
+
+- The `749` prompt-token expansion itself was not the defect. The broken CLI and the fixed CLI both used the same real prompt length, so the issue was in decoding semantics, not prompt assembly length.
+- The Molmo v1 BOS handling was not the differentiator. The reproduced bad output happened on the existing CLI path, and the fixed output came through the same BOS path after the model/preprocessor corrections.
+- The image-feature scatter path was not the root cause. The coherent fixed result came from the same shared CLI/server multimodal runtime path after the RoPE and preprocessor fixes.
+- The server transport path was not unique. The normal BatchScheduler-backed `mlxcel-server --parallel 1` path returned the same coherent answer and the same usage totals as the fixed CLI.
+
+---
+
+## 4. Implementation Summary
+
+| Item | Value |
+|------|-------|
+| Implementation files changed | 2 |
+| Implementation lines added | +158 |
+| Implementation lines deleted | -16 |
+| Implementation commits | 1 |
+| Reviewed implementation head | `8d30a09b79138d408860eb04cf23f94d7be06897` |
+
+The bilingual report artifacts and the report-only commit are excluded from the counts above.
+
+- `src/models/molmo.rs`: default omitted Molmo v1 `rope_impl` to the checkpoint-effective LLaMA split-half path and add regression coverage for omitted vs explicit RoPE controls.
+- `src/vision/processors/molmo.rs`: pad raw black before normalization, preserve fractional `image_masks`, and add deterministic tests for normalized padding and the known 640x480 `9/14` partial border patch case.
+
+---
+
+## 5. Validation
+
+### 5.1 Local deterministic validation
+
+- `cargo fmt --all -- --check`: passed.
+- `cargo test -p mlxcel models::molmo::tests`: passed.
+- `cargo test -p mlxcel vision::processors::molmo::tests`: passed.
+- `cargo test -p mlxcel --test molmo_parity`: passed, but all four tests returned early because the harness searches `models/molmo-7b` rather than `/home/inureyes/models/mlx/molmo-7b`. This suite therefore did **not** provide the real-checkpoint proof for this PR.
+- `cargo clippy -p mlxcel --lib --tests -- -D warnings`: passed.
+- `cargo build --release --features cuda --bin mlxcel --bin mlxcel-server --locked` on NVIDIA GB10 (`sm_121`): passed.
+
+### 5.2 Real-checkpoint A/B on the original failure path
+
+CLI, GB10 CUDA, real 640x480 COCO cats image:
+
+- pre-fix: reproduced the reported incoherent output byte-for-byte at `prompt_tokens=749`, `completion_tokens=40`, `9.35s`, `4.28 tok/s`,
+- post-fix: generated a coherent description of two cats sleeping on a red couch under a pink blanket at `prompt_tokens=749`, `completion_tokens=40`, `4.06s`, `9.85 tok/s`.
+
+### 5.3 Real server validation
+
+Normal BatchScheduler server path (`mlxcel-server --parallel 1`) with the same image and prompt:
+
+- returned the same coherent text as the fixed CLI,
+- and reported `prompt_tokens=749`, `completion_tokens=40`, `total_tokens=789`.
+
+The legacy `--no-batch` mode was also attempted and failed before generation with its pre-existing `CachePool` max-capacity-zero admission error. That failure predates this PR, is independent of the Molmo v1 decode/preprocessor seams, and does not invalidate the normal production scheduler-path verification.
+
+### 5.4 Hosted checks observed on PR #1099
+
+- `Detect changes`: pass
+- `crate versions`: pass
+- `kernel dtype keys`: pass
+- `cross-repo refs`: pass
+- `cargo-deny`: pass
+- `cargo-fmt`: pass
+- `license/cla`: pass
+- `MLX pin extraction`: skipped
+
+---
+
+## 6. Review Outcome
+
+The implementation went through two independent review passes after the first fix landed:
+
+- an implementation review found no remaining correctness gaps after the real-path CLI/server validation and the added regression tests,
+- a security review likewise reported no findings and no new attacker-controlled surface from the changes.
+
+The finalizer pass confirmed that the issue acceptance criteria were met on the normal production scheduler path and that the remaining `--no-batch` `CachePool` failure is pre-existing, out of scope, and non-blocking for this PR.
+
+---
+
+## 7. Technical Takeaways
+
+- Flat config omissions are dangerous when a model family's effective checkpoint behavior no longer matches an old local default. The safe boundary is the checkpoint-effective constructor behavior, not the stale dataclass assumption.
+- Vision preprocessors need reference-faithful padding and mask semantics. Losing fractional border coverage is enough to poison multimodal decoding without causing a hard error.
+- A passing parity harness is only useful if it actually reaches the real checkpoint. Here, `cargo test --test molmo_parity` was valuable as a code-level regression suite but not as the acceptance proof, because it returned early on this machine.
+
+---
+
+## 8. Related Work
+
+- PR #1099: https://github.com/lablup/mlxcel/pull/1099
+- Issue #1087: https://github.com/lablup/mlxcel/issues/1087

--- a/TECHNICAL_REPORTS/1099-molmo-v1-image-decoding-seams-20260811.en.md
+++ b/TECHNICAL_REPORTS/1099-molmo-v1-image-decoding-seams-20260811.en.md
@@ -1,6 +1,6 @@
 # Technical Report: PR #1099 - fix(models): correct Molmo v1 image decoding seams
 
-**Date**: 2026-08-10
+**Date**: 2026-08-11
 **Author**: mlxcel maintainers
 **Reviewer**: implementation, security, and finalizer review cycle
 **Status**: Completed for an open PR

--- a/TECHNICAL_REPORTS/1099-molmo-v1-image-decoding-seams-20260811.ko.md
+++ b/TECHNICAL_REPORTS/1099-molmo-v1-image-decoding-seams-20260811.ko.md
@@ -1,6 +1,6 @@
 # 기술 보고서: PR #1099 - fix(models): correct Molmo v1 image decoding seams
 
-**날짜**: 2026-08-10
+**날짜**: 2026-08-11
 **작성**: mlxcel 메인테이너
 **검토**: 구현, 보안, finalizer 리뷰 사이클
 **상태**: 열린 PR 기준 작성 완료

--- a/TECHNICAL_REPORTS/1099-molmo-v1-image-decoding-seams-20260811.ko.md
+++ b/TECHNICAL_REPORTS/1099-molmo-v1-image-decoding-seams-20260811.ko.md
@@ -1,0 +1,147 @@
+# 기술 보고서: PR #1099 - fix(models): correct Molmo v1 image decoding seams
+
+**날짜**: 2026-08-10
+**작성**: mlxcel 메인테이너
+**검토**: 구현, 보안, finalizer 리뷰 사이클
+**상태**: 열린 PR 기준 작성 완료
+**언어**: Rust, Markdown
+**위험도**: 중간
+
+---
+
+## 요약
+
+PR #1099은 이슈 #1087의 Molmo v1 이미지 조건 생성 결함을 고친다. 실제 COCO 고양이 사진에서 `molmo-7b`만 incoherent한 출력을 내고 `molmo2-4b`는 같은 환경에서 정상 응답하던 문제가 대상이었다. 원인은 서버 경로나 BOS 처리, feature scatter가 아니었다. Molmo v1 디코드 스택의 두 seam이 핵심이었다. `rope_impl`를 생략한 flat config가 체크포인트의 실질적인 LLaMA rotate-half 레이아웃이 아니라, 로컬의 오래된 MLX traditional interleave 기본값으로 떨어지고 있었고, 이미지 전처리도 raw-black padding과 fractional patch coverage를 유지해야 하는 reference 동작에서 벗어나 있었다.
+
+이 PR은 `src/models/molmo.rs`, `src/vision/processors/molmo.rs`에서 두 seam을 바로잡고, 해당 경계를 고정하는 회귀 테스트를 추가했다. 그리고 처음 문제를 재현했던 실제 NVIDIA GB10 CUDA 경로에서 다시 검증했다. 수정 전 CLI는 `prompt_tokens=749`에서 보고된 깨진 출력을 바이트 단위로 그대로 재현했고, 수정 후 CLI와 정상 BatchScheduler 경로의 서버는 둘 다 "빨간 소파와 분홍 담요 위에서 자는 고양이 두 마리"를 일관되게 설명했다. 두 개의 독립 리뷰는 추가 발견 사항이 없다고 결론냈고, finalizer 패스도 PR을 merge-ready로 판단했다.
+
+---
+
+## 1. 문제 정의
+
+### 1.1 사용자에게 보인 실패
+
+이슈 #1087은 `molmo-7b`가 이미지 프롬프트에서 incoherent한 출력을 생성하는 반면, 같은 GB10 CUDA 환경의 `molmo2-4b`는 정상이라는 점을 보고했다. 이 실패는 실제 640x480 COCO 고양이 사진에서 재현됐고, feature 브랜치뿐 아니라 `main`에도 이미 존재했기 때문에 인접 작업 회귀가 아니라 Molmo v1의 기존 결함이었다.
+
+### 1.2 수용 기준
+
+이슈는 세 가지를 요구했다.
+
+- Molmo v1이 실제 사진을 CLI에서 일관되게 설명할 것,
+- 프롬프트 우회가 아니라 실제 root-cause seam을 고칠 것,
+- 그리고 `mlxcel` CLI와 `mlxcel-server` 양쪽에서 검증할 것.
+
+---
+
+## 2. 근본 원인
+
+서로 독립적인 두 seam이 확인됐다.
+
+### 2.1 생략된 `rope_impl`가 잘못된 RoPE 레이아웃을 선택했다
+
+Molmo v1 flat config는 `rope_impl`를 생략할 수 있다. 배포된 체크포인트의 실질 동작은 여전히 LLaMA rotate-half 레이아웃을 기대하는데, 로컬 dataclass 기본값은 이 생략을 MLX traditional interleave RoPE로 해석하고 있었다. 이 불일치는 이미지 조건 추론 이전의 positional rotation부터 어긋나게 만들어, 프롬프트와 서버 경로, 이미지 feature가 맞더라도 디코드가 무의미해진다.
+
+수정은 생략된 Molmo v1 `rope_impl`를 체크포인트의 실질적인 LLaMA 경로로 기본화하고, 명시적인 `interleave`만 MLX traditional 경로로 유지하는 것이다.
+
+### 2.2 이미지 전처리가 reference와 달랐다
+
+`pad_and_partial_pad`에는 두 가지 reference 불일치가 있었다.
+
+- 정규화 뒤에 padding해서, 패딩 픽셀이 normalized black이 아니라 zero-valued normalized-space 픽셀이 됐다.
+- `image_masks`를 boolean으로 threshold해서, reference가 유지하는 fractional border coverage 값이 사라졌다.
+
+이 두 문제는 특히 부분 border patch에서 Molmo v1이 소비하는 visual token을 손상시킨다. 수정은 정규화 전에 raw black으로 padding하고, float mask coverage를 끝까지 유지하는 것이다.
+
+---
+
+## 3. 원인이 아니었던 것
+
+가능성 있어 보였지만 명시적으로 배제된 항목들도 있다.
+
+- `749` 프롬프트 토큰 확장 자체는 문제가 아니었다. 수정 전 CLI와 수정 후 CLI 모두 같은 실제 프롬프트 길이를 썼기 때문에, 문제는 프롬프트 길이가 아니라 디코드 의미론에 있었다.
+- Molmo v1 BOS 처리는 차이를 만든 요소가 아니었다. 보고된 깨진 출력도 기존 CLI 경로에서 나왔고, 수정된 정상 출력도 같은 BOS 경로 위에서 모델/전처리 수정만으로 얻어졌다.
+- 이미지 feature scatter 경로가 root cause는 아니었다. 수정 후 정상 결과는 같은 공용 CLI/server 멀티모달 런타임 경로에서 RoPE와 전처리 수정만으로 나왔다.
+- 서버 전송 경로만의 문제도 아니었다. 정상 BatchScheduler 기반 `mlxcel-server --parallel 1` 경로가 수정된 CLI와 같은 coherent 응답과 같은 usage totals를 반환했다.
+
+---
+
+## 4. 구현 요약
+
+| 항목 | 값 |
+|------|----|
+| 구현 변경 파일 | 2 |
+| 구현 추가 라인 | +158 |
+| 구현 삭제 라인 | -16 |
+| 구현 커밋 수 | 1 |
+| 검토한 구현 head | `8d30a09b79138d408860eb04cf23f94d7be06897` |
+
+위 구현 집계에는 영문·국문 보고서 산출물과 보고서 전용 커밋을 포함하지 않았다.
+
+- `src/models/molmo.rs`: 생략된 Molmo v1 `rope_impl`를 체크포인트의 실질적인 LLaMA split-half 경로로 기본화하고, 생략/명시 RoPE 제어에 대한 회귀 테스트를 추가했다.
+- `src/vision/processors/molmo.rs`: 정규화 전에 raw black padding을 수행하고 fractional `image_masks`를 유지하도록 고쳤으며, normalized padding과 알려진 640x480 `9/14` partial border patch 케이스를 고정하는 결정적 테스트를 추가했다.
+
+---
+
+## 5. 검증
+
+### 5.1 로컬 결정적 검증
+
+- `cargo fmt --all -- --check`: 통과.
+- `cargo test -p mlxcel models::molmo::tests`: 통과.
+- `cargo test -p mlxcel vision::processors::molmo::tests`: 통과.
+- `cargo test -p mlxcel --test molmo_parity`: 통과했지만, 네 개 테스트 모두 `models/molmo-7b`를 찾다가 조기 종료했다. 이 머신의 실제 체크포인트 경로는 `/home/inureyes/models/mlx/molmo-7b`이므로, 이 스위트는 이번 PR의 real-checkpoint 증거가 아니다.
+- `cargo clippy -p mlxcel --lib --tests -- -D warnings`: 통과.
+- NVIDIA GB10(`sm_121`)에서 `cargo build --release --features cuda --bin mlxcel --bin mlxcel-server --locked`: 통과.
+
+### 5.2 원래 실패 경로에서의 실제 체크포인트 A/B
+
+CLI, GB10 CUDA, 실제 640x480 COCO 고양이 이미지:
+
+- 수정 전: 보고된 incoherent 출력을 `prompt_tokens=749`, `completion_tokens=40`, `9.35s`, `4.28 tok/s`로 바이트 단위까지 그대로 재현.
+- 수정 후: `prompt_tokens=749`, `completion_tokens=40`, `4.06s`, `9.85 tok/s`로 "빨간 소파와 분홍 담요 위에서 자는 고양이 두 마리"를 일관되게 설명.
+
+### 5.3 실제 서버 검증
+
+같은 이미지와 프롬프트로 normal BatchScheduler 서버 경로(`mlxcel-server --parallel 1`)를 검증했다.
+
+- 수정된 CLI와 동일한 coherent 텍스트를 반환했고,
+- `prompt_tokens=749`, `completion_tokens=40`, `total_tokens=789`를 보고했다.
+
+기존 `--no-batch` 모드도 시도했지만, generation 전에 기존의 `CachePool` max-capacity-zero admission error로 실패했다. 이 실패는 이번 PR 이전부터 있던 것이고 Molmo v1 decode/preprocessor seam과 독립적이므로, 정상 production scheduler 경로 검증을 무효화하지 않는다.
+
+### 5.4 PR #1099에서 확인한 hosted checks
+
+- `Detect changes`: pass
+- `crate versions`: pass
+- `kernel dtype keys`: pass
+- `cross-repo refs`: pass
+- `cargo-deny`: pass
+- `cargo-fmt`: pass
+- `license/cla`: pass
+- `MLX pin extraction`: skipped
+
+---
+
+## 6. 리뷰 결과
+
+첫 수정 커밋 이후 구현은 두 번의 독립 리뷰를 거쳤다.
+
+- 구현 리뷰는 real-path CLI/server 검증과 추가된 회귀 테스트 이후 남은 정확성 결함이 없다고 판단했다.
+- 보안 리뷰도 새 attacker-controlled surface나 추가 보안 이슈를 발견하지 못했다.
+
+finalizer 패스는 정상 production scheduler 경로에서 이슈 수용 기준이 충족됐고, 남은 `--no-batch` `CachePool` 실패는 기존 이슈이자 범위 밖의 non-blocking 항목이라고 정리했다.
+
+---
+
+## 7. 핵심 기술적 교훈
+
+- 모델 계열의 실제 체크포인트 동작과 오래된 로컬 기본값이 어긋난 상황에서는 flat config omission이 특히 위험하다. 신뢰해야 할 경계는 stale dataclass 가정이 아니라 체크포인트의 실질 constructor 동작이다.
+- 비전 전처리는 padding과 mask 의미론까지 reference에 충실해야 한다. fractional border coverage를 잃는 것만으로도 하드 에러 없이 멀티모달 디코드가 망가질 수 있다.
+- parity 하니스는 실제 체크포인트에 도달할 때만 수용 근거가 된다. 이번 `cargo test --test molmo_parity`는 코드 수준 회귀 스위트로는 유용했지만, 이 머신에서는 조기 종료했기 때문에 acceptance proof가 될 수 없었다.
+
+---
+
+## 8. 관련 작업
+
+- PR #1099: https://github.com/lablup/mlxcel/pull/1099
+- Issue #1087: https://github.com/lablup/mlxcel/issues/1087

--- a/src/models/molmo.rs
+++ b/src/models/molmo.rs
@@ -21,9 +21,10 @@
 //! 1. **No per-head QK normalization.** Molmo2 applies `RMSNorm(head_dim)` to
 //!    Q and K after the reshape; Molmo v1 does not (the v1 tensors have no
 //!    `q_norm`/`k_norm`).
-//! 2. **Interleaved RoPE.** v1 config sets `rope_impl: "interleave"`, which maps
-//!    to `traditional=true` in the MLX fast RoPE kernel (Molmo2 uses the
-//!    rotate-half variant, `traditional=false`).
+//! 2. **Config-selectable RoPE layout.** Molmo-7B-D-0924 uses the LLaMA
+//!    rotate-half layout (`traditional=false` in MLX). Explicit
+//!    `rope_impl: "interleave"` checkpoints still select the consecutive-pair
+//!    layout (`traditional=true`).
 //! 3. **LM head location.** v1 stores the (untied) output projection at
 //!    `language_model.model.ff_out`, not a separate `language_model.lm_head`.
 //!
@@ -74,7 +75,7 @@ pub struct MolmoTextConfig {
     pub layer_norm_eps: f32,
     #[serde(default = "default_rope_theta")]
     pub rope_theta: f32,
-    /// `rope_impl: "interleave"` → traditional/interleaved RoPE.
+    /// RoPE implementation name from the checkpoint config.
     #[serde(default = "default_rope_impl")]
     pub rope_impl: String,
     #[serde(default = "default_qkv_bias")]
@@ -121,7 +122,10 @@ fn default_rope_theta() -> f32 {
     1_000_000.0
 }
 fn default_rope_impl() -> String {
-    "interleave".to_string()
+    // The affected flat MLX Molmo-7B-D-0924-4bit config omits `rope_impl`.
+    // The checkpoint's effective constructor sets `rope_impl="llama"`, which is
+    // MLX's rotate-half layout (`traditional=false`).
+    "llama".to_string()
 }
 fn default_qkv_bias() -> bool {
     true
@@ -149,7 +153,7 @@ impl MolmoTextConfig {
     }
 }
 
-// Molmo v1 Attention (fused biased QKV, NO QK norm, interleaved RoPE).
+// Molmo v1 Attention (fused biased QKV, NO QK norm, config-selected RoPE).
 pub struct MolmoAttention {
     pub att_proj: UnifiedLinear, // Fused QKV projection (with bias)
     pub attn_out: UnifiedLinear, // Output projection
@@ -195,7 +199,7 @@ impl MolmoAttention {
 
         let offset = cache.offset;
 
-        // Interleaved ("traditional") RoPE for Molmo v1.
+        // Molmo v1 checkpoints select either LLaMA rotate-half or interleaved RoPE.
         let q = mlxcel_core::fast_rope(
             &q,
             self.head_dim,
@@ -491,4 +495,56 @@ fn get_weight_copy(weights: &WeightMap, name: &str) -> Result<UniquePtr<MlxArray
         .get(name)
         .map(|w| mlxcel_core::copy(w))
         .ok_or_else(|| format!("Weight not found: {}", name))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::MolmoTextConfig;
+
+    fn parse_config(extra: &str) -> MolmoTextConfig {
+        let comma = if extra.trim().is_empty() { "" } else { "," };
+        serde_json::from_str(&format!(
+            r#"{{
+                "model_type": "molmo",
+                "hidden_size": 3584,
+                "num_hidden_layers": 28,
+                "intermediate_size": 37888,
+                "num_attention_heads": 28,
+                "num_key_value_heads": 4,
+                "vocab_size": 152064,
+                "embedding_size": 152064,
+                "additional_vocab_size": 128,
+                "layer_norm_eps": 0.00001,
+                "rope_theta": 1000000.0
+                {comma}
+                {extra}
+            }}"#
+        ))
+        .expect("parse Molmo config")
+    }
+
+    #[test]
+    fn flat_molmo_7b_config_without_rope_impl_uses_effective_llama_layout() {
+        let config = parse_config("");
+
+        assert_eq!(config.rope_impl, "llama");
+        assert!(
+            !config.rope_traditional(),
+            "Molmo-7B-D-0924 omits rope_impl but uses the LLaMA rotate-half layout"
+        );
+    }
+
+    #[test]
+    fn explicit_interleave_stays_traditional() {
+        let config = parse_config(r#""rope_impl": "interleave""#);
+
+        assert!(config.rope_traditional());
+    }
+
+    #[test]
+    fn explicit_llama_stays_rotate_half() {
+        let config = parse_config(r#""rope_impl": "llama""#);
+
+        assert!(!config.rope_traditional());
+    }
 }

--- a/src/vision/processors/molmo.rs
+++ b/src/vision/processors/molmo.rs
@@ -141,7 +141,7 @@ impl MolmoProcessor {
         let (src, src_mask) = self.resize_and_pad(&img, target_h, target_w, orig_h, orig_w);
 
         let mut patches_arr: Vec<Vec<Vec<f32>>> = Vec::new(); // [crop][h*w][3]
-        let mut mask_arr: Vec<Vec<bool>> = Vec::new(); // [crop][h*w]
+        let mut mask_arr: Vec<Vec<f32>> = Vec::new(); // [crop][h*w]
         let mut patch_ordering: Vec<Vec<Vec<i32>>> = Vec::new(); // [crop][tok_h][tok_w]
 
         let mut on = 0i32;
@@ -275,9 +275,7 @@ impl MolmoProcessor {
         // mirroring upstream so output matches the mlx-vlm Python reference).
         let mut image_masks: Vec<f32> = Vec::with_capacity(n_crops * n_patches);
         for crop_mask in &mask_arr {
-            for &b in crop_mask {
-                image_masks.push(if b { 1.0 } else { 0.0 });
-            }
+            image_masks.extend_from_slice(crop_mask);
         }
         image_masks.extend(std::iter::repeat_n(-1.0, n_patches));
 
@@ -437,7 +435,12 @@ impl MolmoProcessor {
         let top = (target_h - scaled_h) / 2;
         let left = (target_w - scaled_w) / 2;
 
-        let mut out = vec![[0.0f32; 3]; target_h * target_w];
+        let normalized_black = [
+            (0.0 - self.image_mean[0]) / self.image_std[0],
+            (0.0 - self.image_mean[1]) / self.image_std[1],
+            (0.0 - self.image_mean[2]) / self.image_std[2],
+        ];
+        let mut out = vec![normalized_black; target_h * target_w];
         let mut mask = vec![false; target_h * target_w];
         for y in 0..scaled_h {
             for x in 0..scaled_w {
@@ -507,7 +510,7 @@ fn select_tiling(h: usize, w: usize, patch_size: usize, max_num_patches: usize) 
 }
 
 /// Rearrange one crop's pixels into `[h*w][dh*dw*3]` patches and average its
-/// mask into `[h*w]` (then thresholded later). `crop` is row-major [size*size].
+/// mask into `[h*w]`. `crop` is row-major [size*size].
 fn rearrange_crop(
     crop: &[[f32; 3]],
     mask: &[bool],
@@ -515,7 +518,7 @@ fn rearrange_crop(
     patch: usize,
     h: usize,
     w: usize,
-) -> (Vec<Vec<f32>>, Vec<bool>) {
+) -> (Vec<Vec<f32>>, Vec<f32>) {
     let mut patches = Vec::with_capacity(h * w);
     let mut mask_out = Vec::with_capacity(h * w);
     for ph in 0..h {
@@ -538,8 +541,7 @@ fn rearrange_crop(
                 }
             }
             patches.push(vals);
-            // Mean coverage > 0.5 marks the patch as real (matches mean(mask)).
-            mask_out.push(covered * 2 >= patch * patch);
+            mask_out.push(covered as f32 / (patch * patch) as f32);
         }
     }
     (patches, mask_out)
@@ -575,4 +577,88 @@ fn rearrange_global(
         }
     }
     patches
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{MolmoImageTokens, MolmoProcessor, OPENAI_CLIP_MEAN, OPENAI_CLIP_STD};
+
+    const PATCH_DIM: usize = 14 * 14 * 3;
+    const N_PATCHES: usize = 24 * 24;
+
+    fn default_processor() -> MolmoProcessor {
+        MolmoProcessor::new(
+            12,
+            Some((4, 4)),
+            Some(14),
+            Some((336, 336)),
+            Some((12, 12)),
+            None,
+            None,
+            MolmoImageTokens::default(),
+        )
+    }
+
+    fn solid_image(width: u32, height: u32) -> image::DynamicImage {
+        image::DynamicImage::ImageRgb8(image::RgbImage::from_fn(width, height, |_, _| {
+            image::Rgb([128, 64, 32])
+        }))
+    }
+
+    #[test]
+    fn global_pad_pixels_are_normalized_black() {
+        let processor = default_processor();
+        let out = processor.preprocess_image(&solid_image(640, 480));
+
+        let expected = [
+            -OPENAI_CLIP_MEAN[0] / OPENAI_CLIP_STD[0],
+            -OPENAI_CLIP_MEAN[1] / OPENAI_CLIP_STD[1],
+            -OPENAI_CLIP_MEAN[2] / OPENAI_CLIP_STD[2],
+        ];
+        let first_global_patch = &out.pixel_values[..PATCH_DIM];
+
+        for (actual, expected) in first_global_patch[..3].iter().zip(expected) {
+            assert!(
+                (actual - expected).abs() < 1e-6,
+                "padding must be normalized after raw black fill"
+            );
+        }
+    }
+
+    #[test]
+    fn high_res_masks_preserve_fractional_patch_coverage() {
+        let processor = default_processor();
+        let out = processor.preprocess_image(&solid_image(640, 480));
+
+        // The 640x480 control image selects 2x3 high-resolution crops plus the global crop.
+        assert_eq!(out.pixel_values_shape[0], 7);
+        assert_eq!(out.image_masks_shape, [7, N_PATCHES as i32]);
+
+        let high_res_len = (out.pixel_values_shape[0] as usize - 1) * N_PATCHES;
+        let high_res_masks = &out.image_masks[..high_res_len];
+        let sentinel = &out.image_masks[high_res_len..];
+
+        assert!(
+            high_res_masks.contains(&0.0),
+            "left/right padding should produce fully padded high-res patches"
+        );
+        assert!(
+            high_res_masks.contains(&1.0),
+            "real image regions should still produce fully covered patches"
+        );
+        assert!(
+            high_res_masks.iter().any(|&m| m > 0.0 && m < 1.0),
+            "border patches must preserve fractional coverage for pad_and_partial_pad"
+        );
+        let second_horizontal_patch = high_res_masks[1];
+        let expected = 9.0 / 14.0;
+        assert!(
+            (second_horizontal_patch - expected).abs() < 1e-6,
+            "19px side padding leaves 9/14 real pixels in the first crop's second horizontal patch"
+        );
+        assert!(
+            sentinel.iter().all(|&m| m == -1.0),
+            "the final mask row remains the reference sentinel for the global slot"
+        );
+    }
 }


### PR DESCRIPTION
## Summary

Fixes two Molmo v1 seams that corrupt image-conditioned generation: flat Molmo-7B-D-0924 configs now default omitted `rope_impl` to the checkpoint's effective LLaMA rotate-half layout, and image preprocessing now preserves reference padding and fractional mask values for `pad_and_partial_pad`.

## What changed

- Default missing Molmo v1 `rope_impl` to `llama` while preserving explicit `interleave` as MLX traditional RoPE.
- Pad raw black before normalization so padded pixels become normalized black values instead of zero-valued normalized-space pixels.
- Preserve per-patch float coverage in `image_masks`, including partial border patches, instead of thresholding masks to booleans.
- Add deterministic regression tests for the affected flat config omission, explicit RoPE controls, normalized black padding, and the known 640x480 `9/14` partial border patch.

## Validation

- [x] `cargo fmt --all -- --check`
- [x] `cargo test -p mlxcel models::molmo::tests`
- [x] `cargo test -p mlxcel vision::processors::molmo::tests`
- [x] `cargo test -p mlxcel --test molmo_parity`
- [x] `cargo clippy -p mlxcel --lib --tests -- -D warnings`
- [x] `cargo build --release --features cuda --bin mlxcel --bin mlxcel-server --locked` on NVIDIA GB10 (sm_121)
- [x] Real-checkpoint CLI A/B with `/home/inureyes/models/mlx/molmo-7b` and the 640x480 COCO cats image: the pre-fix 749-token prompt reproduced the issue output byte-for-byte; the fixed build generated a coherent description of two cats sleeping on a red couch under a pink blanket.
- [x] Real-checkpoint `mlxcel-server` validation through `POST /v1/chat/completions` with the same image and prompt on the normal BatchScheduler path (`--parallel 1`): coherent output matched the CLI, with `prompt_tokens=749`, `completion_tokens=40`, and `total_tokens=789`.

The legacy `--no-batch` server mode was also attempted and failed before generation with its existing zero-capacity `CachePool` admission error. That path is independent of the Molmo decoder/preprocessor changes; the normal production scheduler path completed the required server generation successfully.

Closes #1087
