### PR TITLE
docs: add technical reports for PRs #1118, #1119 and #1121

### DIFF
--- a/TECHNICAL_REPORTS/1118-cli-dry-sequence-breakers-20260814.en.md
+++ b/TECHNICAL_REPORTS/1118-cli-dry-sequence-breakers-20260814.en.md
@@ -1,0 +1,121 @@
+# Technical Report: PR #1118 - docs: explain CLI DRY runs without sequence breakers
+
+**Date**: 2026-08-14
+**Author**: Jeongkyu Shin
+**Status**: Completed
+**Languages**: Rust (comment and clap help only)
+**Risk Level**: Low
+
+---
+
+## Executive Summary
+
+PR #1118 closes issue #1108. The CLI exposes `--dry-multiplier`, so DRY can be switched on from the command line, but `resolved_cli_sampling_params` hardcodes `dry_sequence_breakers: Vec::new()`. With no breakers the backward match never stops at a newline or punctuation boundary, so `match_len` keeps growing and the penalty is stronger than the same nominal numbers produce on the server. Nothing said so, in the code or in the help text.
+
+This is the documentation fix the issue arrived at after investigation, not the feature the issue originally proposed. Thirteen added lines, all comment or doc-comment. No `--dry-sequence-breakers` CLI flag, no behavior change.
+
+---
+
+## 1. Problem Statement
+
+### 1.1 Background
+
+Issue #1108 began as a flag-parity request: the server has `--dry-sequence-breakers` and the CLI does not, so add it. The investigation recorded in the issue killed that framing. Comparing the CLI's `SamplingOptions` against the server's per-request sampling fields shows the CLI omits nine knobs, not one, including `frequency_penalty`, `presence_penalty`, `xtc_probability`, `xtc_threshold`, `logit_bias`, `repetition_context_size`, `stop` and the loop-detection fields. A narrow CLI sampling surface is therefore deliberate, and "the server has a flag the CLI lacks" is not on its own an argument for anything.
+
+### 1.2 Existing Issues
+
+- **One of the five hardcoded fields is not what the other four are.** `resolved_cli_sampling_params` hardcodes five sampling fields in a contiguous block. Four of them (`frequency_penalty: 0.0`, `presence_penalty: 0.0`, `xtc_probability: 0.0`, `xtc_threshold`) are honest "feature off" defaults: the feature really is off, because no CLI flag can turn it on. `dry_sequence_breakers: Vec::new()` is the exception, because `--dry-multiplier` can turn DRY on. Once it is on, the empty vector is not a disabled feature. It is the feature running in a configuration the user cannot change.
+- **The resulting behavior difference is invisible.** With no breakers, the backward match in `src/lib/mlxcel-core/src/sampling.rs` never terminates at a boundary, so `match_len` keeps growing and the penalty term is larger than the server produces from identical settings. A user who tunes `--dry-multiplier` with `mlxcel run` and then deploys those numbers to `mlxcel-server` gets different output from the same values, with nothing in either help text explaining why.
+- **The investigation itself was at risk of being lost.** Nothing in the code recorded that the empty vector is a scope decision. The next reader would have re-derived the entire nine-knob comparison to reach the same conclusion.
+
+### 1.3 Risk Assessment
+
+| Risk | Impact | Likelihood |
+|---|---|---|
+| Sampling values tuned on the CLI behave differently in production, and the difference is attributed to the model or the seed | Medium | Medium |
+| A future contributor reads the empty vector as an oversight and adds the flag without the scope discussion | Low | Medium |
+| A reader groups the DRY line with the four "feature off" neighbours and concludes DRY is off on the CLI | Low | Medium |
+
+---
+
+## 2. Technical Review
+
+### 2.1 The Diff Is Provably Non-Executable
+
+Thirteen added lines: ten `//` comment lines in `src/commands/generate.rs` and three `///` doc-comment lines in `src/main.rs` (two added, one existing line re-punctuated). No executable statement changed, no field value changed, no clap attribute changed. `cargo fmt --check` is clean, and `rustfmt` does not reflow comments at the project's settings.
+
+### 2.2 Coverage of the One Help Sentence
+
+`SamplingOptions` is flattened into both `GenerateArgs` and `RunArgs`, and the chat path shares the same `SamplingConfig` assembly. One sentence added to the `--dry-multiplier` help therefore covers `mlxcel generate`, `mlxcel run` and `mlxcel chat` without repetition. That coverage is why a single help string was sufficient and why no `docs/` page needed a parallel note.
+
+### 2.3 The Second `dry_multiplier` Was Deliberately Untouched
+
+`src/main.rs` has a second `dry_multiplier` field around line 1245, on `ServeArgs`. `ServeArgs` already exposes `--dry-sequence-breakers` sixteen lines below it. That field is the server side of the very asymmetry being documented, so appending the CLI caveat to it would have made the server's own help text describe a limitation the server does not have. It was left alone.
+
+---
+
+## 3. Technical Decisions
+
+### 3.1 Document the Asymmetry Instead of Removing It
+
+| Option | Pros | Cons |
+|---|---|---|
+| Add `--dry-sequence-breakers` to `SamplingOptions` | Removes the asymmetry outright | Expands a sampling surface that is deliberately a subset; needs tokenizer-time tokenization and a new unit gate; inert at the CLI's default `--temp 0.0` until #1102 lands, since the greedy branch of `build_sampling_config` drops the breakers |
+| Change the CLI default to the llama.cpp breaker set | Matches the widely expected behavior | A silent behavior change to existing CLI invocations, which is exactly what a docs issue must not ship |
+| **Chosen: comment plus one sentence of user-facing text** | Removes the surprise at zero behavior risk; records why the scope decision was made | The asymmetry itself remains, so the CLI still cannot express server-equivalent DRY |
+
+The issue explicitly left the flag available as a separate feature issue, including the acceptance shape it would need: a unit assertion that a parsed flag reaches `ResolvedSamplingParams.dry_sequence_breakers` as token IDs, rather than an output-diff assertion, which is model- and seed-dependent and makes a flaky gate. That path stays open; this PR does not foreclose it.
+
+### 3.2 Put the User-Facing Sentence in clap Help, Not in `docs/`
+
+The clap help is what a user sees at the moment they are choosing a `--dry-multiplier` value, which is the moment the surprise occurs. A `docs/` page is read earlier or not at all. Keeping the change inside `src/` also keeps it in the same file as the flag it qualifies, so a future flag change and its caveat cannot drift apart into separate files.
+
+### 3.3 Explain Why This Field Differs From Its Neighbours
+
+The comment does not just state that the CLI runs DRY without breakers. It states why that line is unlike the four beneath it: those are off because nothing can turn them on, and this one is not, because `--dry-multiplier` can. Without that contrast, the next reader has to redo the comparison to know whether the empty vector is intentional. The comment exists to make the investigation non-repeatable work.
+
+---
+
+## 4. Change Summary
+
+### Statistics
+
+| Item | Value |
+|---|---|
+| Files changed | 2 |
+| Lines added | +13 |
+| Lines deleted | -1 |
+| Executable lines changed | 0 |
+| Tests added | 0 |
+
+### Changes by Area
+
+| Area | File | Summary |
+|---|---|---|
+| Code comment | `src/commands/generate.rs` | Ten-line comment above `dry_sequence_breakers: Vec::new()` recording the scope decision, why it differs in kind from the four "feature off" neighbours, and the resulting `match_len` behavior |
+| User-facing help | `src/main.rs` | `--dry-multiplier` help on `SamplingOptions` gains one sentence: CLI DRY matches across all boundaries, and the server's `--dry-sequence-breakers` has no CLI equivalent |
+
+### Related Commits
+
+| Hash | Type | Message |
+|---|---|---|
+| `33322d66` | docs | docs: explain CLI DRY runs without sequence breakers |
+
+---
+
+## 5. Validation and Follow-up
+
+### Passed
+
+- `cargo fmt --check` clean.
+- `python3 scripts/ci/check_cross_repo_refs.py` passes (no bare `#NNN` added).
+- Diff reviewed line by line as comment-and-help-text-only: every added line matches `^\s*(///|//)`.
+
+### Not Covered
+
+Compilation was not run in the implementation worktree, which had no `target/` directory and would have triggered a full MLX source build for a change that alters no executable line. Multi-line doc comments on clap fields are already used in the same struct (for example on `seed`), so the pattern is established rather than novel.
+
+### Follow-up Candidates
+
+- The flag itself, as a feature issue, with the acceptance shape recorded in 3.1. It would be inert at the CLI's default `--temp 0.0` until #1102 lands.
+- The eight other sampling knobs the CLI omits are undocumented in the same way, but none of them shares this failure mode: each is genuinely unreachable from the CLI, so no user can turn one on and then be surprised by its fixed configuration. Only the `--dry-multiplier` and `dry_sequence_breakers` pair has a switch without its companion setting.

