### PR TITLE
feat(models): support Muse Glimmer MLX 4-bit

### DIFF
--- a/TECHNICAL_REPORTS/1116-muse-glimmer-mlx-4bit-20260812.en.md
+++ b/TECHNICAL_REPORTS/1116-muse-glimmer-mlx-4bit-20260812.en.md
@@ -1,0 +1,150 @@
+# Technical Report: PR #1116 - feat(models): support Muse Glimmer MLX 4-bit
+
+**Date**: 2026-08-12
+**Status**: Completed
+**Languages**: Rust, Markdown
+**Risk Level**: Medium
+
+---
+
+## Executive Summary
+
+PR #1116 adds checkpoint-specific support for the pinned `mlx-community/Muse-Glimmer-30B-4bit` affine-Q4 conversion while preserving the merged dense BF16 Muse path. It normalizes mlx-vlm weight namespaces, propagates the root quantization contract into the text stack, uses quantization-aware text and vision-fusion layers, and keeps the 50-layer vision tower dense.
+
+The security review found and fixed two fail-open metadata cases before PR submission: a non-string `quantization.mode` could bypass the mode comparison, and a missing affine `.biases` sidecar could make the shared loader infer a block-float format. Both VLM and text-only loaders now enforce the same pinned affine contract before kernel selection.
+
+---
+
+## 1. Problem Statement
+
+### 1.1 Background
+
+PR #1101 established Muse Glimmer with the 59.55 GB BF16 checkpoint, but its loader deliberately rejected quantization sidecars. The public mlx-community conversion is approximately 19.41 GB and uses a different root namespace plus root-level affine-Q4 metadata, so it could not be interpreted safely by the BF16-only boundary.
+
+### 1.2 Existing Limitations
+
+- mlx-vlm exports `language_model.*` and unwrapped vision roots that did not match mlxcel's canonical Muse namespaces.
+- The decoder consumed `text_config`, while the published quantization contract lived at the JSON root.
+- Dense-only fusion projections could not load the quantized adapter and projector.
+- The one-shot CLI displayed Muse recipient envelopes and internal `to=self` reasoning even though server routes already separated them.
+- Accepting arbitrary quantization metadata would risk selecting incompatible native kernels or producing silently incorrect output.
+
+### 1.3 Risk Assessment
+
+| Risk | Impact | Mitigation |
+|------|--------|------------|
+| Alias keys overwrite canonical tensors | High | Collision-safe normalization rejects duplicate canonical destinations |
+| Malformed metadata selects an unintended quantization mode | High | Exact affine contract, type checks, parameter validation, and required sidecars |
+| Quantized vision tower reaches an unqualified path | High | Vision-tower sidecars are rejected before model construction |
+| Internal reasoning appears in CLI output | Medium | Reuse the server recipient parser and hide `to=self` by default |
+
+---
+
+## 2. Technical Review
+
+### 2.1 Security and Correctness
+
+- Root `quantization`, compatibility `quantization_config`, and nested `text_config.quantization` must agree.
+- `mode`, when present, must be a string equal to `affine`; group size and bit width pass the shared quantization validator.
+- Normalized weight aliases cannot collide with one another or with canonical keys.
+- Every supported `.scales` tensor requires matching `.weight` and `.biases`; orphan biases, global scales, and vision-tower sidecars are rejected.
+- The text-only loader calls the same weight-map validator as the VLM loader, closing a boundary-specific bypass.
+- No new dependency, network request, authentication/authorization path, filesystem write, subprocess, or unsafe block was added.
+- CLI channel rendering delegates to the existing ATEM/Muse parser. The transformation is linear in already-generated output and does not broaden server-visible data.
+
+No Critical or High issue remains after the two review fixes. The residual risk is limited to the explicitly pinned checkpoint-format contract and hardware qualifications documented below.
+
+### 2.2 Performance
+
+| Scenario | Result |
+|----------|--------|
+| BF16 text decode baseline | 4.25 tok/s |
+| Q4 warm text prefill | 12.43 tok/s |
+| Q4 warm text decode | 13.34 tok/s |
+| Q4 image prefill | 5.80 tok/s including first-use compilation |
+| Q4 image decode | 13.15 tok/s |
+| Post-security-fix exact-source text run | 11.41 prefill / 13.07 decode tok/s |
+
+The Q4 decode path is approximately 3.1x the recorded BF16 rate on the same NVIDIA GB10. The actual image run inserted 64 vision patch tokens and accurately described the solid orange-red fixture.
+
+### 2.3 Compatibility
+
+- Qualified checkpoint: `mlx-community/Muse-Glimmer-30B-4bit` revision `3e7677d7a40d348a3daba263a2b1c0aa41910710`.
+- Qualified hardware: Linux/aarch64 NVIDIA GB10 with CUDA.
+- Preserved path: canonical dense BF16 Muse checkpoint from PR #1101.
+- Explicitly unsupported: video, quantized vision tower, Turbo/INT8 KV, speculative/DFlash, LoRA/adapters, TP/PP, XLA/IREE/OpenXLA, distributed, and disaggregated serving.
+- No new package dependency or wire-format change.
+
+---
+
+## 3. Technical Decisions
+
+### 3.1 Normalize Names Without Copying Tensor Data
+
+**Decision:** Move weight handles into a new collision-checked map after converting published mlx-vlm roots to canonical Muse roots.
+
+**Rationale:** This keeps one runtime namespace for BF16 and Q4 model construction while avoiding tensor-data duplication. Rejecting collisions prevents a crafted alias from silently replacing a canonical weight.
+
+### 3.2 Keep the Vision Tower Dense
+
+**Decision:** Enable quantization-aware layers only for the text stack, LM head, vision adapter, and vision projection.
+
+**Rationale:** The pinned conversion leaves its vision tower dense. Generalizing beyond that evidence would expose untested shapes and kernels, so vision-tower sidecars fail closed.
+
+### 3.3 Share Recipient Parsing Between Server and CLI
+
+**Decision:** Export the server's Muse channel renderer for one-shot CLI display rather than implement a second parser.
+
+**Rationale:** One parser preserves identical `to=self` and `to=user` semantics and reduces the chance that reasoning or structural tokens leak through a divergent CLI implementation.
+
+---
+
+## 4. Change Summary
+
+### Statistics
+
+| Item | Value |
+|------|-------|
+| Files changed | 16 |
+| Lines added | 477 |
+| Lines deleted | 69 |
+| Commits | 2 |
+
+### Major Areas
+
+| Area | Summary |
+|------|---------|
+| Loading/config | Root quantization inheritance, namespace normalization, sidecar and mode validation |
+| Model/vision | Quantization-aware text and fusion layers with dense tower preservation |
+| CLI/tool channels | Shared Muse recipient rendering and reasoning suppression |
+| Tests | Alias, collision, config disagreement, malformed mode, sidecar, CLI, and real-checkpoint coverage |
+| Documentation | Pinned revision, size, support boundary, and GB10 throughput |
+
+### Related Commits
+
+| Hash | Type | Message |
+|------|------|---------|
+| `4ea5aca2` | feat | support Muse Glimmer MLX 4-bit |
+| `9a23ed2e` | fix | enforce Muse affine Q4 contract |
+
+Follow-up to PR #1101.
+
+---
+
+## 5. Validation and Follow-up
+
+### Passed
+
+- `cargo fmt --all --check`
+- Clippy for library and binaries with `-D warnings`
+- 100 Muse-filtered library tests
+- Two CLI help/metadata regressions
+- CUDA release build with `MLX_CUDA_ARCHITECTURES=121`
+- Real pinned-checkpoint text and image generation on NVIDIA GB10
+- Final exact-source text run loaded in 0.480 seconds and printed only `The capital of France is Paris.` without recipient or control-token leakage
+
+### Remaining Boundary
+
+- Hosted PR checks must pass before merge.
+- Apple Silicon/Metal is not qualified by this report.
+- Additional quantization formats and the unsupported execution modes remain separate, evidence-gated follow-ups.

