### PR TITLE
refactor(server): consolidate the SSE keepalive interval and its guard

### DIFF
--- a/TECHNICAL_REPORTS/1133-sse-keepalive-constant-consolidation-20260814.en.md
+++ b/TECHNICAL_REPORTS/1133-sse-keepalive-constant-consolidation-20260814.en.md
@@ -66,6 +66,8 @@ error[E0080]: evaluation panicked: SSE keepalive interval must be less than the 
 
 Setting the constant to 61 fails the build at the assertion, by name, with the message intact. The value was reverted immediately. The point of running it is that before this change the same edit to either of the other two constants compiled cleanly, so the guard's reach is what changed, not its wording.
 
+The reach widened on a second axis that was not obvious going in. `streaming_tests.rs` is included as `#[cfg(test)] #[path = "streaming_tests.rs"] mod tests;`, so the assertion was const-evaluated only in test builds. As a module-level `const _` in `streaming.rs` it is evaluated in every build, which is why the check above reproduces under a plain `cargo check --lib`. The guard now covers three surfaces instead of one and all profiles instead of test-only.
+
 ---
 
 ## 3. Technical Decisions

--- a/TECHNICAL_REPORTS/1133-sse-keepalive-constant-consolidation-20260814.en.md
+++ b/TECHNICAL_REPORTS/1133-sse-keepalive-constant-consolidation-20260814.en.md
@@ -1,0 +1,136 @@
+# Technical Report: PR #1133 - refactor(server): consolidate the SSE keepalive interval and its guard
+
+**Date**: 2026-08-14
+**Author**: Jeongkyu Shin
+**Status**: Completed
+**Languages**: Rust
+**Risk Level**: Low (no observable behaviour change; every keepalive value was 15 and still is)
+
+---
+
+## Executive Summary
+
+The SSE keepalive interval was declared three times, once per streaming surface. The compile-time assertion that gives the number its meaning, that it stays under the 60-second reverse-proxy idle default, named only one of the three. `/v1/responses` and the Anthropic-compatible surface could be raised past a proxy timeout and the build would not notice.
+
+This is not a case of three constants that happened to agree. It is one invariant with one enforcement point and two surfaces outside it. The fix keeps one definition, moves the assertion next to it so coverage follows from where it sits rather than from who remembered to import it, and routes the two `KeepAlive::default()` sites in `router_front.rs` through the newtype they were supposed to use.
+
+---
+
+## 1. Problem Statement
+
+### 1.1 Background
+
+`src/server/streaming.rs` documents the keepalive as a property of SSE in general: a long prefill leaves the stream open and silent for tens of seconds, and nginx, HAProxy and AWS ALB all default to a 60-second idle timeout, so the connection dies before the first token. The interval has to be under 60 for every surface that streams, not for one route family.
+
+Three surfaces stream: the chat and completion routes through `SseKeepAlive`, `/v1/responses` through `ResponseSseKeepAlive`, and the Anthropic-compatible messages route through `AnthropicSseKeepAlive`. Each newtype had an identical `default_for_long_prefill()` body reading a constant declared in its own file.
+
+### 1.2 Existing Issues
+
+- **The guard covered a third of what it described.** `const _: () = assert!(SSE_KEEPALIVE_INTERVAL_SECS < 60, ...)` lived in `streaming_tests.rs` and named the `streaming.rs` constant. The other two were file-private and unnamed by anything. Setting either to 61 compiled cleanly.
+- **The narrow coverage was drift, not scoping.** The module docs state the invariant for SSE generally, and the assertion's own message talks about "most reverse proxies", not about one route family. Nothing in the code said the Responses and Anthropic surfaces were deliberately exempt.
+- **`router_front.rs` bypassed the design.** Two sites built their responses with `KeepAlive::default()`. Under axum 0.7.9 that is 15 seconds, so it was not a live bug, but `streaming.rs` states plainly why the inner `KeepAlive` is private: "to prevent callers from constructing a mismatched keepalive independently". These two sites were exactly that. Lowering the shared constant for proxy compatibility would have left them at 15 with no diagnostic.
+- **A test module was load-bearing for a production invariant.** The assertion is a compile-time check, so putting it in `streaming_tests.rs` worked, but it made the guard's existence depend on a `#[cfg(test)]`-adjacent file that a reader auditing the constant would not think to open.
+
+### 1.3 Risk Assessment
+
+| Risk | Impact | Likelihood |
+|---|---|---|
+| A future proxy-compatibility change lowers one constant and misses the other two, leaving surfaces mismatched | Medium | Medium |
+| The Responses or Anthropic interval is raised past 60 and streams are dropped mid-prefill behind a proxy | High | Low |
+| `router_front.rs` silently keeps 15s after the shared value is lowered | Medium | Low |
+
+---
+
+## 2. Technical Review
+
+### 2.1 What the Invariant Actually Constrains
+
+The assertion is about the wire, not about a type. A proxy sitting in front of the server does not know which route family produced a stream; it applies one idle timeout to all of them. So the correct scope for the guard is "every SSE surface", and the correct number of definitions is one. Placing the assertion beside the definition makes that structural: any surface that reads the constant is covered, and a surface that does not read it is visibly not using the shared interval.
+
+### 2.2 Why the Newtypes Stay Separate
+
+The obvious next step, collapsing the three newtypes into one, is wrong and the issue says so. They are distinct types precisely so a route cannot attach another surface's keepalive: the value a handler receives comes from the channel constructor it called. Merging them would trade a compile-time guarantee for nothing, since the duplication was never in the types. It was in the constant and the assertion, and only those are consolidated here.
+
+### 2.3 The `router_front.rs` Sites Are the Same Defect Seen From the Other End
+
+`KeepAlive::default()` is not a third copy of the constant, it is the absence of one: it takes whatever axum's default happens to be. That it currently equals 15 is a coincidence of the pinned version, not a property anyone chose. Routing both through `SseKeepAlive::default_for_long_prefill()` ties them to the same definition as everything else, and leaves no way to construct an SSE keepalive in `src/server/` that is not derived from `SSE_KEEPALIVE_INTERVAL_SECS`.
+
+### 2.4 Verifying the Guard Is Not Vacuous
+
+An assertion that passes tells you nothing about whether it can fail. The acceptance criterion asks for a demonstration, and the demonstration is decisive:
+
+```
+error[E0080]: evaluation panicked: SSE keepalive interval must be less than the 60s default used by most reverse proxies
+  --> src/server/streaming.rs:77:15
+```
+
+Setting the constant to 61 fails the build at the assertion, by name, with the message intact. The value was reverted immediately. The point of running it is that before this change the same edit to either of the other two constants compiled cleanly, so the guard's reach is what changed, not its wording.
+
+---
+
+## 3. Technical Decisions
+
+### 3.1 One Definition, Not Three Assertions
+
+The alternative was to leave the three constants and add two more assertions. It is fewer lines to change and strictly worse: it keeps three numbers that must agree by convention, and the next surface added starts uncovered again by default. Consolidating makes coverage the default and drift the thing that requires effort.
+
+### 3.2 The Assertion Moves to the Definition, Not to a Shared Test
+
+Keeping it in a test module and importing the other two constants would also work, and would also have to be updated whenever a surface is added. Next to the definition, it needs no maintenance: every consumer reads the constant, so every consumer is covered.
+
+### 3.3 `router_front.rs` Goes Through the Newtype, Not the Constant
+
+Constructing `KeepAlive::new().interval(Duration::from_secs(SSE_KEEPALIVE_INTERVAL_SECS))` inline at both sites would satisfy the letter of the criterion and add two more copies of the construction expression. Calling `SseKeepAlive::default_for_long_prefill()` reuses the one place that expression lives.
+
+### 3.4 The Module Docs Stop Restating the Number
+
+The module docs said "The keepalive interval is 15 seconds". That is a fourth place for the value to drift, in prose where no assertion can reach it. They now name the constant and record that it is shared, which is the fact a reader needs.
+
+---
+
+## 4. Change Summary
+
+### Statistics
+
+| Metric | Value |
+|---|---|
+| Files changed | 5 |
+| Constant definitions removed | 2 |
+| `KeepAlive::default()` call sites removed | 2 |
+| Behaviour changes | 0 |
+
+### Changes by Area
+
+**`src/server/streaming.rs`**
+- `SSE_KEEPALIVE_INTERVAL_SECS` documented as the single definition for every SSE surface.
+- The `const _: () = assert!(... < 60, ...)` moved here from `streaming_tests.rs`, directly under the definition.
+- Module docs point at the constant instead of restating `15`, and record that the invariant now covers all surfaces.
+
+**`src/server/streaming_responses.rs`, `src/server/streaming_anthropic.rs`**
+- Local `const KEEPALIVE_INTERVAL_SECS: u64 = 15;` deleted; both import the shared constant. The newtypes themselves are untouched.
+
+**`src/server/streaming_tests.rs`**
+- Assertion and its now-unused import removed, replaced by a comment recording where the invariant lives and why it moved.
+
+**`src/server/router_front.rs`**
+- Both `KeepAlive::default()` sites build through `SseKeepAlive::default_for_long_prefill()`; the `KeepAlive` import is dropped.
+
+---
+
+## 5. Validation and Follow-up
+
+### Passed
+
+- `cargo test --profile test-fast --features cuda --lib server::streaming` on GB10: 25 passed, 0 failed.
+- `cargo clippy --profile test-fast --features cuda --lib --tests -- -D warnings`.
+- `cargo fmt --all -- --check`.
+- The `61` build-failure check quoted above, reverted afterwards.
+
+### Not Covered
+
+- The acceptance criterion names `--features metal,accelerate`. This is a Linux CUDA box and cannot build that feature set. The affected code is backend-agnostic SSE plumbing that no feature gate reaches, so the CUDA run is equivalent evidence rather than a substitute.
+- No live proxy test. Nothing about the emitted frames changed, so there is nothing new to observe on the wire; the values are identical to those already in production.
+
+### Follow-up
+
+- #1107 consolidates the other half of this duplication, the three `Sse::new(..).keep_alive(..)` attach expressions, and lands directly on top of this.