--- a/TECHNICAL_REPORTS/1118-cli-dry-sequence-breakers-20260814.ko.md
+++ b/TECHNICAL_REPORTS/1118-cli-dry-sequence-breakers-20260814.ko.md
@@ -1,0 +1,121 @@
+# 기술 보고서: PR #1118 - docs: explain CLI DRY runs without sequence breakers
+
+**작성일**: 2026-08-14
+**작성자**: Jeongkyu Shin
+**상태**: 완료
+**언어**: Rust (주석과 clap help만)
+**위험도**: Low
+
+---
+
+## 요약
+
+PR #1118은 이슈 #1108을 해결한다. CLI는 `--dry-multiplier`를 노출하므로 명령행에서 DRY를 켤 수 있지만, `resolved_cli_sampling_params`는 `dry_sequence_breakers: Vec::new()`를 하드코딩한다. breaker가 없으면 역방향 매칭이 개행이나 구두점 경계에서 멈추지 않아 `match_len`이 계속 자라고, 같은 수치를 서버에 넣었을 때보다 페널티가 강해진다. 코드에도 help 문구에도 그 사실이 적혀 있지 않았다.
+
+이 PR은 이슈가 조사 끝에 도달한 문서 수정이며, 이슈가 처음 제안했던 기능 추가가 아니다. 추가된 13줄은 전부 주석 또는 doc comment다. `--dry-sequence-breakers` CLI 플래그는 추가하지 않았고 동작 변경도 없다.
+
+---
+
+## 1. 문제 정의
+
+### 1.1 배경
+
+이슈 #1108은 플래그 parity 요청으로 시작했다. 서버에는 `--dry-sequence-breakers`가 있고 CLI에는 없으니 추가하자는 것이었다. 이슈에 기록된 조사가 그 프레이밍을 폐기했다. CLI의 `SamplingOptions`를 서버의 요청별 sampling 필드와 대조하면 CLI가 빠뜨린 knob은 하나가 아니라 아홉 개다. `frequency_penalty`, `presence_penalty`, `xtc_probability`, `xtc_threshold`, `logit_bias`, `repetition_context_size`, `stop`, 루프 탐지 필드들이 여기 포함된다. 즉 CLI의 좁은 sampling 표면은 의도된 것이고, "서버에 있는 플래그가 CLI에 없다"는 사실만으로는 아무것도 논증하지 못한다.
+
+### 1.2 기존 문제점
+
+- **하드코딩된 다섯 필드 중 하나만 성격이 다르다.** `resolved_cli_sampling_params`는 sampling 필드 다섯 개를 연속된 블록으로 하드코딩한다. 그중 넷(`frequency_penalty: 0.0`, `presence_penalty: 0.0`, `xtc_probability: 0.0`, `xtc_threshold`)은 정직한 "기능 꺼짐" 기본값이다. CLI에 켤 수 있는 플래그가 없으니 실제로 꺼져 있다. `dry_sequence_breakers: Vec::new()`만 예외인데, `--dry-multiplier`로 DRY를 켤 수 있기 때문이다. 켜진 순간 빈 벡터는 꺼진 기능이 아니라, 사용자가 바꿀 수 없는 설정으로 돌아가는 기능이 된다.
+- **그 결과로 생기는 동작 차이가 보이지 않는다.** breaker가 없으면 `src/lib/mlxcel-core/src/sampling.rs`의 역방향 매칭이 경계에서 종료되지 않아 `match_len`이 계속 자라고, 같은 설정에서 서버가 만드는 것보다 페널티 항이 커진다. `mlxcel run`으로 `--dry-multiplier`를 튜닝한 뒤 그 수치를 `mlxcel-server`에 배포한 사용자는 동일한 값에서 다른 출력을 얻고, 어느 help 문구에도 이유가 없다.
+- **조사 자체가 유실될 위험이 있었다.** 빈 벡터가 범위 결정의 결과라는 사실이 코드 어디에도 없었다. 다음 독자는 같은 결론에 이르기 위해 아홉 knob 비교를 처음부터 다시 해야 했을 것이다.
+
+### 1.3 위험성
+
+| 위험 | 영향도 | 발생 가능성 |
+|---|---|---|
+| CLI에서 튜닝한 sampling 값이 프로덕션에서 다르게 동작하고, 그 차이를 모델이나 seed 탓으로 돌림 | Medium | Medium |
+| 이후 기여자가 빈 벡터를 누락으로 읽고 범위 논의 없이 플래그를 추가함 | Low | Medium |
+| 독자가 DRY 줄을 아래의 "기능 꺼짐" 네 줄과 묶어 읽고 CLI에서 DRY가 꺼져 있다고 결론 내림 | Low | Medium |
+
+---
+
+## 2. 기술적 검토 사항
+
+### 2.1 diff가 실행 코드가 아님을 증명 가능
+
+추가된 13줄은 `src/commands/generate.rs`의 `//` 주석 10줄과 `src/main.rs`의 `///` doc comment 3줄(2줄 추가, 기존 1줄의 문장부호 조정)이다. 실행 문장, 필드 값, clap 속성 중 바뀐 것이 없다. `cargo fmt --check`는 clean이고, 프로젝트 설정에서 `rustfmt`는 주석을 재배치하지 않는다.
+
+### 2.2 help 한 문장의 적용 범위
+
+`SamplingOptions`는 `GenerateArgs`와 `RunArgs` 양쪽에 flatten되고, chat 경로도 같은 `SamplingConfig` 조립을 공유한다. 따라서 `--dry-multiplier` help에 문장 하나를 넣으면 `mlxcel generate`, `mlxcel run`, `mlxcel chat`이 중복 없이 모두 덮인다. help 문자열 하나로 충분했던 이유이자, `docs/` 아래에 별도 안내를 병기할 필요가 없던 이유다.
+
+### 2.3 두 번째 `dry_multiplier`는 의도적으로 손대지 않음
+
+`src/main.rs` 1245행 부근에 두 번째 `dry_multiplier` 필드가 있는데, `ServeArgs`에 속한다. `ServeArgs`는 그 16줄 아래에서 이미 `--dry-sequence-breakers`를 노출한다. 이 필드는 지금 문서화하고 있는 비대칭의 서버 쪽 절반이므로, 여기에 CLI 단서를 덧붙였다면 서버 help가 서버에 없는 한계를 설명하게 된다. 그대로 두었다.
+
+---
+
+## 3. 기술적 선택과 그 이유
+
+### 3.1 비대칭을 없애는 대신 문서화
+
+| 옵션 | 장점 | 단점 |
+|---|---|---|
+| `SamplingOptions`에 `--dry-sequence-breakers` 추가 | 비대칭 자체를 제거 | 의도적으로 부분집합인 sampling 표면을 넓힘. tokenizer 시점 토큰화와 새 단위 게이트가 필요. #1102 이전에는 CLI 기본값 `--temp 0.0`에서 무효(`build_sampling_config`의 greedy 갈래가 breaker를 버림) |
+| CLI 기본값을 llama.cpp의 breaker 집합으로 변경 | 널리 기대되는 동작과 일치 | 기존 CLI 호출의 동작이 조용히 바뀜. 문서 이슈가 절대 내보내면 안 되는 종류의 변경 |
+| **선택: 주석 + 사용자 대상 문장 하나** | 동작 위험 0으로 놀라움을 제거하고, 범위 결정의 이유를 기록 | 비대칭은 남으므로 CLI는 여전히 서버와 동등한 DRY를 표현하지 못함 |
+
+이슈는 플래그 추가를 별도 기능 이슈로 열어두었고, 필요한 수용 형태까지 적어두었다. 파싱된 플래그가 `ResolvedSamplingParams.dry_sequence_breakers`에 토큰 ID로 도달하는지 단위 검증으로 확인하는 방식이며, 모델과 seed에 의존해 flaky한 출력 비교 검증은 쓰지 않는다. 그 경로는 열려 있고 이 PR은 그것을 막지 않는다.
+
+### 3.2 사용자 대상 문장을 `docs/`가 아니라 clap help에 배치
+
+clap help는 사용자가 `--dry-multiplier` 값을 고르는 바로 그 순간에 보이는 텍스트이고, 놀라움이 발생하는 시점도 그 순간이다. `docs/` 페이지는 그보다 이르게 읽히거나 아예 읽히지 않는다. 변경을 `src/` 안에 두면 플래그와 그 단서가 같은 파일에 남으므로, 이후 플래그가 바뀔 때 단서만 다른 파일에 남아 어긋나는 일도 없다.
+
+### 3.3 이 필드가 이웃들과 왜 다른지를 함께 적음
+
+주석은 "CLI가 breaker 없이 DRY를 돌린다"만 적지 않는다. 그 줄이 아래 네 줄과 왜 다른지를 적는다. 넷은 켤 수단이 없어서 꺼져 있고, 이 줄은 `--dry-multiplier`로 켤 수 있으므로 그렇지 않다. 이 대비가 없으면 다음 독자는 빈 벡터가 의도인지 알기 위해 비교를 다시 해야 한다. 주석의 존재 이유는 그 조사를 반복하지 않게 만드는 것이다.
+
+---
+
+## 4. 변경 요약
+
+### 통계
+
+| 항목 | 값 |
+|---|---|
+| 변경된 파일 수 | 2 |
+| 추가된 라인 | +13 |
+| 삭제된 라인 | -1 |
+| 변경된 실행 라인 | 0 |
+| 테스트 추가 | 0 |
+
+### 영역별 변경
+
+| 영역 | 파일 | 주요 내용 |
+|---|---|---|
+| 코드 주석 | `src/commands/generate.rs` | `dry_sequence_breakers: Vec::new()` 위에 10줄 주석. 범위 결정임을 기록하고, 아래 네 개의 "기능 꺼짐" 이웃과 성격이 다른 이유와 그로 인한 `match_len` 동작을 설명 |
+| 사용자 대상 help | `src/main.rs` | `SamplingOptions`의 `--dry-multiplier` help에 한 문장 추가. CLI DRY는 모든 경계를 가로질러 매칭하며 서버의 `--dry-sequence-breakers`에 대응하는 CLI 플래그가 없다는 내용 |
+
+### 관련 커밋
+
+| Hash | Type | Message |
+|---|---|---|
+| `33322d66` | docs | docs: explain CLI DRY runs without sequence breakers |
+
+---
+
+## 5. 검증 및 후속 조치
+
+### 통과
+
+- `cargo fmt --check` clean.
+- `python3 scripts/ci/check_cross_repo_refs.py` 통과(새로 추가된 bare `#NNN` 없음).
+- diff를 줄 단위로 확인해 주석과 help 문구뿐임을 검증. 추가된 모든 줄이 `^\s*(///|//)`에 일치.
+
+### 다루지 못한 것
+
+구현 worktree에는 `target/` 디렉터리가 없어 컴파일을 돌리지 않았다. 실행 라인을 하나도 바꾸지 않는 변경을 위해 MLX 전체 소스 빌드를 유발할 이유가 없었다. clap 필드의 여러 줄 doc comment는 같은 구조체 안에서 이미 쓰이고 있으므로(예: `seed`), 새로운 패턴이 아니라 기존 패턴이다.
+
+### 후속 후보
+
+- 플래그 자체를 기능 이슈로 진행하는 것. 필요한 수용 형태는 3.1에 기록되어 있다. #1102 이전에는 CLI 기본값 `--temp 0.0`에서 무효다.
+- CLI가 빠뜨린 나머지 여덟 개 sampling knob도 같은 방식으로 문서화되어 있지 않지만, 어느 것도 이 실패 양상을 공유하지 않는다. 각각은 CLI에서 애초에 도달 불가능하므로 사용자가 켠 뒤 고정된 설정에 놀랄 일이 없다. 스위치만 있고 짝이 되는 설정이 없는 쌍은 `--dry-multiplier`와 `dry_sequence_breakers`뿐이다.

