### PR TITLE
docs: fix stale cross-references left behind by earlier renames

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,6 +1,6 @@
 <!--
 Thanks for opening a pull request! Please fill out the sections below.
-For the full contributor contract see AGENTS.md and CONTRIBUTING.md.
+For the full contributor contract see CONTRIBUTING.md and docs/code-guidelines.md.
 -->
 
 ## Summary

--- a/TECHNICAL_REPORTS/1120-stale-cross-reference-fixes-20260814.en.md
+++ b/TECHNICAL_REPORTS/1120-stale-cross-reference-fixes-20260814.en.md
@@ -1,0 +1,119 @@
+# Technical Report: PR #1120 - docs: fix stale cross-references left behind by earlier renames
+
+**Date**: 2026-08-14
+**Status**: Completed
+**Languages**: Markdown, Rust (comment only)
+**Risk Level**: Low
+
+---
+
+## Executive Summary
+
+PR #1120 closes issue #1106 by repairing four documentation references that earlier renames left pointing at things that no longer exist or no longer describe the tree: the pull request template's link to a deleted `AGENTS.md`, the same dead pointer in a `tests/surgery_cli.rs` doc comment, two `v0.0.27` version stamps in `docs/`, and a missing index entry in `docs/README.md`.
+
+No code or behavior changes. The one `.rs` file in the diff is a rustdoc comment on a constant; the constant's value is untouched.
+
+---
+
+## 1. Problem Statement
+
+### 1.1 Background
+
+Three independent staleness bugs accumulated in documentation that no CI check validates. Each is one line, each is verifiable on its own, and each misleads a reader in a different way.
+
+### 1.2 Existing Issues
+
+- **Dead `AGENTS.md` pointer.** `.github/PULL_REQUEST_TEMPLATE.md:3` sent every first-time contributor to a file that does not exist in a checkout. `AGENTS.md` is listed in `.gitignore` alongside the other local-only working files, so it is a local file by design and no clone has one. `CHANGELOG.md` records that PR #1014 replaced the dead `AGENTS.md` links in `CONTRIBUTING.md`; that pass missed the template, which is the highest-traffic surface of the three. A repo-wide grep during this work found a fourth site the issue had not listed: the doc comment on `REFERENCE_MODEL` in `tests/surgery_cli.rs`.
+- **Version stamps at `v0.0.27`.** `docs/supported-models.md` opened with "model-family support in the v0.0.27 source tree" and `docs/turbo-kv-cache.md` prefixed its allowlist with "As of v0.0.27". The workspace is at `0.5.0-beta.1`. `supported-models.md` is the page both `README.md` and `CONTRIBUTING.md` send readers to for the support matrix, so the stamp advertises the page as many releases out of date.
+- **Incomplete index.** `docs/README.md` enumerated 18 documents while `docs/` holds 19 non-README `.md` files. The unindexed one was `code-guidelines.md`, one of the three core contract documents `CONTRIBUTING.md` names; the other two, `architecture.md` and `adding-models.md`, were both already listed.
+
+### 1.3 Risk Assessment
+
+| Risk | Impact | Likelihood |
+|---|---|---|
+| Contributor cannot find the contributor contract from the PR template | Medium | High |
+| Reader discards a current support matrix as obsolete because of its stamp | Medium | Medium |
+| Contributor never finds `code-guidelines.md` and ships a JIT kernel without dtype in its cache key | Medium | Low |
+
+---
+
+## 2. Technical Review
+
+### 2.1 Correctness
+
+The `v0.0.27` fix was checked to be a stamp problem and not a content problem before the stamps were removed. The three allowlisted model-type prefixes `docs/turbo-kv-cache.md` lists (`qwen3_5`, `qwen3_5_moe`, `qwen3_next`) were compared against `ALLOWED_SYMMETRIC_TURBO_FAMILIES` in `src/lib/mlxcel-core/src/cache/turbo/allowlist.rs` and match exactly, so nothing behind either stamp needed rewriting.
+
+The index fix was checked by arithmetic rather than by eye: the sorted basenames of `ls docs/*.md` minus `README.md` are now byte-identical to the sorted filenames extracted from the numbered list, 19 entries on each side.
+
+### 2.2 Scope Containment
+
+Issue #1106's acceptance criterion 4 is "docs only; no code or behavior change." Criterion 1 is "no reference to `AGENTS.md` remains outside `CHANGELOG.md`." The `tests/surgery_cli.rs` occurrence sits between the two: satisfying criterion 1 requires touching a `.rs` file. The edit is confined to rustdoc comment prose on a `const`, so criterion 4 holds in substance. `rustfmt` leaves comments alone by default (`wrap_comments` is off), so `cargo fmt --all -- --check` is unaffected, and the file is gated behind `#![cfg(feature = "surgery")]` in any case.
+
+The two `AGENTS.md` mentions that remain are both deliberate: the three `CHANGELOG.md` entries are historical records the issue explicitly preserves, and the `.gitignore` line is an ignore pattern, not a cross-reference.
+
+---
+
+## 3. Technical Decisions
+
+### 3.1 Drop the Version Stamps Instead of Bumping Them
+
+| Option | Pros | Cons |
+|---|---|---|
+| Bump both to `0.5.0-beta.1` | Accurate today | Nothing verifies it, so it goes stale at the next release |
+| **Chosen: remove the stamp, strengthen the code pointer** | Cannot go stale; readers are sent to the authority | Loses the "as of" signal for anyone who wanted a snapshot date |
+
+`docs/supported-models.md` already carried a "the runtime source of truth is the code" block naming four source paths, so removing its stamp left the page pointing somewhere durable with no further edit. `docs/turbo-kv-cache.md` named `allowlist.rs` but did not say it was authoritative, so the removed stamp is replaced by that claim: "which is the source of truth for this list."
+
+### 3.2 Point the PR Template at Two Documents
+
+`AGENTS.md` was refactored into focused reference docs (`CHANGELOG.md` records the 313 to 75 line split). The contract it used to hold now lives in `CONTRIBUTING.md` and `docs/code-guidelines.md`, and `CONTRIBUTING.md` links the latter. The template's own checklist already cites `docs/code-guidelines.md` by that exact path, so naming both keeps the header consistent with the body.
+
+---
+
+## 4. Change Summary
+
+### Statistics
+
+| Item | Value |
+|---|---|
+| Files changed | 5 |
+| Lines added | +9 |
+| Lines deleted | -7 |
+| Tests added | 0 |
+
+### Changes by Area
+
+| Area | Files | Summary |
+|---|---|---|
+| Contributor onboarding | `.github/PULL_REQUEST_TEMPLATE.md` | Dead `AGENTS.md` pointer repointed at `CONTRIBUTING.md` and `docs/code-guidelines.md` |
+| Documentation accuracy | `docs/supported-models.md`, `docs/turbo-kv-cache.md` | `v0.0.27` stamps removed; allowlist section gains an explicit source-of-truth pointer |
+| Documentation index | `docs/README.md` | `code-guidelines.md` added as item 19 |
+| Comment hygiene | `tests/surgery_cli.rs` | Dead `AGENTS.md` pointer removed from the `REFERENCE_MODEL` doc comment |
+
+### Related Commits
+
+| Hash | Type | Message |
+|---|---|---|
+| `e251af08` | docs | docs: fix stale cross-references left behind by earlier renames |
+
+---
+
+## 5. Validation and Follow-up
+
+### Passed
+
+- `python3 scripts/ci/check_cross_repo_refs.py` (no bare 3+-digit `#NNN` added).
+- `cargo fmt --all -- --check`.
+- Repo-wide `grep -rn "AGENTS\.md"`: only the three `CHANGELOG.md` history entries and the `.gitignore` pattern remain.
+- `grep -rn "v0\.0\.27" docs/`: no matches.
+- Sorted diff of `ls docs/*.md` basenames against the `docs/README.md` numbered list: identical, 19 entries.
+- CI on PR #1120: crate versions, kernel dtype keys, cross-repo refs, cargo-deny, cargo-fmt all green.
+
+### Related Work
+
+- Issue #1110 is amending the body of `docs/code-guidelines.md` concurrently. This PR only adds an index entry naming that file and does not touch its contents, so the two do not overlap.
+- Issue #1111 amends the "Expected future layout examples" block a few lines below the new item 19 in `docs/README.md`, and is sequenced after this PR for that reason.
+
+### Not Addressed
+
+The stamps are gone, but nothing prevents a future writer from adding a new one. There is no CI check that a document's claims about the code still hold; the mitigation here is structural, naming the code as the authority so the prose has less to go stale about.