--- a/TECHNICAL_REPORTS/1133-sse-keepalive-constant-consolidation-20260814.ko.md
+++ b/TECHNICAL_REPORTS/1133-sse-keepalive-constant-consolidation-20260814.ko.md
@@ -66,6 +66,8 @@ error[E0080]: evaluation panicked: SSE keepalive interval must be less than the 
 
 상수를 61로 두면 그 단언에서, 이름과 메시지를 그대로 달고 빌드가 실패한다. 값은 곧바로 되돌렸다. 이 확인을 실제로 돌린 이유는, 이번 변경 전에는 나머지 두 상수에 같은 수정을 해도 깨끗이 컴파일됐다는 데 있다. 바뀐 것은 가드의 문구가 아니라 사정거리다.
 
+들어갈 때는 보이지 않던 두 번째 축에서도 사정거리가 늘었다. `streaming_tests.rs`는 `#[cfg(test)] #[path = "streaming_tests.rs"] mod tests;`로 포함되므로 단언이 테스트 빌드에서만 const 평가됐다. `streaming.rs`의 모듈 수준 `const _`가 되면서 모든 빌드에서 평가된다. 위 확인이 평범한 `cargo check --lib`에서 재현되는 이유가 그것이다. 이제 가드는 표면 하나가 아니라 셋을, 테스트 빌드만이 아니라 모든 프로파일을 덮는다.
+
 ---
 
 ## 3. 기술적 결정