--- a/TECHNICAL_REPORTS/1119-paged-decode-v2-env-vars-20260814.en.md
+++ b/TECHNICAL_REPORTS/1119-paged-decode-v2-env-vars-20260814.en.md
@@ -1,0 +1,135 @@
+# Technical Report: PR #1119 - docs: add the six paged-decode v2 variables and correct the NATIVE row
+
+**Date**: 2026-08-14
+**Author**: Jeongkyu Shin
+**Status**: Completed
+**Languages**: Markdown
+**Risk Level**: Low
+
+---
+
+## Executive Summary
+
+PR #1119 closes issue #1104. `docs/environment-variables.md` claims to be the index for `MLXCEL_*` variables, but six paged-decode v2 variables that are read from Rust were absent from it, and the one paged-attention row that was present told operators the opposite of what `README.md` and `docs/CONTINUOUS_BATCHING.md` told them.
+
+The six variables were added with defaults read from their definition sites rather than from the issue text, and the `MLXCEL_PAGED_ATTENTION_NATIVE` row was rewritten to describe both of its consumers. Docs only, one file, no behavior change.
+
+---
+
+## 1. Problem Statement
+
+### 1.1 Background
+
+Issue #899 made the fused paged-decode v2 kernel the production decode path for pool-backed continuous batching. That promotion added a second consumer to an existing variable and introduced five new ones, but the reference page was not updated with it. The result is the worst failure mode a reference page has: not a gap, but a confident wrong answer.
+
+### 1.2 Existing Issues
+
+- **Six variables read from Rust, none listed.** `MLXCEL_PAGED_ATTENTION_V2`, `MLXCEL_PAGED_DECODE_V2_CHUNK`, `MLXCEL_PAGED_DECODE_V2_TARGET_CTAS`, `MLXCEL_PAGED_SLAB_BLOCKS`, `MLXCEL_PAGED_V2_MIN_KV_TOKENS` and `MLXCEL_PAGED_V2_MIN_KV_TOKENS_PER_REQUEST`. The last three are already documented as operator-facing knobs in `docs/CONTINUOUS_BATCHING.md`, and `MLXCEL_CASCADE_ATTENTION`, a sibling from the same feature area, was already on the page. That pattern makes the omission drift rather than a deliberate withholding of internals.
+- **A row that contradicted two other documents.** The `MLXCEL_PAGED_ATTENTION_NATIVE` row ended by calling the variable "a control for external mlxcel-core consumers and `examples/paged_attention_kernel_bench.rs`, not a server knob", which was true when #710 retired the library entry point and false after #899. `README.md` and `docs/CONTINUOUS_BATCHING.md` both describe `MLXCEL_PAGED_ATTENTION_NATIVE=0` as the server-side kill switch. An operator who opened the reference page specifically to find that kill switch was told it did not apply to them.
+
+### 1.3 Risk Assessment
+
+| Risk | Impact | Likelihood |
+|---|---|---|
+| Operator cannot disable the v2 decode path during an incident because the reference page says the variable is not a server knob | High | Medium |
+| Operator sizes the paged pool by guesswork because `MLXCEL_PAGED_SLAB_BLOCKS` is undocumented, and the fused path silently stays unreachable | Medium | Medium |
+| Contributor treats the three diagnostic variables as supported tuning knobs because nothing marks them diagnostic | Low | Medium |
+
+---
+
+## 2. Technical Review
+
+### 2.1 Defaults Traced to Definition Sites
+
+The issue supplied some defaults in prose. None of them were copied. Each was read at its definition site, which is what caught the discrepancy in section 3.2 below.
+
+| Variable | Default as documented | Source |
+|---|---|---|
+| `MLXCEL_PAGED_ATTENTION_V2` | off | `paged_v2/mod.rs` (`V2_ENV`, `parse_v2_enabled`) |
+| `MLXCEL_PAGED_DECODE_V2_CHUNK` | unset (planned or autotuned chunk size) | `autotune/ops/paged_decode_v2_chunk.rs` (`CHUNK_ENV`) |
+| `MLXCEL_PAGED_DECODE_V2_TARGET_CTAS` | derived: Apple `gpu_core_count * 8` floored at 64, every other host including CUDA `512` | `paged_v2/plan.rs` (`device_target_ctas`) |
+| `MLXCEL_PAGED_SLAB_BLOCKS` | derived `ceil(per_slot_ctx / block_size) * batch`, floored at the 32-block pool default, capped at the per-layer budget share | `execution/memory_estimate.rs` (`resolve_paged_slab_blocks`), `cache/paged.rs` (`POOL_SLAB_BLOCKS = 32`) |
+| `MLXCEL_PAGED_V2_MIN_KV_TOKENS` | `4096` | `paged_v2/dispatch.rs` (`MIN_SINGLE_REQUEST_KV_TOKENS`) |
+| `MLXCEL_PAGED_V2_MIN_KV_TOKENS_PER_REQUEST` | `512` | `paged_v2/dispatch.rs` (`MIN_BATCHED_KV_TOKENS_PER_REQUEST`) |
+
+### 2.2 The Rewritten NATIVE Row
+
+The replacement row is written against `resolve_dispatch_decision` and `resolve_paged_v2_dispatch` in `src/lib/mlxcel-core/src/layers.rs`, which is where the two-consumer structure actually lives. It states both consumers, keeps the #710 retirement as history rather than as the current claim, and notes that the override is checked before the selector in both consumers while a forced dispatch still goes through the kernel's structural declines (single-slab layer, servable geometry, non-empty batch). The Default cell was widened to cover the server floors as well as the library selector's regime, since one cell now describes two dispatch policies.
+
+### 2.3 Scope Containment
+
+One file changed, +26/-1. `README.md` and `docs/CONTINUOUS_BATCHING.md` already stated the correct behavior and were deliberately not touched: the reference page was the document that disagreed with them, so editing the other two would have moved the inconsistency rather than closed it.
+
+---
+
+## 3. Technical Decisions
+
+### 3.1 Split the Six Across Two Sections Rather Than One
+
+| Option | Pros | Cons |
+|---|---|---|
+| One new section holding all six | Keeps the feature area in one place | Puts three kernel-development switches in front of operators as if they were tuning knobs |
+| **Chosen: three in a new operator-facing section, three in the existing diagnostic section marked Diagnostic** | Audience matches the section; the diagnostic marker survives even if the row is read out of context | The feature area is now described in two places on one page |
+
+The new `## Paged decode v2 variables` section holds `MLXCEL_PAGED_SLAB_BLOCKS`, `MLXCEL_PAGED_V2_MIN_KV_TOKENS` and `MLXCEL_PAGED_V2_MIN_KV_TOKENS_PER_REQUEST`, placed after the KV cache section. `MLXCEL_PAGED_ATTENTION_V2`, `MLXCEL_PAGED_DECODE_V2_CHUNK` and `MLXCEL_PAGED_DECODE_V2_TARGET_CTAS` went into `## Hardware and kernel diagnostic variables`, each prefixed **Diagnostic**. The split is reconnected by a lead-in that names `MLXCEL_PAGED_ATTENTION_NATIVE` as the kill switch and links to the diagnostic section by anchor.
+
+`MLXCEL_PAGED_ATTENTION_V2` in particular needed the marker: it is issue #898's comparison gate for the library-only v1 entry point, and it does not gate the server's production v2 decode at all. Without an explicit statement of that, its name reads like the master switch for the whole feature.
+
+### 3.2 Document the Behavior, Not the Warning Text
+
+`resolve_paged_slab_blocks` in `src/execution/memory_estimate.rs` matches on the parsed value: `Ok(0)` returns `None`, `Ok(n)` returns `Some(n)`, and `Err(_)` logs `"... is not a non-negative integer; using the derived slab size"` and then also returns `None`. `None` means no override, and the pool falls back to `POOL_SLAB_BLOCKS = 32`, so an unparseable value takes the same path as `0` and lands on the historical 32-block default, not on the derived size the warning names.
+
+The row documents what happens ("a value that is not a non-negative integer warns and leaves that same 32-block default in place") rather than what the warning says. Correcting the warning string is a code change and was out of scope for a docs issue; see section 5.
+
+### 3.3 Cross-Link Instead of Duplicating
+
+The dispatch policy, the per-outcome startup log lines, and the list of shapes the fused kernel declines are all already written in `docs/CONTINUOUS_BATCHING.md`. The new section links `CONTINUOUS_BATCHING.md#seeing-which-path-ran` instead of restating them, which is the same instruction the issue gave. A reference page that duplicates a guide acquires its own drift, which is precisely the failure this PR was fixing.
+
+---
+
+## 4. Change Summary
+
+### Statistics
+
+| Item | Value |
+|---|---|
+| Files changed | 1 |
+| Lines added | +26 |
+| Lines deleted | -1 |
+| Variables newly documented | 6 |
+| Rows rewritten | 1 |
+
+### Changes by Area
+
+| Area | File | Summary |
+|---|---|---|
+| Operator reference | `docs/environment-variables.md` | New `## Paged decode v2 variables` section with three operator knobs, a lead-in naming the kill switch, and a cross-link to the continuous-batching guide |
+| Diagnostic reference | `docs/environment-variables.md` | Three rows added to `## Hardware and kernel diagnostic variables`, each marked **Diagnostic** |
+| Correctness | `docs/environment-variables.md` | `MLXCEL_PAGED_ATTENTION_NATIVE` row rewritten to describe both consumers; #710 kept as history; Default cell widened to cover the server floors |
+
+### Related Commits
+
+| Hash | Type | Message |
+|---|---|---|
+| `cf4e22cd` | docs | docs: add the six paged-decode v2 variables and correct the NATIVE row |
+
+---
+
+## 5. Validation and Follow-up
+
+### Passed
+
+- Every default traced to its definition site rather than to the issue text (table in 2.1).
+- `python3 scripts/ci/check_cross_repo_refs.py` passes.
+- Added rows verified to keep the 4-column shape of the sections they joined.
+- `git diff --stat` is `docs/environment-variables.md` only, so no build or test surface is involved.
+
+### Found and Deliberately Not Fixed
+
+- **`docs/turbo-kv-cache.md` carries the same stale framing.** Around lines 298 to 312 it still says #710 retired the pooled entry point so that "`MLXCEL_PAGED_ATTENTION_NATIVE` is a control for external mlxcel-core consumers and the kernel bench, not a server knob". That is the identical pre-#899 claim this PR corrected on the reference page. Issue #1104 scoped one file, so the second site is a separate follow-up.
+- **The `MLXCEL_PAGED_SLAB_BLOCKS` warning text is wrong in the code.** As traced in 3.2, the `Err(_)` arm warns "using the derived slab size" and then returns `None`, which keeps the 32-block pool default instead. Fixing the message is a Rust change and was out of scope here.
+
+### Follow-up Candidates
+
+- The CI check the issue suggested: diff `MLXCEL_*` occurrences in `src/**/*.rs` against the table in `docs/environment-variables.md`, modeled on `scripts/ci/check_kernel_dtype_keys.py`. This PR closed today's gap by hand; nothing prevents the next feature from reopening it.
+- `MLXCEL_PAGED_DECODE_V2_TARGET_CTAS` is documented as unvalidated on CUDA, where the fixed `512` target should probably be derived from the SM count. The row records that honestly rather than presenting the constant as calibrated.