--- a/TECHNICAL_REPORTS/1120-stale-cross-reference-fixes-20260814.ko.md
+++ b/TECHNICAL_REPORTS/1120-stale-cross-reference-fixes-20260814.ko.md
@@ -1,0 +1,119 @@
+# 기술 보고서: PR #1120 - docs: fix stale cross-references left behind by earlier renames
+
+**작성일**: 2026-08-14
+**상태**: 완료
+**언어**: Markdown, Rust (주석만)
+**위험도**: Low
+
+---
+
+## 요약
+
+PR #1120은 이슈 #1106을 해결한다. 과거 리네임 작업이 남긴 네 곳의 문서 참조를 고쳤다. 삭제된 `AGENTS.md`를 가리키던 PR 템플릿, 같은 죽은 참조가 남아 있던 `tests/surgery_cli.rs` 문서 주석, `docs/` 아래 두 곳의 `v0.0.27` 버전 스탬프, 그리고 `docs/README.md` 목차에서 빠져 있던 항목이다.
+
+코드 변경과 동작 변경은 없다. diff에 포함된 `.rs` 파일 하나는 상수에 달린 rustdoc 주석이며, 상수 값 자체는 그대로다.
+
+---
+
+## 1. 문제 정의
+
+### 1.1 배경
+
+CI가 검증하지 않는 문서 영역에 서로 독립적인 staleness 버그 세 건이 쌓였다. 각각 한 줄짜리이고, 각각 독립적으로 검증 가능하며, 각각 다른 방식으로 독자를 오도한다.
+
+### 1.2 기존 문제점
+
+- **죽은 `AGENTS.md` 참조.** `.github/PULL_REQUEST_TEMPLATE.md:3`이 첫 기여자 전원을 체크아웃에 존재하지 않는 파일로 안내하고 있었다. `AGENTS.md`는 `.gitignore`에 다른 로컬 전용 작업 파일들과 함께 등재되어 있다. 즉 설계상 로컬 파일이며 어떤 clone에도 존재하지 않는다. `CHANGELOG.md`는 PR #1014가 `CONTRIBUTING.md`의 죽은 `AGENTS.md` 링크를 교체했다고 기록하지만, 그 작업은 세 표면 중 트래픽이 가장 많은 템플릿을 놓쳤다. 이번 작업에서 저장소 전체 grep으로 이슈가 열거하지 않은 네 번째 지점도 찾았다. `tests/surgery_cli.rs`의 `REFERENCE_MODEL` 문서 주석이다.
+- **`v0.0.27` 버전 스탬프.** `docs/supported-models.md`는 "model-family support in the v0.0.27 source tree"로 시작했고, `docs/turbo-kv-cache.md`는 allowlist 앞에 "As of v0.0.27"을 달고 있었다. 워크스페이스 버전은 `0.5.0-beta.1`이다. `supported-models.md`는 `README.md`와 `CONTRIBUTING.md`가 모두 지원 매트릭스를 보라고 안내하는 페이지이므로, 이 스탬프는 페이지 전체를 여러 릴리스 뒤처진 문서처럼 보이게 만든다.
+- **불완전한 목차.** `docs/README.md`는 18개 문서를 열거했지만 `docs/`에는 README를 제외한 `.md` 파일이 19개 있다. 빠진 항목은 `code-guidelines.md`로, `CONTRIBUTING.md`가 지목하는 세 개의 핵심 계약 문서 중 하나다. 나머지 둘인 `architecture.md`와 `adding-models.md`는 이미 목차에 있었다.
+
+### 1.3 위험성
+
+| 위험 | 영향도 | 발생 가능성 |
+|---|---|---|
+| 기여자가 PR 템플릿에서 기여 계약 문서를 찾지 못함 | Medium | High |
+| 스탬프 때문에 현재 유효한 지원 매트릭스를 낡은 문서로 판단해 무시함 | Medium | Medium |
+| 기여자가 `code-guidelines.md`를 끝내 찾지 못하고 dtype이 캐시 키에 빠진 JIT 커널을 머지함 | Medium | Low |
+
+---
+
+## 2. 기술적 검토 사항
+
+### 2.1 정확성
+
+`v0.0.27` 수정은 스탬프를 제거하기 전에 이것이 내용 문제가 아니라 스탬프 문제임을 먼저 확인했다. `docs/turbo-kv-cache.md`가 열거한 세 개의 allowlist model-type prefix(`qwen3_5`, `qwen3_5_moe`, `qwen3_next`)를 `src/lib/mlxcel-core/src/cache/turbo/allowlist.rs`의 `ALLOWED_SYMMETRIC_TURBO_FAMILIES`와 대조한 결과 정확히 일치했다. 두 스탬프 뒤의 내용은 다시 쓸 필요가 없었다.
+
+목차 수정은 눈으로가 아니라 산술로 확인했다. `README.md`를 제외한 `ls docs/*.md`의 basename 정렬 결과와 번호 목록에서 추출한 파일명 정렬 결과가 이제 양쪽 모두 19개로 완전히 동일하다.
+
+### 2.2 범위 통제
+
+이슈 #1106의 수용 기준 4는 "docs only; no code or behavior change"이고, 기준 1은 "`CHANGELOG.md` 밖에 `AGENTS.md` 참조가 남아 있지 않을 것"이다. `tests/surgery_cli.rs`의 참조는 두 기준 사이에 놓인다. 기준 1을 만족하려면 `.rs` 파일을 건드려야 한다. 수정은 `const`에 달린 rustdoc 주석 문장으로 한정했으므로 기준 4도 실질적으로 유지된다. `rustfmt`는 기본값에서 주석을 재정렬하지 않으므로(`wrap_comments`가 off) `cargo fmt --all -- --check`에 영향이 없고, 해당 파일은 어차피 `#![cfg(feature = "surgery")]` 뒤에 있다.
+
+남아 있는 `AGENTS.md` 언급 두 종류는 모두 의도적이다. `CHANGELOG.md`의 세 항목은 이슈가 명시적으로 보존하라고 한 기록이고, `.gitignore` 한 줄은 참조가 아니라 ignore 패턴이다.
+
+---
+
+## 3. 기술적 선택과 그 이유
+
+### 3.1 버전 스탬프를 올리지 않고 제거
+
+| 옵션 | 장점 | 단점 |
+|---|---|---|
+| 양쪽을 `0.5.0-beta.1`로 갱신 | 오늘 기준으로는 정확 | 아무도 검증하지 않으므로 다음 릴리스에 다시 낡음 |
+| **선택: 스탬프 제거 후 코드 포인터 강화** | 낡을 수 없고, 독자를 권위 있는 출처로 보냄 | 스냅샷 시점을 알고 싶던 독자는 "as of" 신호를 잃음 |
+
+`docs/supported-models.md`에는 이미 소스 경로 네 개를 지목하는 "the runtime source of truth is the code" 블록이 있어서, 스탬프만 제거해도 페이지가 지속 가능한 대상을 가리키게 되고 추가 편집이 필요 없었다. `docs/turbo-kv-cache.md`는 `allowlist.rs`를 언급하되 그것이 권위 있는 출처라고는 말하지 않았으므로, 제거한 스탬프 자리에 그 주장을 넣었다. "which is the source of truth for this list."
+
+### 3.2 PR 템플릿이 두 문서를 가리키게 함
+
+`AGENTS.md`는 이미 focused reference docs로 분해되었다(`CHANGELOG.md`가 313줄에서 75줄로 줄인 분할을 기록하고 있다). 그것이 담고 있던 계약은 이제 `CONTRIBUTING.md`와 `docs/code-guidelines.md`에 있고, `CONTRIBUTING.md`가 후자를 링크한다. 템플릿의 체크리스트가 이미 `docs/code-guidelines.md`를 정확히 그 경로로 인용하고 있으므로, 헤더에서 둘을 함께 지목하면 본문과 일관된다.
+
+---
+
+## 4. 변경 요약
+
+### 통계
+
+| 항목 | 값 |
+|---|---|
+| 변경된 파일 수 | 5 |
+| 추가된 라인 | +9 |
+| 삭제된 라인 | -7 |
+| 테스트 추가 | 0 |
+
+### 영역별 변경
+
+| 영역 | 파일 | 주요 내용 |
+|---|---|---|
+| 기여자 온보딩 | `.github/PULL_REQUEST_TEMPLATE.md` | 죽은 `AGENTS.md` 참조를 `CONTRIBUTING.md`와 `docs/code-guidelines.md`로 재지정 |
+| 문서 정확성 | `docs/supported-models.md`, `docs/turbo-kv-cache.md` | `v0.0.27` 스탬프 제거, allowlist 절에 source-of-truth 포인터 추가 |
+| 문서 목차 | `docs/README.md` | `code-guidelines.md`를 19번 항목으로 추가 |
+| 주석 정리 | `tests/surgery_cli.rs` | `REFERENCE_MODEL` 문서 주석에서 죽은 `AGENTS.md` 참조 제거 |
+
+### 관련 커밋
+
+| Hash | Type | Message |
+|---|---|---|
+| `e251af08` | docs | docs: fix stale cross-references left behind by earlier renames |
+
+---
+
+## 5. 검증 및 후속 조치
+
+### 통과
+
+- `python3 scripts/ci/check_cross_repo_refs.py` (새로 추가된 3자리 이상 bare `#NNN` 없음).
+- `cargo fmt --all -- --check`.
+- 저장소 전체 `grep -rn "AGENTS\.md"`: `CHANGELOG.md`의 기록 세 건과 `.gitignore` 패턴만 남음.
+- `grep -rn "v0\.0\.27" docs/`: 매치 없음.
+- `ls docs/*.md` basename 정렬 결과와 `docs/README.md` 번호 목록의 정렬 diff: 동일, 양쪽 19개.
+- PR #1120 CI: crate versions, kernel dtype keys, cross-repo refs, cargo-deny, cargo-fmt 전부 green.
+
+### 관련 작업
+
+- 이슈 #1110이 `docs/code-guidelines.md` 본문을 동시에 수정하고 있다. 이 PR은 그 파일을 지목하는 목차 항목만 추가하고 내용은 건드리지 않으므로 충돌하지 않는다.
+- 이슈 #1111은 `docs/README.md`에서 새 19번 항목 몇 줄 아래의 "Expected future layout examples" 블록을 수정한다. 그 때문에 이 PR 다음 순서로 배치했다.
+
+### 처리하지 않은 것
+
+스탬프는 사라졌지만, 앞으로 누군가 새 스탬프를 다는 것을 막는 장치는 없다. 문서의 주장이 코드와 여전히 일치하는지 검사하는 CI는 없다. 이번 완화책은 구조적인 것으로, 코드를 권위 있는 출처로 지목해 산문이 낡을 여지 자체를 줄이는 방식이다.