--- a/TECHNICAL_REPORTS/1116-muse-glimmer-mlx-4bit-20260812.ko.md
+++ b/TECHNICAL_REPORTS/1116-muse-glimmer-mlx-4bit-20260812.ko.md
@@ -1,0 +1,150 @@
+# 기술 보고서: PR #1116 - feat(models): support Muse Glimmer MLX 4-bit
+
+**작성일**: 2026-08-12
+**상태**: 완료
+**언어**: Rust, Markdown
+**위험도**: Medium
+
+---
+
+## 요약
+
+PR #1116은 기존 dense BF16 Muse 경로를 유지하면서 pinned `mlx-community/Muse-Glimmer-30B-4bit` affine-Q4 변환을 체크포인트 형식 단위로 지원한다. mlx-vlm weight namespace를 정규화하고, root quantization contract를 text stack에 전달하며, text와 vision-fusion layer를 quantization-aware 형태로 로드하되 50-layer vision tower는 dense로 유지한다.
+
+PR 제출 전 보안 검토에서 두 가지 fail-open metadata 경계를 찾아 교정했다. 문자열이 아닌 `quantization.mode`가 mode 비교를 우회할 수 있었고, affine `.biases` sidecar가 빠지면 공용 loader가 block-float 형식으로 추론할 수 있었다. 이제 VLM과 text-only loader 모두 kernel 선택 전에 동일한 pinned affine contract를 강제한다.
+
+---
+
+## 1. 문제 정의
+
+### 1.1 배경
+
+PR #1101은 59.55 GB BF16 체크포인트로 Muse Glimmer baseline을 구축했지만 quantization sidecar는 의도적으로 거부했다. 공개 mlx-community 변환은 약 19.41 GB이며 다른 root namespace와 root-level affine-Q4 metadata를 사용하므로 기존 BF16 전용 경계로 안전하게 해석할 수 없었다.
+
+### 1.2 기존 한계
+
+- mlx-vlm의 `language_model.*` 및 wrapper 없는 vision root가 mlxcel의 canonical Muse namespace와 일치하지 않았다.
+- decoder는 `text_config`를 소비하지만 공개 quantization contract는 JSON root에 있었다.
+- dense 전용 fusion projection이 양자화된 adapter와 projector를 로드할 수 없었다.
+- server route는 Muse recipient channel을 분리했지만 one-shot CLI는 envelope와 내부 `to=self` reasoning을 그대로 표시했다.
+- 임의의 quantization metadata를 허용하면 호환되지 않는 native kernel 선택 또는 조용한 오출력 위험이 있었다.
+
+### 1.3 위험 평가
+
+| 위험 | 영향도 | 완화 |
+|------|--------|------|
+| Alias key가 canonical tensor를 덮어씀 | High | canonical destination이 중복되면 정규화를 거부 |
+| 잘못된 metadata가 의도하지 않은 quantization mode를 선택 | High | affine 고정, type/parameter 검증, 필수 sidecar 강제 |
+| 양자화된 vision tower가 미검증 경로에 진입 | High | 모델 구성 전에 vision-tower sidecar 거부 |
+| 내부 reasoning이 CLI 출력에 노출 | Medium | server recipient parser를 재사용하고 기본적으로 `to=self` 숨김 |
+
+---
+
+## 2. 기술 검토
+
+### 2.1 보안과 정확성
+
+- Root `quantization`, 호환용 `quantization_config`, nested `text_config.quantization`이 서로 일치해야 한다.
+- `mode`가 있으면 문자열 `affine`이어야 하며, group size와 bit width는 공용 quantization validator를 통과해야 한다.
+- 정규화된 weight alias는 서로 또는 canonical key와 충돌할 수 없다.
+- 지원되는 모든 `.scales` tensor에는 `.weight`와 `.biases`가 필요하며, orphan biases, global scales, vision-tower sidecar는 거부한다.
+- Text-only loader가 VLM loader와 동일한 weight-map validator를 호출해 경계별 우회를 차단한다.
+- 새 dependency, network request, 인증/인가 경로, filesystem write, subprocess, unsafe block은 추가되지 않았다.
+- CLI channel rendering은 기존 ATEM/Muse parser에 위임한다. 이미 생성된 출력에 대한 선형 변환이며 server-visible data 범위를 넓히지 않는다.
+
+두 보안 교정 이후 남은 Critical/High 이슈는 없다. 잔여 위험은 아래에 명시한 pinned checkpoint-format contract와 hardware qualification 범위로 제한된다.
+
+### 2.2 성능
+
+| 시나리오 | 결과 |
+|----------|------|
+| BF16 text decode baseline | 4.25 tok/s |
+| Q4 warm text prefill | 12.43 tok/s |
+| Q4 warm text decode | 13.34 tok/s |
+| Q4 image prefill | 5.80 tok/s, first-use compile 포함 |
+| Q4 image decode | 13.15 tok/s |
+| 보안 교정 후 exact-source text 실행 | 11.41 prefill / 13.07 decode tok/s |
+
+동일 NVIDIA GB10에서 Q4 decode는 기록된 BF16보다 약 3.1배 빠르다. 실제 이미지 실행은 64개 vision patch token을 삽입했고 단색 orange-red fixture를 정확히 묘사했다.
+
+### 2.3 호환성
+
+- 검증 체크포인트: `mlx-community/Muse-Glimmer-30B-4bit` revision `3e7677d7a40d348a3daba263a2b1c0aa41910710`.
+- 검증 하드웨어: Linux/aarch64 NVIDIA GB10, CUDA.
+- 보존 경로: PR #1101의 canonical dense BF16 Muse checkpoint.
+- 명시적 미지원: video, quantized vision tower, Turbo/INT8 KV, speculative/DFlash, LoRA/adapters, TP/PP, XLA/IREE/OpenXLA, distributed, disaggregated serving.
+- 새 package dependency나 wire-format 변경 없음.
+
+---
+
+## 3. 기술적 선택과 이유
+
+### 3.1 Tensor Data를 복사하지 않는 이름 정규화
+
+**선택:** 공개 mlx-vlm root를 canonical Muse root로 변환하면서 weight handle을 collision-checked map으로 이동한다.
+
+**이유:** BF16과 Q4 model construction이 하나의 runtime namespace를 사용하면서 tensor data 복제를 피한다. 충돌 거부는 crafted alias가 canonical weight를 조용히 교체하는 것을 막는다.
+
+### 3.2 Vision Tower Dense 유지
+
+**선택:** Text stack, LM head, vision adapter, vision projection만 quantization-aware layer를 활성화한다.
+
+**이유:** Pinned conversion의 vision tower는 dense다. 그 증거를 넘어 일반화하면 미검증 shape와 kernel이 노출되므로 vision-tower sidecar는 fail-closed 처리한다.
+
+### 3.3 Server와 CLI의 Recipient Parsing 공유
+
+**선택:** 별도 parser를 구현하지 않고 server의 Muse channel renderer를 one-shot CLI에 export한다.
+
+**이유:** 하나의 parser가 동일한 `to=self`/`to=user` 의미를 보존하고, 서로 다른 CLI 구현에서 reasoning 또는 구조 token이 새는 위험을 줄인다.
+
+---
+
+## 4. 변경 요약
+
+### 통계
+
+| 항목 | 값 |
+|------|----|
+| 변경 파일 | 16 |
+| 추가 라인 | 477 |
+| 삭제 라인 | 69 |
+| 커밋 | 2 |
+
+### 주요 영역
+
+| 영역 | 요약 |
+|------|------|
+| Loading/config | Root quantization 상속, namespace 정규화, sidecar와 mode 검증 |
+| Model/vision | Dense tower를 유지하는 quantization-aware text/fusion layer |
+| CLI/tool channel | 공유 Muse recipient rendering과 reasoning suppression |
+| Tests | Alias, collision, config 불일치, malformed mode, sidecar, CLI, real-checkpoint coverage |
+| Documentation | Pinned revision, 크기, 지원 경계, GB10 throughput |
+
+### 관련 커밋
+
+| Hash | 유형 | 메시지 |
+|------|------|--------|
+| `4ea5aca2` | feat | support Muse Glimmer MLX 4-bit |
+| `9a23ed2e` | fix | enforce Muse affine Q4 contract |
+
+PR #1101의 후속 작업이다.
+
+---
+
+## 5. 검증과 후속 조치
+
+### 통과
+
+- `cargo fmt --all --check`
+- Library와 binary 대상 Clippy `-D warnings`
+- Muse-filtered library test 100개
+- CLI help/metadata regression 2개
+- `MLX_CUDA_ARCHITECTURES=121` CUDA release build
+- NVIDIA GB10에서 pinned checkpoint text/image 실제 생성
+- 최종 exact-source text 실행은 0.480초에 로드됐고 recipient/control-token 노출 없이 `The capital of France is Paris.`만 출력
+
+### 남은 경계
+
+- 머지 전 hosted PR check가 모두 통과해야 한다.
+- 이 보고서는 Apple Silicon/Metal을 qualification하지 않는다.
+- 추가 quantization format과 미지원 실행 모드는 각각 별도의 evidence-gated follow-up으로 유지한다.

--- a/docs/adding-models.md
+++ b/docs/adding-models.md
@@ -176,8 +176,12 @@ summarizes runtime capabilities with:
 Muse Glimmer is the current example of this rule. Its first baseline targets
 `meta-models/Muse-Glimmer-30B` revision
 `97c77dff50b2797bcc558fa2d909761dbc575c59`, dense BF16 weights of about
-59.55 GB, 131072 context, 2048-token sliding layers plus growing full layers,
-4096 visual tokens per image, ATEM tool calls, and `reasoning_strength`
+59.55 GB, and its quantized contract targets
+`mlx-community/Muse-Glimmer-30B-4bit` revision
+`3e7677d7a40d348a3daba263a2b1c0aa41910710`, MLX affine-Q4 text and fusion
+weights with a dense vision tower, and about 19.41 GB of tensors. Both expose
+131072 context, 2048-token sliding layers plus growing full layers, 4096 visual
+tokens per image, ATEM tool calls, and `reasoning_strength`
 `low`/`medium`/`high`/`xhigh` with `high` by default. Do not mark a large VLM
 as real-checkpoint qualified until the hardware gate records load, memory,
 throughput, text/image/multi-image, tool-call, long-context, and scheduler