--- a/TECHNICAL_REPORTS/1133-sse-keepalive-constant-consolidation-20260814.ko.md
+++ b/TECHNICAL_REPORTS/1133-sse-keepalive-constant-consolidation-20260814.ko.md
@@ -1,0 +1,136 @@
+# 기술 보고서: PR #1133 - refactor(server): consolidate the SSE keepalive interval and its guard
+
+**작성일**: 2026-08-14
+**작성자**: Jeongkyu Shin
+**상태**: 완료
+**언어**: Rust
+**위험도**: Low (관측 가능한 동작 변화 없음. 모든 keepalive 값은 원래 15였고 지금도 15다)
+
+---
+
+## 요약
+
+SSE keepalive 간격이 스트리밍 표면마다 하나씩, 총 세 번 선언돼 있었다. 이 숫자에 의미를 부여하는 컴파일 타임 단언, 즉 역방향 프록시의 60초 유휴 기본값보다 작아야 한다는 조건은 셋 중 하나만 이름으로 지목했다. `/v1/responses`와 Anthropic 호환 표면은 프록시 타임아웃을 넘겨 올려도 빌드가 알아채지 못했다.
+
+우연히 값이 같은 상수 셋의 문제가 아니다. 불변식 하나에 강제 지점 하나가 있고, 표면 둘이 그 바깥에 있던 문제다. 정의를 하나로 두고, 단언을 정의 옆으로 옮겨 커버리지가 "누가 import를 기억했는가"가 아니라 "어디에 놓였는가"에서 따라 나오게 했다. `router_front.rs`의 `KeepAlive::default()` 두 곳도 원래 쓰기로 되어 있던 newtype을 거치게 했다.
+
+---
+
+## 1. 문제 정의
+
+### 1.1 배경
+
+`src/server/streaming.rs`는 keepalive를 SSE 일반의 성질로 적어 두었다. 긴 prefill은 수십 초 동안 스트림을 열어 둔 채 침묵하고, nginx와 HAProxy와 AWS ALB는 모두 유휴 타임아웃 기본값이 60초라 첫 토큰이 도착하기 전에 연결이 끊긴다. 간격이 60 미만이어야 하는 것은 스트리밍하는 모든 표면이지 특정 라우트 계열이 아니다.
+
+스트리밍하는 표면은 셋이다. chat과 completion 라우트가 `SseKeepAlive`로, `/v1/responses`가 `ResponseSseKeepAlive`로, Anthropic 호환 messages 라우트가 `AnthropicSseKeepAlive`로 나간다. 각 newtype의 `default_for_long_prefill()` 본문은 서로 같았고, 각자 자기 파일에 선언된 상수를 읽었다.
+
+### 1.2 기존 문제점
+
+- **가드가 자기가 서술한 범위의 3분의 1만 덮었다.** `const _: () = assert!(SSE_KEEPALIVE_INTERVAL_SECS < 60, ...)`는 `streaming_tests.rs`에 있었고 `streaming.rs` 상수만 지목했다. 나머지 둘은 파일 전용이었고 어떤 단언도 이름을 부르지 않았다. 둘 중 아무거나 61로 바꿔도 깨끗이 컴파일됐다.
+- **좁은 커버리지는 의도한 범위 제한이 아니라 흘러내림이었다.** 모듈 문서는 불변식을 SSE 일반에 대해 진술하고, 단언 메시지 자체도 "most reverse proxies"를 말하지 특정 라우트 계열을 말하지 않는다. Responses와 Anthropic 표면이 일부러 면제됐다는 근거는 코드 어디에도 없었다.
+- **`router_front.rs`가 설계를 우회했다.** 두 곳이 응답을 `KeepAlive::default()`로 만들었다. axum 0.7.9에서 그 값은 15초이므로 살아 있는 버그는 아니었다. 하지만 `streaming.rs`는 내부 `KeepAlive`를 왜 비공개로 두는지 분명히 적어 두었다. "호출자가 독립적으로 어긋난 keepalive를 만드는 것을 막기 위해"다. 이 두 곳이 정확히 그 경우였다. 프록시 호환을 위해 공유 상수를 낮추면 이 둘만 아무 신호 없이 15에 남는다.
+- **프로덕션 불변식이 테스트 모듈에 얹혀 있었다.** 단언이 컴파일 타임 검사라 `streaming_tests.rs`에 있어도 동작하기는 했다. 다만 상수를 감사하려는 사람이 열어 볼 생각을 하지 않을 파일에 가드의 존재가 달려 있게 됐다.
+
+### 1.3 위험 평가
+
+| 위험 | 영향 | 가능성 |
+|---|---|---|
+| 나중에 프록시 호환 작업이 상수 하나만 낮추고 나머지 둘을 놓쳐 표면 간 값이 어긋난다 | Medium | Medium |
+| Responses나 Anthropic 간격이 60을 넘겨 올라가 프록시 뒤에서 prefill 도중 스트림이 끊긴다 | High | Low |
+| 공유 값을 낮춘 뒤에도 `router_front.rs`가 조용히 15초를 유지한다 | Medium | Low |
+
+---
+
+## 2. 기술 검토
+
+### 2.1 이 불변식이 실제로 제약하는 대상
+
+단언이 다루는 것은 타입이 아니라 회선이다. 서버 앞의 프록시는 어느 라우트 계열이 스트림을 만들었는지 모르고, 모두에게 같은 유휴 타임아웃을 적용한다. 따라서 가드의 올바른 범위는 "모든 SSE 표면"이고 올바른 정의 개수는 하나다. 단언을 정의 옆에 두면 그 관계가 구조가 된다. 상수를 읽는 표면은 자동으로 덮이고, 읽지 않는 표면은 공유 간격을 쓰지 않는다는 사실이 눈에 보인다.
+
+### 2.2 newtype 셋을 그대로 두는 이유
+
+다음 수순처럼 보이는 것, 즉 newtype 셋을 하나로 합치는 것은 틀렸고 이슈도 그렇게 적었다. 이들이 서로 다른 타입인 이유가 바로 라우트가 다른 표면의 keepalive를 붙이지 못하게 하는 데 있다. 핸들러가 받는 값은 자기가 호출한 채널 생성자에서 나온다. 합치면 컴파일 타임 보장을 내주고 아무것도 얻지 못한다. 중복은 애초에 타입에 있지 않았다. 상수와 단언에 있었고 이번에 합친 것도 그 둘뿐이다.
+
+### 2.3 `router_front.rs`의 두 곳은 같은 결함의 반대편이다
+
+`KeepAlive::default()`는 상수의 세 번째 사본이 아니라 상수의 부재다. axum의 기본값이 무엇이든 그대로 받는다. 그 값이 지금 15인 것은 고정된 버전에서 나온 우연이지 누가 고른 성질이 아니다. 둘 다 `SseKeepAlive::default_for_long_prefill()`을 거치게 하면 나머지 전부와 같은 정의에 묶이고, `src/server/` 안에서 `SSE_KEEPALIVE_INTERVAL_SECS`에서 파생되지 않은 SSE keepalive를 만들 방법이 남지 않는다.
+
+### 2.4 가드가 공허하지 않음을 확인하기
+
+통과하는 단언은 그것이 실패할 수 있는지에 대해 아무것도 알려 주지 않는다. 수용 기준이 실연을 요구했고, 실연 결과는 분명하다.
+
+```
+error[E0080]: evaluation panicked: SSE keepalive interval must be less than the 60s default used by most reverse proxies
+  --> src/server/streaming.rs:77:15
+```
+
+상수를 61로 두면 그 단언에서, 이름과 메시지를 그대로 달고 빌드가 실패한다. 값은 곧바로 되돌렸다. 이 확인을 실제로 돌린 이유는, 이번 변경 전에는 나머지 두 상수에 같은 수정을 해도 깨끗이 컴파일됐다는 데 있다. 바뀐 것은 가드의 문구가 아니라 사정거리다.
+
+---
+
+## 3. 기술적 결정
+
+### 3.1 단언 셋이 아니라 정의 하나
+
+대안은 상수 셋을 그대로 두고 단언 둘을 더하는 것이었다. 고칠 줄 수는 적고 결과는 확실히 더 나쁘다. 관례로만 일치해야 하는 숫자 셋이 남고, 다음에 추가되는 표면은 다시 기본값이 미커버 상태다. 합치면 커버가 기본이 되고, 흘러내리는 쪽이 수고를 요구하게 된다.
+
+### 3.2 단언은 공유 테스트가 아니라 정의 옆으로
+
+테스트 모듈에 두고 나머지 두 상수를 import하는 방법도 되기는 한다. 그리고 표면이 추가될 때마다 손봐야 한다. 정의 옆에 두면 손볼 일이 없다. 모든 소비자가 그 상수를 읽으므로 모든 소비자가 덮인다.
+
+### 3.3 `router_front.rs`는 상수가 아니라 newtype을 거친다
+
+두 곳에 `KeepAlive::new().interval(Duration::from_secs(SSE_KEEPALIVE_INTERVAL_SECS))`를 인라인으로 쓰면 기준의 문구는 만족하면서 생성 식 사본을 둘 더 만든다. `SseKeepAlive::default_for_long_prefill()`을 부르면 그 식이 사는 유일한 자리를 재사용한다.
+
+### 3.4 모듈 문서가 숫자를 다시 적지 않는다
+
+모듈 문서에는 "The keepalive interval is 15 seconds"라고 적혀 있었다. 어떤 단언도 닿지 못하는 산문에 값이 흘러내릴 네 번째 자리가 있었던 셈이다. 이제는 상수를 이름으로 가리키고 그것이 공유된다는 사실을 적는다. 독자에게 필요한 정보는 그쪽이다.
+
+---
+
+## 4. 변경 요약
+
+### 통계
+
+| 항목 | 값 |
+|---|---|
+| 변경 파일 | 5 |
+| 제거한 상수 정의 | 2 |
+| 제거한 `KeepAlive::default()` 호출부 | 2 |
+| 동작 변경 | 0 |
+
+### 영역별 변경
+
+**`src/server/streaming.rs`**
+- `SSE_KEEPALIVE_INTERVAL_SECS`를 모든 SSE 표면의 단일 정의로 문서화.
+- `const _: () = assert!(... < 60, ...)`를 `streaming_tests.rs`에서 정의 바로 아래로 이동.
+- 모듈 문서가 `15`를 다시 적는 대신 상수를 가리키고, 불변식이 이제 모든 표면을 덮는다는 사실을 기록.
+
+**`src/server/streaming_responses.rs`, `src/server/streaming_anthropic.rs`**
+- 파일 전용 `const KEEPALIVE_INTERVAL_SECS: u64 = 15;` 삭제, 공유 상수 import. newtype 자체는 손대지 않았다.
+
+**`src/server/streaming_tests.rs`**
+- 단언과 이제 쓰이지 않는 import 제거. 불변식이 어디로 왜 옮겨 갔는지 기록하는 주석으로 대체.
+
+**`src/server/router_front.rs`**
+- `KeepAlive::default()` 두 곳이 `SseKeepAlive::default_for_long_prefill()`을 거친다. `KeepAlive` import 제거.
+
+---
+
+## 5. 검증과 후속
+
+### 통과
+
+- GB10에서 `cargo test --profile test-fast --features cuda --lib server::streaming`: 25개 통과, 0개 실패.
+- `cargo clippy --profile test-fast --features cuda --lib --tests -- -D warnings`.
+- `cargo fmt --all -- --check`.
+- 위에 인용한 `61` 빌드 실패 확인. 확인 후 되돌렸다.
+
+### 덮지 않은 것
+
+- 수용 기준은 `--features metal,accelerate`를 지목한다. 이 장비는 Linux CUDA 박스라 그 피처 조합을 빌드할 수 없다. 해당 코드는 어떤 피처 게이트도 닿지 않는 백엔드 무관 SSE 배관이므로, CUDA 실행이 대체재가 아니라 동등한 증거다.
+- 실제 프록시 시험은 없다. 나가는 프레임에 바뀐 것이 없으므로 회선에서 새로 관찰할 것도 없다. 값은 이미 프로덕션에 있는 것과 동일하다.
+
+### 후속
+
+- #1107이 이 중복의 나머지 절반, 즉 `Sse::new(..).keep_alive(..)` 부착 식 셋을 합치며 이 변경 위에 바로 얹힌다.