--- a/docs/README.md
+++ b/docs/README.md
@@ -31,6 +31,7 @@ Current GitHub-facing docs:
 16. `mla-absorbed-decode.md` — DeepSeek-family matrix-absorbed MLA decode over a compressed-latent KV cache: the identity, the cache layout, the flags, and what is and is not verified.
 17. `cascade-attention.md` — shared-prompt-prefix (cascade) decode: computing a prefix shared by several concurrent sequences once per step instead of once per sequence, the two-level decomposition, the flags, and how to tell which path a launch took.
 18. `sparse-paged-decode.md` — sparse attention reduced to page indirection over the fused v2 decode kernel: the addressing argument, the MiniMax-M3 routing, why DeepSeek Sparse Attention is not routed, where the dispatch floor sits, the kill switch, and the benchmark harness.
+19. `code-guidelines.md`: the `// Used by:` annotation convention for shared functions, and the JIT kernel rule that every varying input dtype must appear in `template_args` because CUDA keys the compiled-module cache on it.
 
 ## Architecture Decision Records
 

--- a/docs/supported-models.md
+++ b/docs/supported-models.md
@@ -1,7 +1,7 @@
 # Supported models
 
-This page summarizes model-family support in the v0.0.27 source tree. The
-runtime source of truth is the code, not this prose page:
+This page summarizes model-family support in the source tree. The runtime
+source of truth is the code, not this prose page:
 
 - detection: `src/models/detection.rs`
 - `ModelType` enum and module exports: `src/models/mod.rs`

