### PR TITLE
docs: explain CLI DRY runs without sequence breakers

### DIFF
--- a/src/commands/generate.rs
+++ b/src/commands/generate.rs
@@ -909,6 +909,16 @@ fn resolved_cli_sampling_params(
         dry_base: args.sampling.dry_base,
         dry_allowed_length: args.sampling.dry_allowed_length,
         dry_penalty_last_n: args.sampling.dry_penalty_last_n,
+        // The CLI runs DRY with no sequence breakers. This is a deliberate scope
+        // decision, not an oversight, and it differs in kind from the four
+        // "feature off" defaults below it. Those four are genuinely off because
+        // the CLI has no flag that could turn them on; this one is not, because
+        // the CLI does expose `--dry-multiplier`, so DRY can be switched on and
+        // then the empty vector is an unchangeable configuration rather than a
+        // disabled feature. With no breakers the backward match never stops at a
+        // newline or punctuation boundary, so `match_len` keeps growing and the
+        // penalty is stronger than the same nominal settings produce on the
+        // server, whose `--dry-sequence-breakers` has no CLI equivalent.
         dry_sequence_breakers: Vec::new(),
         frequency_penalty: 0.0,
         presence_penalty: 0.0,

--- a/src/main.rs
+++ b/src/main.rs
@@ -609,7 +609,9 @@ pub(crate) struct SamplingOptions {
     #[arg(long, default_value_t = 1.0, value_name = "FLOAT")]
     pub(crate) repetition_penalty: f32,
 
-    /// DRY (Don't Repeat Yourself) penalty multiplier (0.0 = disabled)
+    /// DRY (Don't Repeat Yourself) penalty multiplier (0.0 = disabled).
+    /// CLI DRY matches across all boundaries; the server's
+    /// `--dry-sequence-breakers` has no CLI equivalent.
     #[arg(long, default_value_t = 0.0, value_name = "FLOAT")]
     pub(crate) dry_multiplier: f32,
 


### PR DESCRIPTION
## Summary

The CLI exposes `--dry-multiplier`, so DRY can be switched on from the command line, but `resolved_cli_sampling_params` hardcodes `dry_sequence_breakers: Vec::new()`. With no breakers the backward match never stops at a newline or punctuation boundary, so `match_len` keeps growing and the penalty is stronger than the same nominal settings produce on the server. Neither the help text nor the code said so, so a user tuning `--dry-multiplier` with `mlxcel run` and then deploying those numbers to `mlxcel-server` got different behavior from identical values with nothing explaining why.

This is the documentation fix the issue settled on after investigation, not the feature. No `--dry-sequence-breakers` CLI flag is added, and there is no behavior change.

## What changed

- `src/commands/generate.rs`: comment above `dry_sequence_breakers: Vec::new()` recording that the CLI runs DRY without sequence breakers as a deliberate scope decision, and why it differs in kind from the four neighbouring "feature off" defaults. Those four (`frequency_penalty`, `presence_penalty`, `xtc_probability`, `xtc_threshold`) are genuinely off because the CLI has no flag that could enable them. This one is not, because `--dry-multiplier` can switch DRY on, at which point the empty vector is an unchangeable configuration rather than a disabled feature.
- `src/main.rs`: one sentence added to the `--dry-multiplier` clap help on `SamplingOptions`, stating that CLI DRY matches across all boundaries and that the server's `--dry-sequence-breakers` has no CLI equivalent.

## Notes

`SamplingOptions` is flattened into both `GenerateArgs` and `RunArgs`, and the chat path shares the same `SamplingConfig` assembly, so the one help-text sentence covers `mlxcel generate`, `mlxcel run`, and `mlxcel chat`. The second `dry_multiplier` field in `src/main.rs` belongs to `ServeArgs`, which already exposes `--dry-sequence-breakers` as its own flag; it is the server side of the very asymmetry being documented and is intentionally left untouched.

The user-facing sentence went into the clap help rather than a file under `docs/` to keep the change inside `src/`.

## Test plan

- [x] `cargo fmt --check` clean
- [x] `python3 scripts/ci/check_cross_repo_refs.py` passes (no bare `#NNN` added)
- [x] Diff reviewed as comment-and-help-text-only: 13 added lines, all `//` comment or `///` doc-comment lines, no executable statement changed

Compilation was not run in this worktree, which has no `target/` directory and would trigger a full MLX source build. The diff changes no executable line; multi-line doc comments on clap fields are already used in this same struct (for example `seed`), so the pattern is established.

Closes #1108
