### PR TITLE
fix(detect): read RT-DETRv2 outputs by dtype instead of assuming f32

### DIFF
--- a/docs/supported-models.md
+++ b/docs/supported-models.md
@@ -250,8 +250,26 @@ page is OCRed as one `plain` region, matching the reference. A one-line summary
 reports the counts, so a region that disappeared is visible rather than silent.
 
 Regions are OCRed and printed in the order the file lists them; nothing
-reorders them. The reference detector emits reading order, so supply the
-detections in reading order.
+reorders them. The reference detector emits reading order, and so does `mlxcel
+detect` (top to bottom, then left to right), so the two commands pipe together
+directly:
+
+```bash
+mlxcel detect -m models/docling-layout-heron-mlx-bf16 -i page.png --format json > layout.json
+mlxcel generate -m models/falcon-ocr -i page.png --layout-detections layout.json
+```
+
+A hand-written file should likewise be supplied in reading order.
+
+One page element can arrive under several labels. A DETR-style detection head
+takes no per-query argmax, so a heading that scores above the threshold as
+`section_header`, `title`, and `page_header` is emitted three times, each entry
+carrying the same box; `mlxcel detect` prints them together, most confident
+first. That is the detector's intended output, not a duplicate, so the planner
+collapses same-box entries to one region rather than OCRing the text once per
+label. The label it keeps is the highest-confidence one that maps to an OCR
+category, so a box detected as both `picture` and `text` is still read as text
+instead of being skipped on the un-OCRable label.
 
 ### Phi-4 Multimodal audio
 