--- a/docs/turbo-kv-cache.md
+++ b/docs/turbo-kv-cache.md
@@ -163,8 +163,9 @@ the runtime. The flag is inert for `fp16` and `int8` cache modes.
 ## Symmetric Turbo4 allowlist
 
 K-side quantization can strongly affect softmax quality. The code therefore has
-an allowlist helper in `src/lib/mlxcel-core/src/cache/turbo/allowlist.rs`.
-As of v0.0.27, the hard-coded allowlisted model-type prefixes are:
+an allowlist helper in `src/lib/mlxcel-core/src/cache/turbo/allowlist.rs`, which
+is the source of truth for this list. The hard-coded allowlisted model-type
+prefixes are:
 
 - `qwen3_5`
 - `qwen3_5_moe`

--- a/tests/surgery_cli.rs
+++ b/tests/surgery_cli.rs
@@ -38,8 +38,8 @@ use std::process::Command;
 
 /// Reference model directory used for the bit-exactness check. Chosen
 /// because it is small (~0.5 B parameters), quantized (no bf16
-/// conversion to worry about), and is one of the recommended test
-/// models in `AGENTS.md`.
+/// conversion to worry about), and is one of the standard local
+/// smoke-test checkpoints.
 const REFERENCE_MODEL: &str = "models/qwen2.5-0.5b-4bit";
 
 /// Locate the freshly built `mlxcel` binary under `target/`.