--- a/TECHNICAL_REPORTS/1119-paged-decode-v2-env-vars-20260814.ko.md
+++ b/TECHNICAL_REPORTS/1119-paged-decode-v2-env-vars-20260814.ko.md
@@ -1,0 +1,135 @@
+# 기술 보고서: PR #1119 - docs: add the six paged-decode v2 variables and correct the NATIVE row
+
+**작성일**: 2026-08-14
+**작성자**: Jeongkyu Shin
+**상태**: 완료
+**언어**: Markdown
+**위험도**: Low
+
+---
+
+## 요약
+
+PR #1119는 이슈 #1104를 해결한다. `docs/environment-variables.md`는 `MLXCEL_*` 변수의 색인을 자처하지만, Rust에서 실제로 읽는 paged-decode v2 변수 여섯 개가 빠져 있었다. 게다가 유일하게 실려 있던 paged-attention 행은 `README.md`와 `docs/CONTINUOUS_BATCHING.md`가 말하는 것과 정반대를 운영자에게 알려주고 있었다.
+
+여섯 변수를 이슈 본문이 아니라 정의 지점의 코드에서 읽은 기본값과 함께 추가했고, `MLXCEL_PAGED_ATTENTION_NATIVE` 행은 두 소비자를 모두 설명하도록 다시 썼다. 문서만 변경, 파일 하나, 동작 변경 없음.
+
+---
+
+## 1. 문제 정의
+
+### 1.1 배경
+
+이슈 #899가 fused paged-decode v2 커널을 pool 기반 continuous batching의 프로덕션 decode 경로로 승격시켰다. 이 승격으로 기존 변수 하나에 두 번째 소비자가 생기고 새 변수 다섯 개가 도입되었지만, 레퍼런스 페이지는 함께 갱신되지 않았다. 그 결과 레퍼런스 문서가 가질 수 있는 최악의 실패 형태가 남았다. 빈칸이 아니라 확신에 찬 오답이다.
+
+### 1.2 기존 문제점
+
+- **Rust에서 읽는 변수 여섯 개가 전부 미등재.** `MLXCEL_PAGED_ATTENTION_V2`, `MLXCEL_PAGED_DECODE_V2_CHUNK`, `MLXCEL_PAGED_DECODE_V2_TARGET_CTAS`, `MLXCEL_PAGED_SLAB_BLOCKS`, `MLXCEL_PAGED_V2_MIN_KV_TOKENS`, `MLXCEL_PAGED_V2_MIN_KV_TOKENS_PER_REQUEST`. 이 중 뒤의 셋은 이미 `docs/CONTINUOUS_BATCHING.md`에 운영자용 knob으로 문서화되어 있었고, 같은 기능 영역의 형제 변수인 `MLXCEL_CASCADE_ATTENTION`은 이미 이 페이지에 실려 있었다. 이 패턴은 내부 전용 변수를 의도적으로 감춘 것이 아니라 단순 drift임을 보여준다.
+- **다른 문서 두 개와 모순되는 행.** `MLXCEL_PAGED_ATTENTION_NATIVE` 행은 이 변수가 "a control for external mlxcel-core consumers and `examples/paged_attention_kernel_bench.rs`, not a server knob"이라는 문장으로 끝났다. #710이 라이브러리 진입점을 정리하던 시점에는 참이었고 #899 이후에는 거짓이다. `README.md`와 `docs/CONTINUOUS_BATCHING.md`는 둘 다 `MLXCEL_PAGED_ATTENTION_NATIVE=0`을 서버 측 kill switch로 설명한다. 바로 그 kill switch를 찾으려고 레퍼런스 페이지를 연 운영자가 "이 변수는 당신과 무관하다"는 답을 받은 셈이다.
+
+### 1.3 위험성
+
+| 위험 | 영향도 | 발생 가능성 |
+|---|---|---|
+| 장애 상황에서 운영자가 v2 decode 경로를 끄지 못함. 레퍼런스 페이지가 서버 knob이 아니라고 말하기 때문 | High | Medium |
+| `MLXCEL_PAGED_SLAB_BLOCKS`가 문서화되지 않아 운영자가 pool 크기를 추측으로 잡고, fused 경로가 조용히 도달 불가 상태로 남음 | Medium | Medium |
+| diagnostic 표시가 없어 기여자가 진단용 변수 셋을 지원되는 튜닝 knob으로 오해함 | Low | Medium |
+
+---
+
+## 2. 기술적 검토 사항
+
+### 2.1 기본값을 정의 지점에서 읽음
+
+이슈는 일부 기본값을 산문으로 제시했다. 그중 어느 것도 그대로 옮기지 않고 전부 정의 지점에서 다시 읽었다. 아래 3.2의 불일치를 발견한 것이 이 절차 덕분이다.
+
+| 변수 | 문서화된 기본값 | 출처 |
+|---|---|---|
+| `MLXCEL_PAGED_ATTENTION_V2` | off | `paged_v2/mod.rs` (`V2_ENV`, `parse_v2_enabled`) |
+| `MLXCEL_PAGED_DECODE_V2_CHUNK` | unset (계획되었거나 autotune된 chunk 크기) | `autotune/ops/paged_decode_v2_chunk.rs` (`CHUNK_ENV`) |
+| `MLXCEL_PAGED_DECODE_V2_TARGET_CTAS` | 유도값: Apple은 `gpu_core_count * 8`에 하한 64, CUDA를 포함한 그 외 호스트는 `512` | `paged_v2/plan.rs` (`device_target_ctas`) |
+| `MLXCEL_PAGED_SLAB_BLOCKS` | 유도값 `ceil(per_slot_ctx / block_size) * batch`, 32블록 pool 기본값을 하한으로, 레이어당 예산 몫을 상한으로 | `execution/memory_estimate.rs` (`resolve_paged_slab_blocks`), `cache/paged.rs` (`POOL_SLAB_BLOCKS = 32`) |
+| `MLXCEL_PAGED_V2_MIN_KV_TOKENS` | `4096` | `paged_v2/dispatch.rs` (`MIN_SINGLE_REQUEST_KV_TOKENS`) |
+| `MLXCEL_PAGED_V2_MIN_KV_TOKENS_PER_REQUEST` | `512` | `paged_v2/dispatch.rs` (`MIN_BATCHED_KV_TOKENS_PER_REQUEST`) |
+
+### 2.2 다시 쓴 NATIVE 행
+
+교체된 행은 `src/lib/mlxcel-core/src/layers.rs`의 `resolve_dispatch_decision`과 `resolve_paged_v2_dispatch`를 근거로 작성했다. 두 소비자 구조가 실제로 존재하는 곳이 거기다. 새 행은 소비자 둘을 모두 명시하고, #710의 정리를 현재 진술이 아니라 이력으로 남기며, 두 소비자 모두에서 override가 selector보다 먼저 검사되지만 강제 dispatch도 커널의 구조적 거부(단일 slab 레이어, 서비스 가능한 geometry, 비어 있지 않은 batch)는 그대로 통과해야 한다는 점을 적었다. Default 셀은 이제 한 칸이 두 개의 dispatch 정책을 설명하므로, 라이브러리 selector의 영역뿐 아니라 서버 쪽 token floor까지 포함하도록 넓혔다.
+
+### 2.3 범위 통제
+
+파일 하나, +26/-1. `README.md`와 `docs/CONTINUOUS_BATCHING.md`는 이미 올바른 동작을 서술하고 있었으므로 의도적으로 건드리지 않았다. 둘과 어긋나 있던 쪽이 레퍼런스 페이지였고, 나머지 둘을 고쳤다면 불일치를 해소하는 대신 옮기기만 했을 것이다.
+
+---
+
+## 3. 기술적 선택과 그 이유
+
+### 3.1 여섯 개를 한 절이 아니라 두 절로 분리
+
+| 옵션 | 장점 | 단점 |
+|---|---|---|
+| 여섯 개를 새 절 하나에 모음 | 기능 영역이 한곳에 모임 | 커널 개발용 스위치 셋을 운영자 앞에 튜닝 knob처럼 내놓게 됨 |
+| **선택: 셋은 새 운영자용 절, 셋은 기존 diagnostic 절에 Diagnostic 표시** | 절의 독자와 대상이 일치하고, 행만 따로 읽혀도 diagnostic 표시가 남음 | 한 페이지 안에서 기능 영역이 두 곳에 서술됨 |
+
+새 `## Paged decode v2 variables` 절은 `MLXCEL_PAGED_SLAB_BLOCKS`, `MLXCEL_PAGED_V2_MIN_KV_TOKENS`, `MLXCEL_PAGED_V2_MIN_KV_TOKENS_PER_REQUEST`를 담고 KV cache 절 뒤에 배치했다. `MLXCEL_PAGED_ATTENTION_V2`, `MLXCEL_PAGED_DECODE_V2_CHUNK`, `MLXCEL_PAGED_DECODE_V2_TARGET_CTAS`는 `## Hardware and kernel diagnostic variables`로 보내고 각각 **Diagnostic**을 앞에 붙였다. 분리된 두 절은 `MLXCEL_PAGED_ATTENTION_NATIVE`를 kill switch로 지목하고 diagnostic 절을 anchor로 링크하는 도입부로 다시 연결했다.
+
+특히 `MLXCEL_PAGED_ATTENTION_V2`에는 이 표시가 필요했다. 이 변수는 이슈 #898이 라이브러리 전용 v1 진입점을 비교하려고 둔 gate이며, 서버의 프로덕션 v2 decode는 전혀 gate하지 않는다. 그 사실을 명시하지 않으면 이름만 보고 기능 전체의 마스터 스위치로 읽히기 쉽다.
+
+### 3.2 경고 문구가 아니라 실제 동작을 문서화
+
+`src/execution/memory_estimate.rs`의 `resolve_paged_slab_blocks`는 파싱 결과로 분기한다. `Ok(0)`은 `None`을 반환하고, `Ok(n)`은 `Some(n)`을, `Err(_)`은 `"... is not a non-negative integer; using the derived slab size"`를 경고로 남긴 뒤 역시 `None`을 반환한다. `None`은 override 없음을 뜻하고, pool은 `POOL_SLAB_BLOCKS = 32`로 되돌아간다. 즉 파싱 불가 값은 `0`과 같은 경로를 타고 과거의 32블록 기본값에 안착하며, 경고가 말하는 유도값(derived size)에는 도달하지 않는다.
+
+해당 행은 경고가 뭐라고 말하는지가 아니라 실제로 무슨 일이 일어나는지를 적었다("a value that is not a non-negative integer warns and leaves that same 32-block default in place"). 경고 문자열을 고치는 것은 코드 변경이라 문서 이슈의 범위 밖이었다. 5절 참조.
+
+### 3.3 중복 서술 대신 상호 링크
+
+dispatch 정책, 결과별 startup 로그 라인, fused 커널이 거부하는 형태 목록은 모두 `docs/CONTINUOUS_BATCHING.md`에 이미 쓰여 있다. 새 절은 이를 다시 쓰는 대신 `CONTINUOUS_BATCHING.md#seeing-which-path-ran`을 링크했다. 이슈가 지시한 방식이기도 하다. 가이드를 복제한 레퍼런스 페이지는 자기 몫의 drift를 따로 갖게 되는데, 그것이 바로 이 PR이 고치고 있던 실패 양상이다.
+
+---
+
+## 4. 변경 요약
+
+### 통계
+
+| 항목 | 값 |
+|---|---|
+| 변경된 파일 수 | 1 |
+| 추가된 라인 | +26 |
+| 삭제된 라인 | -1 |
+| 새로 문서화한 변수 | 6 |
+| 다시 쓴 행 | 1 |
+
+### 영역별 변경
+
+| 영역 | 파일 | 주요 내용 |
+|---|---|---|
+| 운영자 레퍼런스 | `docs/environment-variables.md` | 새 `## Paged decode v2 variables` 절에 운영자용 knob 셋, kill switch를 지목하는 도입부, continuous batching 가이드 상호 링크 |
+| 진단 레퍼런스 | `docs/environment-variables.md` | `## Hardware and kernel diagnostic variables`에 행 셋 추가, 각각 **Diagnostic** 표시 |
+| 정확성 | `docs/environment-variables.md` | `MLXCEL_PAGED_ATTENTION_NATIVE` 행을 두 소비자 서술로 재작성, #710은 이력으로 유지, Default 셀을 서버 floor까지 포함하도록 확장 |
+
+### 관련 커밋
+
+| Hash | Type | Message |
+|---|---|---|
+| `cf4e22cd` | docs | docs: add the six paged-decode v2 variables and correct the NATIVE row |
+
+---
+
+## 5. 검증 및 후속 조치
+
+### 통과
+
+- 모든 기본값을 이슈 본문이 아니라 정의 지점에서 확인(2.1 표).
+- `python3 scripts/ci/check_cross_repo_refs.py` 통과.
+- 추가한 행이 편입된 절의 4열 구조를 유지하는지 확인.
+- `git diff --stat` 결과가 `docs/environment-variables.md` 하나뿐이므로 빌드나 테스트 표면과 무관.
+
+### 발견했으나 의도적으로 고치지 않은 것
+
+- **`docs/turbo-kv-cache.md`에 같은 낡은 서술이 남아 있다.** 298행에서 312행 부근에 여전히 #710이 pooled 진입점을 정리했으므로 "`MLXCEL_PAGED_ATTENTION_NATIVE` is a control for external mlxcel-core consumers and the kernel bench, not a server knob"이라고 적혀 있다. 이 PR이 레퍼런스 페이지에서 바로잡은 pre-#899 주장과 동일하다. 이슈 #1104는 파일 하나로 범위를 잡았으므로 두 번째 지점은 별도 후속 작업이다.
+- **`MLXCEL_PAGED_SLAB_BLOCKS`의 경고 문구 자체가 코드에서 틀렸다.** 3.2에서 추적했듯 `Err(_)` 갈래는 "using the derived slab size"라고 경고한 뒤 `None`을 반환하며, 실제로는 32블록 pool 기본값이 유지된다. 메시지 수정은 Rust 변경이라 이번 범위 밖이다.
+
+### 후속 후보
+
+- 이슈가 제안한 CI 검사: `src/**/*.rs`의 `MLXCEL_*` 등장과 `docs/environment-variables.md` 표를 대조하는 스크립트로, `scripts/ci/check_kernel_dtype_keys.py`를 본뜬 형태. 이 PR은 오늘의 간극을 수작업으로 메웠을 뿐이고, 다음 기능이 같은 간극을 다시 여는 것을 막는 장치는 없다.
+- `MLXCEL_PAGED_DECODE_V2_TARGET_CTAS`는 CUDA에서 미검증이라고 문서에 명시했다. CUDA의 고정값 `512`는 SM 수에서 유도하는 편이 옳을 가능성이 높다. 해당 행은 이 상수를 보정된 값처럼 제시하지 않고 있는 그대로 적었다.