--- a/docs/supported-models.md
+++ b/docs/supported-models.md
@@ -112,12 +112,17 @@ Implemented VLM variants include:
 - Hunyuan-VL (`hunyuan_vl`, e.g. HunyuanOCR): Tencent's vision-language family. A ViT with a per-patch conv embedding, bilinearly interpolated learned position embeddings, and full attention over the packed patch sequence feeds a `perceive` merger: a stride-2 conv pair over the raster grid, a learned `image_newline` column, a linear to the decoder width, and learned `image_begin` / `image_end` rows. Per image that yields `mh * (mw + 1) + 2` feature rows, matching the prompt placeholder count exactly. The decoder is the Hunyuan dense stack (per-head Q/K RMSNorm after the rotation, DynamicNTK-alpha rope base) with XD-RoPE at prefill: 4D `[P, T, H, W]` position ids split across the frequency dims, degenerating to the standard rotation for text; decode uses sequential positions. Validated against `hadeseus/HunyuanOCR-mlx-4bit` (text 4-bit, vision bf16). Best for OCR: text spotting, document parsing, and grounded extraction.
 - MiniMax-M3-VL (`minimax_m3_vl`): MiniMax's vision-language model on top of the MiniMax-M3 text backbone. A CLIP-style ViT (hidden 1280, 16 heads, 32 layers, patch 14, `pre_layrnorm`, LayerNorm + exact-GELU blocks with separate `q/k/v/out` projections) runs native-resolution packing: Qwen2-VL-style dynamic `smart_resize` to `patch_size * spatial_merge_size = 28`-aligned dimensions, `image_grid_thw` patchify, per-image `cu_seqlens` variable-length attention, and 3D (t, h, w) vision RoPE (temporal axis inert for images, trailing dims unrotated). A two-stage projector then maps features to the text width: a per-patch `multi_modal_projector` (`linear_1 -> GELU -> linear_2`, into `projection_dim` 6144) followed by a `patch_merge_mlp` that folds each `spatial_merge_size^2 = 4` adjacent patches (`linear_1` [6144, 24576] `-> GELU -> linear_2`). Each `]<]image[>[` placeholder expands to `grid_t * (h/2) * (w/2)` tokens (`vision_start` 200029, `vision_end` 200030), which the merged features replace LLaVA-style; the MiniMax-M3 hybrid dense/MoE decoder then runs its standard partial 1D RoPE. The vision tower runs in f32 (non-quantized in the checkpoint) while the text tower may be quantized in community exports. Image and multi-image inputs are wired end to end (CLI and server); video is out of scope for this port. The only public checkpoint (`MiniMaxAI/MiniMax-M3`, 427B) exceeds the development machine, so image Q&A parity is deferred to a runtime validation once a fitting quantized conversion exists; the merge gate is the unit tests plus the real nested-config parse.
 - Muse Glimmer (`muse_glimmer`, `MuseGlimmerForConditionalGeneration`): Meta's
-  30B VLM, targeting the pinned public checkpoint
+  30B VLM, supporting the pinned public BF16 checkpoint
   `meta-models/Muse-Glimmer-30B` revision
   `97c77dff50b2797bcc558fa2d909761dbc575c59` and local path
-  `models/mlx/muse-glimmer-30b`. The baseline loads only the canonical dense
-  BF16 checkpoint (59,553,253,376 tensor bytes), so plan for a GB10-class /
-  128 GB unified-memory host and serialize other large jobs while testing it.
+  `models/mlx/muse-glimmer-30b`, plus the MLX affine-Q4 checkpoint
+  `mlx-community/Muse-Glimmer-30B-4bit` revision
+  `3e7677d7a40d348a3daba263a2b1c0aa41910710` and local path
+  `models/mlx/muse-glimmer-30b-4bit`. The BF16 weights occupy
+  59,553,253,376 tensor bytes. The Q4 conversion occupies 19,414,521,856 bytes,
+  packs the text embedding, decoder projections, untied LM head, vision adapter,
+  and vision projection at 4 bits with group size 64, while keeping the
+  50-layer vision tower dense.
   The text decoder exposes a 131072-token context window and owns a mixed cache:
   sliding layers keep a 2048-token rotating KV window while full-attention
   layers grow across the prompt/context. The vision path supports text-only,
@@ -134,9 +139,11 @@ Implemented VLM variants include:
   `200008`. OpenAI Chat Completions, Responses, Anthropic-compatible routes,
   classic CLI generation, continuous batching, streaming, expanded usage
   accounting, text/image/multi-image, ATEM replay, and reasoning output are
-  wired. Unsupported baseline paths are video, quantized checkpoints or
+  wired. Unsupported paths are video, quantized vision-tower weights,
   Turbo/INT8 KV quantization, DFlash/speculative decoding, LoRA/adapters, TP,
-  PP, XLA/IREE/OpenXLA, and distributed/disaggregated serving.
+  PP, XLA/IREE/OpenXLA, and distributed/disaggregated serving. Quantization
+  support is checkpoint-format specific; the pinned mlx-community affine-Q4
+  layout is the qualified contract, not arbitrary GGUF or external packings.
 
   The 2026-08-11 real-checkpoint gate ran on Linux/aarch64 with an NVIDIA GB10
   (CUDA 13.0, driver 580.173.02). Greedy CLI text generation was coherent at
@@ -148,6 +155,22 @@ Implemented VLM variants include:
   and process `VmHWM` reached 4.136 GiB. MLX's allocator counters report zero on
   this CUDA backend, so those OS measurements are recorded explicitly rather
   than presented as allocator/device-only memory.
+
+  The 2026-08-12 affine-Q4 smoke gate used the pinned mlx-community revision on
+  the same GB10. A 69-token text prompt prefixed at 7.22 tok/s and decoded 64
+  greedy tokens at 13.21 tok/s on the first measurement. A warm rerun reached
+  the final answer `The capital of France is Paris.` after 152 generated tokens,
+  prefilling at 12.43 tok/s and decoding at 13.34 tok/s. A real image expanded
+  to 64 patch tokens,
+  produced an accurate solid orange-red description, and measured 5.80 tok/s
+  over the 130-token multimodal prefill plus 13.15 decode tok/s; that cold image
+  run included first-use CUDA kernel compilation. This is approximately 3.1x
+  the BF16 text decode rate above. The CLI also separates Muse's `to=self`
+  reasoning from `to=user` content, hiding reasoning and envelope tokens unless
+  `--show-reasoning` is requested. A clean final-source release rebuild repeated
+  the same answer with no leaked control tokens at 12.97 decode tok/s; its cold
+  prefill was 3.15 tok/s, showing why cold and warm prefill are reported
+  separately.
 - FastVLM (`llava_qwen2` / `fastvlm`): Apple's low-latency VLM. A FastViTHD hybrid encoder runs entirely on channels-last maps: a conv stem, three RepMixer stages (depthwise token mixing plus a BatchNorm ConvFFN), two attention stages with channel LayerNorm and `head_dim` 32 self-attention, inter-stage large-kernel PatchEmbed downsamples, RepCPE position encoders, and a squeeze-excite `conv_exp` head. Each 1024x1024 pad-to-square image becomes a `(16, 16, 3072)` map flattened to 256 tokens, projected to the Qwen2 decoder width by an `mlp2x_gelu` MLP. The `<image>` placeholder is the fixed `-200` sentinel (not a vocabulary token); the runtime splices one sentinel per image, expands it to 256 tokens, and scatters the image embeddings (LLaVA merge). The text decoder is stock Qwen2, reused unchanged. The loader accepts both the genuine (`apple/FastVLM-0.5B`) and converted (`mlx-community/FastVLM-0.5B-bf16`) weight layouts. Best for fast image description and grounded chat.
 - GLM-OCR (`glm_ocr`): document-OCR sibling of GLM-4V. A 24-block ViT (3D patch embedding, per-head q/k RMSNorm on the packed `cu_seqlens` attention, 2D vision RoPE, Conv2d spatial downsample, SwiGLU patch merger) feeds a 16-layer GLM-4 text decoder driven by full-width even/odd MRoPE (`rope_parameters` with `mrope_section [16, 24, 24]`, `partial_rotary_factor 1.0`). The tower has no learned position embedding or post-conv norm, and the loader drops the next-n prediction (MTP) layer. Patches are reordered from the processor's raster order into spatial-merge-window order so the rotary, downsample, and merged-token grid stay spatially aligned (OCR reads scrambled patches wrong). Best for plain text, tables, and formula recognition.
 - Youtu-VL
@@ -453,9 +476,12 @@ The grapheme-to-phoneme front-end is a self-contained American-English phonemize
 Do not infer quality or speed from the ability to load a quantized checkpoint.
 Run a smoke test and, for release claims, a benchmark/quality gate.
 