--- a/src/server/router_front.rs
+++ b/src/server/router_front.rs
@@ -81,7 +81,7 @@ use std::time::Duration;
 
 use anyhow::Result;
 use axum::extract::State;
-use axum::response::sse::{Event, KeepAlive, Sse};
+use axum::response::sse::{Event, Sse};
 use axum::response::{IntoResponse, Response};
 use axum::routing::{get, post};
 use axum::{Json, Router};
@@ -101,6 +101,7 @@ use crate::distributed::tcp_transport::TcpTransport;
 use crate::distributed::transport::{Transport, TransportBackend};
 use crate::server::ChatTemplateProcessor;
 use crate::server::config::{ServerConfig, ServerGenerateOptions};
+use crate::server::streaming::SseKeepAlive;
 use crate::server::tool_calls::stream_filter::{FilterOutput, StreamFilter};
 use crate::server::types::request::ChatCompletionRequest;
 use crate::server::types::{CompletionChunk, CompletionRequest, CompletionResponse, ErrorResponse};
@@ -810,8 +811,12 @@ async fn route_chat(state: Arc<RouterState>, request: ChatCompletionRequest) -> 
             state2.finalize_request(&request_id_str2, completed);
         });
 
+        // Go through the shared newtype rather than `KeepAlive::default()`, so
+        // the router-front streams track `SSE_KEEPALIVE_INTERVAL_SECS` if it is
+        // ever lowered for proxy compatibility (#1105). `KeepAlive::default()`
+        // is 15s under axum 0.7.9 too, so this is not a behaviour change today.
         Ok(Sse::new(UnboundedReceiverStream::new(chunk_rx))
-            .keep_alive(KeepAlive::default())
+            .keep_alive(SseKeepAlive::default_for_long_prefill().into_inner())
             .into_response())
     } else {
         // Non-streaming: collect all tokens (filtered) then return a single
@@ -1074,8 +1079,12 @@ async fn route_completion(state: Arc<RouterState>, request: CompletionRequest) -
             state2.finalize_request(&response_id2, result.is_ok());
         });
 
