### PR TITLE
feat(server): classify snapshot-divergence rejects in prompt-cache stats

### DIFF
--- a/src/server/batch/observability.rs
+++ b/src/server/batch/observability.rs
@@ -455,14 +455,30 @@ impl BatchObservability {
         seq_id: Option<u64>,
         context_len: usize,
     ) {
+        self.record_prompt_cache_reject_detailed(reason, seq_id, context_len, None);
+    }
+
+    /// [`Self::record_prompt_cache_reject`] plus the stored entry's token
+    /// length, for decline sites that have one specific stored entry in view
+    /// (issue #1147). `entry_len` lands in the `last_reject` snapshot and is
+    /// surfaced as `last_reject_entry_len` on `/v1/cache/stats`; the counters
+    /// themselves are unchanged.
+    pub fn record_prompt_cache_reject_detailed(
+        &self,
+        reason: PromptCacheRejectReason,
+        seq_id: Option<u64>,
+        context_len: usize,
+        entry_len: Option<usize>,
+    ) {
         self.prompt_cache_reject_reasons
-            .record(reason, seq_id, context_len);
+            .record_detailed(reason, seq_id, context_len, entry_len);
         if apc_trace_enabled() {
             tracing::info!(
                 apc_event = "reject",
                 reason = reason.as_str(),
                 seq_id = ?seq_id,
                 context_len,
+                entry_len = ?entry_len,
                 "prompt-cache reject"
             );
         }
@@ -699,11 +715,15 @@ impl BatchObservability {
             prompt_cache_reject_block_boundary_floor: self
                 .prompt_cache_reject_reasons
                 .count(PromptCacheRejectReason::BlockBoundaryFloor),
+            prompt_cache_reject_snapshot_diverged: self
+                .prompt_cache_reject_reasons
+                .count(PromptCacheRejectReason::SnapshotDiverged),
             prompt_cache_last_reject: self.prompt_cache_reject_reasons.last().map(|r| {
                 PromptCacheLastRejectSnapshot {
                     reason: r.reason,
                     seq_id: r.seq_id,
                     context_len: r.context_len as u64,
+                    entry_len: r.entry_len.map(|len| len as u64),
                     at_unix_ms: r.at_unix_ms,
                 }
             }),
@@ -799,6 +819,12 @@ pub struct ObservabilitySnapshot {
     pub prompt_cache_reject_empty_set: u64,
     pub prompt_cache_reject_layout_constraints: u64,
     pub prompt_cache_reject_block_boundary_floor: u64,
+    /// Structural snapshot-divergence declines (issue #1147): a same-session
+    /// snapshot candidate existed but was not a prefix of the request. A
+    /// non-zero value here alongside `snapshot_hits = 0` is the signature of
+    /// the multi-turn miss class epic #1148 covers, and separates it from a
+    /// genuinely cold store.
+    pub prompt_cache_reject_snapshot_diverged: u64,
     /// Most recent prompt-cache reject/decline event, if any has happened
     /// yet.
     pub prompt_cache_last_reject: Option<PromptCacheLastRejectSnapshot>,
@@ -812,6 +838,12 @@ pub struct PromptCacheLastRejectSnapshot {
     pub reason: &'static str,
     pub seq_id: Option<u64>,
     pub context_len: u64,
+    /// Token length of the stored entry the decline was about, when the
+    /// decline site had one specific entry in view. `None` for every reason
+    /// except `snapshot_diverged` today; there it is the stored snapshot's
+    /// length, so `context_len` / `entry_len` reads as "agreed on N of M
+    /// stored tokens".
+    pub entry_len: Option<u64>,
     pub at_unix_ms: u64,
 }
 
@@ -989,6 +1021,7 @@ mod tests {
         assert_eq!(snap.prompt_cache_reject_empty_set, 0);
         assert_eq!(snap.prompt_cache_reject_layout_constraints, 0);
         assert_eq!(snap.prompt_cache_reject_block_boundary_floor, 0);
+        assert_eq!(snap.prompt_cache_reject_snapshot_diverged, 0);
         assert!(snap.prompt_cache_last_reject.is_none());
     }
 
@@ -1008,6 +1041,42 @@ mod tests {
         assert_eq!(snap.prompt_cache_reject_prefix_too_short, 0);
         assert_eq!(snap.prompt_cache_reject_empty_set, 0);
         assert_eq!(snap.prompt_cache_reject_layout_constraints, 0);
+        assert_eq!(snap.prompt_cache_reject_snapshot_diverged, 0);
+    }
+
+    #[test]
+    fn snapshot_divergence_reject_carries_both_lengths() {
+        // Issue #1147: the divergence reject is only useful if it says how
+        // far the stored entry and the request agreed AND how long the stored
+        // entry was. A bare counter would leave an operator back where the
+        // epic started, detokenizing by hand.
+        let obs = BatchObservability::new();
+        obs.record_prompt_cache_reject_detailed(
+            PromptCacheRejectReason::SnapshotDiverged,
+            None,
+            90,
+            Some(139),
+        );
+
+        let snap = obs.snapshot();
+        assert_eq!(snap.prompt_cache_reject_snapshot_diverged, 1);
+        let last = snap
+            .prompt_cache_last_reject
+            .expect("a reject has been recorded");
+        assert_eq!(last.reason, "snapshot_diverged");
+        assert_eq!(last.context_len, 90, "common prefix length");
+        assert_eq!(last.entry_len, Some(139), "stored entry length");
+    }
+
+    #[test]
+    fn rejects_without_a_stored_entry_leave_entry_len_unset() {
+        let obs = BatchObservability::new();
+        obs.record_prompt_cache_reject(PromptCacheRejectReason::LayoutConstraints, Some(4), 64);
+        let last = obs
+            .snapshot()
+            .prompt_cache_last_reject
+            .expect("a reject has been recorded");
+        assert_eq!(last.entry_len, None);
     }
 
     #[test]

--- a/src/server/batch/scheduler.rs
+++ b/src/server/batch/scheduler.rs
@@ -70,7 +70,7 @@ use crate::server::model_provider::{GenerateEvent, ModelRequest};
 use crate::server::prompt_cache::key::PromptCacheKey;
 use crate::server::prompt_cache::metrics::PromptCacheRejectReason;
 use crate::server::prompt_cache::{
-    CacheEntry, DetachedKvSet, ModelSnapshotEntry, PromptCacheStore,
+    CacheEntry, DetachedKvSet, ModelSnapshotEntry, PromptCacheStore, SnapshotLookupOutcome,
 };
 use crate::server::state::BatchMetrics;
 use crate::server::thinking_budget::{
@@ -1804,8 +1804,36 @@ impl BatchScheduler {
 
         let store = self.prompt_cache.as_ref()?.clone();
         let key = Self::compose_prompt_cache_key(ctx, tokens);
-        if self.model.supports_snapshot_reuse()
-            && let Some((snapshot_entry, matched_len)) = store.lookup_snapshot_prefix(&key, tokens)
+        let snapshot_outcome = if self.model.supports_snapshot_reuse() {
+            store.lookup_snapshot_outcome(&key, tokens)
+        } else {
+            SnapshotLookupOutcome::NoCandidate
+        };
+        // A snapshot candidate that sits in this request's own session bucket
+        // but is not a prefix of it is a structural miss, not an empty store
+        // (issue #1147). Classify it so `/v1/cache/stats` can tell the two
+        // apart; the multi-turn miss class in epic #1148 is otherwise
+        // invisible. `NoCandidate` deliberately records nothing, so the
+        // counter never fires for a cold store or a foreign session bucket.
+        if let SnapshotLookupOutcome::Diverged(divergence) = &snapshot_outcome {
+            tracing::debug!(
+                common_prefix = divergence.common_prefix_len,
+                stored_len = divergence.stored_len,
+                request_len = tokens.len(),
+                "prompt-cache snapshot candidate diverged from request"
+            );
+            self.batch_observability
+                .record_prompt_cache_reject_detailed(
+                    PromptCacheRejectReason::SnapshotDiverged,
+                    None,
+                    divergence.common_prefix_len,
+                    Some(divergence.stored_len),
+                );
+        }
+        if let SnapshotLookupOutcome::Hit {
+            entry: snapshot_entry,
+            matched_len,
+        } = snapshot_outcome
         {
             let seq_id = match self.allocate_sequence_state() {
                 Ok(id) => id,

--- a/src/server/prompt_cache/metrics.rs
+++ b/src/server/prompt_cache/metrics.rs
@@ -60,12 +60,25 @@ pub enum PromptCacheRejectReason {
     /// The paged pool's block-size floor pushed the adoptable/donatable
     /// length below `min_prefix_tokens`.
     BlockBoundaryFloor,
+    /// A snapshot candidate existed in the request's own session bucket, but
+    /// its stored token vector is not a prefix of the request: the two
+    /// diverge before the stored entry ends, so the exact-prefix snapshot
+    /// path cannot adopt it (issue #1147).
+    ///
+    /// This is the structural multi-turn miss that epic #1148 documents. It
+    /// is emitted only when a same-bucket candidate was actually examined, so
+    /// a zero counter alongside advancing `snapshot_lookups` genuinely means
+    /// "nothing to reuse", not "reuse was silently declined". The reject
+    /// carries the divergence geometry: `context_len` is the longest common
+    /// prefix with the request, and the reject's `entry_len` is the stored
+    /// entry's token count.
+    SnapshotDiverged,
 }
 
 impl PromptCacheRejectReason {
     /// All variants, in the stable order used by Prometheus/`/v1/cache/stats`
     /// exposition helpers.
-    pub const ALL: [Self; 7] = [
+    pub const ALL: [Self; 8] = [
         Self::Oversized,
         Self::Disabled,
         Self::PrefixTooShort,
@@ -73,6 +86,7 @@ impl PromptCacheRejectReason {
         Self::EmptySet,
         Self::LayoutConstraints,
         Self::BlockBoundaryFloor,
+        Self::SnapshotDiverged,
     ];
 
     /// Stable lowercase snake_case label used as the Prometheus `reason`
@@ -86,6 +100,7 @@ impl PromptCacheRejectReason {
             Self::EmptySet => "empty_set",
             Self::LayoutConstraints => "layout_constraints",
             Self::BlockBoundaryFloor => "block_boundary_floor",
+            Self::SnapshotDiverged => "snapshot_diverged",
         }
     }
 }
@@ -108,11 +123,20 @@ impl From<&InsertError> for PromptCacheRejectReason {
 /// `context_len` carries whatever length context the call site has
 /// available: the matched-prefix length for adopt declines, or the donated
 /// token count for donate declines.
+///
+/// `entry_len` is the token length of the specific stored entry the decline
+/// was about, when the call site knows it. It is `None` for the declines that
+/// have no single stored entry in view (every reason except
+/// [`PromptCacheRejectReason::SnapshotDiverged`] today). Together with
+/// `context_len` it makes a divergence reject self-describing: "a stored
+/// entry of `entry_len` tokens shared `context_len` of them with the
+/// request".
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct PromptCacheLastReject {
     pub reason: &'static str,
     pub seq_id: Option<u64>,
     pub context_len: usize,
+    pub entry_len: Option<usize>,
     pub at_unix_ms: u64,
 }
 
@@ -133,6 +157,7 @@ pub struct PromptCacheRejectCounters {
     empty_set: AtomicU64,
     layout_constraints: AtomicU64,
     block_boundary_floor: AtomicU64,
+    snapshot_diverged: AtomicU64,
     last: Mutex<Option<PromptCacheLastReject>>,
 }
 
@@ -150,6 +175,7 @@ impl PromptCacheRejectCounters {
             PromptCacheRejectReason::EmptySet => &self.empty_set,
             PromptCacheRejectReason::LayoutConstraints => &self.layout_constraints,
             PromptCacheRejectReason::BlockBoundaryFloor => &self.block_boundary_floor,
+            PromptCacheRejectReason::SnapshotDiverged => &self.snapshot_diverged,
         }
     }
 
@@ -157,6 +183,19 @@ impl PromptCacheRejectCounters {
     /// snapshot. Cheap: one relaxed atomic increment plus a short-lived
     /// mutex hold to swap the small `Copy`-ish snapshot value.
     pub fn record(&self, reason: PromptCacheRejectReason, seq_id: Option<u64>, context_len: usize) {
+        self.record_detailed(reason, seq_id, context_len, None);
+    }
+
+    /// [`Self::record`] plus the stored entry's token length, for the decline
+    /// sites that have a specific stored entry in view (issue #1147). See
+    /// [`PromptCacheLastReject::entry_len`].
+    pub fn record_detailed(
+        &self,
+        reason: PromptCacheRejectReason,
+        seq_id: Option<u64>,
+        context_len: usize,
+        entry_len: Option<usize>,
+    ) {
         self.counter(reason).fetch_add(1, Ordering::Relaxed);
         let at_unix_ms = SystemTime::now()
             .duration_since(UNIX_EPOCH)
@@ -167,6 +206,7 @@ impl PromptCacheRejectCounters {
                 reason: reason.as_str(),
                 seq_id,
                 context_len,
+                entry_len,
                 at_unix_ms,
             });
         }

--- a/src/server/prompt_cache/mod.rs
+++ b/src/server/prompt_cache/mod.rs
@@ -53,6 +53,8 @@ mod types;
 mod apc_integration_tests;
 #[cfg(test)]
 mod prefix_matcher_tests;
+#[cfg(test)]
+mod snapshot_divergence_tests;
 
 pub use apc_lookup::ApcStoreStats;
 pub use block_hash::{
@@ -73,5 +75,5 @@ pub use metrics::{
     PromptCacheRejectCounters, PromptCacheRejectReason,
 };
 pub use policy::{ApcConfig, PromptCacheConfig, PromptCacheStats};
-pub use store::PromptCacheStore;
+pub use store::{PromptCacheStore, SnapshotDivergence, SnapshotLookupOutcome};
 pub use types::{BucketKey, InsertError};

--- a/src/server/prompt_cache/snapshot_divergence_tests.rs
+++ b/src/server/prompt_cache/snapshot_divergence_tests.rs
@@ -1,0 +1,343 @@
+// Copyright 2025-2026 Lablup Inc. and Jeongkyu Shin
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Classified snapshot-divergence rejects (issue #1147).
+//!
+//! Fixtures reproduce the three divergence classes epic #1148 verified live
+//! against real checkpoints, at the token-vector level the store actually
+//! compares:
+//!
+//! * **(a) generation-prompt-only scaffold tokens** — gemma-4-31b-it-4bit.
+//!   The template appends an empty thought scaffold to the generation prompt
+//!   but not when the assistant turn is re-rendered as history. Measured:
+//!   stored entry 139 tokens (94 prompt + 45 generated), turn-2 prompt shares
+//!   90 of them, divergence tokens `[100, 45518, 107, 101]`. Qwen 3.5 with
+//!   `enable_thinking=false` reaches the same shape through its empty
+//!   `<think>\n\n</think>\n\n` injection.
+//! * **(b) thinking stripped from history** — qwen3.5-4b-4bit, default
+//!   thinking mode. History renders the assistant turn without its `<think>`
+//!   block while the stored vector holds the primed `<think>\n` plus the
+//!   reasoning body, so the two diverge immediately after the assistant
+//!   header.
+//! * **(c) retokenization drift** — falcon-h1-tiny-90m-instruct-4bit. No
+//!   thinking scaffold at all: the stored vector holds 120 sampled completion
+//!   tokens and the same reply text re-tokenizes to 118, so a plain template
+//!   still diverges near the end of an otherwise matching prefix.
+//!
+//! Each class must land on the same `SnapshotDiverged` classification, and
+//! the negative cases (cold store, foreign session, foreign model bucket,
+//! genuine hit) must not.
+
+use std::time::Duration;
+
+use mlxcel_core::generate::ModelStateSnapshot;
+
+use super::entry::ModelSnapshotEntry;
+use super::key::{MultimodalDigest, PromptCacheKey};
+use super::policy::PromptCacheConfig;
+use super::store::{PromptCacheStore, SnapshotDivergence, SnapshotLookupOutcome};
+
+const SESSION: &str = "chat-1";
+
+fn store_with_snapshots() -> PromptCacheStore {
+    let cfg = PromptCacheConfig::new(true, 1 << 20, 64, Duration::from_secs(3600), 4)
+        .with_snapshot_limits(1 << 20, 64, Duration::from_secs(3600));
+    PromptCacheStore::with_config(cfg)
+}
+
+fn key<'a>(model: &'a str, session: Option<&'a str>, tokens: &'a [i32]) -> PromptCacheKey<'a> {
+    PromptCacheKey::new_full(
+        model,
+        None,
+        "tpl",
+        session,
+        MultimodalDigest::empty(),
+        tokens,
+    )
+}
+
+fn snapshot(tokens: Vec<i32>, family: &str) -> ModelSnapshotEntry {
+    let snapshot = ModelStateSnapshot::new(family, tokens.len());
+    ModelSnapshotEntry::new(tokens, snapshot)
+}
+
+/// Synthetic token run standing in for a stretch of chat text. Distinct
+/// `base` values produce disjoint runs, so a divergence is unambiguous.
+fn run(base: i32, n: usize) -> Vec<i32> {
+    (0..n as i32).map(|i| base + i).collect()
+}
+
+fn insert(store: &PromptCacheStore, family: &str, tokens: &[i32]) {
+    store
+        .insert_snapshot(
+            &key("m", Some(SESSION), tokens),
+            snapshot(tokens.to_vec(), family),
+        )
+        .expect("snapshot insert succeeds");
+}
+
+fn diverged(outcome: SnapshotLookupOutcome) -> SnapshotDivergence {
+    match outcome {
+        SnapshotLookupOutcome::Diverged(d) => d,
+        SnapshotLookupOutcome::Hit { matched_len, .. } => {
+            panic!("expected a divergence report, got a hit at {matched_len} tokens")
+        }
+        SnapshotLookupOutcome::NoCandidate => {
+            panic!(
+                "expected a divergence report, got NoCandidate (indistinguishable from a cold store)"
+            )
+        }
+    }
+}
+
+// -- class (a): generation-prompt-only scaffold tokens --------------------
+
+#[test]
+fn generation_prompt_scaffold_divergence_is_classified_with_its_geometry() {
+    // Gemma 4 shape, at the measured lengths: 94 prompt tokens + 45 generated
+    // tokens stored, of which the turn-2 prompt reproduces only the first 90
+    // before the template's thought scaffold appears.
+    let store = store_with_snapshots();
+    let shared = run(1_000, 90);
+    let mut stored = shared.clone();
+    // The 4 scaffold tokens the generation prompt carried, then the reply.
+    stored.extend([100, 45_518, 107, 101]);
+    stored.extend(run(5_000, 45));
+    assert_eq!(stored.len(), 139);
+    insert(&store, "gemma4", &stored);
+
+    // Turn 2 re-renders the assistant turn as history: no scaffold, so the
+    // reply text follows the shared prefix directly, then the new user turn.
+    let mut request = shared.clone();
+    request.extend(run(5_000, 45));
+    request.extend(run(7_000, 30));
+
+    let report =
+        diverged(store.lookup_snapshot_outcome(&key("m", Some(SESSION), &request), &request));
+    assert_eq!(
+        report.common_prefix_len, 90,
+        "the classification must carry how far the vectors agreed"
+    );
+    assert_eq!(
+        report.stored_len, 139,
+        "the classification must carry the stored entry length, not just a counter"
+    );
+    // The counter is not a proxy for the hit counter: this is still a miss.
+    assert!(
+        store
+            .lookup_snapshot_prefix(&key("m", Some(SESSION), &request), &request)
+            .is_none()
+    );
+}
+
+// -- class (b): thinking stripped from the history re-render --------------
+
+#[test]
+fn thinking_stripped_from_history_divergence_is_classified() {
+    // Qwen 3.5 default thinking mode: the vectors part company right after
+    // the assistant header, because the stored vector continues into the
+    // primed `<think>\n` while the history re-render goes straight to the
+    // visible answer.
+    let store = store_with_snapshots();
+    let header = run(2_000, 61);
+    let mut stored = header.clone();
+    stored.extend(run(3_100, 62)); // `<think>\n` + reasoning body + answer
+    insert(&store, "qwen3_5", &stored);
+
+    let mut request = header.clone();
+    request.extend(run(4_100, 40)); // answer only, no reasoning
+    request.extend(run(8_000, 22)); // new user turn
+
+    let report =
+        diverged(store.lookup_snapshot_outcome(&key("m", Some(SESSION), &request), &request));
+    assert_eq!(report.common_prefix_len, header.len());
+    assert_eq!(report.stored_len, stored.len());
+}
+
+// -- class (c): retokenization drift --------------------------------------
+
+#[test]
+fn retokenization_drift_divergence_is_classified() {
+    // Falcon-H1 shape: plain ChatML, no thinking scaffold, and the miss is
+    // still structural. 120 sampled completion tokens are stored; the same
+    // reply text re-tokenizes to 118, so the vectors agree through the prompt
+    // and the first stretch of the reply and then drift.
+    let store = store_with_snapshots();
+    let prompt = run(500, 130);
+    let mut stored = prompt.clone();
+    stored.extend(run(6_000, 100)); // identically-tokenizing head of the reply
+    stored.extend(run(9_000, 20)); // 20 sampled tokens
+    assert_eq!(stored.len() - prompt.len(), 120);
+    insert(&store, "falcon_h1", &stored);
+
+    let mut request = prompt.clone();
+    request.extend(run(6_000, 100));
+    request.extend(run(9_500, 18)); // same text, 18 tokens after re-tokenizing
+    request.extend(run(11_000, 25));
+
+    let report =
+        diverged(store.lookup_snapshot_outcome(&key("m", Some(SESSION), &request), &request));
+    assert_eq!(report.common_prefix_len, 230);
+    assert_eq!(report.stored_len, 250);
+    assert!(
+        report.common_prefix_len < report.stored_len,
+        "a divergence report always means the stored tail is unusable"
+    );
+}
+
+// -- no false classification ----------------------------------------------
+
+#[test]
+fn cold_store_reports_no_candidate_not_a_divergence() {
+    let store = store_with_snapshots();
+    let request = run(1_000, 40);
+    assert!(matches!(
+        store.lookup_snapshot_outcome(&key("m", Some(SESSION), &request), &request),
+        SnapshotLookupOutcome::NoCandidate
+    ));
+}
+
+#[test]
+fn foreign_session_bucket_reports_no_candidate_not_a_divergence() {
+    let store = store_with_snapshots();
+    let stored = run(1_000, 40);
+    insert(&store, "gemma4", &stored);
+
+    let mut request = run(1_000, 30);
+    request.extend(run(20_000, 12));
+    // Same tokens, different session: the candidate is not this caller's to
+    // diverge from, so classifying it would be a false positive.
+    assert!(matches!(
+        store.lookup_snapshot_outcome(&key("m", Some("chat-2"), &request), &request),
+        SnapshotLookupOutcome::NoCandidate
+    ));
+    // A sessionless caller must not see the session-bound entry either.
+    assert!(matches!(
+        store.lookup_snapshot_outcome(&key("m", None, &request), &request),
+        SnapshotLookupOutcome::NoCandidate
+    ));
+}
+
+#[test]
+fn foreign_model_bucket_reports_no_candidate_not_a_divergence() {
+    let store = store_with_snapshots();
+    let stored = run(1_000, 40);
+    insert(&store, "gemma4", &stored);
+
+    let mut request = run(1_000, 30);
+    request.extend(run(20_000, 12));
+    assert!(matches!(
+        store.lookup_snapshot_outcome(&key("other-model", Some(SESSION), &request), &request),
+        SnapshotLookupOutcome::NoCandidate
+    ));
+}
+
+#[test]
+fn exact_prefix_still_hits_and_reports_no_divergence() {
+    let store = store_with_snapshots();
+    let stored = run(1_000, 40);
+    insert(&store, "gemma4", &stored);
+
+    let mut request = stored.clone();
+    request.extend(run(20_000, 12));
+    match store.lookup_snapshot_outcome(&key("m", Some(SESSION), &request), &request) {
+        SnapshotLookupOutcome::Hit { matched_len, entry } => {
+            assert_eq!(matched_len, stored.len());
+            assert_eq!(entry.tokens, stored);
+        }
+        other => panic!("exact prefix must still hit, got {other:?}"),
+    }
+}
+
+#[test]
+fn a_hit_wins_over_a_sibling_divergence() {
+    // With both a usable and an unusable candidate in the bucket, the lookup
+    // must adopt rather than report a reject: a divergence classification is
+    // only ever a description of a miss.
+    let store = store_with_snapshots();
+    let usable = run(1_000, 40);
+    insert(&store, "gemma4", &usable);
+    let mut unusable = run(1_000, 20);
+    unusable.extend(run(30_000, 15));
+    insert(&store, "gemma4", &unusable);
+
+    let mut request = usable.clone();
+    request.extend(run(20_000, 12));
+    assert!(matches!(
+        store.lookup_snapshot_outcome(&key("m", Some(SESSION), &request), &request),
+        SnapshotLookupOutcome::Hit { .. }
+    ));
+}
+
+#[test]
+fn the_longest_common_prefix_candidate_is_the_one_reported() {
+    let store = store_with_snapshots();
+    let shared = run(1_000, 40);
+    let mut shallow = run(1_000, 10);
+    shallow.extend(run(30_000, 15));
+    insert(&store, "gemma4", &shallow);
+    let mut deep = shared.clone();
+    deep.extend(run(31_000, 9));
+    insert(&store, "gemma4", &deep);
+
+    let mut request = shared.clone();
+    request.extend(run(32_000, 20));
+    let report =
+        diverged(store.lookup_snapshot_outcome(&key("m", Some(SESSION), &request), &request));
+    assert_eq!(report.common_prefix_len, 40, "best candidate is reported");
+    assert_eq!(report.stored_len, deep.len());
+}
+
+#[test]
+fn a_request_shorter_than_the_stored_entry_is_a_divergence() {
+    // The stored vector extends past the request, so it is not a prefix of
+    // it and cannot be restored. The two lengths say exactly that.
+    let store = store_with_snapshots();
+    let stored = run(1_000, 40);
+    insert(&store, "gemma4", &stored);
+
+    let request = run(1_000, 25);
+    let report =
+        diverged(store.lookup_snapshot_outcome(&key("m", Some(SESSION), &request), &request));
+    assert_eq!(report.common_prefix_len, 25);
+    assert_eq!(report.stored_len, 40);
+}
+
+#[test]
+fn a_disabled_store_reports_no_candidate() {
+    let cfg = PromptCacheConfig::new(false, 1 << 20, 64, Duration::from_secs(3600), 4)
+        .with_snapshot_limits(1 << 20, 64, Duration::from_secs(3600));
+    let store = PromptCacheStore::with_config(cfg);
+    let request = run(1_000, 40);
+    assert!(matches!(
+        store.lookup_snapshot_outcome(&key("m", Some(SESSION), &request), &request),
+        SnapshotLookupOutcome::NoCandidate
+    ));
+}
+
+#[test]
+fn divergence_does_not_inflate_the_snapshot_hit_counters() {
+    let store = store_with_snapshots();
+    let mut stored = run(1_000, 20);
+    stored.extend(run(30_000, 20));
+    insert(&store, "gemma4", &stored);
+
+    let mut request = run(1_000, 20);
+    request.extend(run(40_000, 25));
+    let _ = store.lookup_snapshot_outcome(&key("m", Some(SESSION), &request), &request);
+
+    let stats = store.stats();
+    assert_eq!(stats.snapshot_lookups, 1, "the lookup is still counted");
+    assert_eq!(stats.snapshot_hits, 0, "a divergence is a miss, not a hit");
+}

--- a/src/server/prompt_cache/store.rs
+++ b/src/server/prompt_cache/store.rs
@@ -57,6 +57,43 @@ pub(super) struct SnapshotSlot {
     sessionless: SessionlessBucketKey,
 }
 
+/// Geometry of a structural snapshot miss (issue #1147).
+///
+/// Emitted when the request's own session bucket held a snapshot candidate
+/// whose stored token vector is not a prefix of the request. The two lengths
+/// are what makes the miss diagnosable without token-level detokenization:
+/// `common_prefix_len` is how far the stored vector and the request agreed,
+/// `stored_len` is how long the stored vector actually is, and the difference
+/// between them is the divergent tail that the exact-prefix path cannot use.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct SnapshotDivergence {
+    /// Longest common token prefix between the stored entry and the request.
+    pub common_prefix_len: usize,
+    /// Token count of the stored entry.
+    pub stored_len: usize,
+}
+
+/// Result of a snapshot lookup, with the miss reason preserved.
+///
+/// [`PromptCacheStore::lookup_snapshot_prefix`] collapses this to
+/// `Option<..>`; callers that report metrics should use
+/// [`PromptCacheStore::lookup_snapshot_outcome`] so a structural divergence
+/// is distinguishable from a genuinely cold store.
+#[derive(Debug, Clone)]
+pub enum SnapshotLookupOutcome {
+    /// A stored snapshot is an exact prefix of the request and was adopted.
+    Hit {
+        entry: Arc<ModelSnapshotEntry>,
+        /// Token count the restored snapshot covers.
+        matched_len: usize,
+    },
+    /// A same-session candidate existed but diverged from the request.
+    Diverged(SnapshotDivergence),
+    /// No candidate in this request's session bucket at all: an empty store,
+    /// a different model/template/session bucket, or a disabled cache.
+    NoCandidate,
+}
+
 struct Inner {
     config: PromptCacheConfig,
     // Primary map: digest -> entry.
@@ -898,16 +935,46 @@ impl PromptCacheStore {
     /// matches exactly. That preserves the recurrent-state invariant: a full
     /// SSM / linear-attention state cannot be truncated to an arbitrary earlier
     /// token boundary.
+    ///
+    /// Thin wrapper over [`Self::lookup_snapshot_outcome`] for callers that
+    /// only care about the hit. Callers that also want the structural-miss
+    /// diagnosis (issue #1147) should use the outcome form directly.
     pub fn lookup_snapshot_prefix(
         &self,
         key: &PromptCacheKey<'_>,
         tokens: &[i32],
     ) -> Option<(Arc<ModelSnapshotEntry>, usize)> {
+        match self.lookup_snapshot_outcome(key, tokens) {
+            SnapshotLookupOutcome::Hit { entry, matched_len } => Some((entry, matched_len)),
+            SnapshotLookupOutcome::Diverged(_) | SnapshotLookupOutcome::NoCandidate => None,
+        }
+    }
+
+    /// [`Self::lookup_snapshot_prefix`] with the miss reason attached.
+    ///
+    /// Distinguishing the two miss shapes is the whole point (issue #1147):
+    /// an empty store and a store holding an entry that diverges from the
+    /// request on a chat-template artifact both used to return a bare `None`,
+    /// so a structural multi-turn miss looked exactly like a cold cache in
+    /// `/v1/cache/stats`. When a candidate does exist in the request's own
+    /// session bucket but is not a prefix of the request, this reports the
+    /// divergence geometry so the caller can classify the reject.
+    ///
+    /// The divergence report is scoped to same-bucket candidates only, so a
+    /// cold store, a different model/template bucket, and a different session
+    /// all still report [`SnapshotLookupOutcome::NoCandidate`]. When several
+    /// candidates diverge, the one with the longest common prefix is reported
+    /// (ties broken by recency), matching the hit path's preference order.
+    pub fn lookup_snapshot_outcome(
+        &self,
+        key: &PromptCacheKey<'_>,
+        tokens: &[i32],
+    ) -> SnapshotLookupOutcome {
         {
             let now = Instant::now();
             let mut guard = self.inner.write().expect("prompt cache inner lock");
             if !guard.config.is_enabled() {
-                return None;
+                return SnapshotLookupOutcome::NoCandidate;
             }
             let (freed, count) = guard.sweep_snapshot_ttl(now);
             if let Some(per_entry) = freed.checked_div(count) {
@@ -919,10 +986,11 @@ impl PromptCacheStore {
         }
 
         let sessionless = SessionlessBucketKey::from_key(key);
-        let best = {
+        let (best, diverged) = {
             let guard = self.inner.read().expect("prompt cache inner lock");
             let min_len = guard.config.min_prefix_tokens;
             let mut best: Option<(PromptCacheKeyDigest, usize, Instant)> = None;
+            let mut diverged: Option<(SnapshotDivergence, Instant)> = None;
             for (digest, slot) in &guard.snapshots {
                 if slot.sessionless != sessionless {
                     continue;
@@ -936,13 +1004,34 @@ impl PromptCacheStore {
                     continue;
                 }
                 let len = slot.entry.tokens.len();
-                if len < min_len || len > tokens.len() {
-                    continue;
-                }
-                if slot.entry.tokens.as_slice() != &tokens[..len] {
-                    continue;
-                }
                 let last_used = slot.entry.last_used();
+                let is_prefix =
+                    len <= tokens.len() && slot.entry.tokens.as_slice() == &tokens[..len];
+                if !is_prefix {
+                    // Same bucket, same session, but the stored vector is not
+                    // a prefix of this request. Record how far the two agreed
+                    // so the caller can report a classified reject instead of
+                    // an indistinguishable miss.
+                    let report = SnapshotDivergence {
+                        common_prefix_len: common_prefix_len(slot.entry.tokens.as_slice(), tokens),
+                        stored_len: len,
+                    };
+                    let replace = match &diverged {
+                        None => true,
+                        Some((existing, existing_used)) => {
+                            report.common_prefix_len > existing.common_prefix_len
+                                || (report.common_prefix_len == existing.common_prefix_len
+                                    && last_used > *existing_used)
+                        }
+                    };
+                    if replace {
+                        diverged = Some((report, last_used));
+                    }
+                    continue;
+                }
+                if len < min_len {
+                    continue;
+                }
                 let replace = match best {
                     None => true,
                     Some((_, best_len, best_used)) => {
@@ -953,7 +1042,7 @@ impl PromptCacheStore {
                     best = Some((*digest, len, last_used));
                 }
             }
-            best
+            (best, diverged.map(|(report, _)| report))
         };
 
         let (entry, matched_len) = {
@@ -967,7 +1056,7 @@ impl PromptCacheStore {
                             drop(guard);
                             let metrics = Arc::clone(&self.metrics);
                             metrics.record_snapshot_lookup(false, 0);
-                            return None;
+                            return SnapshotLookupOutcome::NoCandidate;
                         }
                     };
                     guard.snapshot_hits = guard.snapshot_hits.saturating_add(1);
@@ -983,7 +1072,13 @@ impl PromptCacheStore {
             Some(_) => metrics.record_snapshot_lookup(true, matched_len),
             None => metrics.record_snapshot_lookup(false, 0),
         }
-        entry.map(|e| (e, matched_len))
+        match entry {
+            Some(entry) => SnapshotLookupOutcome::Hit { entry, matched_len },
+            None => match diverged {
+                Some(report) => SnapshotLookupOutcome::Diverged(report),
+                None => SnapshotLookupOutcome::NoCandidate,
+            },
+        }
     }
 
     /// Account a lookup miss and return `None`. Factored out so the
@@ -1151,11 +1246,14 @@ fn select_best_by_scan(
     }
 }
 
-/// Length of the longest common token prefix between `a` and `b`. Used by
-/// the APC partial-adoption scan path so a candidate whose
-/// stored prefix diverges inside the request still surfaces with its
-/// actual common-prefix length, ready for the block-hash discriminator
-/// to clamp.
+/// Length of the longest common token prefix between `a` and `b`.
+///
+/// Used by: [`select_best_by_scan`] (APC partial-adoption scan path, so a
+/// candidate whose stored prefix diverges inside the request still surfaces
+/// with its actual common-prefix length, ready for the block-hash
+/// discriminator to clamp) and
+/// [`PromptCacheStore::lookup_snapshot_outcome`] (issue #1147, to report how
+/// far a diverging snapshot candidate agreed with the request).
 fn common_prefix_len(a: &[i32], b: &[i32]) -> usize {
     a.iter().zip(b.iter()).take_while(|(x, y)| x == y).count()
 }

--- a/src/server/routes/cache.rs
+++ b/src/server/routes/cache.rs
@@ -78,9 +78,11 @@ pub(crate) struct RejectReasonStats {
     pub empty_set: u64,
     pub layout_constraints: u64,
     pub block_boundary_floor: u64,
+    pub snapshot_diverged: u64,
     pub last_reason: Option<String>,
     pub last_seq_id: Option<u64>,
     pub last_context_len: Option<u64>,
+    pub last_entry_len: Option<u64>,
     pub last_at_unix_ms: Option<u64>,
 }
 
@@ -97,9 +99,11 @@ impl RejectReasonStats {
             empty_set: snap.prompt_cache_reject_empty_set,
             layout_constraints: snap.prompt_cache_reject_layout_constraints,
             block_boundary_floor: snap.prompt_cache_reject_block_boundary_floor,
+            snapshot_diverged: snap.prompt_cache_reject_snapshot_diverged,
             last_reason: last.map(|r| r.reason.to_string()),
             last_seq_id: last.and_then(|r| r.seq_id),
             last_context_len: last.map(|r| r.context_len),
+            last_entry_len: last.and_then(|r| r.entry_len),
             last_at_unix_ms: last.map(|r| r.at_unix_ms),
         }
     }
@@ -219,6 +223,16 @@ pub struct CacheStatsResponse {
     /// Paged pool block-size floor pushed the adoptable/donatable length
     /// below `min_prefix_tokens` (adopt path only).
     pub reject_block_boundary_floor: u64,
+    /// Structural snapshot-divergence declines (issue #1147, adopt path
+    /// only): a snapshot candidate existed in the request's own session
+    /// bucket but its stored token vector is not a prefix of the request, so
+    /// the exact-prefix snapshot path could not adopt it. This is what
+    /// separates the multi-turn miss of epic #1148 from an empty store: with
+    /// `snapshot_lookups` advancing and `snapshot_hits` at zero, a non-zero
+    /// count here means the entry was there and structurally unusable, while
+    /// a zero count means there was nothing to reuse. `last_reject_context_len`
+    /// and `last_reject_entry_len` carry the geometry of the most recent one.
+    pub reject_snapshot_diverged: u64,
     /// Reason label of the most recent reject/decline event, if any has
     /// happened yet.
     pub last_reject_reason: Option<String>,
@@ -226,8 +240,14 @@ pub struct CacheStatsResponse {
     /// decline site (see [`crate::server::prompt_cache::PromptCacheLastReject`]).
     pub last_reject_seq_id: Option<u64>,
     /// Matched-prefix length (adopt) or donated token count (donate) at the
-    /// time of the most recent reject.
+    /// time of the most recent reject. For `snapshot_diverged` this is the
+    /// longest common prefix between the stored entry and the request.
     pub last_reject_context_len: Option<u64>,
+    /// Token length of the stored entry involved in the most recent reject,
+    /// when the decline site had one specific entry in view. Populated for
+    /// `snapshot_diverged` (the stored snapshot's length) and `null` for the
+    /// other reasons.
+    pub last_reject_entry_len: Option<u64>,
     /// Unix epoch milliseconds of the most recent reject.
     pub last_reject_at_unix_ms: Option<u64>,
 }
@@ -336,9 +356,11 @@ pub(crate) fn build_stats_response(
                 reject_empty_set: reject.empty_set,
                 reject_layout_constraints: reject.layout_constraints,
                 reject_block_boundary_floor: reject.block_boundary_floor,
+                reject_snapshot_diverged: reject.snapshot_diverged,
                 last_reject_reason: reject.last_reason,
                 last_reject_seq_id: reject.last_seq_id,
                 last_reject_context_len: reject.last_context_len,
+                last_reject_entry_len: reject.last_entry_len,
                 last_reject_at_unix_ms: reject.last_at_unix_ms,
             }
         }
@@ -391,9 +413,11 @@ pub(crate) fn build_stats_response(
             reject_empty_set: reject.empty_set,
             reject_layout_constraints: reject.layout_constraints,
             reject_block_boundary_floor: reject.block_boundary_floor,
+            reject_snapshot_diverged: reject.snapshot_diverged,
             last_reject_reason: reject.last_reason,
             last_reject_seq_id: reject.last_seq_id,
             last_reject_context_len: reject.last_context_len,
+            last_reject_entry_len: reject.last_entry_len,
             last_reject_at_unix_ms: reject.last_at_unix_ms,
         },
     }

--- a/src/server/routes/cache_tests.rs
+++ b/src/server/routes/cache_tests.rs
@@ -125,9 +125,11 @@ fn cache_stats_response_serializes_with_expected_keys() {
         reject_empty_set: 4,
         reject_layout_constraints: 5,
         reject_block_boundary_floor: 6,
+        reject_snapshot_diverged: 7,
         last_reject_reason: Some("oversized".to_string()),
         last_reject_seq_id: Some(42),
         last_reject_context_len: Some(128),
+        last_reject_entry_len: Some(139),
         last_reject_at_unix_ms: Some(1_700_000_000_000),
     };
     let json = serde_json::to_string(&resp).expect("serialize");
@@ -164,9 +166,11 @@ fn cache_stats_response_serializes_with_expected_keys() {
         "\"reject_empty_set\":4",
         "\"reject_layout_constraints\":5",
         "\"reject_block_boundary_floor\":6",
+        "\"reject_snapshot_diverged\":7",
         "\"last_reject_reason\":\"oversized\"",
         "\"last_reject_seq_id\":42",
         "\"last_reject_context_len\":128",
+        "\"last_reject_entry_len\":139",
         "\"last_reject_at_unix_ms\":1700000000000",
     ] {
         assert!(json.contains(key), "expected `{key}` in: {json}");
@@ -279,9 +283,11 @@ fn cache_stats_response_disabled_payload_uses_zero_counters() {
         reject_empty_set: 0,
         reject_layout_constraints: 0,
         reject_block_boundary_floor: 0,
+        reject_snapshot_diverged: 0,
         last_reject_reason: None,
         last_reject_seq_id: None,
         last_reject_context_len: None,
+        last_reject_entry_len: None,
         last_reject_at_unix_ms: None,
     };
     assert!(!resp.enabled);
@@ -369,6 +375,74 @@ fn paged_block_stats_projects_from_observability_snapshot() {
     assert_eq!(paged.bytes_reserved, 4096);
     assert_eq!(paged.bytes_in_use, 2048);
     assert_eq!(paged.block_budget, 16);
+}
+
+#[test]
+fn snapshot_divergence_reject_reaches_the_stats_body_with_its_geometry() {
+    // The full data path the route uses for issue #1147: the scheduler's
+    // classified reject → `BatchObservability` → snapshot →
+    // `RejectReasonStats::from_observability` → `build_stats_response` →
+    // JSON. The numbers are the gemma-4 two-turn scenario epic #1148
+    // measured: a 139-token stored entry sharing 90 tokens with the request.
+    use crate::server::batch::BatchObservability;
+    use crate::server::prompt_cache::PromptCacheRejectReason;
+
+    let obs = BatchObservability::new();
+    obs.record_prompt_cache_reject_detailed(
+        PromptCacheRejectReason::SnapshotDiverged,
+        None,
+        90,
+        Some(139),
+    );
+
+    let reject = RejectReasonStats::from_observability(&obs.snapshot());
+    assert_eq!(reject.snapshot_diverged, 1);
+    assert_eq!(reject.last_reason.as_deref(), Some("snapshot_diverged"));
+    assert_eq!(reject.last_context_len, Some(90));
+    assert_eq!(reject.last_entry_len, Some(139));
+
+    let cfg = PromptCacheConfig::default();
+    let resp =
+        super::super::cache::build_stats_response(None, &cfg, PagedBlockStats::default(), reject);
+    assert_eq!(resp.reject_snapshot_diverged, 1);
+    let json = serde_json::to_string(&resp).expect("serialize");
+    for key in [
+        "\"reject_snapshot_diverged\":1",
+        "\"last_reject_reason\":\"snapshot_diverged\"",
+        "\"last_reject_context_len\":90",
+        "\"last_reject_entry_len\":139",
+    ] {
+        assert!(json.contains(key), "expected `{key}` in: {json}");
+    }
+}
+
+#[test]
+fn other_reject_reasons_leave_the_stats_divergence_counter_at_zero() {
+    // The divergence counter must stay a specific signal: an operator seeing
+    // it non-zero has to be able to conclude a snapshot candidate really was
+    // there and really was unusable. Any other reject must not move it, and
+    // must leave `last_reject_entry_len` null rather than borrowing a stale
+    // length.
+    use crate::server::batch::BatchObservability;
+    use crate::server::prompt_cache::PromptCacheRejectReason;
+
+    let obs = BatchObservability::new();
+    obs.record_prompt_cache_reject(PromptCacheRejectReason::ModeMismatch, None, 12);
+    obs.record_prompt_cache_reject(PromptCacheRejectReason::EmptySet, Some(3), 0);
+
+    let reject = RejectReasonStats::from_observability(&obs.snapshot());
+    assert_eq!(reject.snapshot_diverged, 0);
+    assert_eq!(reject.last_reason.as_deref(), Some("empty_set"));
+    assert_eq!(reject.last_entry_len, None);
+
+    let cfg = PromptCacheConfig::default();
+    let resp =
+        super::super::cache::build_stats_response(None, &cfg, PagedBlockStats::default(), reject);
+    assert_eq!(resp.reject_snapshot_diverged, 0);
+    assert_eq!(resp.last_reject_entry_len, None);
+    let json = serde_json::to_string(&resp).expect("serialize");
+    assert!(json.contains("\"reject_snapshot_diverged\":0"), "{json}");
+    assert!(json.contains("\"last_reject_entry_len\":null"), "{json}");
 }
 
 #[test]

--- a/src/server/routes/metrics.rs
+++ b/src/server/routes/metrics.rs
@@ -129,6 +129,7 @@ pub async fn metrics(State(state): State<AppState>) -> Response {
     let pc_reject_empty_set = obs.prompt_cache_reject_empty_set;
     let pc_reject_layout_constraints = obs.prompt_cache_reject_layout_constraints;
     let pc_reject_block_boundary_floor = obs.prompt_cache_reject_block_boundary_floor;
+    let pc_reject_snapshot_diverged = obs.prompt_cache_reject_snapshot_diverged;
 
     let pp_snapshot = state.pp_observability.snapshot();
     let body = format!(
@@ -274,7 +275,8 @@ pub async fn metrics(State(state): State<AppState>) -> Response {
          mlxcel_prompt_cache_reject_total{{reason=\"mode_mismatch\"}} {pc_reject_mode_mismatch}\n\
          mlxcel_prompt_cache_reject_total{{reason=\"empty_set\"}} {pc_reject_empty_set}\n\
          mlxcel_prompt_cache_reject_total{{reason=\"layout_constraints\"}} {pc_reject_layout_constraints}\n\
-         mlxcel_prompt_cache_reject_total{{reason=\"block_boundary_floor\"}} {pc_reject_block_boundary_floor}\n",
+         mlxcel_prompt_cache_reject_total{{reason=\"block_boundary_floor\"}} {pc_reject_block_boundary_floor}\n\
+         mlxcel_prompt_cache_reject_total{{reason=\"snapshot_diverged\"}} {pc_reject_snapshot_diverged}\n",
         gen_time_sec = gen_time_ms as f64 / 1000.0,
         seq_started = obs.sequences_started,
         seq_completed = obs.sequences_completed,
@@ -321,6 +323,7 @@ pub async fn metrics(State(state): State<AppState>) -> Response {
         pc_reject_empty_set = pc_reject_empty_set,
         pc_reject_layout_constraints = pc_reject_layout_constraints,
         pc_reject_block_boundary_floor = pc_reject_block_boundary_floor,
+        pc_reject_snapshot_diverged = pc_reject_snapshot_diverged,
     );
 
     let mut body = body;


### PR DESCRIPTION
## Summary

A snapshot candidate that sits in the request's own session bucket but is not a prefix of it used to return a bare `None` from `lookup_snapshot_prefix`, which made the structural multi-turn miss of epic #1148 indistinguishable from an empty store in `/v1/cache/stats`. Diagnosing it required manual token-level detokenization. This adds a `snapshot_diverged` reject reason carrying the divergence geometry, so the stats surface says it directly.

## What changed

- `src/server/prompt_cache/store.rs`: new `SnapshotDivergence { common_prefix_len, stored_len }` and `SnapshotLookupOutcome { Hit, Diverged, NoCandidate }`, plus `lookup_snapshot_outcome` which reports the best diverging same-session candidate when there is no exact-prefix hit. `lookup_snapshot_prefix` stays as a thin wrapper with its old signature and behavior.
- `src/server/prompt_cache/metrics.rs`: `PromptCacheRejectReason::SnapshotDiverged` (label `snapshot_diverged`), counted by `PromptCacheRejectCounters`; `PromptCacheLastReject` gains `entry_len` and `record_detailed` for the sites that have a specific stored entry in view. `record` delegates with `None`, so no existing call site changes behavior.
- `src/server/batch/scheduler.rs`: `try_adopt_cached_prefix` consumes the outcome and records the classified reject. `NoCandidate` records nothing, so a cold store and a foreign session bucket never emit the reject.
- `src/server/batch/observability.rs`: `record_prompt_cache_reject_detailed`, the `prompt_cache_reject_snapshot_diverged` counter, and `entry_len` on the last-reject snapshot.
- `src/server/routes/cache.rs`, `src/server/routes/metrics.rs`: `reject_snapshot_diverged` and `last_reject_entry_len` on `/v1/cache/stats`, and the `reason="snapshot_diverged"` series on `/metrics`.
- `src/server/prompt_cache/snapshot_divergence_tests.rs` (new): the three divergence classes epic #1148 verified live, at the token-vector level the store compares, plus the no-false-classification cases.

## Test plan

- [x] `cargo test --release --lib server::prompt_cache` (153 passed)
- [x] `cargo test --release --lib server::routes::cache` (19 passed)
- [x] `cargo test --release --lib server::batch::observability` (15 passed)
- [x] `cargo clippy --lib --tests -- -D warnings`, `cargo fmt --check`
- [x] Real checkpoints, multi-turn chat through the production `/v1/chat/completions` path with counter verification on `/v1/cache/stats`:

| Checkpoint | Family path | Turn | `snapshot_lookups` / `hits` | `reject_snapshot_diverged` | `last_reject_context_len` / `entry_len` |
|---|---|---|---|---|---|
| qwen3.5-0.8b-4bit | Attention + GatedDeltaNet | cold store | 0 / 0 | 0 | null / null |
| qwen3.5-0.8b-4bit | | after donate | 1 / 0 | 0 | null / null |
| qwen3.5-0.8b-4bit | | turn 2 (`cached_tokens = 0`) | 2 / 0 | 1 | 33 / 95 |
| falcon-h1-tiny-90m-instruct-4bit | Mamba hybrid | turn 2 (`cached_tokens = 95`) | 2 / 1 | 0 | null / null |
| falcon-h1-tiny-90m-instruct-4bit | | early-divergence turn (`cached_tokens = 0`) | 4 / 2 | 1 | 23 / 139 |

Two families on different hybrid paths both classify, so the reject is family-agnostic rather than a property of one template. The falcon-h1 turn-2 row is the negative control that matters most: class (c) retokenization drift is data-dependent, that reply re-tokenized identically, the lookup correctly returned a hit, and the divergence counter stayed at zero. It only moves once no stored entry is a prefix of the request. The cold-store row confirms an empty store emits nothing.

The gemma-4-31b-it-4bit row named in the issue is left to the orchestrator's large-model pass; the 90/139 geometry from that scenario is pinned as a unit-test fixture in `snapshot_divergence_tests.rs`.

Closes #1147