-Muse Glimmer is deliberately narrower than the table above for its first
-baseline: only the canonical dense BF16 checkpoint is supported. Quantized Muse
-weights and non-FP16/Turbo KV-cache modes are follow-ups because the model owns a
+Muse Glimmer supports both the canonical dense BF16 checkpoint and the pinned
+`mlx-community/Muse-Glimmer-30B-4bit` affine-Q4 conversion. The Q4 path
+normalizes mlx-vlm's `language_model.*` roots and inherits the root-level
+quantization contract into the text decoder and fusion projections; the vision
+tower remains dense.
+Non-FP16/Turbo KV-cache modes are a separate follow-up because the model owns a
 mixed 2048-token sliding plus growing full-layer cache.
 
 ## Distributed support summary
@@ -467,7 +493,7 @@ mixed 2048-token sliding plus growing full-layer cache.
 | VLM under TP/PP | Partial. Vision tower / projector partitioning is not uniformly supported. |
 | Disaggregated inference | Infrastructure exists; validate per topology and workload. |
 
-Muse Glimmer is single-process dense BF16 only in this baseline: TP, PP,
+Muse Glimmer is single-process for both BF16 and affine Q4: TP, PP,
 XLA/IREE/OpenXLA, distributed, and disaggregated serving must remain disabled
 until each path has explicit mixed-cache and multimodal validation.
 