+        // Go through the shared newtype rather than `KeepAlive::default()`, so
+        // the router-front streams track `SSE_KEEPALIVE_INTERVAL_SECS` if it is
+        // ever lowered for proxy compatibility (#1105). `KeepAlive::default()`
+        // is 15s under axum 0.7.9 too, so this is not a behaviour change today.
         Ok(Sse::new(UnboundedReceiverStream::new(chunk_rx))
-            .keep_alive(KeepAlive::default())
+            .keep_alive(SseKeepAlive::default_for_long_prefill().into_inner())
             .into_response())
     } else {
         // Non-streaming: collect all tokens, then return a single

--- a/src/server/streaming.rs
+++ b/src/server/streaming.rs
@@ -28,8 +28,12 @@
 //!
 //! `sse_channel` returns a keepalive configuration via `SseKeepAlive` that
 //! route handlers must attach to the `Sse` response with `.keep_alive()`. The
-//! keepalive interval is 15 seconds — shorter than typical proxy idle timeouts
-//! and long enough not to spam comment events for short responses.
+//! interval is [`SSE_KEEPALIVE_INTERVAL_SECS`], short enough to beat typical
+//! proxy idle timeouts and long enough not to spam comment events for short
+//! responses. That constant is the single definition for every SSE surface in
+//! the server, including the Responses and Anthropic-compatible ones, and the
+//! `< 60` invariant is asserted next to it so it cannot be raised past a proxy
+//! timeout on any of them.
 
 use std::convert::Infallible;
 use std::sync::Arc;
@@ -51,7 +55,29 @@ pub(crate) const DONE_MARKER: &str = "[DONE]";
 /// 15 seconds is shorter than virtually all proxy idle timeouts (nginx
 /// default 60 s, HAProxy 60 s, AWS ALB 60 s) while being long enough to
 /// avoid noticeable overhead for ordinary short responses.
+///
+/// This is the single definition for every SSE surface. `streaming_responses`
+/// and `streaming_anthropic` keep their own newtypes, so a route cannot attach
+/// another surface's keepalive, but they read the interval from here (#1105).
 pub(crate) const SSE_KEEPALIVE_INTERVAL_SECS: u64 = 15;
+
+/// The SSE keepalive interval must stay under typical reverse-proxy idle
+/// timeouts (nginx 60 s, HAProxy 60 s, AWS ALB 60 s) or a long prefill will
+/// have its connection dropped before the first token arrives.
+///
+/// This lives next to the definition rather than in the test module so it
+/// covers every consumer by construction (#1105). It was previously in
+/// `streaming_tests.rs` and guarded only this constant, while
+/// `streaming_responses.rs` and `streaming_anthropic.rs` carried their own
+/// file-private copies that nothing checked.
+///
+/// Enforced as a `const` assertion so a regression fails the build rather than
+/// a test run. (Using `assert!` on a constant expression in a runtime test
+/// triggers `clippy::assertions_on_constants`.)
+const _: () = assert!(
+    SSE_KEEPALIVE_INTERVAL_SECS < 60,
+    "SSE keepalive interval must be less than the 60s default used by most reverse proxies"
+);
 
 /// Keepalive configuration attached to an `Sse` response.
 ///

--- a/src/server/streaming.rs
+++ b/src/server/streaming.rs
@@ -27,7 +27,9 @@
 //! will drop the connection before the first token arrives.
 //!
 //! `sse_channel` returns a keepalive configuration via `SseKeepAlive` that
-//! route handlers must attach to the `Sse` response with `.keep_alive()`. The
+//! route handlers must attach to the `Sse` response with `.keep_alive()`.
+//! Streams that do not come from `sse_channel` (`router_front.rs`) build the
+//! same newtype directly rather than reaching for `KeepAlive::default()`. The
 //! interval is [`SSE_KEEPALIVE_INTERVAL_SECS`], short enough to beat typical
 //! proxy idle timeouts and long enough not to spam comment events for short
 //! responses. That constant is the single definition for every SSE surface in
@@ -81,13 +83,17 @@ const _: () = assert!(
 
 /// Keepalive configuration attached to an `Sse` response.
 ///
-/// Constructed by `sse_channel` and passed through to route handlers so they
-/// can call `Sse::new(stream).keep_alive(keepalive.into_inner())`. Using a
+/// Usually constructed by `sse_channel` and passed through to a route handler,
+/// which calls `Sse::new(stream).keep_alive(keepalive.into_inner())`. Using a
 /// newtype keeps the keepalive wired to the same channel creation point and
 /// makes it impossible to forget to attach it. The inner `KeepAlive` is private
 /// to prevent callers from constructing a mismatched keepalive independently.
 ///
-/// Used by: chat.rs, completions.rs, native_completion.rs
+/// `router_front.rs` builds its own with `default_for_long_prefill` because its
+/// streams do not come from `sse_channel`, but it goes through this type rather
+/// than `KeepAlive::default()` so it tracks the shared interval (#1105).
+///
+/// Used by: chat.rs, completions.rs, native_completion.rs, router_front.rs
 pub(crate) struct SseKeepAlive(KeepAlive);
 
 impl SseKeepAlive {
@@ -135,9 +141,10 @@ pub(crate) struct BlockingSseSender {
 /// `BatchScheduler` can abort orphaned sequences.
 ///
 /// The `keepalive` value must be attached to the `Sse` response via
-/// `Sse::new(stream).keep_alive(keepalive.0)` in the route handler. This
-/// ensures proxy idle timeouts do not close the connection during long prefill
-/// phases before the first generated token arrives.
+/// `Sse::new(stream).keep_alive(keepalive.into_inner())` in the route handler
+/// (the inner field is private, so `.0` is not reachable from outside this
+/// module). This ensures proxy idle timeouts do not close the connection during
+/// long prefill phases before the first generated token arrives.
 ///
 /// Used by: chat.rs, completions.rs, native_completion.rs
 pub(crate) fn sse_channel(

--- a/src/server/streaming_anthropic.rs
+++ b/src/server/streaming_anthropic.rs
@@ -37,10 +37,9 @@ use futures::StreamExt;
 use tokio::sync::mpsc;
 use tokio_stream::wrappers::ReceiverStream;
 
+use crate::server::streaming::SSE_KEEPALIVE_INTERVAL_SECS;
 use crate::server::types::anthropic_response::AnthropicResponseBlock;
 use crate::server::types::anthropic_stream::{AnthropicBlockDelta, AnthropicStreamEvent};
-
-const KEEPALIVE_INTERVAL_SECS: u64 = 15;
 
 /// Cancellation token shared with the scheduler for client-disconnect detection.
 pub(crate) type CancellationToken = Arc<AtomicBool>;
@@ -84,7 +83,7 @@ impl AnthropicSseKeepAlive {
         // Anthropic clients accept `ping` events; the axum keepalive comment
         // frame is also tolerated. We use the standard keepalive comment to
         // match the Responses-API encoder.
-        Self(KeepAlive::new().interval(Duration::from_secs(KEEPALIVE_INTERVAL_SECS)))
+        Self(KeepAlive::new().interval(Duration::from_secs(SSE_KEEPALIVE_INTERVAL_SECS)))
     }
 
     pub fn into_inner(self) -> KeepAlive {

--- a/src/server/streaming_responses.rs
+++ b/src/server/streaming_responses.rs
@@ -47,9 +47,8 @@ use futures::{Stream, StreamExt};
 use tokio::sync::mpsc;
 use tokio_stream::wrappers::ReceiverStream;
 
+use crate::server::streaming::SSE_KEEPALIVE_INTERVAL_SECS;
 use crate::server::types::responses_stream::{ResponseStreamEvent, SequenceCounter};
-
-const KEEPALIVE_INTERVAL_SECS: u64 = 15;
 
 /// Cancellation token shared with the scheduler for client-disconnect detection.
 pub(crate) type CancellationToken = Arc<AtomicBool>;
@@ -92,7 +91,7 @@ pub struct ResponseSseKeepAlive(KeepAlive);
 
 impl ResponseSseKeepAlive {
     fn default_for_long_prefill() -> Self {
-        Self(KeepAlive::new().interval(Duration::from_secs(KEEPALIVE_INTERVAL_SECS)))
+        Self(KeepAlive::new().interval(Duration::from_secs(SSE_KEEPALIVE_INTERVAL_SECS)))
     }
 
     pub fn into_inner(self) -> KeepAlive {

--- a/src/server/streaming_tests.rs
+++ b/src/server/streaming_tests.rs
@@ -15,10 +15,7 @@
 use serde::{Serialize, Serializer};
 use serde_json::Value;
 
-use super::{
-    CancellationToken, DONE_MARKER, SSE_KEEPALIVE_INTERVAL_SECS, payload_channel,
-    serialize_json_data,
-};
+use super::{CancellationToken, DONE_MARKER, payload_channel, serialize_json_data};
 use crate::server::types::{ChatCompletionChunk, CompletionChunk};
 
 #[derive(Serialize)]
@@ -298,17 +295,11 @@ fn sender_without_cancellation_token_does_not_panic_on_dropped_receiver() {
 
 // ── Long-prefill keepalive regression tests ────────────────────
 
-/// The SSE keepalive interval must be less than typical proxy idle timeouts
-/// (nginx 60 s, HAProxy 60 s, AWS ALB 60 s) so that long-prefill requests
-/// keep the connection alive.
-///
-/// This is enforced as a `const` assertion so a regression is caught at
-/// compile time rather than test time. (Using `assert!` on a constant
-/// expression triggers `clippy::assertions_on_constants`.)
-const _: () = assert!(
-    SSE_KEEPALIVE_INTERVAL_SECS < 60,
-    "SSE keepalive interval must be less than the 60s default used by most reverse proxies"
-);
+// The proxy-timeout invariant (`SSE_KEEPALIVE_INTERVAL_SECS < 60`) used to be
+// asserted here. It moved next to the constant in `streaming.rs` (#1105) so it
+// covers every SSE surface by construction: the Responses and Anthropic
+// keepalives now read the same constant instead of carrying file-private copies
+// that this assertion could not see.
 
 /// During a long prefill phase (no events from the model worker), the SSE
 /// channel must remain open and operational. This test exercises the token


### PR DESCRIPTION
## Summary

The 15-second SSE keepalive interval was declared three times, once per surface, and the compile-time assertion that gives the number its meaning guarded only one of them. `/v1/responses` and the Anthropic-compatible surface could therefore be raised past a reverse-proxy idle timeout without the build failing. This consolidates the constant and moves the guard next to it, so it covers every consumer by construction.

## What changed

- `src/server/streaming.rs`: `SSE_KEEPALIVE_INTERVAL_SECS` is now documented as the single definition for every SSE surface, and the `const _: () = assert!(SSE_KEEPALIVE_INTERVAL_SECS < 60, ...)` moved here from `streaming_tests.rs` to sit directly under it. The module docs no longer restate `15`; they point at the constant and record that the invariant now covers all surfaces.
- `src/server/streaming_responses.rs`, `src/server/streaming_anthropic.rs`: local `const KEEPALIVE_INTERVAL_SECS: u64 = 15;` deleted; both import the shared constant. The two newtypes are untouched and stay distinct, which is the property #1105 asks to keep: a route cannot attach another surface's keepalive, because the type it receives comes from the channel constructor it called. Only the constant and the assertion were duplicated.
- `src/server/streaming_tests.rs`: the assertion and its now-unused import are removed, replaced by a comment recording where the invariant lives and why it moved.
- `src/server/router_front.rs`: both `KeepAlive::default()` sites now build through `SseKeepAlive::default_for_long_prefill()`. Behaviourally identical today (`KeepAlive::new()` is 15s under axum 0.7.9), but it restores the design the newtype exists for: if the shared constant is ever lowered for proxy compatibility, these two streams would otherwise silently keep 15s.

Behaviour is unchanged. Every value was already 15 and still is.

## Acceptance criteria

| Criterion | Evidence |
|---|---|
| Exactly one `15` literal for the SSE keepalive interval in `src/server/` | `grep -rn "KEEPALIVE_INTERVAL_SECS.*=" src/server/` returns one line, `streaming.rs` |
| Changing it to `61` fails the build, attributable to the shared assertion | Verified locally, then reverted. See below |
| No `KeepAlive::default()` call sites remain in `src/server/` | `grep -rn "KeepAlive::default()" src/` returns four lines, all comment text in the two explanatory blocks left at the former call sites, and zero code |
| `server::streaming` tests green | 25 passed, 0 failed |

The `61` check, run against `cargo check --profile test-fast --features cuda --lib` and then reverted:

```
error[E0080]: evaluation panicked: SSE keepalive interval must be less than the 60s default used by most reverse proxies
  --> src/server/streaming.rs:77:15
   |
77 |   const _: () = assert!(
   |  _______________^
78 | |     SSE_KEEPALIVE_INTERVAL_SECS < 60,
79 | |     "SSE keepalive interval must be less than the 60s default used by most reverse proxies"
80 | | );
   | |_^ evaluation of `server::streaming::_` failed here
```

Before this change the same edit compiled cleanly for the Responses and Anthropic surfaces, because their copies were never named by any assertion.

## Test plan

- [x] `cargo test --profile test-fast --features cuda --lib server::streaming`: 25 passed, 0 failed
- [x] `cargo clippy --profile test-fast --features cuda --lib --tests -- -D warnings`
- [x] `cargo fmt --all -- --check`
- [x] The `61` build-failure check above, reverted afterwards

The acceptance criterion names `--features metal,accelerate`. This is a Linux CUDA box and cannot build that feature set; the feature selection does not reach any of this code, which is backend-agnostic SSE plumbing. No `CHANGELOG.md` entry: nothing observable changes for a user.

Closes #1105


---

## Review round

A review pass confirmed the refactor is behaviour-neutral against the vendored axum 0.7.9 source: `KeepAlive::default()` is `KeepAlive::new()`, which sets `max_interval: Duration::from_secs(15)` and the `:\n\n` comment event, so `SseKeepAlive::default_for_long_prefill()` overwrites `max_interval` with the same value and leaves the event alone. The two `router_front` sites emit the same frame on the same schedule.

It also found the guard's reach widened on a second axis that was not obvious going in. `streaming_tests.rs` is included under `#[cfg(test)]`, so the assertion was const-evaluated only in test builds. As a module-level `const _` in `streaming.rs` it is evaluated in every build, which is why the `61` check above reproduces under a plain `cargo check --lib`. Three surfaces instead of one, and all profiles instead of test-only.

One finding was that this PR made the `SseKeepAlive` rustdoc stale in the act of fixing the constants: it said the type is "constructed by `sse_channel`" and listed three consumers, while `router_front.rs` now constructs it directly and is a fourth. Fixed, along with two pre-existing inaccuracies in the same file (the `sse_channel` doc pointed at `keepalive.0`, which is private outside the module, and the module-doc lead-in presented the keepalive as something only `sse_channel` hands out).