--- a/TECHNICAL_REPORTS/1121-utils-used-by-annotations-20260814.en.md
+++ b/TECHNICAL_REPORTS/1121-utils-used-by-annotations-20260814.en.md
@@ -1,0 +1,139 @@
+# Technical Report: PR #1121 - docs(core): annotate the three tracked shared functions in utils.rs
+
+**Date**: 2026-08-14
+**Author**: Jeongkyu Shin
+**Status**: Completed
+**Languages**: Rust (comment only), Markdown
+**Risk Level**: Low
+
+---
+
+## Executive Summary
+
+PR #1121 closes issue #1110. `docs/code-guidelines.md` opens with the shared-function `Used by:` rule and names `create_causal_mask`, `softcap` and `repeat_kv` in `utils.rs` as the components to track. The PR annotates all three and adds a policy section for helpers with too many callers to enumerate.
+
+The defect turned out to be worse than the issue described. The issue recorded `create_causal_mask` as carrying no annotation. It carried one, and that annotation was stale in a way that inverted its meaning: it named families that no longer call the function at all. Replacing a wrong roster is a stronger fix than adding a missing one, because a missing annotation makes a contributor go look, while a wrong one tells them not to.
+
+---
+
+## 1. Problem Statement
+
+### 1.1 Background
+
+The `Used by:` convention exists so a contributor can see the blast radius of a shared helper before changing it. `docs/code-guidelines.md` states the purpose in those terms: prevent a fix for one model from breaking others, and make it clear which models need retesting. The convention is otherwise well followed across `src/`, and a neighbour in the same file, `create_causal_mask_with_left_padding`, carries `/// Used by: BatchQuantizedKVCache, BatchTurboQuantKVCache`. So this was an omission, not a file-level exemption.
+
+### 1.2 Existing Issues
+
+- **`create_causal_mask` carried a stale annotation, not a missing one.** The pre-PR line read: `Used by: Llama, Qwen, Mixtral, Gemma, Cohere, Phi, OLMo, Exaone, GLM4, MiniCPM, DeepSeek, Hunyuan, StarCoder2 and other causal attention callers`. Grep at this commit shows that `mixtral.rs`, `phi.rs`, `phi3small.rs`, `starcoder2.rs`, `llama3.rs`, `gemma.rs`, `gemma2.rs`, `cohere.rs`, `glm4.rs`, `olmoe.rs` and `qwen3_moe.rs` call it **zero** times each. Those families moved to the implicit-causal fused-SDPA path, passing `mask: None` when `seq_len > 1`. The annotation was therefore not merely incomplete: it named as users the exact families that are unaffected by a change to the function, and omitted the hybrid, sliding-window, VLM and MLA decoders that actually depend on it. A contributor trusting it would have retested the wrong set.
+- **`repeat_kv` and `softcap` carried nothing.** Both are short enough to enumerate literally, so no judgement call was involved and the gap was pure omission.
+- **The guideline had no answer for a 40-caller helper.** The issue asked for one explicitly, so the next person with a large shared function would not re-litigate the choice between enumerating and summarizing.
+
+### 1.3 Risk Assessment
+
+| Risk | Impact | Likelihood |
+|---|---|---|
+| Contributor changes `create_causal_mask` and retests the families the stale list named, none of which call it, while the hybrid and VLM decoders that do call it go untested | High | Medium |
+| Contributor reads the guideline, opens its own named example, finds no annotation, and concludes the convention is unenforced | Medium | Medium |
+| A future large helper gets an enumerated 40-name roster that is stale within a release | Medium | Medium |
+
+---
+
+## 2. Technical Review
+
+### 2.1 Every List Derived by Grep at This Commit
+
+No list was copied from the issue body or from the previous annotation. Measured at commit `f0bf3a2c`:
+
+| Function | Issue's figure | Measured | Command |
+|---|---|---|---|
+| `create_causal_mask` | 46 | 44 non-test under `src/models` (46 including `diffusion_gemma/tests.rs` and `phi3small_tests.rs`), 55 across all of `src` | `grep -rln '\bcreate_causal_mask(' src --include='*.rs'` |
+| `repeat_kv` | 12 | 12 under `src/models`, 14 including the DeepSeek-OCR Qwen2 vision encoder and the Qwen3-Omni MoE speech layers | `grep -rln '\brepeat_kv(' src --include='*.rs'` |
+| `softcap` | 1 | 1 production caller (RecurrentGemma), plus the core unit tests | `grep -rn '\bsoftcap(' src --include='*.rs'` |
+
+The issue's 46 for `create_causal_mask` counted two test files. The nine callers outside `src/models` are `lib.rs`, `layers.rs`, `cache.rs`, the tensor-parallel Llama runtime, the GLM4 pipeline stage executor, disaggregated handoff, and three test files.
+
+`softcap` needs one caveat that a naive grep does not surface: `src/lib/mlxcel-xla/src/emitter/model.rs` defines its own private `fn softcap` for the XLA emitter, which is a different function in a different crate. It appears in the grep output and is not a caller of the `utils.rs` helper. The annotation counts only genuine callers.
+
+### 2.2 Verification of the "Not Used By" Half
+
+Each family named in a group was verified by per-file grep to have at least one call, and each family named in the "not used by" list was verified to have zero. That second check is the one that matters most here, because the "not used by" clause is the part that would have prevented the original staleness from misleading anyone.
+
+### 2.3 Scope Containment
+
+The `.rs` diff is provably comment-only: every added and removed line in `src/lib/mlxcel-core/src/utils.rs` matches `^\s*(///|//)`. No function body, signature, or value changed. `cargo fmt --check` is clean, which follows from `rustfmt` not reflowing comments at the project's settings.
+
+---
+
+## 3. Technical Decisions
+
+### 3.1 Rule Plus Representatives Instead of a 44-Name Roster
+
+| Option | Pros | Cons |
+|---|---|---|
+| List all 44 non-test callers by name | Exact today | Wrong by the next release, and long enough that nobody repairs it, which is how the original annotation got into this state |
+| Name only the exceptions ("all decoders except X, Y") | Short | The exception set is itself large and shifting; it inverts the same maintenance problem |
+| **Chosen: a rule for why a caller is on the list, representatives per group, an explicit "not used by", and the regenerating grep** | Survives churn because the rule holds even as membership changes; a reader can rebuild the exact set in one command | Not literally exhaustive, so a reader who needs the precise set must run the grep |
+
+The rule is the load-bearing part: callers are the decoders that materialize an explicit prefill mask rather than leaving `mask: None` for fused SDPA to apply causality itself. That sentence stays true when a model is added or migrated. The four groups (hybrid and mixed-layer stacks, sliding-window and chunked families, VLM decoders, MLA and custom-attention decoders) each name their representatives, and the annotation closes with the grep that regenerates the exact list.
+
+### 3.2 Keep the "Not Used By" Half
+
+It would have been shorter to list only the users. The negative half is what makes the annotation robust against the exact failure it replaced: a contributor assuming that a shared helper still covers a family that moved off it several releases ago. Naming Llama3, Mixtral, Gemma, Gemma2, Cohere, Phi, GLM4, StarCoder2, Qwen3Moe and OLMoE as explicitly not-callers, with the reason (they pass `mask: None` for `seq_len > 1`), converts the old wrong roster into a documented correction.
+
+### 3.3 Record the Policy in the Guideline, Not Just in the Comment
+
+The issue asked for this directly. `docs/code-guidelines.md` gains a "When the caller list is too long to enumerate" section holding the four-part policy, with `create_causal_mask` as the worked example. The section also notes that public items take `///` rather than the `//` shown in the older format example, so the annotation survives into rustdoc. Recording it once in the guideline means the next 40-caller helper does not reopen the same choice.
+
+### 3.4 Place the Annotations at the End of the Doc Block
+
+All three annotations sit at the end of the existing doc block, after the `# Returns` section, matching the neighbouring `create_causal_mask_with_left_padding`. This keeps the function's own description first and the caller roster last, so a long roster does not push the actual documentation below the fold.
+
+---
+
+## 4. Change Summary
+
+### Statistics
+
+| Item | Value |
+|---|---|
+| Files changed | 2 |
+| Lines added | +62 |
+| Lines deleted | -2 |
+| Executable lines changed | 0 |
+| Functions annotated | 3 |
+
+### Changes by Area
+
+| Area | File | Summary |
+|---|---|---|
+| Correctness of an existing annotation | `src/lib/mlxcel-core/src/utils.rs` | `create_causal_mask`: stale roster naming non-callers replaced with a rule-level annotation, four caller groups with representatives, the non-`src/models` callers, an explicit "not used by", and the regenerating grep |
+| New annotation | `src/lib/mlxcel-core/src/utils.rs` | `repeat_kv`: literal list of all 14 callers plus the reason most decoders never call it |
+| New annotation | `src/lib/mlxcel-core/src/utils.rs` | `softcap`: names RecurrentGemma as the single production caller and records that Gemma 2 and Gemma 3 route through the fused `compiled_softcap` / `compiled_softcap_sdpa` kernels instead |
+| Convention | `docs/code-guidelines.md` | New "When the caller list is too long to enumerate" section holding the policy, with `create_causal_mask` as the worked example, and a note that public items use `///` |
+
+### Related Commits
+
+| Hash | Type | Message |
+|---|---|---|
+| `f0bf3a2c` | docs | docs(core): annotate the three tracked shared functions in utils.rs |
+
+---
+
+## 5. Validation and Follow-up
+
+### Passed
+
+- `.rs` diff provably comment-only: every added and removed line matches `^\s*(///|//)`.
+- `cargo fmt --check` clean.
+- `python3 scripts/ci/check_cross_repo_refs.py` clean.
+- Each family named in an annotation verified by per-file grep to have at least one call; each family in the "not used by" list verified to have zero.
+
+### Correction Against the Issue
+
+The issue's table recorded `create_causal_mask` as unannotated, with 46 model-file callers. Both figures needed correcting at implementation time: the function did carry an annotation, and 46 counted two test files against a real non-test count of 44. Neither correction changes what the PR had to do, but the first changes what the defect was. The remedy for a missing annotation is to add one; the remedy for an annotation that names non-callers is to replace it and to say in the file why those families are no longer users, which is what the "not used by" clause does.
+
+### Follow-up Candidates
+
+- No CI check enforces this convention, unlike the JIT kernel dtype-key rule enforced by `make verify-kernel-dtype-keys` and `scripts/ci/check_kernel_dtype_keys.py`. A checker that flags a `pub fn` in `utils.rs` or `layers.rs` with more than N cross-module callers and no `Used by:` line would keep this from recurring. The issue notes it is larger than the issue itself.
+- The staleness this PR found is not specific to `create_causal_mask`. Any long-lived `Used by:` roster elsewhere in `src/` can rot the same way, and nothing has audited the rest of them.
+- `docs/code-guidelines.md` also lists KVCache, Attention and Normalization in `layers.rs` as tracked shared components. This PR covered only the `utils.rs` half of that list.