--- a/src/commands/detect.rs
+++ b/src/commands/detect.rs
@@ -57,13 +57,8 @@ pub(crate) fn run_detect(args: DetectArgs) -> Result<()> {
         .predict_path(&args.image)
         .map_err(|e| anyhow!("detection failed: {e}"))?;
 
-    // Sort detections by descending confidence for stable, readable output.
     let mut detections = result.detections;
-    detections.sort_by(|a, b| {
-        b.score
-            .partial_cmp(&a.score)
-            .unwrap_or(std::cmp::Ordering::Equal)
-    });
+    sort_reading_order(&mut detections);
 
     match args.format {
         OutputFormat::Text => {
@@ -121,6 +116,42 @@ pub(crate) fn run_detect(args: DetectArgs) -> Result<()> {
     Ok(())
 }
 
+/// Order detections top-to-bottom then left-to-right, so the emitted list is
+/// document reading order rather than detector confidence order.
+///
+/// This is what makes `mlxcel detect --format json | mlxcel generate
+/// --layout-detections` correct end to end: the Falcon-OCR layout path
+/// deliberately preserves the order of the file it is handed (the reference
+/// detector, PP-DocLayoutV3, carries an `order_logits` head and emits reading
+/// order directly), so whatever order this command prints becomes the order the
+/// per-region OCR output appears in. RT-DETRv2 has no order head, so the order
+/// is derived from geometry here instead.
+///
+/// The comparison is a strict total order so the output is reproducible:
+/// top edge, then left edge, then descending confidence, then class id. The
+/// confidence tiebreak keeps the several labels a single query can emit (see
+/// `decode_detections`) adjacent and most-confident-first, since they share one
+/// box and therefore compare equal on geometry.
+///
+/// Geometry-derived order is an approximation: it reads a multi-column page
+/// row-wise rather than column-wise, because nothing in the box coordinates
+/// distinguishes a two-column layout from a wide single-column one.
+fn sort_reading_order(detections: &mut [mlxcel::vision::detection::Detection]) {
+    detections.sort_by(|a, b| {
+        let key = |d: &mlxcel::vision::detection::Detection| (d.bbox[1], d.bbox[0]);
+        let (ka, kb) = (key(a), key(b));
+        ka.0.partial_cmp(&kb.0)
+            .unwrap_or(std::cmp::Ordering::Equal)
+            .then_with(|| ka.1.partial_cmp(&kb.1).unwrap_or(std::cmp::Ordering::Equal))
+            .then_with(|| {
+                b.score
+                    .partial_cmp(&a.score)
+                    .unwrap_or(std::cmp::Ordering::Equal)
+            })
+            .then_with(|| a.label.cmp(&b.label))
+    });
+}
+
 /// Output format for the `detect` subcommand.
 #[derive(Clone, Copy, Debug, Default, clap::ValueEnum)]
 pub(crate) enum OutputFormat {
@@ -130,3 +161,7 @@ pub(crate) enum OutputFormat {
     /// Machine-readable JSON.
     Json,
 }
+
+#[cfg(test)]
+#[path = "detect_tests.rs"]
+mod tests;

--- a/src/commands/detect_tests.rs
+++ b/src/commands/detect_tests.rs
@@ -1,0 +1,106 @@
+// Copyright 2025-2026 Lablup Inc. and Jeongkyu Shin
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Unit tests for `mlxcel detect` output ordering.
+
+use super::*;
+use mlxcel::vision::detection::Detection;
+
+fn det(class_name: &str, label: usize, bbox: [f32; 4], score: f32) -> Detection {
+    Detection {
+        bbox,
+        score,
+        label,
+        class_name: class_name.to_string(),
+    }
+}
+
+/// The emitted list is document reading order, not detector confidence order.
+///
+/// `mlxcel generate --layout-detections` preserves the order of the file it is
+/// handed, so this ordering is what makes the two commands compose into
+/// correctly ordered per-region OCR (issue #1089).
+#[test]
+fn detections_are_emitted_in_reading_order() {
+    // A page whose confidence order and reading order disagree: the body
+    // paragraphs score highest but sit below the headings that introduce them.
+    let mut dets = vec![
+        det("text", 9, [59.0, 213.0, 957.0, 427.0], 0.947),
+        det("text", 9, [64.0, 541.0, 943.0, 718.0], 0.926),
+        det("text", 9, [70.0, 825.0, 961.0, 962.0], 0.808),
+        det("section_header", 7, [72.0, 153.0, 463.0, 185.0], 0.798),
+        det("section_header", 7, [81.0, 482.0, 513.0, 513.0], 0.712),
+        det("section_header", 7, [80.0, 60.0, 771.0, 109.0], 0.706),
+        det("page_footer", 4, [80.0, 1200.0, 670.0, 1237.0], 0.510),
+    ];
+    sort_reading_order(&mut dets);
+
+    let tops: Vec<f32> = dets.iter().map(|d| d.bbox[1]).collect();
+    assert_eq!(
+        tops,
+        vec![60.0, 153.0, 213.0, 482.0, 541.0, 825.0, 1200.0],
+        "expected top-to-bottom order, got {tops:?}"
+    );
+    // The footer is last, which is the whole point on a tall page.
+    assert_eq!(dets.last().unwrap().class_name, "page_footer");
+}
+
+/// Boxes on the same line read left to right.
+#[test]
+fn boxes_sharing_a_top_edge_read_left_to_right() {
+    let mut dets = vec![
+        det("text", 9, [500.0, 100.0, 900.0, 150.0], 0.5),
+        det("text", 9, [100.0, 100.0, 400.0, 150.0], 0.4),
+    ];
+    sort_reading_order(&mut dets);
+    let lefts: Vec<f32> = dets.iter().map(|d| d.bbox[0]).collect();
+    assert_eq!(lefts, vec![100.0, 500.0]);
+}
+
+/// The several labels one query can emit share a box, so they compare equal on
+/// geometry. They must stay adjacent and most-confident-first, which is what
+/// lets the layout planner keep the best label when it collapses them to one
+/// region.
+#[test]
+fn labels_sharing_one_box_stay_adjacent_most_confident_first() {
+    let heading = [80.0, 60.0, 771.0, 109.0];
+    let mut dets = vec![
+        det("page_header", 5, heading, 0.400),
+        det("title", 10, heading, 0.415),
+        det("text", 9, [59.0, 213.0, 957.0, 427.0], 0.947),
+        det("section_header", 7, heading, 0.706),
+    ];
+    sort_reading_order(&mut dets);
+
+    let names: Vec<&str> = dets.iter().map(|d| d.class_name.as_str()).collect();
+    assert_eq!(
+        names,
+        vec!["section_header", "title", "page_header", "text"],
+        "the heading's labels must group together, best first"
+    );
+}
+
+/// The order is a strict total order, so equal geometry and equal confidence
+/// still sort reproducibly rather than depending on input order.
+#[test]
+fn fully_tied_detections_order_by_class_id() {
+    let same = [10.0, 10.0, 100.0, 50.0];
+    let mut dets = vec![det("text", 9, same, 0.5), det("footnote", 1, same, 0.5)];
+    sort_reading_order(&mut dets);
+    assert_eq!(dets[0].label, 1);
+
+    let mut reversed = vec![det("footnote", 1, same, 0.5), det("text", 9, same, 0.5)];
+    sort_reading_order(&mut reversed);
+    assert_eq!(reversed[0].label, 1, "order must not depend on input order");
+}

--- a/src/commands/generate_falcon_ocr_tests.rs
+++ b/src/commands/generate_falcon_ocr_tests.rs
@@ -380,3 +380,81 @@ fn region_answers_drop_the_task_terminators() {
     );
     assert_eq!(clean_region_answer("plain text"), "plain text");
 }
+
+/// Verbatim `mlxcel detect --format json` output for a real multi-region page:
+/// a heading, a body paragraph, and a footer on a 1000x1300 portrait page, as
+/// produced by the docling-layout-heron checkpoint after the readback fix in
+/// issue #1089. Kept literal, not regenerated, so a change to either command's
+/// contract shows up here.
+const DETECT_PIPELINE_JSON: &str = r#"{
+  "image": "page.png",
+  "threshold": 0.30000001192092896,
+  "detections": [
+    {"label": "section_header", "label_id": 7, "confidence": 0.6150878667831421,
+     "box": {"l": 80.078125, "t": 58.3984375, "r": 771.484375, "b": 105.37109375}},
+    {"label": "title", "label_id": 10, "confidence": 0.4148988723754883,
+     "box": {"l": 80.078125, "t": 58.3984375, "r": 771.484375, "b": 105.37109375}},
+    {"label": "list_item", "label_id": 3, "confidence": 0.31742626428604126,
+     "box": {"l": 80.078125, "t": 58.3984375, "r": 771.484375, "b": 105.37109375}},
+    {"label": "text", "label_id": 9, "confidence": 0.9149009585380554,
+     "box": {"l": 62.5, "t": 197.412109375, "r": 953.125, "b": 335.791015625}},
+    {"label": "page_footer", "label_id": 4, "confidence": 0.5,
+     "box": {"l": 78.125, "t": 1200.341796875, "r": 671.875, "b": 1237.158203125}}
+  ]
+}"#;
+
+/// `mlxcel detect --format json | mlxcel generate --layout-detections` must
+/// plan one region per page element, in reading order (issue #1089).
+///
+/// This pins the composition of the two commands at the seam they share: the
+/// detector's JSON goes in unmodified, and what comes out is the region list
+/// the per-region OCR loop walks, in the order it prints them. Three things
+/// have to hold at once, and each was broken or unverified before: the boxes
+/// must be real page geometry rather than one collapsed rectangle, the heading
+/// must be OCRed once rather than once per label, and the footer must come last
+/// rather than first (it outranks nothing on confidence, but it is last on the
+/// page).
+#[test]
+fn detect_json_plans_into_reading_ordered_regions_without_repeats() {
+    let detections = parse_layout_detections(DETECT_PIPELINE_JSON).expect("detect JSON parses");
+    assert_eq!(detections.len(), 5, "all five entries survive parsing");
+
+    let plans = plan(&detections);
+
+    let categories: Vec<&str> = plans.iter().map(|p| p.category.as_str()).collect();
+    assert_eq!(
+        categories,
+        vec!["section_header", "text", "page_footer"],
+        "one region per page element, in reading order"
+    );
+
+    // Reading order: strictly increasing down the page.
+    let tops: Vec<f32> = plans.iter().map(|p| p.bbox[1]).collect();
+    assert!(
+        tops.windows(2).all(|w| w[0] < w[1]),
+        "regions must run down the page, got {tops:?}"
+    );
+
+    // Each region is a distinct rectangle: no collapse onto one box.
+    for (i, a) in plans.iter().enumerate() {
+        for b in plans.iter().skip(i + 1) {
+            assert_ne!(a.bbox, b.bbox, "two regions share a box");
+        }
+    }
+
+    // The footer reaches the bottom of a 1300-tall page. Before the fix every
+    // detection shared one box that stopped near the middle of the page.
+    let footer = plans.last().expect("a footer region");
+    assert_eq!(footer.category, "page_footer");
+    assert!(
+        footer.bbox[3] > 1200.0,
+        "footer must reach the bottom of the page, got {:?}",
+        footer.bbox
+    );
+
+    // Every region crops to something OCRable.
+    for plan in &plans {
+        let (_, _, w, h) = plan.crop;
+        assert!(w >= MIN_CROP_DIM && h >= MIN_CROP_DIM, "{plan:?}");
+    }
+}

--- a/src/vision/detection/rt_detr_v2/common.rs
+++ b/src/vision/detection/rt_detr_v2/common.rs
@@ -34,10 +34,13 @@ pub fn copy_weight_opt(weights: &WeightMap, key: &str) -> Option<UniquePtr<MlxAr
     weights.get(key).map(|w| mlxcel_core::copy(w))
 }
 
-/// Cast an array to float32 for numerically-sensitive sub-graphs (softmax,
-/// attention, anchor logits). The detection head's box coordinates are
-/// precision-sensitive, so the whole forward runs in f32 regardless of the
-/// checkpoint's stored dtype.
+/// Cast an array to float32.
+///
+/// Used to normalize the input image to f32 before the vision tower. Note that
+/// this does not pin the *graph* to f32: MLX settles each op on its operand
+/// dtypes, so the first conv against a bf16 weight brings the graph back to
+/// bf16 for a bf16 checkpoint. Anything reading model outputs back to the host
+/// must convert by dtype rather than assuming a width.
 pub fn to_f32(x: &MlxArray) -> UniquePtr<MlxArray> {
     mlxcel_core::astype(x, mlxcel_core::dtype::FLOAT32)
 }

--- a/src/vision/detection/rt_detr_v2/mod.rs
+++ b/src/vision/detection/rt_detr_v2/mod.rs
@@ -30,10 +30,17 @@
 //! token stream, so it lives outside the `LanguageModel`/generate flow. It is
 //! driven through [`RtDetrV2Predictor`] (see the `detect` CLI subcommand).
 //!
-//! The whole forward path runs in float32 for box-coordinate precision,
-//! regardless of the stored checkpoint dtype (the shipped checkpoints are
-//! bf16). This matches the reference, whose dtype-sensitive ops (softmax, SDPA,
-//! anchor logits) are computed in f32 and whose predictor reads f32 anyway.
+//! Dtype: the forward graph inherits the checkpoint dtype. `pixel_values`
+//! enters as f32, but the first conv against a bf16 weight settles the graph
+//! into bf16, so `pred_logits` and `pred_boxes` come back as bf16 for the
+//! shipped bf16 checkpoints. This matches the reference, which also runs in the
+//! checkpoint dtype.
+//!
+//! Because the output dtype tracks the checkpoint rather than being fixed,
+//! anything that reads these arrays back as host floats must convert by dtype
+//! rather than assuming a width. [`predictor`]'s readback casts to f32 before
+//! touching raw bytes for exactly this reason; see the note on its `read_output_f32`
+//! for what a fixed-width parse does to a bf16 buffer.
 
 pub mod backbone;
 pub mod common;

--- a/src/vision/detection/rt_detr_v2/model.rs
+++ b/src/vision/detection/rt_detr_v2/model.rs
@@ -161,9 +161,12 @@ impl RtDetrV2Model {
 
     /// Forward pass.
     ///
-    /// `pixel_values`: (B, image_size, image_size, 3) NHWC in [0, 1]. The whole
-    /// graph runs in f32 for box-coordinate precision regardless of the stored
-    /// checkpoint dtype.
+    /// `pixel_values`: (B, image_size, image_size, 3) NHWC in [0, 1].
+    ///
+    /// The returned arrays carry the checkpoint's dtype, not f32: the input is
+    /// cast to f32 here, but the first conv against a bf16 weight settles the
+    /// graph into bf16 for the shipped bf16 checkpoints. Read the outputs
+    /// through a dtype-aware conversion.
     pub fn forward(&self, pixel_values: &MlxArray) -> DetectionOutput {
         let pixel_values = to_f32(pixel_values);
         let enc_features = self.vision.forward(&pixel_values);

--- a/src/vision/detection/rt_detr_v2/predictor.rs
+++ b/src/vision/detection/rt_detr_v2/predictor.rs
@@ -90,69 +90,121 @@ impl RtDetrV2Predictor {
         let q = logits_shape[1] as usize;
         let num_labels = logits_shape[2] as usize;
 
-        let logits = to_f32_vec(&out.pred_logits); // length B*Q*num_labels
-        let boxes = to_f32_vec(&out.pred_boxes); // length B*Q*4
+        let logits = read_output_f32(&out.pred_logits); // length B*Q*num_labels
+        let boxes = read_output_f32(&out.pred_boxes); // length B*Q*4
 
-        let detections =
-            self.decode_one(&logits, &boxes, q, num_labels, img_w as f32, img_h as f32);
+        // Guard the readback seam. A dtype or layout change that shortens
+        // either buffer used to sail through silently, because the decode
+        // indexes by `query * num_labels` / `query * 4` and simply saw fewer
+        // entries than the shapes advertise. Fail loudly instead.
+        if logits.len() != q * num_labels || boxes.len() != q * 4 {
+            return Err(format!(
+                "RT-DETRv2 output readback mismatch: pred_logits has {} values (expected \
+                 {q}x{num_labels}={}), pred_boxes has {} values (expected {q}x4={})",
+                logits.len(),
+                q * num_labels,
+                boxes.len(),
+                q * 4
+            ));
+        }
+
+        let detections = decode_detections(
+            &logits,
+            &boxes,
+            q,
+            num_labels,
+            img_w as f32,
+            img_h as f32,
+            self.threshold,
+            self.labels.as_deref(),
+        );
         Ok(DetectionResult { detections })
     }
+}
 
-    /// Top-K extraction across the flat `(queries x labels)` score space.
-    fn decode_one(
-        &self,
-        logits: &[f32],
-        boxes: &[f32],
-        q: usize,
-        num_labels: usize,
-        img_w: f32,
-        img_h: f32,
-    ) -> Vec<Detection> {
-        // scores = sigmoid(logits), flattened to q*num_labels.
-        let flat_len = q * num_labels;
-        let mut scored: Vec<(usize, f32)> = Vec::with_capacity(flat_len);
-        for (i, &l) in logits.iter().take(flat_len).enumerate() {
-            scored.push((i, sigmoid(l)));
-        }
-        // Top-K = top-`q` by score (upstream takes k = min(Q, flat.size) = Q).
-        let k = q.min(flat_len);
-        // Partial sort: select the k highest scores, then sort descending.
-        scored.sort_by(|a, b| b.1.partial_cmp(&a.1).unwrap_or(std::cmp::Ordering::Equal));
-        scored.truncate(k);
+/// Map one normalized `(cx, cy, w, h)` box to `(left, top, right, bottom)` in
+/// original-image pixels.
+///
+/// The RT-DETRv2 preprocessor resizes straight to `image_size x image_size`
+/// with `do_pad: false` (no letterbox, no aspect-preserving padding), so the
+/// forward transform is an independent per-axis scale and its inverse is the
+/// same independent per-axis scale: x by the original width, y by the original
+/// height. There is no padding offset to subtract and no single shared scale
+/// factor; a tall page and a wide page go through the identical code path.
+pub fn denormalize_box(cxcywh: [f32; 4], img_w: f32, img_h: f32) -> [f32; 4] {
+    let cx = cxcywh[0] * img_w;
+    let cy = cxcywh[1] * img_h;
+    let bw = cxcywh[2] * img_w;
+    let bh = cxcywh[3] * img_h;
+    [
+        (cx - bw / 2.0).clamp(0.0, img_w),
+        (cy - bh / 2.0).clamp(0.0, img_h),
+        (cx + bw / 2.0).clamp(0.0, img_w),
+        (cy + bh / 2.0).clamp(0.0, img_h),
+    ]
+}
 
-        let mut detections = Vec::new();
-        for (flat_idx, score) in scored {
-            if score < self.threshold {
-                continue;
-            }
-            let query = flat_idx / num_labels;
-            let label = flat_idx % num_labels;
-
-            // box = boxes[query] = (cx, cy, w, h) normalized.
-            let bx = query * 4;
-            let cx = boxes[bx] * img_w;
-            let cy = boxes[bx + 1] * img_h;
-            let bw = boxes[bx + 2] * img_w;
-            let bh = boxes[bx + 3] * img_h;
-            let x1 = (cx - bw / 2.0).clamp(0.0, img_w);
-            let y1 = (cy - bh / 2.0).clamp(0.0, img_h);
-            let x2 = (cx + bw / 2.0).clamp(0.0, img_w);
-            let y2 = (cy + bh / 2.0).clamp(0.0, img_h);
-
-            let class_name = match &self.labels {
-                Some(names) if label < names.len() => names[label].clone(),
-                _ => label.to_string(),
-            };
-
-            detections.push(Detection {
-                bbox: [x1, y1, x2, y2],
-                score,
-                label,
-                class_name,
-            });
-        }
-        detections
+/// Top-K extraction across the flat `(queries x labels)` score space.
+///
+/// Mirrors `RTDetrImageProcessor.post_process_object_detection` for
+/// `use_focal_loss=True`: the top-K runs over the flattened
+/// `(queries x labels)` grid with no per-query argmax, so a single query whose
+/// sigmoid clears the threshold under several classes legitimately emits one
+/// detection per class, all sharing that query's box. This is the reference
+/// head's semantics, not a duplication bug; callers that need one label per
+/// region should pick the highest-scoring entry per box.
+#[allow(clippy::too_many_arguments)]
+pub fn decode_detections(
+    logits: &[f32],
+    boxes: &[f32],
+    q: usize,
+    num_labels: usize,
+    img_w: f32,
+    img_h: f32,
+    threshold: f32,
+    labels: Option<&[String]>,
+) -> Vec<Detection> {
+    // scores = sigmoid(logits), flattened to q*num_labels.
+    let flat_len = q * num_labels;
+    let mut scored: Vec<(usize, f32)> = Vec::with_capacity(flat_len);
+    for (i, &l) in logits.iter().take(flat_len).enumerate() {
+        scored.push((i, sigmoid(l)));
     }
+    // Top-K = top-`q` by score (upstream takes k = min(Q, flat.size) = Q).
+    let k = q.min(flat_len);
+    // Partial sort: select the k highest scores, then sort descending.
+    scored.sort_by(|a, b| b.1.partial_cmp(&a.1).unwrap_or(std::cmp::Ordering::Equal));
+    scored.truncate(k);
+
+    let mut detections = Vec::new();
+    for (flat_idx, score) in scored {
+        if score < threshold {
+            continue;
+        }
+        let query = flat_idx / num_labels;
+        let label = flat_idx % num_labels;
+
+        // box = boxes[query] = (cx, cy, w, h) normalized.
+        let bx = query * 4;
+        let bbox = denormalize_box(
+            [boxes[bx], boxes[bx + 1], boxes[bx + 2], boxes[bx + 3]],
+            img_w,
+            img_h,
+        );
+
+        let class_name = match labels {
+            Some(names) if label < names.len() => names[label].clone(),
+            _ => label.to_string(),
+        };
+
+        detections.push(Detection {
+            bbox,
+            score,
+            label,
+            class_name,
+        });
+    }
+    detections
 }
 
 fn sigmoid(x: f32) -> f32 {
@@ -161,10 +213,18 @@ fn sigmoid(x: f32) -> f32 {
 
 /// Materialize an MLX array and read it back as a row-major `Vec<f32>`.
 ///
-/// The forward path produces f32 outputs, so a direct 4-byte LE parse is
-/// correct. `contiguous` guarantees row-major before extraction.
-fn to_f32_vec(arr: &MlxArray) -> Vec<f32> {
-    let contiguous = mlxcel_core::contiguous(arr, false);
+/// The forward graph inherits the checkpoint dtype: the shipped RT-DETRv2
+/// checkpoints are bf16, so `pred_logits` and `pred_boxes` come back as bf16
+/// even though `pixel_values` enters as f32. `array_to_raw_bytes` hands back
+/// the buffer verbatim, so the cast to f32 must happen *before* the 4-byte LE
+/// parse. Parsing a bf16 buffer 4 bytes at a time silently reinterprets each
+/// adjacent pair of values as one f32 (bf16 is the high half of an f32, so the
+/// result is the odd-indexed element polluted with the even one's bits) and
+/// halves the element count, which scrambles every query/label/box association
+/// downstream without erroring.
+pub(crate) fn read_output_f32(arr: &MlxArray) -> Vec<f32> {
+    let as_f32 = mlxcel_core::astype(arr, mlxcel_core::dtype::FLOAT32);
+    let contiguous = mlxcel_core::contiguous(&as_f32, false);
     let c = contiguous.as_ref().expect("contiguous returned null");
     mlxcel_core::eval(c);
     let bytes = mlxcel_core::array_to_raw_bytes(c);

--- a/src/vision/detection/rt_detr_v2/tests.rs
+++ b/src/vision/detection/rt_detr_v2/tests.rs
@@ -138,3 +138,244 @@ fn inverse_sigmoid_is_logit() {
     let v = read_f32(&back);
     assert!((v[0] - 0.73).abs() < 1e-4, "got {}", v[0]);
 }
+
+// ---------------------------------------------------------------------------
+// Output readback and box denormalization (issue #1089).
+//
+// The detector used to return boxes that matched no page content. The seam was
+// the host readback in `predictor`: the forward graph inherits the checkpoint
+// dtype (bf16 for the shipped checkpoints), but the readback parsed the raw
+// buffer as 4-byte f32. bf16 is the high half of an f32, so a 4-byte parse over
+// a bf16 buffer fuses each adjacent pair into one bogus f32 and returns half
+// the elements, which silently misaligns every query/label/box association.
+//
+// These pin both halves of that seam without needing a checkpoint: the dtype
+// round-trip, and the pixel mapping for tall / wide / square images.
+// ---------------------------------------------------------------------------
+
+/// A bf16 array must read back element-for-element, not pair-fused.
+///
+/// This is the exact failure that produced the wrong boxes: a length mismatch
+/// here means the decode indexes `query * num_labels` into a buffer half the
+/// size it expects.
+#[test]
+fn bf16_output_reads_back_elementwise() {
+    let values: Vec<f32> = (0..64).map(|i| (i as f32) * 0.015_625 - 0.5).collect();
+    let f32_arr = mlxcel_core::from_slice_f32(&values, &[1, 16, 4]);
+    let bf16_arr = mlxcel_core::astype(&f32_arr, mlxcel_core::dtype::BFLOAT16);
+
+    let got = super::predictor::read_output_f32(&bf16_arr);
+
+    assert_eq!(
+        got.len(),
+        values.len(),
+        "bf16 readback returned {} of {} elements; a fixed-width parse fuses \
+         adjacent bf16 values into one f32",
+        got.len(),
+        values.len()
+    );
+    // The chosen values are exact in bf16 (multiples of 1/64 in [-0.5, 0.5)),
+    // so the round-trip is lossless and can be compared exactly.
+    for (i, (g, w)) in got.iter().zip(values.iter()).enumerate() {
+        assert!((g - w).abs() < 1e-6, "element {i}: got {g}, want {w}");
+    }
+}
+
+/// The same readback must stay correct for an f32 array, so the fix is a
+/// dtype-normalizing conversion rather than a bf16 special case.
+#[test]
+fn f32_output_reads_back_elementwise() {
+    let values: Vec<f32> = (0..32).map(|i| i as f32 * 0.1).collect();
+    let arr = mlxcel_core::from_slice_f32(&values, &[1, 8, 4]);
+    let got = super::predictor::read_output_f32(&arr);
+    assert_eq!(got.len(), values.len());
+    for (g, w) in got.iter().zip(values.iter()) {
+        assert!((g - w).abs() < 1e-6);
+    }
+}
+
+/// The box mapping is an independent per-axis scale, so a box at the same
+/// normalized position must land at the proportional pixel position on a tall,
+/// a wide, and a square page alike.
+///
+/// The RT-DETRv2 preprocessor resizes straight to a square with `do_pad:
+/// false`, so there is no letterbox offset to undo and no shared scale factor.
+#[test]
+fn denormalize_box_scales_each_axis_independently() {
+    use super::predictor::denormalize_box;
+
+    // A box centered at (0.25, 0.94) sized (0.4, 0.04): the footer band of a
+    // page, left-of-center. Deliberately near the bottom edge, where a bad
+    // inverse transform shows up worst.
+    let norm = [0.25, 0.94, 0.4, 0.04];
+
+    // Tall portrait page.
+    let b = denormalize_box(norm, 1000.0, 1300.0);
+    assert!((b[0] - 50.0).abs() < 1e-3, "left {}", b[0]);
+    assert!((b[1] - 1196.0).abs() < 1e-3, "top {}", b[1]);
+    assert!((b[2] - 450.0).abs() < 1e-3, "right {}", b[2]);
+    assert!((b[3] - 1248.0).abs() < 1e-3, "bottom {}", b[3]);
+
+    // Wide landscape page: same normalized box, axes swapped.
+    let b = denormalize_box(norm, 1300.0, 1000.0);
+    assert!((b[0] - 65.0).abs() < 1e-3, "left {}", b[0]);
+    assert!((b[1] - 920.0).abs() < 1e-3, "top {}", b[1]);
+    assert!((b[2] - 585.0).abs() < 1e-3, "right {}", b[2]);
+    assert!((b[3] - 960.0).abs() < 1e-3, "bottom {}", b[3]);
+
+    // Square page.
+    let b = denormalize_box(norm, 1000.0, 1000.0);
+    assert!((b[0] - 50.0).abs() < 1e-3, "left {}", b[0]);
+    assert!((b[1] - 920.0).abs() < 1e-3, "top {}", b[1]);
+    assert!((b[2] - 450.0).abs() < 1e-3, "right {}", b[2]);
+    assert!((b[3] - 960.0).abs() < 1e-3, "bottom {}", b[3]);
+}
+
+/// A box running past an edge clamps to the page, and the clamp uses the
+/// per-axis extent rather than a single dimension.
+#[test]
+fn denormalize_box_clamps_per_axis() {
+    use super::predictor::denormalize_box;
+
+    // Full-page box, oversized: clamps to exactly the page rectangle.
+    let b = denormalize_box([0.5, 0.5, 2.0, 2.0], 1000.0, 1300.0);
+    assert_eq!(b, [0.0, 0.0, 1000.0, 1300.0]);
+
+    // A box hanging off the top-left corner clamps only the two low edges.
+    let b = denormalize_box([0.05, 0.02, 0.4, 0.1], 1000.0, 1300.0);
+    assert_eq!(b[0], 0.0);
+    assert_eq!(b[1], 0.0);
+    assert!((b[2] - 250.0).abs() < 1e-3, "right {}", b[2]);
+    assert!((b[3] - 91.0).abs() < 1e-3, "bottom {}", b[3]);
+}
+
+/// A synthetic page with three known regions must decode to three boxes that
+/// land on those regions, on a tall page.
+///
+/// This is the end-to-end shape of the reported failure: before the fix, every
+/// detection collapsed onto one origin-anchored box that reached neither the
+/// footer nor any drawn element. The logits/boxes here stand in for the model
+/// output so the geometry is pinned without a checkpoint.
+#[test]
+fn decode_places_known_regions_on_a_tall_page() {
+    use super::predictor::decode_detections;
+
+    let (img_w, img_h) = (1000.0f32, 1300.0f32);
+    let num_labels = 3;
+    let labels: Vec<String> = vec!["title".into(), "text".into(), "page_footer".into()];
+
+    // Three queries, each one region of a portrait page, in (cx, cy, w, h).
+    //   q0 title  : x 80..680,   y 60..110   -> c(0.38, 0.0654) s(0.60, 0.0385)
+    //   q1 body   : x 80..900,   y 300..330  -> c(0.49, 0.2423) s(0.82, 0.0231)
+    //   q2 footer : x 80..300,   y 1220..1250 -> c(0.19, 0.95)  s(0.22, 0.0231)
+    let boxes: Vec<f32> = vec![
+        0.38,
+        0.065_384_6,
+        0.60,
+        0.038_461_5, //
+        0.49,
+        0.242_307_7,
+        0.82,
+        0.023_076_9, //
+        0.19,
+        0.95,
+        0.22,
+        0.023_076_9,
+    ];
+    // Logit 2.0 -> sigmoid 0.881 (kept); -2.0 -> 0.119 (dropped by threshold).
+    let (hi, lo) = (2.0f32, -2.0f32);
+    let logits: Vec<f32> = vec![
+        hi, lo, lo, // q0 -> title
+        lo, hi, lo, // q1 -> text
+        lo, lo, hi, // q2 -> page_footer
+    ];
+
+    let dets = decode_detections(
+        &logits,
+        &boxes,
+        3,
+        num_labels,
+        img_w,
+        img_h,
+        0.3,
+        Some(&labels),
+    );
+
+    assert_eq!(dets.len(), 3, "expected one detection per region: {dets:?}");
+
+    let find = |name: &str| {
+        dets.iter()
+            .find(|d| d.class_name == name)
+            .unwrap_or_else(|| panic!("no {name} detection in {dets:?}"))
+    };
+
+    let title = find("title");
+    assert!((title.bbox[0] - 80.0).abs() < 1.0, "{:?}", title.bbox);
+    assert!((title.bbox[1] - 60.0).abs() < 1.0, "{:?}", title.bbox);
+    assert!((title.bbox[2] - 680.0).abs() < 1.0, "{:?}", title.bbox);
+    assert!((title.bbox[3] - 110.0).abs() < 1.0, "{:?}", title.bbox);
+
+    let body = find("text");
+    assert!((body.bbox[0] - 80.0).abs() < 1.0, "{:?}", body.bbox);
+    assert!((body.bbox[1] - 300.0).abs() < 1.0, "{:?}", body.bbox);
+    assert!((body.bbox[2] - 900.0).abs() < 1.0, "{:?}", body.bbox);
+    assert!((body.bbox[3] - 330.0).abs() < 1.0, "{:?}", body.bbox);
+
+    // The regression that started this issue: the footer detection must reach
+    // the bottom of a tall page, not stop short around the midpoint.
+    let footer = find("page_footer");
+    assert!((footer.bbox[0] - 80.0).abs() < 1.0, "{:?}", footer.bbox);
+    assert!((footer.bbox[1] - 1220.0).abs() < 1.0, "{:?}", footer.bbox);
+    assert!((footer.bbox[2] - 300.0).abs() < 1.0, "{:?}", footer.bbox);
+    assert!((footer.bbox[3] - 1250.0).abs() < 1.0, "{:?}", footer.bbox);
+    assert!(
+        footer.bbox[3] > img_h * 0.9,
+        "footer must reach the bottom of a {img_h}-tall page, got {:?}",
+        footer.bbox
+    );
+
+    // Every region gets its own box: no collapse onto a single rectangle.
+    assert_ne!(title.bbox, body.bbox);
+    assert_ne!(body.bbox, footer.bbox);
+}
+
+/// One query clearing the threshold under several classes emits one detection
+/// per class, all sharing that query's box.
+///
+/// This is `RTDetrImageProcessor.post_process_object_detection` semantics for
+/// `use_focal_loss=True`: the top-K runs over the flattened
+/// `(queries x labels)` grid with no per-query argmax. Repeated boxes are the
+/// head's intended output, so this test states the contract rather than
+/// treating the repeat as a defect. What was broken was the geometry, not the
+/// repetition.
+///
+/// Two queries are needed to observe this: K is `num_queries`, so a
+/// single-query input can only ever yield one entry no matter how many classes
+/// clear the threshold.
+#[test]
+fn one_query_may_emit_several_labels_sharing_its_box() {
+    use super::predictor::decode_detections;
+
+    let labels: Vec<String> = vec!["title".into(), "section_header".into(), "text".into()];
+    // q0 is a real region; q1 is an empty background query.
+    let boxes: Vec<f32> = vec![
+        0.5, 0.1, 0.6, 0.04, //
+        0.5, 0.5, 0.1, 0.1,
+    ];
+    // Two of q0's classes clear 0.3; its third and all of q1 stay well below,
+    // so the top-2 are both q0 entries.
+    let logits: Vec<f32> = vec![
+        1.5, 0.8, -3.0, //
+        -4.0, -4.0, -4.0,
+    ];
+
+    let dets = decode_detections(&logits, &boxes, 2, 3, 1000.0, 1300.0, 0.3, Some(&labels));
+
+    assert_eq!(dets.len(), 2, "{dets:?}");
+    assert_eq!(dets[0].bbox, dets[1].bbox, "same query -> same box");
+    assert!(dets[0].score > dets[1].score, "sorted by score descending");
+    let names: Vec<&str> = dets.iter().map(|d| d.class_name.as_str()).collect();
+    assert_eq!(names, vec!["title", "section_header"]);
+    // Both entries describe q0's region, not q1's.
+    assert!((dets[0].bbox[1] - 104.0).abs() < 1.0, "{:?}", dets[0].bbox);
+}

--- a/src/vision/falcon_ocr_layout.rs
+++ b/src/vision/falcon_ocr_layout.rs
@@ -145,6 +145,13 @@ fn containment_ratio(small: &[f32; 4], large: &[f32; 4]) -> f32 {
 ///
 /// Without this, an inline formula detected inside a paragraph is OCRed twice
 /// and the page text duplicates.
+///
+/// The container must be *strictly* larger, matching the reference: equal-area
+/// boxes would otherwise delete each other and the region would vanish
+/// entirely. Collapsing the same-box duplicates a DETR head emits is a separate
+/// concern handled in [`plan_layout_region_boxes`], which can consult the OCR
+/// category mapping that this pure-geometry filter has no business knowing
+/// about.
 pub fn filter_nested_detections(
     detections: &[Detection],
     containment_threshold: f32,
@@ -274,11 +281,28 @@ pub fn plan_layout_region_boxes(
     }
 
     let kept = filter_nested_detections(detections, containment_threshold);
-    let mut plans = Vec::with_capacity(kept.len());
+    let mut plans: Vec<LayoutOcrPlan> = Vec::with_capacity(kept.len());
     for det in kept {
         let Some(ocr_category) = layout_to_ocr_category(&det.class_name) else {
             continue;
         };
+        // One region, one OCR run. A DETR-style detection head takes no
+        // per-query argmax, so a single query whose sigmoid clears the
+        // threshold under several classes emits one detection per class, each
+        // carrying that query's box verbatim (see
+        // `rt_detr_v2::predictor::decode_detections`). Those entries are
+        // alternative labels for one region, not several regions, so OCRing
+        // each of them would repeat the same text once per label.
+        //
+        // The check runs after the category mapping, not before, so a box
+        // labelled both `picture` (no OCR category) and `text` still gets
+        // OCRed as text instead of being dropped on the un-OCRable label. The
+        // surviving entry is the first that both maps to a category and crops,
+        // which for `mlxcel detect` output is the highest-confidence such label
+        // for that box.
+        if plans.iter().any(|plan| plan.bbox == det.bbox) {
+            continue;
+        }
         let Some(crop) = crop_rect(image_width, image_height, &det.bbox, min_dim, max_dim) else {
             continue;
         };

--- a/src/vision/falcon_ocr_layout_tests.rs
+++ b/src/vision/falcon_ocr_layout_tests.rs
@@ -226,3 +226,57 @@ fn detections_become_ordered_regions_with_their_own_instruction() {
         (300, 140)
     );
 }
+
+/// A DETR-style head emits one detection per class above threshold, all
+/// carrying the same query's box. Those are alternative labels for one region,
+/// so the planner must OCR that region once, not once per label (issue #1089).
+#[test]
+fn a_box_repeated_under_several_labels_becomes_one_region() {
+    let img = page();
+    // What `mlxcel detect` prints for a heading: one box, three labels,
+    // highest confidence first.
+    let heading = [10.0, 10.0, 300.0, 60.0];
+    let dets = vec![
+        det("section_header", heading, 0.71),
+        det("title", heading, 0.41),
+        det("page_header", heading, 0.40),
+        det("text", [10.0, 100.0, 300.0, 200.0], 0.95),
+    ];
+    let plans = plan_layout_regions(&img, &dets, 0.8, MIN_CROP_DIM, 1024);
+    assert_eq!(
+        plans.len(),
+        2,
+        "the heading must plan as one region, not three: {:?}",
+        plans.iter().map(|p| &p.category).collect::<Vec<_>>()
+    );
+    // The surviving label is the first one supplied for that box.
+    assert_eq!(plans[0].category, "section_header");
+    assert_eq!(plans[1].category, "text");
+}
+
+/// Collapsing duplicates must not drop a region whose highest-confidence label
+/// happens to be un-OCRable: the dedup runs after the category mapping, so a
+/// box labelled both `picture` and `text` is still read as text.
+#[test]
+fn a_duplicate_box_falls_through_to_its_first_ocrable_label() {
+    let img = page();
+    let region = [10.0, 10.0, 300.0, 120.0];
+    let dets = vec![det("picture", region, 0.80), det("text", region, 0.55)];
+    let plans = plan_layout_regions(&img, &dets, 0.8, MIN_CROP_DIM, 1024);
+    assert_eq!(plans.len(), 1, "{plans:?}");
+    assert_eq!(plans[0].category, "text");
+    assert_eq!(plans[0].ocr_category, OcrCategory::Text);
+}
+
+/// Two genuinely distinct regions that share a bounding-box *size* are not
+/// duplicates and must both survive.
+#[test]
+fn same_sized_boxes_at_different_positions_stay_separate() {
+    let img = page();
+    let dets = vec![
+        det("text", [10.0, 10.0, 210.0, 110.0], 0.9),
+        det("text", [10.0, 150.0, 210.0, 250.0], 0.9),
+    ];
+    let plans = plan_layout_regions(&img, &dets, 0.8, MIN_CROP_DIM, 1024);
+    assert_eq!(plans.len(), 2, "{plans:?}");
+}


### PR DESCRIPTION
## Summary

`mlxcel detect` returned boxes that matched no page content. The cause is the host readback in `predictor`, not the coordinate mapping: the forward graph inherits the checkpoint dtype (bf16), but the readback parsed the raw buffer as 4-byte f32, fusing each adjacent pair of bf16 values into one bogus float and returning half the elements. The decode then indexed `query * num_labels` and `query * 4` into buffers half the advertised size, misaligning every query, label, and box association without erroring.

## Root cause, and how it differs from the issue's hypothesis

The issue hypothesised that the letterbox/resize normalization was not being undone for tall aspect ratios. That is not what was wrong, and the aspect-ratio dependence was a coincidence of which garbage indices happened to survive: the same collapse reproduces on a **square** page.

There is no letterbox to undo. The checkpoint's own `preprocessor_config.json` sets `do_pad: false` and resizes straight to 640x640, so the forward transform is an independent per-axis scale and its inverse is the same independent per-axis scale. That code was already correct and is unchanged in behavior.

What was wrong sits one layer later. `pixel_values` is cast to f32, but the first conv against a bf16 weight settles the graph back into bf16, so `pred_logits` and `pred_boxes` are bf16 for the shipped checkpoints. bf16 is the high half of an f32, so a 4-byte little-endian parse over that buffer returns `n/2` values that are the odd-indexed elements polluted with the even ones' bits. Three module doc comments asserted the whole graph ran in f32, which is what let the mismatch sit unnoticed; they now describe what actually happens.

## What changed

- `src/vision/detection/rt_detr_v2/predictor.rs`: `read_output_f32` (was `to_f32_vec`) casts to f32 before reading raw bytes. `predict_path` rejects a readback length mismatch instead of silently consuming a short buffer. `decode_detections` and `denormalize_box` are split out of the predictor method so the seam is unit-testable without a checkpoint.
- `src/vision/detection/rt_detr_v2/{mod,model,common}.rs`: correct the doc comments that claimed the graph runs in f32.
- `src/commands/detect.rs`: emit detections in reading order (top to bottom, then left to right) instead of descending confidence, as a strict total order with confidence and class id as tiebreaks.
- `src/vision/falcon_ocr_layout.rs`: the region planner collapses same-box detections to one region, after the OCR category mapping. `filter_nested_detections` stays a pure geometry filter mirroring the reference.
- `docs/supported-models.md`: document the pipe, the reading order, and the duplicate-label collapse.
- Tests in `src/vision/detection/rt_detr_v2/tests.rs`, `src/commands/detect_tests.rs`, `src/vision/falcon_ocr_layout_tests.rs`, `src/commands/generate_falcon_ocr_tests.rs`.

## Multi-label duplication: settled as intended head behavior

Confirmed intended, and kept. The top-K runs over the flattened `(queries x labels)` grid with no per-query argmax, matching `RTDetrImageProcessor.post_process_object_detection` for `use_focal_loss=True`, so one query clearing the threshold under several classes legitimately emits one detection per class sharing that query's box. `detect` still prints all of it.

It did have one real consequence, now fixed: the OCR planner would have transcribed such a region once per label. The planner collapses same-box entries to one region, after the category mapping so a box labelled both `picture` and `text` is read as text rather than dropped on the un-OCRable label.

## Verification

Run on GB10 / CUDA sm_121 against the local `docling-layout-heron-mlx-bf16` checkpoint, with PIL-drawn pages of known geometry.

Before, on the 1000x1300 portrait page, all detections shared one box `(0.0, 0.0, 551.5, 658.6)`. After, each drawn element gets its own box on its own content:

```
section_header  0.706    80.08    60.14   771.48   108.70   <- heading drawn at x 80, y 55-105
section_header  0.798    72.27   152.66   462.89   185.03
text            0.947    58.59   213.28   957.03   426.56
section_header  0.712    81.05   482.42   512.70   512.89
text            0.926    64.45   541.46   943.36   717.92
text            0.808    72.27   825.20   958.98   962.30
```

A footer drawn at x 80, y 1200 on the same tall page returns `page_footer 0.51 (78.13, 1200.34)-(671.88, 1237.16)`.

## Test plan

- [x] `cargo test --profile test-fast --features cuda --lib vision::detection::rt_detr_v2` (30 passed)
- [x] `cargo test --profile test-fast --features cuda --lib vision::falcon_ocr_layout` (15 passed)
- [x] `cargo test --profile test-fast --features cuda --bin mlxcel commands::` (158 passed)
- [x] `cargo clippy --profile test-fast --features cuda --lib --bin mlxcel` (clean)
- [x] `cargo fmt`
- [x] `mlxcel detect` reproduced the defect before the change and returns content-aligned geometry after, on 1000x1300, 1300x1000, and 1000x1000 pages
- [x] `mlxcel detect --format json` output fed to `mlxcel generate --layout-detections`: parses, plans into reading-ordered regions with no repeats, and reaches the Falcon-OCR model gate

Note on the last item: this box has no Falcon-OCR checkpoint, so the OCR decode itself was not executed. Everything up to it was: the detector JSON is accepted verbatim, and `detect_json_plans_into_reading_ordered_regions_without_repeats` pins the planned region list (order, per-element uniqueness, footer reaching the bottom of the page) against literal `detect --format json` output.

The broad `--lib vision::` selector reports 3 failures on this box, confirmed identical on unmodified `origin/main`, so they are pre-existing and unrelated.

Closes #1089