--- a/src/commands/generate.rs
+++ b/src/commands/generate.rs
@@ -992,6 +992,15 @@ fn filter_reasoning_for_display(
     generated_text: &str,
     show_reasoning: bool,
 ) -> String {
+    let dim = io::stdout().is_terminal();
+    if let Some(rendered) = mlxcel::server::tool_calls::render_muse_channels_for_display(
+        generated_text,
+        show_reasoning,
+        dim,
+    ) {
+        return rendered;
+    }
+
     let markers = tokenizer.infer_thinking_markers();
     // When the rendered prompt primed an open thinking marker (`<think>\n` for
     // Qwen-style, `<|channel>thought\n` for a thinking-on Gemma-4 channel) the
@@ -999,7 +1008,6 @@ fn filter_reasoning_for_display(
     // start the filter in the reasoning state to keep the primed thought body
     // and its raw close marker off the terminal.
     let primed = mlxcel::reasoning_stream::prompt_primed_open_thinking(&markers, prompt);
-    let dim = io::stdout().is_terminal();
     mlxcel::reasoning_stream::render_full(&markers, generated_text, primed, show_reasoning, dim)
 }
 

--- a/src/loading/mod.rs
+++ b/src/loading/mod.rs
@@ -62,11 +62,11 @@ pub(crate) use self::vlm::load_llava_iree_host_preprocessor;
 #[cfg(feature = "xla-iree")]
 pub(crate) use self::vlm::load_qwen2_vl_iree_host_preprocessor;
 pub use self::vlm::load_qwen3_omni_speech;
-pub(crate) use self::vlm::normalize_muse_glimmer_weights;
 #[cfg(feature = "xla-iree")]
 pub(crate) use self::vlm::{
     Phi4MMXlaVisionComponents, load_phi4mm_xla_media_components, load_phi4mm_xla_text_embeddings,
 };
+pub(crate) use self::vlm::{ensure_supported_muse_weight_map, normalize_muse_glimmer_weights};
 
 /// Resolve model path: if a file is given, use its parent directory.
 ///

--- a/src/loading/mod.rs
+++ b/src/loading/mod.rs
@@ -62,6 +62,7 @@ pub(crate) use self::vlm::load_llava_iree_host_preprocessor;
 #[cfg(feature = "xla-iree")]
 pub(crate) use self::vlm::load_qwen2_vl_iree_host_preprocessor;
 pub use self::vlm::load_qwen3_omni_speech;
+pub(crate) use self::vlm::normalize_muse_glimmer_weights;
 #[cfg(feature = "xla-iree")]
 pub(crate) use self::vlm::{
     Phi4MMXlaVisionComponents, load_phi4mm_xla_media_components, load_phi4mm_xla_text_embeddings,

--- a/src/loading/vlm.rs
+++ b/src/loading/vlm.rs
@@ -125,7 +125,9 @@ pub(crate) use llava::{load_llava_bunny_vlm, load_llava_host_preprocessor, load_
 pub(crate) use locateanything::load_locateanything_vlm;
 pub(crate) use minimax_m3_vl::load_minimax_m3_vl;
 pub(crate) use mllama::load_mllama_vlm;
-pub(crate) use muse_glimmer::{load_muse_glimmer_vlm, normalize_muse_glimmer_weights};
+pub(crate) use muse_glimmer::{
+    ensure_supported_muse_weight_map, load_muse_glimmer_vlm, normalize_muse_glimmer_weights,
+};
 pub(crate) use nemotron_h_nano_omni::load_nemotron_h_nano_omni_vlm;
 pub(crate) use paddleocr::load_paddleocr_vl;
 pub(crate) use pixtral::{load_mistral3_vlm, load_pixtral_vlm};

--- a/src/loading/vlm.rs
+++ b/src/loading/vlm.rs
@@ -125,7 +125,7 @@ pub(crate) use llava::{load_llava_bunny_vlm, load_llava_host_preprocessor, load_
 pub(crate) use locateanything::load_locateanything_vlm;
 pub(crate) use minimax_m3_vl::load_minimax_m3_vl;
 pub(crate) use mllama::load_mllama_vlm;
-pub(crate) use muse_glimmer::load_muse_glimmer_vlm;
+pub(crate) use muse_glimmer::{load_muse_glimmer_vlm, normalize_muse_glimmer_weights};
 pub(crate) use nemotron_h_nano_omni::load_nemotron_h_nano_omni_vlm;
 pub(crate) use paddleocr::load_paddleocr_vl;
 pub(crate) use pixtral::{load_mistral3_vlm, load_pixtral_vlm};

--- a/src/loading/vlm_muse_glimmer.rs
+++ b/src/loading/vlm_muse_glimmer.rs
@@ -14,7 +14,8 @@
 
 //! Muse Glimmer VLM loading boundary.
 //!
-//! Builds the concrete Muse model from the canonical dense checkpoint roots.
+//! Builds the concrete Muse model from the canonical BF16 checkpoint or the
+//! mlx-vlm affine-quantized checkpoint layout.
 //! Request-time image expansion and ordered feature scatter are provided by
 //! the dedicated Muse multimodal runtime.
 
@@ -27,6 +28,7 @@ use crate::LoadedModel;
 use crate::models::muse_glimmer::{
     MuseGlimmerConfig, MuseGlimmerTextModel, MuseGlimmerTextWrapper,
 };
+use crate::models::muse_glimmer_config::inherit_muse_text_quantization;
 use crate::vision::encoders::muse_glimmer::{
     MUSE_GLIMMER_VISION_TOWER_ROOT, MuseGlimmerVisionTower,
 };
@@ -64,8 +66,12 @@ pub(crate) fn load_muse_glimmer_vlm_model(model_path: &Path) -> Result<MuseGlimm
     }
     let processor = MuseGlimmerImageProcessor::from_model_dir(model_path, &config.vision_config)
         .map_err(anyhow::Error::msg)?;
-    let weights = load_vlm_weights_common_filtered(model_path, None, keep_muse_glimmer_weight)?;
-    ensure_dense_muse_weight_map(&weights)?;
+    let weights = normalize_muse_glimmer_weights(load_vlm_weights_common_filtered(
+        model_path,
+        None,
+        keep_muse_glimmer_weight,
+    )?)?;
+    ensure_supported_muse_weight_map(&weights, &config)?;
     build_muse_glimmer_vlm_from_weights(
         &weights,
         &config,
@@ -75,7 +81,8 @@ pub(crate) fn load_muse_glimmer_vlm_model(model_path: &Path) -> Result<MuseGlimm
 }
 
 pub(crate) fn parse_muse_glimmer_config(model_path: &Path) -> Result<MuseGlimmerConfig> {
-    let (_config_str, full_config) = read_sanitized_vlm_config(model_path)?;
+    let (_config_str, mut full_config) = read_sanitized_vlm_config(model_path)?;
+    inherit_muse_text_quantization(&mut full_config).map_err(anyhow::Error::msg)?;
     serde_json::from_value(full_config)
         .map_err(|e| anyhow::anyhow!("Failed to parse Muse Glimmer config.json: {}", e))
 }
@@ -87,7 +94,7 @@ pub(crate) fn build_muse_glimmer_vlm_from_weights(
     eos_token_ids: Vec<i32>,
 ) -> Result<MuseGlimmerVlmModel> {
     ensure_supported_muse_vlm_config(config)?;
-    ensure_dense_muse_weight_map(weights)?;
+    ensure_supported_muse_weight_map(weights, config)?;
     let text_model = build_muse_glimmer_text_from_weights(weights, config, eos_token_ids)?;
     let text = MuseGlimmerTextWrapper::new(text_model);
     let vision_tower = MuseGlimmerVisionTower::from_weights(weights, &config.vision_config)
@@ -196,6 +203,7 @@ impl MuseWeightInventory {
 }
 
 pub(crate) fn classify_muse_weight_key(key: &str) -> Option<MuseWeightRoot> {
+    let key = normalize_muse_weight_key(key);
     MuseWeightRoot::all()
         .into_iter()
         .find(|root| key.starts_with(&format!("{}.", root.prefix())))
@@ -203,6 +211,43 @@ pub(crate) fn classify_muse_weight_key(key: &str) -> Option<MuseWeightRoot> {
 
 pub(crate) fn keep_muse_glimmer_weight(key: &str) -> bool {
     classify_muse_weight_key(key).is_some()
+}
+
+/// Normalize the two published Muse checkpoint layouts to the names consumed
+/// by the Rust model. Meta BF16 already uses the canonical `model.*` roots;
+/// mlx-vlm exports strip that wrapper and nests the head below
+/// `language_model.lm_head`.
+pub(crate) fn normalize_muse_weight_key(key: &str) -> String {
+    if let Some(rest) = key.strip_prefix("language_model.model.") {
+        return format!("{MUSE_GLIMMER_LANGUAGE_ROOT}.{rest}");
+    }
+    if let Some(rest) = key.strip_prefix("language_model.lm_head.") {
+        return format!("{MUSE_GLIMMER_LM_HEAD_ROOT}.{rest}");
+    }
+    for (raw_root, canonical_root) in [
+        ("vision_tower.", MUSE_GLIMMER_VISION_TOWER_ROOT),
+        ("vision_adapter.", MUSE_GLIMMER_VISION_ADAPTER_ROOT),
+        ("vision_projection.", MUSE_GLIMMER_VISION_PROJECTION_ROOT),
+    ] {
+        if let Some(rest) = key.strip_prefix(raw_root) {
+            return format!("{canonical_root}.{rest}");
+        }
+    }
+    key.to_string()
+}
+
+pub(crate) fn normalize_muse_glimmer_weights(raw_weights: WeightMap) -> Result<WeightMap> {
+    let mut weights = WeightMap::new();
+    for (raw_key, value) in raw_weights {
+        let key = normalize_muse_weight_key(&raw_key);
+        if weights.contains_key(&key) {
+            return Err(anyhow::anyhow!(
+                "Muse Glimmer checkpoint keys {raw_key:?} and another source both normalize to {key:?}"
+            ));
+        }
+        weights.insert(key, value);
+    }
+    Ok(weights)
 }
 
 pub(crate) fn read_muse_weight_inventory_from_index(
@@ -227,7 +272,6 @@ pub(crate) fn read_muse_weight_inventory_from_index(
         total: 0,
     };
     for key in weight_map.keys() {
-        ensure_dense_muse_key(key)?;
         let root = classify_muse_weight_key(key)
             .ok_or_else(|| anyhow::anyhow!("Unknown Muse Glimmer checkpoint weight root: {key}"))?;
         inventory.increment(root);
@@ -238,11 +282,6 @@ pub(crate) fn read_muse_weight_inventory_from_index(
 
 fn ensure_supported_muse_vlm_config(config: &MuseGlimmerConfig) -> Result<()> {
     config.validate().map_err(anyhow::Error::msg)?;
-    if config.text_config.quantization.is_some() {
-        return Err(anyhow::anyhow!(
-            "Muse Glimmer VLM supports only the canonical dense BF16 checkpoint; quantized text_config is not supported"
-        ));
-    }
     if config.vision_config.patch_temporal != 2 {
         return Err(anyhow::anyhow!(
             "Muse Glimmer VLM supports static image duplication only; video temporal layouts are not supported"
@@ -256,20 +295,46 @@ fn ensure_supported_muse_vlm_config(config: &MuseGlimmerConfig) -> Result<()> {
     Ok(())
 }
 
-fn ensure_dense_muse_weight_map(weights: &WeightMap) -> Result<()> {
+fn ensure_supported_muse_weight_map(weights: &WeightMap, config: &MuseGlimmerConfig) -> Result<()> {
+    let mut scale_count = 0usize;
     for key in weights.keys() {
-        ensure_dense_muse_key(key)?;
+        let sidecar_suffix = [".scales", ".biases", ".global_scale"]
+            .into_iter()
+            .find(|suffix| key.ends_with(suffix));
+        let Some(suffix) = sidecar_suffix else {
+            continue;
+        };
+        if !key.starts_with(&format!("{MUSE_GLIMMER_LANGUAGE_ROOT}."))
+            && !key.starts_with(&format!("{MUSE_GLIMMER_LM_HEAD_ROOT}."))
+            && !key.starts_with(&format!("{MUSE_GLIMMER_VISION_ADAPTER_ROOT}."))
+            && !key.starts_with(&format!("{MUSE_GLIMMER_VISION_PROJECTION_ROOT}."))
+        {
+            return Err(anyhow::anyhow!(
+                "Muse Glimmer supports quantized text and vision-fusion weights only; found unsupported vision-tower sidecar {key}"
+            ));
+        }
+        if config.text_config.quantization.is_none() {
+            return Err(anyhow::anyhow!(
+                "Muse Glimmer checkpoint contains quantization sidecar {key}, but config.json declares no quantization contract"
+            ));
+        }
+        let prefix = key.strip_suffix(suffix).unwrap_or(key);
+        if !weights.contains_key(&format!("{prefix}.weight")) {
+            return Err(anyhow::anyhow!(
+                "Muse Glimmer quantization sidecar {key} has no matching {prefix}.weight"
+            ));
+        }
+        if suffix == ".scales" {
+            scale_count += 1;
+        } else if !weights.contains_key(&format!("{prefix}.scales")) {
+            return Err(anyhow::anyhow!(
+                "Muse Glimmer quantization sidecar {key} has no matching {prefix}.scales"
+            ));
+        }
     }
-    Ok(())
-}
-
-fn ensure_dense_muse_key(key: &str) -> Result<()> {
-    if [".scales", ".biases", ".global_scale"]
-        .iter()
-        .any(|suffix| key.ends_with(suffix))
-    {
+    if config.text_config.quantization.is_some() && scale_count == 0 {
         return Err(anyhow::anyhow!(
-            "Muse Glimmer VLM supports only canonical dense BF16 weights; found quantization sidecar {key}"
+            "Muse Glimmer config.json declares quantization, but the checkpoint contains no supported .scales tensors"
         ));
     }
     Ok(())

--- a/src/loading/vlm_muse_glimmer.rs
+++ b/src/loading/vlm_muse_glimmer.rs
@@ -295,7 +295,10 @@ fn ensure_supported_muse_vlm_config(config: &MuseGlimmerConfig) -> Result<()> {
     Ok(())
 }
 
-fn ensure_supported_muse_weight_map(weights: &WeightMap, config: &MuseGlimmerConfig) -> Result<()> {
+pub(crate) fn ensure_supported_muse_weight_map(
+    weights: &WeightMap,
+    config: &MuseGlimmerConfig,
+) -> Result<()> {
     let mut scale_count = 0usize;
     for key in weights.keys() {
         let sidecar_suffix = [".scales", ".biases", ".global_scale"]
@@ -318,6 +321,11 @@ fn ensure_supported_muse_weight_map(weights: &WeightMap, config: &MuseGlimmerCon
                 "Muse Glimmer checkpoint contains quantization sidecar {key}, but config.json declares no quantization contract"
             ));
         }
+        if suffix == ".global_scale" {
+            return Err(anyhow::anyhow!(
+                "Muse Glimmer pinned affine-Q4 layout does not support global-scale sidecar {key}"
+            ));
+        }
         let prefix = key.strip_suffix(suffix).unwrap_or(key);
         if !weights.contains_key(&format!("{prefix}.weight")) {
             return Err(anyhow::anyhow!(
@@ -326,6 +334,11 @@ fn ensure_supported_muse_weight_map(weights: &WeightMap, config: &MuseGlimmerCon
         }
         if suffix == ".scales" {
             scale_count += 1;
+            if !weights.contains_key(&format!("{prefix}.biases")) {
+                return Err(anyhow::anyhow!(
+                    "Muse Glimmer affine quantization sidecar {key} has no matching {prefix}.biases"
+                ));
+            }
         } else if !weights.contains_key(&format!("{prefix}.scales")) {
             return Err(anyhow::anyhow!(
                 "Muse Glimmer quantization sidecar {key} has no matching {prefix}.scales"

--- a/src/loading/vlm_muse_glimmer_tests.rs
+++ b/src/loading/vlm_muse_glimmer_tests.rs
@@ -416,19 +416,50 @@ fn muse_glimmer_xla_image_preprocessor_rejects_family_explicitly() {
 }
 
 #[test]
-fn builder_rejects_quantization_and_video_temporal_layouts() {
+fn muse_quantization_contract_accepts_text_sidecars_and_rejects_unsafe_layouts() {
     let mut config = tiny_config();
     config.text_config.quantization = Some(MuseQuantization {
         group_size: 64,
         bits: 4,
     });
-    let weights = tiny_weights(&tiny_config());
-    let processor = MuseGlimmerImageProcessor::from_vision_config(&config.vision_config);
-    let err = build_muse_glimmer_vlm_from_weights(&weights, &config, processor, Vec::new())
+    let mut weights = tiny_weights(&config);
+    put(&mut weights, "lm_head.scales", &[16, 1], 0.1);
+    put(&mut weights, "lm_head.biases", &[16, 1], 0.0);
+    put(
+        &mut weights,
+        "model.vision_adapter.fc1.scales",
+        &[8, 1],
+        0.1,
+    );
+    put(
+        &mut weights,
+        "model.vision_adapter.fc1.biases",
+        &[8, 1],
+        0.0,
+    );
+    assert!(ensure_supported_muse_weight_map(&weights, &config).is_ok());
+
+    let dense_config = tiny_config();
+    let err = ensure_supported_muse_weight_map(&weights, &dense_config)
         .map(|_| "unexpected success".to_string())
         .unwrap_or_else(|err| err.to_string());
-    assert!(err.contains("dense BF16"));
+    assert!(err.contains("declares no quantization contract"));
 
+    put(
+        &mut weights,
+        "model.vision_tower.patch_embedder.patch_embedding.scales",
+        &[4, 1],
+        0.1,
+    );
+    let err = ensure_supported_muse_weight_map(&weights, &config)
+        .map(|_| "unexpected success".to_string())
+        .unwrap_or_else(|err| err.to_string());
+    assert!(err.contains("vision-tower sidecar"));
+}
+
+#[test]
+fn builder_rejects_video_temporal_layouts() {
+    let weights = tiny_weights(&tiny_config());
     let mut config = tiny_config();
     config.vision_config.patch_temporal = 4;
     let processor = MuseGlimmerImageProcessor::from_vision_config(&config.vision_config);
@@ -459,7 +490,7 @@ fn pinned_weight_index_classifies_each_source_weight_once() {
 }
 
 #[test]
-fn muse_weight_classifier_rejects_unknowns_and_quant_sidecars() {
+fn muse_weight_classifier_normalizes_mlx_vlm_roots_and_rejects_unknowns() {
     assert_eq!(
         classify_muse_weight_key("model.vision_tower.layers.0.attn.q_proj.weight"),
         Some(MuseWeightRoot::VisionTower)
@@ -481,9 +512,60 @@ fn muse_weight_classifier_rejects_unknowns_and_quant_sidecars() {
         Some(MuseWeightRoot::LmHead)
     );
     assert_eq!(classify_muse_weight_key("model.mm_projector.weight"), None);
+    assert_eq!(
+        normalize_muse_weight_key("language_model.model.layers.0.mlp.up_proj.scales"),
+        "model.language_model.layers.0.mlp.up_proj.scales"
+    );
+    assert_eq!(
+        normalize_muse_weight_key("language_model.lm_head.biases"),
+        "lm_head.biases"
+    );
+    assert_eq!(
+        normalize_muse_weight_key("vision_tower.layers.0.attn.q_proj.weight"),
+        "model.vision_tower.layers.0.attn.q_proj.weight"
+    );
+    assert_eq!(
+        classify_muse_weight_key("language_model.model.embed_tokens.scales"),
+        Some(MuseWeightRoot::LanguageModel)
+    );
+    assert_eq!(
+        classify_muse_weight_key("language_model.lm_head.weight"),
+        Some(MuseWeightRoot::LmHead)
+    );
+}
 
-    let err = ensure_dense_muse_key("model.language_model.layers.0.mlp.up_proj.scales")
+#[test]
+fn root_quantization_is_inherited_into_muse_text_config() {
+    let quantization = serde_json::json!({
+        "group_size": 64,
+        "bits": 4,
+        "mode": "affine"
+    });
+    let mut config = serde_json::json!({
+        "quantization": quantization,
+        "quantization_config": quantization,
+        "text_config": {}
+    });
+    if let Err(err) = inherit_muse_text_quantization(&mut config) {
+        panic!("root Muse quantization should be inherited: {err}");
+    }
+    assert_eq!(
+        config["text_config"]["quantization"],
+        serde_json::json!({"group_size": 64, "bits": 4, "mode": "affine"})
+    );
+
+    config["quantization_config"]["bits"] = serde_json::json!(8);
+    let err = inherit_muse_text_quantization(&mut config)
         .map(|_| "unexpected success".to_string())
-        .unwrap_or_else(|err| err.to_string());
-    assert!(err.contains("quantization sidecar"));
+        .unwrap_or_else(|err| err);
+    assert!(err.contains("disagree"));
+
+    let mut unsupported_mode = serde_json::json!({
+        "quantization": {"group_size": 64, "bits": 4, "mode": "mxfp4"},
+        "text_config": {}
+    });
+    let err = inherit_muse_text_quantization(&mut unsupported_mode)
+        .map(|_| "unexpected success".to_string())
+        .unwrap_or_else(|err| err);
+    assert!(err.contains("must be \"affine\""));
 }

--- a/src/loading/vlm_muse_glimmer_tests.rs
+++ b/src/loading/vlm_muse_glimmer_tests.rs
@@ -568,4 +568,36 @@ fn root_quantization_is_inherited_into_muse_text_config() {
         .map(|_| "unexpected success".to_string())
         .unwrap_or_else(|err| err);
     assert!(err.contains("must be \"affine\""));
+
+    let mut non_string_mode = serde_json::json!({
+        "quantization": {"group_size": 64, "bits": 4, "mode": 4},
+        "text_config": {}
+    });
+    let err = inherit_muse_text_quantization(&mut non_string_mode)
+        .map(|_| "unexpected success".to_string())
+        .unwrap_or_else(|err| err);
+    assert!(err.contains("must be a string"));
+}
+
+#[test]
+fn muse_affine_quantization_rejects_missing_biases_and_global_scale() {
+    let mut config = tiny_config();
+    config.text_config.quantization = Some(MuseQuantization {
+        group_size: 64,
+        bits: 4,
+    });
+    let mut weights = tiny_weights(&config);
+    put(&mut weights, "lm_head.scales", &[16, 1], 0.1);
+
+    let err = ensure_supported_muse_weight_map(&weights, &config)
+        .map(|_| "unexpected success".to_string())
+        .unwrap_or_else(|err| err.to_string());
+    assert!(err.contains("no matching lm_head.biases"));
+
+    put(&mut weights, "lm_head.biases", &[16, 1], 0.0);
+    put(&mut weights, "lm_head.global_scale", &[1], 1.0);
+    let err = ensure_supported_muse_weight_map(&weights, &config)
+        .map(|_| "unexpected success".to_string())
+        .unwrap_or_else(|err| err.to_string());
+    assert!(err.contains("does not support global-scale sidecar"));
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -60,11 +60,11 @@ Tensor Parallel Runtime:
                        LoRA unsupported, server batching supported for listed dense runtimes
                        except Gemma 4 E2B-style conservative fallback checkpoints
 
-Muse Glimmer 30B baseline:
-  dense BF16 only (~59.55 GB weights; GB10-class unified memory expected)
+Muse Glimmer 30B checkpoints:
+  dense BF16 (~59.55 GB) and pinned mlx-community affine 4-bit (~19.41 GB)
   text, single-image, multi-image CLI/server routes, reasoning strengths, and ATEM tools
-  unsupported: video, quantization/Turbo KV, speculative/DFlash, LoRA/adapters, TP/PP, XLA/distributed
-  qualified on the pinned BF16 checkpoint with NVIDIA GB10; see supported-models.md for metrics
+  unsupported: video, quantized vision tower/Turbo KV, speculative/DFlash, LoRA/adapters, TP/PP, XLA/distributed
+  qualified checkpoints and GB10 metrics are recorded in supported-models.md
 
 For more information, visit: https://github.com/lablup/mlxcel"
 )]

--- a/src/main_tests.rs
+++ b/src/main_tests.rs
@@ -119,7 +119,7 @@ fn supported_models_output_describes_muse_glimmer_baseline() {
 
     assert!(out.contains("Muse VLM:"), "missing Muse VLM family: {out}");
     assert!(
-        out.contains("Muse Glimmer 30B VLM (BF16, mixed 2048 sliding/full cache, ATEM)"),
+        out.contains("Muse Glimmer 30B VLM (BF16/MLX 4-bit, mixed 2048 sliding/full cache, ATEM)"),
         "missing Muse Glimmer operational summary: {out}"
     );
 }
@@ -130,15 +130,16 @@ fn top_level_help_mentions_muse_glimmer_limits() {
     let help = command.render_long_help().to_string();
 
     for expected in [
-        "Muse Glimmer 30B baseline",
+        "Muse Glimmer 30B checkpoints",
         "59.55 GB",
-        "GB10-class unified memory",
+        "19.41 GB",
+        "mlx-community affine 4-bit",
         "reasoning strengths",
         "ATEM tools",
         "speculative/DFlash",
         "TP/PP",
         "XLA/distributed",
-        "qualified on the pinned BF16 checkpoint with NVIDIA GB10",
+        "qualified checkpoints and GB10 metrics",
     ] {
         assert!(
             help.contains(expected),

--- a/src/models/mod.rs
+++ b/src/models/mod.rs
@@ -894,7 +894,7 @@ impl ModelType {
                 "MiniMax VLM",
             ),
             ModelType::MuseGlimmerVLM => (
-                "Muse Glimmer 30B VLM (BF16, mixed 2048 sliding/full cache, ATEM)",
+                "Muse Glimmer 30B VLM (BF16/MLX 4-bit, mixed 2048 sliding/full cache, ATEM)",
                 "Muse VLM",
             ),
             ModelType::Mixtral => ("Mixtral (MoE)", "MoE (other)"),

--- a/src/models/muse_glimmer.rs
+++ b/src/models/muse_glimmer.rs
@@ -180,6 +180,8 @@ impl MuseGlimmerTextModel {
             crate::models::load_text_weights(model_dir, None)?,
         )
         .map_err(|err| err.to_string())?;
+        crate::loading::ensure_supported_muse_weight_map(&weights, &config)
+            .map_err(|err| err.to_string())?;
         let eos_token_ids = crate::loading::read_eos_token_ids(model_dir);
         let model = Self::from_weights(
             &weights,

--- a/src/models/muse_glimmer.rs
+++ b/src/models/muse_glimmer.rs
@@ -27,6 +27,7 @@ use mlxcel_core::{MlxArray, UniquePtr};
 use std::path::Path;
 
 pub(crate) use super::muse_glimmer_cache::MuseCache;
+use super::muse_glimmer_config::inherit_muse_text_quantization;
 pub use super::muse_glimmer_config::{
     DEFAULT_IMAGE_END_TOKEN_ID, DEFAULT_IMAGE_PLACEHOLDER_TOKEN_ID, DEFAULT_IMAGE_START_TOKEN_ID,
     DEFAULT_IMAGE_TOKEN_ID, DEFAULT_PAD_TOKEN_ID, DEFAULT_VIDEO_TOKEN_ID, MuseGlimmerConfig,
@@ -170,9 +171,15 @@ impl MuseGlimmerTextModel {
         let model_dir = model_dir.as_ref();
         let config_str = std::fs::read_to_string(model_dir.join("config.json"))
             .map_err(|e| format!("Failed to read config.json: {e}"))?;
-        let config: MuseGlimmerConfig = serde_json::from_str(&config_str)
+        let mut config_value: serde_json::Value = serde_json::from_str(&config_str)
             .map_err(|e| format!("Failed to parse config.json: {e}"))?;
-        let weights = crate::models::load_text_weights(model_dir, None)?;
+        inherit_muse_text_quantization(&mut config_value)?;
+        let config: MuseGlimmerConfig = serde_json::from_value(config_value)
+            .map_err(|e| format!("Failed to parse config.json: {e}"))?;
+        let weights = crate::loading::normalize_muse_glimmer_weights(
+            crate::models::load_text_weights(model_dir, None)?,
+        )
+        .map_err(|err| err.to_string())?;
         let eos_token_ids = crate::loading::read_eos_token_ids(model_dir);
         let model = Self::from_weights(
             &weights,

--- a/src/models/muse_glimmer_config.rs
+++ b/src/models/muse_glimmer_config.rs
@@ -354,12 +354,15 @@ pub(crate) fn inherit_muse_text_quantization(config: &mut Value) -> Result<(), S
     if let Some(mode) = text_config
         .get("quantization")
         .and_then(|quantization| quantization.get("mode"))
-        .and_then(Value::as_str)
-        && mode != "affine"
     {
-        return Err(format!(
-            "Muse Glimmer quantization.mode must be \"affine\" for the pinned mlx-community checkpoint layout, got {mode:?}"
-        ));
+        let mode = mode.as_str().ok_or_else(|| {
+            "Muse Glimmer quantization.mode must be a string when present".to_string()
+        })?;
+        if mode != "affine" {
+            return Err(format!(
+                "Muse Glimmer quantization.mode must be \"affine\" for the pinned mlx-community checkpoint layout, got {mode:?}"
+            ));
+        }
     }
     Ok(())
 }

--- a/src/models/muse_glimmer_config.rs
+++ b/src/models/muse_glimmer_config.rs
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 use serde::Deserialize;
+use serde_json::Value;
 
 pub const DEFAULT_IMAGE_TOKEN_ID: i32 = 200_092;
 pub const DEFAULT_IMAGE_PLACEHOLDER_TOKEN_ID: i32 = 200_090;
@@ -241,6 +242,13 @@ fn default_vision_rope_theta() -> f32 {
 
 impl MuseGlimmerTextConfig {
     pub fn validate(&self) -> Result<(), String> {
+        if let Some(quantization) = &self.quantization {
+            mlxcel_core::layers::validate_quantization_params(
+                quantization.group_size,
+                quantization.bits,
+            )
+            .map_err(|err| format!("Muse Glimmer {err}"))?;
+        }
         if self.num_attention_heads == 0 {
             return Err("Muse Glimmer num_attention_heads must be non-zero".to_string());
         }
@@ -300,6 +308,60 @@ impl MuseGlimmerTextConfig {
             .or_else(|| self.rope_parameters.as_ref().map(|p| p.rope_theta))
             .or(Some(default_rope_theta()))
     }
+}
+
+/// Carry the MLX checkpoint's root-level quantization contract into the text
+/// sub-config consumed by the decoder.
+///
+/// `mlx-community/Muse-Glimmer-30B-4bit` follows mlx-vlm's common layout: the
+/// affine `{group_size, bits, mode}` block lives at the config root while the
+/// packed tensors live below `language_model.*`. The Rust decoder receives
+/// only `text_config`, so leaving the block at the root would make every
+/// `UnifiedLinear` interpret the packed weights with fallback parameters.
+pub(crate) fn inherit_muse_text_quantization(config: &mut Value) -> Result<(), String> {
+    let root_quantization = config.get("quantization").filter(|value| !value.is_null());
+    let compatibility_quantization = config
+        .get("quantization_config")
+        .filter(|value| !value.is_null());
+
+    if let (Some(root), Some(compatibility)) = (root_quantization, compatibility_quantization)
+        && root != compatibility
+    {
+        return Err("Muse Glimmer root quantization and quantization_config disagree".to_string());
+    }
+
+    let Some(quantization) = root_quantization.or(compatibility_quantization).cloned() else {
+        return Ok(());
+    };
+    let text_config = config
+        .get_mut("text_config")
+        .and_then(Value::as_object_mut)
+        .ok_or_else(|| "Muse Glimmer config.json has no text_config object".to_string())?;
+
+    if let Some(nested) = text_config
+        .get("quantization")
+        .filter(|value| !value.is_null())
+    {
+        if nested != &quantization {
+            return Err(
+                "Muse Glimmer root and text_config quantization contracts disagree".to_string(),
+            );
+        }
+    } else {
+        text_config.insert("quantization".to_string(), quantization);
+    }
+
+    if let Some(mode) = text_config
+        .get("quantization")
+        .and_then(|quantization| quantization.get("mode"))
+        .and_then(Value::as_str)
+        && mode != "affine"
+    {
+        return Err(format!(
+            "Muse Glimmer quantization.mode must be \"affine\" for the pinned mlx-community checkpoint layout, got {mode:?}"
+        ));
+    }
+    Ok(())
 }
 
 impl MuseGlimmerConfig {

--- a/src/server/tool_calls/atem.rs
+++ b/src/server/tool_calls/atem.rs
@@ -163,6 +163,43 @@ pub(super) fn split_muse_channels(text: &str) -> (String, Option<String>) {
     )
 }
 
+/// Render Muse/Onyx recipient-oriented channels for terminal display.
+///
+/// Returns `None` when `text` is not a Muse envelope so callers can fall back
+/// to the regular reasoning-marker filter. Reasoning addressed to `self` is
+/// hidden by default and shown before user-visible content when requested.
+pub fn render_muse_channels_for_display(
+    text: &str,
+    show_reasoning: bool,
+    dim_reasoning: bool,
+) -> Option<String> {
+    let trimmed = text.trim();
+    if !trimmed.contains("<|message|>")
+        || !(trimmed.starts_with("to=")
+            || trimmed.starts_with(" to=")
+            || trimmed.contains("<|start|>assistant"))
+    {
+        return None;
+    }
+
+    let (content, reasoning) = split_muse_channels(text);
+    let mut rendered = String::new();
+    if show_reasoning && let Some(reasoning) = reasoning {
+        if dim_reasoning {
+            rendered.push_str("\x1b[2m");
+            rendered.push_str(&reasoning);
+            rendered.push_str("\x1b[0m");
+        } else {
+            rendered.push_str(&reasoning);
+        }
+        if !content.is_empty() {
+            rendered.push('\n');
+        }
+    }
+    rendered.push_str(&content);
+    Some(rendered)
+}
+
 fn append_channel_text(target: &mut String, text: &str) {
     if text.is_empty() {
         return;

--- a/src/server/tool_calls/atem_tests.rs
+++ b/src/server/tool_calls/atem_tests.rs
@@ -65,6 +65,29 @@ fn muse_recipient_envelope_keeps_user_answer_content() {
     );
 }
 
+#[test]
+fn muse_cli_render_hides_reasoning_and_control_markers() {
+    let text = concat!(
+        " to=self<|message|>Think first.<|eom|>",
+        "<|start|>assistant to=user<|message|>Done.<|eot|>"
+    );
+
+    let hidden = render_muse_channels_for_display(text, false, false).unwrap();
+    assert_eq!(hidden, "Done.");
+
+    let shown = render_muse_channels_for_display(text, true, false).unwrap();
+    assert_eq!(shown, "Think first.\nDone.");
+    assert!(!shown.contains("<|"));
+}
+
+#[test]
+fn muse_cli_render_is_inert_for_plain_text() {
+    assert_eq!(
+        render_muse_channels_for_display("plain answer", false, false),
+        None
+    );
+}
+
 fn atem_block(body: &str) -> String {
     format!("<atem:function_calls>\n{body}</atem:function_calls>")
 }

--- a/src/server/tool_calls/mod.rs
+++ b/src/server/tool_calls/mod.rs
@@ -26,6 +26,7 @@ pub mod parser;
 pub mod stream_filter;
 pub mod types;
 
+pub use atem::render_muse_channels_for_display;
 pub use parser::{clean_structural_tokens, generate_tool_call_id, parse_tool_calls};
 pub use types::{ParsedToolCall, ToolCallFormat, ToolCallParseResult};
 

--- a/src/vision/encoders/muse_glimmer_fusion.rs
+++ b/src/vision/encoders/muse_glimmer_fusion.rs
@@ -15,11 +15,10 @@
 //! Muse Glimmer post-tower visual-token fusion.
 
 use crate::models::muse_glimmer::MuseGlimmerConfig;
-use mlxcel_core::layers::Linear;
+use mlxcel_core::layers::UnifiedLinear;
 use mlxcel_core::weights::WeightMap;
 use mlxcel_core::{MlxArray, UniquePtr};
 
-use super::muse_glimmer_layers::{BiasMode, load_linear};
 use super::qwen2_vl::concat_many;
 
 pub const MUSE_GLIMMER_VISION_ADAPTER_ROOT: &str = "model.vision_adapter";
@@ -27,7 +26,7 @@ pub const MUSE_GLIMMER_VISION_PROJECTION_ROOT: &str = "model.vision_projection";
 
 pub struct MuseGlimmerVisionFusion {
     adapter: MuseGlimmerVisionAdapter,
-    projection: Linear,
+    projection: UnifiedLinear,
     merge_size: usize,
     tower_hidden_size: usize,
     norm_eps: f32,
@@ -47,12 +46,13 @@ impl MuseGlimmerVisionFusion {
         }
 
         let adapter = MuseGlimmerVisionAdapter::from_weights(weights, config)?;
-        let projection = load_linear(
+        let projection = load_fusion_linear(
             weights,
             MUSE_GLIMMER_VISION_PROJECTION_ROOT,
-            BiasMode::Forbidden,
+            config.text_config.group_size(),
+            config.text_config.bits(),
         )?;
-        let projection_shape = mlxcel_core::array_shape(&projection.weight);
+        let projection_shape = unified_linear_shape(&projection)?;
         let expected_projection = vec![
             config.text_config.hidden_size as i32,
             config.projector_hidden_size as i32,
@@ -90,21 +90,23 @@ impl MuseGlimmerVisionFusion {
 }
 
 pub struct MuseGlimmerVisionAdapter {
-    fc1: Linear,
-    fc2: Linear,
+    fc1: UnifiedLinear,
+    fc2: UnifiedLinear,
 }
 
 impl MuseGlimmerVisionAdapter {
     pub fn from_weights(weights: &WeightMap, config: &MuseGlimmerConfig) -> Result<Self, String> {
-        let fc1 = load_linear(
+        let fc1 = load_fusion_linear(
             weights,
             &format!("{MUSE_GLIMMER_VISION_ADAPTER_ROOT}.fc1"),
-            BiasMode::Forbidden,
+            config.text_config.group_size(),
+            config.text_config.bits(),
         )?;
-        let fc2 = load_linear(
+        let fc2 = load_fusion_linear(
             weights,
             &format!("{MUSE_GLIMMER_VISION_ADAPTER_ROOT}.fc2"),
-            BiasMode::Forbidden,
+            config.text_config.group_size(),
+            config.text_config.bits(),
         )?;
         check_linear_shape(
             &fc1,
@@ -212,8 +214,45 @@ pub fn weightless_perception_norm(hidden_states: &MlxArray, eps: f32) -> UniqueP
     mlxcel_core::fast_rms_norm_no_weight(hidden_states, eps)
 }
 
-fn check_linear_shape(linear: &Linear, expected: &[i32], label: &str) -> Result<(), String> {
-    let actual = mlxcel_core::array_shape(&linear.weight);
+fn load_fusion_linear(
+    weights: &WeightMap,
+    prefix: &str,
+    group_size: i32,
+    bits: i32,
+) -> Result<UnifiedLinear, String> {
+    if weights.contains_key(&format!("{prefix}.bias")) {
+        return Err(format!(
+            "Muse Glimmer vision fusion linear must not have bias: {prefix}.bias"
+        ));
+    }
+    UnifiedLinear::from_weights(weights, prefix, group_size, bits)
+}
+
+fn unified_linear_shape(linear: &UnifiedLinear) -> Result<Vec<i32>, String> {
+    match linear {
+        UnifiedLinear::Regular(linear) => Ok(mlxcel_core::array_shape(&linear.weight)),
+        UnifiedLinear::Quantized { weight, .. } => {
+            let packed = mlxcel_core::array_shape(&weight.weight);
+            let scales = mlxcel_core::array_shape(&weight.scales);
+            if packed.len() != 2 || scales.len() != 2 || packed[0] != scales[0] {
+                return Err(format!(
+                    "Muse Glimmer quantized vision fusion linear has inconsistent weight/scales shapes: weight={packed:?}, scales={scales:?}"
+                ));
+            }
+            let logical_input = i64::from(scales[1]) * i64::from(weight.group_size);
+            let logical_input = i32::try_from(logical_input).map_err(|_| {
+                format!(
+                    "Muse Glimmer quantized vision fusion input width overflows i32: {} * {}",
+                    scales[1], weight.group_size
+                )
+            })?;
+            Ok(vec![packed[0], logical_input])
+        }
+    }
+}
+
+fn check_linear_shape(linear: &UnifiedLinear, expected: &[i32], label: &str) -> Result<(), String> {
+    let actual = unified_linear_shape(linear)?;
     if actual != expected {
         return Err(format!(
             "{label} weight must be {expected:?}, got {actual:?}"


### PR DESCRIPTION
## Summary

- Support the pinned `mlx-community/Muse-Glimmer-30B-4bit` affine-Q4 checkpoint while preserving the canonical BF16 path and dense vision tower.
- Normalize mlx-vlm weight roots, inherit the root quantization contract into the text configuration, and load text plus vision-fusion projections through quantization-aware layers.
- Reuse the server ATEM channel parser in one-shot CLI generation so `to=self` reasoning and structural tokens stay hidden by default while `to=user` content remains visible.
- Document the pinned revision, checkpoint layout, unsupported paths, and real NVIDIA GB10 qualification results.

## Security review

- Reject conflicting root/nested quantization contracts, unsupported or non-string modes, invalid group-size/bit combinations, alias collisions, orphan sidecars, missing affine biases, global-scale sidecars, and quantized vision-tower tensors before kernel selection.
- Apply identical checkpoint validation to both VLM and text-only loading so malformed metadata cannot bypass the multimodal boundary or be inferred as another block-float format.
- Keep checkpoint-format support fail-closed to the pinned affine-Q4 layout; this change adds no dependency, network, authentication, filesystem-write, shell-command, or unsafe-code surface.
- Reviewed the output-channel path for reasoning disclosure and bounded behavior; it delegates to the existing server parser and changes only local CLI presentation.

## Validation

- `cargo fmt --all --check`
- `env -u MLXCEL_BACKEND cargo clippy --fix --allow-dirty --lib --bins -- -D warnings`
- `env -u MLXCEL_BACKEND cargo test --quiet muse_ --lib` — 100 passed
- `cargo test --quiet --bin mlxcel top_level_help_mentions_muse_glimmer_limits` — passed
- `cargo test --quiet --bin mlxcel supported_models_output_describes_muse_glimmer_baseline` — passed
- `env -u MLXCEL_BACKEND MLX_CUDA_ARCHITECTURES=121 cargo build --release --features cuda --bin mlxcel` — passed
- Exact-source real-checkpoint rerun on NVIDIA GB10 loaded the pinned Q4 model in 0.480s, printed only `The capital of France is Paris.`, prefilling at 11.41 tok/s and decoding at 13.07 tok/s.

## Performance and compatibility

- Warm text qualification reached 12.43 prefill tok/s and 13.34 decode tok/s; the image path inserted 64 vision tokens, described the orange-red test image correctly, and decoded at 13.15 tok/s.
- The Q4 text decode rate is approximately 3.1x the recorded BF16 baseline of 4.25 tok/s on the same GB10.
- Scope remains single-process pinned BF16/affine-Q4 Muse inference. Video, quantized vision tower, Turbo/INT8 KV, speculative/DFlash, LoRA/adapters, TP/PP, XLA/IREE/OpenXLA, distributed, and disaggregated paths remain unsupported.

Follow-up to #1101.