--- a/TECHNICAL_REPORTS/1121-utils-used-by-annotations-20260814.ko.md
+++ b/TECHNICAL_REPORTS/1121-utils-used-by-annotations-20260814.ko.md
@@ -1,0 +1,139 @@
+# 기술 보고서: PR #1121 - docs(core): annotate the three tracked shared functions in utils.rs
+
+**작성일**: 2026-08-14
+**작성자**: Jeongkyu Shin
+**상태**: 완료
+**언어**: Rust (주석만), Markdown
+**위험도**: Low
+
+---
+
+## 요약
+
+PR #1121은 이슈 #1110을 해결한다. `docs/code-guidelines.md`는 공유 함수 `Used by:` 규칙으로 시작하면서 `utils.rs`의 `create_causal_mask`, `softcap`, `repeat_kv`를 추적 대상 컴포넌트로 지목한다. 이 PR은 셋 모두에 주석을 달고, 호출자가 너무 많아 나열이 불가능한 헬퍼를 위한 정책 절을 추가했다.
+
+실제 결함은 이슈가 서술한 것보다 나빴다. 이슈는 `create_causal_mask`에 주석이 없다고 기록했다. 주석은 있었고, 의미가 뒤집힐 정도로 낡아 있었다. 이제는 그 함수를 전혀 호출하지 않는 계열들을 사용자로 나열하고 있었기 때문이다. 잘못된 명단을 교체하는 일은 빠진 명단을 채우는 일보다 더 중요한 수정이다. 주석이 없으면 기여자가 직접 찾아보지만, 틀린 주석은 찾아보지 말라고 말하기 때문이다.
+
+---
+
+## 1. 문제 정의
+
+### 1.1 배경
+
+`Used by:` 관례는 기여자가 공유 헬퍼를 바꾸기 전에 영향 범위를 볼 수 있게 하려고 존재한다. `docs/code-guidelines.md`도 그 목적을 그대로 적는다. 한 모델을 고치다가 다른 모델을 깨뜨리는 일을 막고, 변경 후 재테스트가 필요한 모델을 분명히 하기 위해서다. 이 관례는 `src/` 전반에서 대체로 잘 지켜지고 있고, 같은 파일의 이웃인 `create_causal_mask_with_left_padding`은 `/// Used by: BatchQuantizedKVCache, BatchTurboQuantKVCache`를 달고 있다. 즉 파일 단위 예외가 아니라 누락이었다.
+
+### 1.2 기존 문제점
+
+- **`create_causal_mask`는 주석이 없던 게 아니라 낡은 주석을 달고 있었다.** PR 이전의 줄은 `Used by: Llama, Qwen, Mixtral, Gemma, Cohere, Phi, OLMo, Exaone, GLM4, MiniCPM, DeepSeek, Hunyuan, StarCoder2 and other causal attention callers`였다. 이 커밋 시점의 grep 결과 `mixtral.rs`, `phi.rs`, `phi3small.rs`, `starcoder2.rs`, `llama3.rs`, `gemma.rs`, `gemma2.rs`, `cohere.rs`, `glm4.rs`, `olmoe.rs`, `qwen3_moe.rs`는 각각 호출 횟수가 **0**이다. 이 계열들은 `seq_len > 1`에서 `mask: None`을 넘기는 implicit-causal fused-SDPA 경로로 옮겨 갔다. 따라서 주석은 단순히 불완전한 게 아니었다. 이 함수를 바꿔도 영향받지 않는 계열들을 사용자로 지목하고, 실제로 의존하는 hybrid, sliding-window, VLM, MLA decoder들은 빠뜨리고 있었다. 이 주석을 믿은 기여자는 엉뚱한 집합을 재테스트했을 것이다.
+- **`repeat_kv`와 `softcap`은 아무 주석도 없었다.** 둘 다 그대로 나열해도 될 만큼 짧아서 판단이 필요 없었고, 순수한 누락이었다.
+- **호출자가 40개인 헬퍼에 대해 가이드라인에 답이 없었다.** 이슈가 이를 명시적으로 요구했다. 큰 공유 함수를 다루는 다음 사람이 나열과 요약 사이의 선택을 다시 논의하지 않도록 하기 위해서다.
+
+### 1.3 위험성
+
+| 위험 | 영향도 | 발생 가능성 |
+|---|---|---|
+| 기여자가 `create_causal_mask`를 바꾸고 낡은 명단에 적힌 계열들(전부 이 함수를 호출하지 않는다)을 재테스트하는 동안, 실제 호출자인 hybrid와 VLM decoder는 검증되지 않고 지나감 | High | Medium |
+| 기여자가 가이드라인을 읽고 그 문서가 직접 지목한 예시 함수를 열었는데 주석이 없어 관례가 강제되지 않는다고 결론 내림 | Medium | Medium |
+| 앞으로 큰 헬퍼에 40개짜리 이름 명단이 달리고 한 릴리스 만에 낡음 | Medium | Medium |
+
+---
+
+## 2. 기술적 검토 사항
+
+### 2.1 모든 목록을 이 커밋에서 grep으로 도출
+
+어떤 목록도 이슈 본문이나 기존 주석에서 옮기지 않았다. 커밋 `f0bf3a2c` 기준 측정값이다.
+
+| 함수 | 이슈 수치 | 실측 | 명령 |
+|---|---|---|---|
+| `create_causal_mask` | 46 | `src/models` 아래 비테스트 44개(`diffusion_gemma/tests.rs`와 `phi3small_tests.rs` 포함 시 46), `src` 전체 55개 | `grep -rln '\bcreate_causal_mask(' src --include='*.rs'` |
+| `repeat_kv` | 12 | `src/models` 아래 12개, DeepSeek-OCR Qwen2 vision encoder와 Qwen3-Omni MoE speech layers 포함 시 14개 | `grep -rln '\brepeat_kv(' src --include='*.rs'` |
+| `softcap` | 1 | 프로덕션 호출자 1개(RecurrentGemma), 그리고 core 단위 테스트 | `grep -rn '\bsoftcap(' src --include='*.rs'` |
+
+`create_causal_mask`의 이슈 수치 46은 테스트 파일 두 개를 포함한 값이다. `src/models` 밖의 호출자 아홉은 `lib.rs`, `layers.rs`, `cache.rs`, tensor-parallel Llama runtime, GLM4 파이프라인 stage executor, disaggregated handoff, 그리고 테스트 파일 셋이다.
+
+`softcap`에는 단순 grep으로는 드러나지 않는 단서가 하나 필요하다. `src/lib/mlxcel-xla/src/emitter/model.rs`가 XLA emitter용으로 자체 private `fn softcap`을 정의하는데, 이는 다른 크레이트의 다른 함수다. grep 결과에는 나오지만 `utils.rs` 헬퍼의 호출자가 아니다. 주석은 진짜 호출자만 센다.
+
+### 2.2 "Not used by" 절반의 검증
+
+각 그룹에 이름이 오른 계열은 파일별 grep으로 최소 한 번 호출함을 확인했고, "not used by" 목록에 오른 계열은 호출 0임을 확인했다. 여기서는 두 번째 검사가 더 중요하다. 원래의 낡은 주석이 사람을 오도하는 것을 막았을 부분이 바로 "not used by" 절이기 때문이다.
+
+### 2.3 범위 통제
+
+`.rs` diff가 주석뿐임을 증명할 수 있다. `src/lib/mlxcel-core/src/utils.rs`에서 추가되고 삭제된 모든 줄이 `^\s*(///|//)`에 일치한다. 함수 본문, 시그니처, 값 중 바뀐 것이 없다. `cargo fmt --check`는 clean이며, 이는 프로젝트 설정에서 `rustfmt`가 주석을 재배치하지 않는 데서 따라온다.
+
+---
+
+## 3. 기술적 선택과 그 이유
+
+### 3.1 44개 이름 명단 대신 규칙 + 대표 사례
+
+| 옵션 | 장점 | 단점 |
+|---|---|---|
+| 비테스트 호출자 44개를 전부 이름으로 나열 | 오늘 기준으로는 정확 | 다음 릴리스에 틀려지고, 길이 때문에 아무도 고치지 않는다. 원래 주석이 이 상태가 된 경로가 바로 그것이다 |
+| 예외만 나열("X, Y를 제외한 모든 decoder") | 짧다 | 예외 집합 자체가 크고 계속 바뀐다. 유지보수 문제를 뒤집을 뿐이다 |
+| **선택: 호출자가 왜 목록에 있는지에 대한 규칙, 그룹별 대표, 명시적 "not used by", 목록을 재생성하는 grep** | 구성원이 바뀌어도 규칙은 유지되므로 변화에 견딘다. 정확한 집합은 한 줄 명령으로 재생성 가능 | 문자 그대로 전수는 아니므로, 정확한 집합이 필요한 독자는 grep을 실행해야 한다 |
+
+핵심은 규칙이다. 호출자는 fused SDPA가 causality를 적용하도록 `mask: None`을 남기는 대신 명시적 prefill mask를 직접 만드는 decoder들이다. 이 문장은 모델이 추가되거나 이전되어도 참으로 남는다. 네 그룹(hybrid와 mixed-layer stack, sliding-window와 chunked 계열, VLM decoder, MLA와 custom-attention decoder)마다 대표를 적었고, 주석은 정확한 목록을 재생성하는 grep으로 끝난다.
+
+### 3.2 "Not used by" 절반을 유지
+
+사용자만 나열했다면 더 짧았을 것이다. 이 부정 절반이야말로 이 주석이 대체한 바로 그 실패에 대해 견고함을 만든다. 즉 공유 헬퍼가 몇 릴리스 전에 이미 떠난 계열까지 여전히 덮고 있다고 기여자가 가정하는 실패다. Llama3, Mixtral, Gemma, Gemma2, Cohere, Phi, GLM4, StarCoder2, Qwen3Moe, OLMoE를 명시적 비호출자로 적고 그 이유(`seq_len > 1`에서 `mask: None`을 넘긴다)까지 남기면, 과거의 틀린 명단이 문서화된 정정으로 바뀐다.
+
+### 3.3 정책을 주석뿐 아니라 가이드라인에도 기록
+
+이슈가 직접 요구한 사항이다. `docs/code-guidelines.md`에 "When the caller list is too long to enumerate" 절이 생겼고, 네 부분으로 이뤄진 정책과 함께 `create_causal_mask`를 실제 예시로 담았다. 이 절은 공개 아이템에 옛 형식 예시의 `//` 대신 `///`를 쓴다는 점도 적는다. 그래야 주석이 rustdoc까지 살아남는다. 가이드라인에 한 번 기록해 두면 다음에 호출자 40개짜리 헬퍼가 나와도 같은 선택을 다시 열지 않는다.
+
+### 3.4 주석을 doc 블록 끝에 배치
+
+세 주석 모두 기존 doc 블록의 `# Returns` 절 뒤, 즉 블록 끝에 놓았다. 같은 파일의 이웃 `create_causal_mask_with_left_padding`과 같은 배치다. 이렇게 하면 함수 자체의 설명이 앞에 오고 호출자 명단이 뒤로 가므로, 긴 명단이 실제 문서를 아래로 밀어내지 않는다.
+
+---
+
+## 4. 변경 요약
+
+### 통계
+
+| 항목 | 값 |
+|---|---|
+| 변경된 파일 수 | 2 |
+| 추가된 라인 | +62 |
+| 삭제된 라인 | -2 |
+| 변경된 실행 라인 | 0 |
+| 주석을 단 함수 | 3 |
+
+### 영역별 변경
+
+| 영역 | 파일 | 주요 내용 |
+|---|---|---|
+| 기존 주석의 정확성 | `src/lib/mlxcel-core/src/utils.rs` | `create_causal_mask`: 비호출자를 나열하던 낡은 명단을 규칙 수준 주석으로 교체. 대표를 포함한 호출자 네 그룹, `src/models` 밖 호출자, 명시적 "not used by", 재생성 grep |
+| 신규 주석 | `src/lib/mlxcel-core/src/utils.rs` | `repeat_kv`: 호출자 14개 전체 나열과 대부분의 decoder가 호출하지 않는 이유 |
+| 신규 주석 | `src/lib/mlxcel-core/src/utils.rs` | `softcap`: 유일한 프로덕션 호출자로 RecurrentGemma를 지목하고, Gemma 2와 Gemma 3은 fused `compiled_softcap` / `compiled_softcap_sdpa` 커널을 거친다는 사실 기록 |
+| 관례 | `docs/code-guidelines.md` | 새 "When the caller list is too long to enumerate" 절에 정책과 `create_causal_mask` 실제 예시, 공개 아이템은 `///`를 쓴다는 주의 |
+
+### 관련 커밋
+
+| Hash | Type | Message |
+|---|---|---|
+| `f0bf3a2c` | docs | docs(core): annotate the three tracked shared functions in utils.rs |
+
+---
+
+## 5. 검증 및 후속 조치
+
+### 통과
+
+- `.rs` diff가 주석뿐임을 증명: 추가되고 삭제된 모든 줄이 `^\s*(///|//)`에 일치.
+- `cargo fmt --check` clean.
+- `python3 scripts/ci/check_cross_repo_refs.py` clean.
+- 주석에 이름이 오른 계열은 파일별 grep으로 최소 1회 호출 확인, "not used by" 목록의 계열은 0회 확인.
+
+### 이슈에 대한 정정
+
+이슈의 표는 `create_causal_mask`를 주석 없음, 모델 파일 호출자 46개로 기록했다. 구현 시점에 두 수치 모두 정정이 필요했다. 이 함수는 주석을 달고 있었고, 46은 테스트 파일 두 개를 포함한 값으로 실제 비테스트 수는 44다. 두 정정 모두 PR이 해야 할 일을 바꾸지는 않지만, 첫 번째는 결함의 성격을 바꾼다. 주석 누락의 해법은 추가하는 것이고, 비호출자를 나열하는 주석의 해법은 교체하면서 왜 그 계열들이 더 이상 사용자가 아닌지를 파일 안에 적는 것이다. "not used by" 절이 하는 일이 정확히 그것이다.
+
+### 후속 후보
+
+- 이 관례를 강제하는 CI 검사가 없다. `make verify-kernel-dtype-keys`와 `scripts/ci/check_kernel_dtype_keys.py`가 강제하는 JIT 커널 dtype-key 규칙과 대비된다. `utils.rs`나 `layers.rs`의 `pub fn` 중 교차 모듈 호출자가 N개를 넘고 `Used by:` 줄이 없는 것을 잡아내는 검사기가 있으면 재발을 막을 수 있다. 이슈도 이것이 이슈 자체보다 큰 작업이라고 적고 있다.
+- 이번에 발견한 staleness는 `create_causal_mask`만의 문제가 아니다. `src/` 어디에 있든 오래된 `Used by:` 명단은 같은 방식으로 썩을 수 있고, 나머지를 감사한 적은 없다.
+- `docs/code-guidelines.md`는 `layers.rs`의 KVCache, Attention, Normalization도 추적 대상 공유 컴포넌트로 열거한다. 이 PR은 그 목록의 `utils.rs` 절반만 다뤘다.