### PR DESCRIPTION
## Summary

Three independent one-line documentation staleness fixes from #1106, plus one dangling reference that acceptance criterion 1 turned up outside the three named sites. No code or behavior change.

## What changed

**7a. `.github/PULL_REQUEST_TEMPLATE.md`** told first-time contributors to read `AGENTS.md`, which does not exist in a checkout (it is gitignored alongside the other local agent files). PR #1014 replaced the dead links in `CONTRIBUTING.md` but missed the template, which is the surface every contributor sees first. It now points at `CONTRIBUTING.md` and `docs/code-guidelines.md`.

**7a follow-on. `tests/surgery_cli.rs`** carried the same dead `AGENTS.md` pointer in the doc comment on `REFERENCE_MODEL`. Acceptance criterion 1 ("no reference to `AGENTS.md` remains outside `CHANGELOG.md`") covers it, so the comment is reworded. Comment text only: no code, no behavior, no test change. The remaining `AGENTS.md` occurrences are the three historical `CHANGELOG.md` entries, which stay, and the `.gitignore` pattern, which is intentional and not a cross-reference.

**7b. `docs/supported-models.md` and `docs/turbo-kv-cache.md`** both stamped themselves as describing the `v0.0.27` source tree while the workspace is at `0.5.0-beta.1`. The stamps are dropped rather than bumped, per the issue's reasoning: a stamp nothing verifies goes stale again, and both pages already name the code as the source of truth. This is a stamp change only. The three allowlisted prefixes `turbo-kv-cache.md` lists (`qwen3_5`, `qwen3_5_moe`, `qwen3_next`) still match `ALLOWED_SYMMETRIC_TURBO_FAMILIES` in `src/lib/mlxcel-core/src/cache/turbo/allowlist.rs` exactly, so nothing behind either stamp needed rewriting. The allowlist section gains an explicit pointer to that file as the source of truth in place of the stamp.

**7c. `docs/README.md`** enumerated 18 documents while `docs/` holds 19 non-README `.md` files. The missing entry, `code-guidelines.md`, is one of the three core contract documents `CONTRIBUTING.md` names, and the only one of the three that was unindexed. It is added as item 19, described by its two rules: the `// Used by:` shared-function convention and the JIT kernel dtype cache-key requirement.

## Test plan

- [x] `python3 scripts/ci/check_cross_repo_refs.py` passes
- [x] `cargo fmt --all -- --check` passes
- [x] No `AGENTS.md` reference remains outside `CHANGELOG.md` (verified by repo-wide grep; `.gitignore` pattern excluded as intentional)
- [x] No `v0.0.27` reference remains under `docs/` (verified by grep)
- [x] `ls docs/*.md` and the `docs/README.md` numbered list agree exactly, 19 entries each (verified by sorted diff)

Closes #1106