### PR DESCRIPTION
## Summary

Four PRs merged on 2026-08-13. Two of them, #1120 and #1122, got their bilingual technical reports from the chain workflow. #1118, #1119 and #1121 merged without one. This PR closes that gap after the fact so the batch is uniformly documented.

Six files, `.en.md` and `.ko.md` per PR, following the naming and section shape of the two reports already in `TECHNICAL_REPORTS/` from this same batch. No source, documentation, or build file is touched.

## What is here

| PR | Issue | Squash commit | Report |
|---|---|---|---|
| #1119 | #1104 | `cf4e22cd` | `1119-paged-decode-v2-env-vars-20260814.{en,ko}.md` |
| #1118 | #1108 | `33322d66` | `1118-cli-dry-sequence-breakers-20260814.{en,ko}.md` |
| #1121 | #1110 | `f0bf3a2c` | `1121-utils-used-by-annotations-20260814.{en,ko}.md` |

Each report was written from the merged diff (`git show <commit>`) and the linked issue body, not from the PR description alone. Each records at least one thing the issue did not contain.

## Findings recorded in the reports

**#1121 (issue #1110).** The issue was wrong on a load-bearing point. It recorded `create_causal_mask` as carrying no `Used by:` annotation. It carried one, and that annotation named Llama, Mixtral, Gemma, Cohere, Phi, GLM4, StarCoder2 and OLMo among its users while grep at that commit shows `mixtral.rs`, `phi.rs`, `phi3small.rs`, `starcoder2.rs`, `llama3.rs`, `gemma.rs`, `gemma2.rs`, `cohere.rs`, `glm4.rs`, `olmoe.rs` and `qwen3_moe.rs` each calling it zero times. Those families moved to the implicit-causal fused-SDPA path (`mask: None` when `seq_len > 1`). The PR therefore replaced a misleading roster rather than adding a missing one, which is a stronger defect than the issue described: a missing annotation sends a contributor to look, a wrong one tells them not to. Measured counts at that commit: 44 non-test callers under `src/models` (the issue's 46 counted `diffusion_gemma/tests.rs` and `phi3small_tests.rs`), 55 across all of `src`.

**#1119 (issue #1104).** All six variable defaults were traced to their definition sites rather than to the issue text. Two out-of-scope defects are recorded rather than fixed: `docs/turbo-kv-cache.md` around lines 298 to 312 still carries the same pre-#899 "not a server knob" framing this PR corrected in `environment-variables.md`, and in `src/execution/memory_estimate.rs` the `Err(_)` arm of `resolve_paged_slab_blocks` warns "using the derived slab size" and then returns `None`, which keeps the 32-block pool default instead, so the warning describes behavior that does not happen.

**#1118 (issue #1108).** The issue was reframed away from a flag-parity feature request into a docs fix after investigation showed the CLI omits nine server sampling knobs, not one. The change is comment-and-help-text only, 13 added lines all matching `^\s*(///|//)`. The second `dry_multiplier` field in `src/main.rs` belongs to `ServeArgs`, which already exposes `--dry-sequence-breakers` sixteen lines below, so it was deliberately left alone.

## Notes

`TECHNICAL_REPORTS/` is listed in `.gitignore` but is tracked through the `TECHNICAL_REPORTS/.keep-reports` marker, so the six files were staged with `git add -f`.

## Test plan

- [x] `git status --porcelain` shows exactly the six intended files staged and nothing else
- [x] Every claim in each report checked against the merged commit: caller counts re-run with `git grep` at `f0bf3a2c`, variable defaults re-read at their definition sites, diffstats taken from `git show --stat`
- [x] No build, test, lint, or format surface involved: the diff is six new Markdown files under `TECHNICAL_REPORTS/`
