### PR TITLE
feat(models): restore Gemma 4 snapshots at the longest common prefix

### DIFF
--- a/src/lib/mlxcel-core/src/cache.rs
+++ b/src/lib/mlxcel-core/src/cache.rs
@@ -3881,6 +3881,47 @@ pub struct RotatingKVCacheSnapshotState {
     pub turbo_seed: u32,
 }
 
+impl RotatingKVCacheSnapshotState {
+    /// Whether the ring is still linear: every logical token `t` sits at
+    /// physical slot `t`, and nothing has been overwritten or dropped.
+    ///
+    /// Two independent things can break linearity, and both must be excluded:
+    ///
+    /// * **Wrap.** Once `idx` has rolled over (`update_in_place` resets it to
+    ///   `0` at `idx >= max_size`), the oldest live token no longer sits at
+    ///   slot 0 and `idx` stops tracking `offset`. `idx == offset` is exactly
+    ///   the not-yet-wrapped condition, and it stays true at the boundary
+    ///   `offset == max_size`, where the buffer is full but the rollover has
+    ///   not happened yet.
+    /// * **Over-window prefill.** `update_concat` deliberately stores more
+    ///   than `max_size` entries for one step after a prefill longer than the
+    ///   window, keeping `idx == offset`. That buffer is temporary: the next
+    ///   single-token update re-slices it from the back and pins `idx` to
+    ///   `max_size`. Trimming into that state would desynchronize `idx` from
+    ///   the physical layout, so `offset <= max_size` is required as well.
+    ///
+    /// Buffered speculative mode (`buffer_size > 0`) keeps its own compaction
+    /// invariants and is excluded outright; snapshots are captured outside
+    /// MTP, so this costs nothing in practice.
+    pub fn is_unwrapped(&self) -> bool {
+        self.buffer_size == 0 && self.idx == self.offset && self.offset <= self.max_size
+    }
+
+    /// Whether this rotating state can be restored covering only its first
+    /// `target_len` tokens (issue #1145).
+    ///
+    /// Follows the upstream mlx-lm `can_trim_prompt_cache` precedent
+    /// (https://github.com/ml-explore/mlx-lm/blob/main/mlx_lm/models/cache.py),
+    /// which allows a rotating trim only while the cache is unwrapped. Only
+    /// FP16 storage is snapshot-capable today, so any other mode declines.
+    pub fn can_truncate_to(&self, target_len: i32) -> bool {
+        self.mode == KVCacheMode::Fp16
+            && target_len >= 0
+            && target_len <= self.offset
+            && self.is_unwrapped()
+    }
+}
+
 impl RotatingKVCache {
     /// Create a new rotating KV cache with specified maximum size (FP16 mode).
     pub fn new(max_size: i32) -> Self {
@@ -5051,6 +5092,19 @@ impl RotatingKVCache {
     /// `max_size`).
     ///
     /// Used by: Gemma 4 MTP `rollback_speculative_cache`.
+    /// Whether this cache currently supports trimming.
+    ///
+    /// Mirrors upstream mlx-lm `RotatingKVCache.is_trimmable`, which gates on
+    /// the ring still being linear. Unlike [`KVCache::is_trimmable`] (always
+    /// `true`), a rotating cache that has wrapped has genuinely lost the
+    /// tokens a trim would need to expose, so the answer is state-dependent.
+    ///
+    /// Used by: `can_trim_prompt_cache`-style validation, and the Gemma 4
+    /// partial snapshot restore (issue #1145).
+    pub fn is_trimmable(&self) -> bool {
+        self.snapshot_state().is_unwrapped()
+    }
+
     pub fn trim(&mut self, n: i32) -> i32 {
         let n = if self.buffer_size > 0 {
             n.min(self.idx).min(self.offset)
@@ -6737,6 +6791,134 @@ impl CachePool {
         }
         self.paged_pool = Some(Rc::new(RefCell::new(pool)));
         Ok(())
+    }
+}
+
+#[cfg(test)]
+mod rotating_truncation_tests {
+    //! Wrap-boundary rules for the partial snapshot restore (issue #1145).
+    //!
+    //! These operate on the scalar snapshot state alone, so they pin the
+    //! decision rule itself without needing MLX arrays or a loaded model.
+    use super::*;
+
+    fn state(max_size: i32, offset: i32, idx: i32) -> RotatingKVCacheSnapshotState {
+        RotatingKVCacheSnapshotState {
+            max_size,
+            buffer_size: 0,
+            offset,
+            start_position: 0,
+            idx,
+            step: 256,
+            mode: KVCacheMode::Fp16,
+            turbo_seed: 0,
+        }
+    }
+
+    #[test]
+    fn unwrapped_cache_truncates_to_any_earlier_boundary() {
+        let s = state(1024, 400, 400);
+        assert!(s.is_unwrapped());
+        for target in [0, 1, 90, 399, 400] {
+            assert!(s.can_truncate_to(target), "target {target} should be valid");
+        }
+    }
+
+    #[test]
+    fn truncation_target_past_the_stored_offset_is_refused() {
+        let s = state(1024, 400, 400);
+        assert!(!s.can_truncate_to(401));
+        assert!(!s.can_truncate_to(-1));
+    }
+
+    #[test]
+    fn the_wrap_boundary_is_inclusive_at_offset_equal_to_the_window() {
+        // At offset == max_size the ring is exactly full but `update_in_place`
+        // has not rolled `idx` over yet, so every token still sits at its own
+        // slot and a trim is mechanically identical to the dense case. This is
+        // the boundary the issue calls out: accepted here, refused one step
+        // later.
+        let full = state(1024, 1024, 1024);
+        assert!(full.is_unwrapped());
+        assert!(full.can_truncate_to(512));
+
+        // One token further the ring has wrapped: `idx` restarted at 0 and the
+        // token that used to be at slot 0 is gone.
+        let wrapped = state(1024, 1025, 1);
+        assert!(!wrapped.is_unwrapped());
+        assert!(!wrapped.can_truncate_to(512));
+    }
+
+    #[test]
+    fn a_wrapped_cache_is_refused_even_for_a_target_inside_the_live_window() {
+        // The live window still covers [1500, 2500), but truncating to 2000
+        // would need slots in temporal order from 0, which the ring no longer
+        // provides.
+        let s = state(1024, 2500, 452);
+        assert!(!s.is_unwrapped());
+        assert!(!s.can_truncate_to(2000));
+        assert!(!s.can_truncate_to(2500));
+    }
+
+    #[test]
+    fn an_over_window_prefill_buffer_is_refused_despite_idx_matching_offset() {
+        // `update_concat` stores more than `max_size` entries for one step
+        // after a long prefill, keeping idx == offset. The next single-token
+        // update re-slices that buffer from the back, so trimming into this
+        // state would desynchronize idx from the physical layout.
+        let s = state(1024, 3000, 3000);
+        assert!(!s.is_unwrapped());
+        assert!(!s.can_truncate_to(900));
+    }
+
+    #[test]
+    fn buffered_speculative_mode_is_excluded() {
+        let mut s = state(1024, 400, 400);
+        s.buffer_size = 128;
+        assert!(!s.is_unwrapped());
+        assert!(!s.can_truncate_to(200));
+    }
+
+    #[test]
+    fn non_fp16_storage_is_refused() {
+        // Only FP16 is snapshot-capable; the quantized sidecars do not travel
+        // in the snapshot container, so a truncating restore has nothing to
+        // rebuild them from.
+        let mut s = state(1024, 400, 400);
+        s.mode = KVCacheMode::Int8;
+        assert!(!s.can_truncate_to(200));
+    }
+
+    #[test]
+    fn an_empty_cache_truncates_only_to_zero() {
+        let s = state(1024, 0, 0);
+        assert!(s.can_truncate_to(0));
+        assert!(!s.can_truncate_to(1));
+    }
+
+    #[test]
+    fn is_trimmable_tracks_the_live_cache_through_its_wrap() {
+        let mut cache = RotatingKVCache::new(4);
+        assert!(cache.is_trimmable(), "a fresh cache is trivially trimmable");
+        for i in 0..4 {
+            let k = ffi::from_slice_f32(&[i as f32], &[1, 1, 1, 1]);
+            let v = ffi::from_slice_f32(&[(i * 10) as f32], &[1, 1, 1, 1]);
+            cache.update_and_fetch(k, v);
+        }
+        assert_eq!(cache.offset, 4);
+        assert!(
+            cache.is_trimmable(),
+            "a full but unwrapped ring is still trimmable"
+        );
+
+        let k = ffi::from_slice_f32(&[4.0], &[1, 1, 1, 1]);
+        let v = ffi::from_slice_f32(&[40.0], &[1, 1, 1, 1]);
+        cache.update_and_fetch(k, v);
+        assert_eq!(cache.offset, 5);
+        assert!(
+            !cache.is_trimmable(),
+            "past the window the ring has wrapped"
+        );
     }
 }
 

--- a/src/lib/mlxcel-core/src/generate.rs
+++ b/src/lib/mlxcel-core/src/generate.rs
@@ -537,6 +537,40 @@ pub trait LanguageModel {
         Err("model does not support exact-prefix state snapshots".to_string())
     }
 
+    /// Whether `snapshot` can be restored covering only its first
+    /// `target_len` tokens instead of all of them (issue #1145).
+    ///
+    /// This is the model's own answer, not something the prompt-cache store
+    /// may infer from a family name: only the model knows how its per-layer
+    /// state is laid out and whether dropping a tail is mechanically sound.
+    /// The default is `false`, so a family opts in explicitly. That default
+    /// is the safe one for the recurrent families (GatedDeltaNet, Mamba and
+    /// the SSM hybrids), whose state is a fixed-size summary of every token
+    /// consumed and cannot be rewound to an earlier boundary at all.
+    ///
+    /// Implementors must answer for the state actually stored in `snapshot`,
+    /// per layer, at this specific `target_len`. A blanket `true` would let
+    /// the caller install a corrupt cache.
+    fn snapshot_truncatable_to(&self, _snapshot: &ModelStateSnapshot, _target_len: usize) -> bool {
+        false
+    }
+
+    /// Restore `snapshot` into `seq_id` covering only its first `target_len`
+    /// tokens.
+    ///
+    /// Callers must have had [`Self::snapshot_truncatable_to`] agree for the
+    /// same snapshot and length first. Implementors should still re-check
+    /// rather than trust the caller, and return `Err` instead of installing a
+    /// partially truncated state.
+    fn restore_sequence_state_truncated(
+        &self,
+        _seq_id: SequenceId,
+        _snapshot: &ModelStateSnapshot,
+        _target_len: usize,
+    ) -> Result<(), String> {
+        Err("model does not support truncated state snapshot restore".to_string())
+    }
+
     /// Describe how one sequence's runtime state should be allocated.
     ///
     /// Phase 0 keeps the default behavior aligned with today's

--- a/src/loaded_model.rs
+++ b/src/loaded_model.rs
@@ -475,6 +475,26 @@ impl LanguageModel for LoadedModel {
         delegate_language_model!(self, restore_sequence_state(seq_id, snapshot))
     }
 
+    fn snapshot_truncatable_to(
+        &self,
+        snapshot: &mlxcel_core::generate::ModelStateSnapshot,
+        target_len: usize,
+    ) -> bool {
+        delegate_language_model!(self, snapshot_truncatable_to(snapshot, target_len))
+    }
+
+    fn restore_sequence_state_truncated(
+        &self,
+        seq_id: mlxcel_core::cache::SequenceId,
+        snapshot: &mlxcel_core::generate::ModelStateSnapshot,
+        target_len: usize,
+    ) -> Result<(), String> {
+        delegate_language_model!(
+            self,
+            restore_sequence_state_truncated(seq_id, snapshot, target_len)
+        )
+    }
+
     fn sequence_state_layout(&self) -> mlxcel_core::cache::SequenceStateLayout {
         delegate_language_model!(self, sequence_state_layout())
     }

--- a/src/models/gemma4.rs
+++ b/src/models/gemma4.rs
@@ -1176,6 +1176,22 @@ impl Cache {
         }
     }
 
+    /// Whether this cache holds any K/V at all.
+    ///
+    /// KV-shared layers (`AttentionProjections::KvShared`) never populate
+    /// their own cache: they compute only Q and borrow K/V from an earlier
+    /// layer. `snapshot_into` skips such a layer entirely and `restore_from`
+    /// leaves it fresh, so any per-layer operation that follows a restore has
+    /// to tolerate an empty cache rather than assume a populated one.
+    ///
+    /// Used by: Gemma 4 [`Self::truncate_to`].
+    pub(crate) fn is_populated(&self) -> bool {
+        match self {
+            Self::Standard(cache) => cache.keys.is_some(),
+            Self::Rotating(cache) => cache.keys.is_some(),
+        }
+    }
+
     pub(crate) fn snapshot_into(
         &self,
         snapshot: &mut ModelStateSnapshot,
@@ -1329,6 +1345,131 @@ impl Cache {
                 };
                 cache.restore_fp16_snapshot_state(state, keys, values)?;
             }
+        }
+        Ok(())
+    }
+
+    /// Whether the layer state stored under `prefix` can be restored covering
+    /// only its first `target_len` tokens (issue #1145).
+    ///
+    /// Answers from the snapshot's own scalars rather than from a live cache,
+    /// because the prompt-cache store has to decide before it allocates a
+    /// sequence. A prefix with no stored tensors is vacuously truncatable: the
+    /// layer captured nothing, so `restore_from` leaves a fresh cache and
+    /// there is no tail to drop.
+    ///
+    /// Full-attention layers keep every token at its own slot and truncate
+    /// unconditionally. Sliding layers defer to
+    /// [`RotatingKVCacheSnapshotState::can_truncate_to`], which is the
+    /// load-bearing check: it holds only while the ring has not wrapped.
+    ///
+    /// Used by: Gemma 4 `snapshot_truncatable_to`.
+    pub(crate) fn snapshot_truncatable_to(
+        snapshot: &ModelStateSnapshot,
+        prefix: &str,
+        target_len: i32,
+    ) -> bool {
+        if target_len < 0 {
+            return false;
+        }
+        if snapshot
+            .tensor(&format!("{prefix}.rotating.keys"))
+            .is_some()
+        {
+            let mode = match restore_i32(snapshot, format!("{prefix}.rotating.mode"))
+                .map(kv_cache_mode_from_i32)
+                .transpose()
+            {
+                Ok(mode) => mode.unwrap_or(KVCacheMode::Fp16),
+                Err(_) => return false,
+            };
+            let Some(max_size) = restore_i32(snapshot, format!("{prefix}.rotating.max_size"))
+            else {
+                return false;
+            };
+            let Some(offset) = restore_i32(snapshot, format!("{prefix}.rotating.offset")) else {
+                return false;
+            };
+            let Some(idx) = restore_i32(snapshot, format!("{prefix}.rotating.idx")) else {
+                return false;
+            };
+            let state = RotatingKVCacheSnapshotState {
+                max_size,
+                buffer_size: restore_i32(snapshot, format!("{prefix}.rotating.buffer_size"))
+                    .unwrap_or(0),
+                offset,
+                start_position: restore_i32(snapshot, format!("{prefix}.rotating.start_position"))
+                    .unwrap_or(0),
+                idx,
+                step: 256,
+                mode,
+                turbo_seed: 0,
+            };
+            return state.can_truncate_to(target_len);
+        }
+        if snapshot
+            .tensor(&format!("{prefix}.standard.keys"))
+            .is_some()
+        {
+            let mode = match restore_i32(snapshot, format!("{prefix}.standard.mode"))
+                .map(kv_cache_mode_from_i32)
+                .transpose()
+            {
+                Ok(mode) => mode.unwrap_or(KVCacheMode::Fp16),
+                Err(_) => return false,
+            };
+            if mode != KVCacheMode::Fp16 {
+                return false;
+            }
+            let Some(offset) = restore_i32(snapshot, format!("{prefix}.standard.offset")) else {
+                return false;
+            };
+            return target_len <= offset;
+        }
+        // Nothing stored for this layer.
+        true
+    }
+
+    /// Drop everything past `target_len` tokens, leaving the cache in the
+    /// state it would have had if only the first `target_len` tokens had ever
+    /// been processed (issue #1145).
+    ///
+    /// Both arms rewind through the existing `trim` implementations, so this
+    /// inherits their semantics exactly: the physical buffer keeps its
+    /// capacity and the next update overwrites the rewound tail in place.
+    ///
+    /// Used by: Gemma 4 `restore_sequence_state_truncated`.
+    pub(crate) fn truncate_to(&mut self, target_len: i32) -> Result<(), String> {
+        // A layer that stored nothing has nothing to drop. This is the
+        // KV-shared case: `snapshot_into` skipped it, `restore_from` left the
+        // cache fresh, and demanding `target_len <= offset` here would fail
+        // against an offset of 0 even though the restore is perfectly sound.
+        // Observed on gemma-4-e2b-it-4bit, whose layer 15 is KV-shared.
+        if !self.is_populated() {
+            return Ok(());
+        }
+        let offset = self.offset();
+        if target_len > offset {
+            return Err(format!(
+                "Gemma 4 truncate: target {target_len} exceeds cached offset {offset}"
+            ));
+        }
+        if let Self::Rotating(cache) = self
+            && !cache.is_trimmable()
+        {
+            return Err(
+                "Gemma 4 truncate: rotating cache has wrapped and cannot be trimmed".to_string(),
+            );
+        }
+        let drop = offset - target_len;
+        if drop == 0 {
+            return Ok(());
+        }
+        let trimmed = self.trim_speculative(drop);
+        if trimmed != drop {
+            return Err(format!(
+                "Gemma 4 truncate: trimmed {trimmed} of {drop} requested tokens"
+            ));
         }
         Ok(())
     }
@@ -5460,6 +5601,63 @@ impl LanguageModel for Gemma4Wrapper {
         let mut state = self.model.make_caches();
         for (idx, cache) in state.iter_mut().enumerate() {
             cache.restore_from(snapshot, &format!("layer{idx}"))?;
+        }
+        self.sequence_state.replace_sequence_state(seq_id, state);
+        Ok(())
+    }
+
+    /// Gemma 4 runs sliding and full attention layers in a fixed pattern, and
+    /// both are ordinary KV state. A truncating restore is therefore possible
+    /// whenever every sliding layer is still unwrapped at `target_len`, which
+    /// is the whole short-and-medium-conversation regime under the model's
+    /// sliding window (issue #1145).
+    ///
+    /// The check is per layer at the requested target, never a global
+    /// conversation-length heuristic: the layers do not share a window state,
+    /// and one wrapped sliding layer is enough to make the restore unsound.
+    fn snapshot_truncatable_to(&self, snapshot: &ModelStateSnapshot, target_len: usize) -> bool {
+        if snapshot.family() != "gemma4" {
+            return false;
+        }
+        if target_len > snapshot.token_len() {
+            return false;
+        }
+        let Ok(target) = i32::try_from(target_len) else {
+            return false;
+        };
+        (0..self.num_layers())
+            .all(|idx| Cache::snapshot_truncatable_to(snapshot, &format!("layer{idx}"), target))
+    }
+
+    fn restore_sequence_state_truncated(
+        &self,
+        seq_id: SequenceId,
+        snapshot: &ModelStateSnapshot,
+        target_len: usize,
+    ) -> Result<(), String> {
+        if snapshot.family() != "gemma4" {
+            return Err(format!(
+                "cannot restore {} snapshot into Gemma 4",
+                snapshot.family()
+            ));
+        }
+        let target = i32::try_from(target_len)
+            .map_err(|_| format!("Gemma 4 truncated restore: target {target_len} out of range"))?;
+        // Re-check rather than trust the caller: installing a partially
+        // truncated state would corrupt generation silently, while an error
+        // here just falls back to a cold prefill.
+        if !self.snapshot_truncatable_to(snapshot, target_len) {
+            return Err(format!(
+                "Gemma 4 truncated restore: snapshot cannot be truncated to {target_len} tokens"
+            ));
+        }
+        let mut state = self.model.make_caches();
+        for (idx, cache) in state.iter_mut().enumerate() {
+            let prefix = format!("layer{idx}");
+            cache.restore_from(snapshot, &prefix)?;
+            cache
+                .truncate_to(target)
+                .map_err(|err| format!("{prefix}: {err}"))?;
         }
         self.sequence_state.replace_sequence_state(seq_id, state);
         Ok(())

--- a/src/models/gemma4_tests.rs
+++ b/src/models/gemma4_tests.rs
@@ -1059,6 +1059,148 @@ mod snapshot_prompt_cache {
             );
         }
     }
+
+    // -- partial (truncating) restore, issue #1145 ------------------------
+    //
+    // The fixture is one sliding-attention layer with sliding_window = 8, so
+    // a prefill under 8 tokens leaves the ring unwrapped and a prefill past it
+    // does not. That is the whole decision boundary in miniature.
+
+    fn prefill(wrapper: &super::super::Gemma4Wrapper, seq: SequenceId, ids: &[i32]) {
+        wrapper.prepare_sequence_state(seq);
+        let prompt = mlxcel_core::from_slice_i32(ids, &[1, ids.len() as i32]);
+        let _ = wrapper.forward_with_sequence_id(&prompt, Some(seq), &mut [], None);
+    }
+
+    #[test]
+    #[ignore = "requires serial MLX execution"]
+    fn gemma4_reports_truncatable_only_while_the_sliding_layer_is_unwrapped() {
+        let wrapper = super::build_synthetic_wrapper();
+
+        let unwrapped = SequenceId::from_raw(920);
+        prefill(&wrapper, unwrapped, &[1, 2, 3, 4, 5]);
+        let snap = wrapper
+            .snapshot_sequence_state(unwrapped, 5)
+            .expect("snapshot");
+        assert!(wrapper.snapshot_truncatable_to(&snap, 3));
+        assert!(
+            wrapper.snapshot_truncatable_to(&snap, 5),
+            "no-op truncation"
+        );
+        assert!(
+            !wrapper.snapshot_truncatable_to(&snap, 6),
+            "cannot invent tokens the snapshot never held"
+        );
+
+        // Past the sliding window the ring has dropped its oldest entries, so
+        // the prefix a truncation would need is simply gone.
+        let wrapped = SequenceId::from_raw(921);
+        prefill(&wrapper, wrapped, &[1, 2, 3, 4, 5, 6, 7, 1, 2, 3]);
+        let wrapped_snap = wrapper
+            .snapshot_sequence_state(wrapped, 10)
+            .expect("snapshot");
+        assert!(
+            !wrapper.snapshot_truncatable_to(&wrapped_snap, 5),
+            "a wrapped sliding layer must decline"
+        );
+        assert!(
+            wrapper
+                .restore_sequence_state_truncated(SequenceId::from_raw(922), &wrapped_snap, 5)
+                .is_err(),
+            "the restore re-checks rather than trusting the caller"
+        );
+    }
+
+    #[test]
+    #[ignore = "requires serial MLX execution"]
+    fn gemma4_full_attention_layers_truncate_past_the_sliding_window() {
+        // Full-attention layers keep every token, so the window bound that
+        // constrains sliding layers does not apply to them.
+        let wrapper = super::build_synthetic_wrapper_with_layer("full_attention");
+        let seq = SequenceId::from_raw(930);
+        prefill(&wrapper, seq, &[1, 2, 3, 4, 5, 6, 7, 1, 2, 3]);
+        let snap = wrapper.snapshot_sequence_state(seq, 10).expect("snapshot");
+        assert!(wrapper.snapshot_truncatable_to(&snap, 4));
+    }
+
+    #[test]
+    #[ignore = "requires serial MLX execution"]
+    fn gemma4_truncation_tolerates_layers_that_stored_nothing() {
+        // KV-shared layers compute only Q and borrow K/V from an earlier
+        // layer, so they never populate their own cache: `snapshot_into`
+        // skips them and `restore_from` leaves them fresh. Truncation has to
+        // treat that as a no-op. gemma-4-e2b-it-4bit hits this on layer 15,
+        // and a single-layer synthetic fixture cannot reach it, so the case
+        // is pinned directly on the cache type.
+        let empty_rotating = Cache::Rotating(RotatingKVCache::new(8));
+        assert!(!empty_rotating.is_populated());
+        let mut empty_rotating = empty_rotating;
+        empty_rotating
+            .truncate_to(34)
+            .expect("an unpopulated rotating layer truncates to a no-op");
+
+        let mut empty_standard = Cache::Standard(KVCache::new());
+        assert!(!empty_standard.is_populated());
+        empty_standard
+            .truncate_to(34)
+            .expect("an unpopulated standard layer truncates to a no-op");
+
+        // A populated layer still rejects a target past what it holds.
+        let mut populated = Cache::Standard(KVCache::new());
+        if let Cache::Standard(cache) = &mut populated {
+            let keys = mlxcel_core::from_slice_f32(&[1.0, 2.0], &[1, 1, 2, 1]);
+            let values = mlxcel_core::from_slice_f32(&[10.0, 20.0], &[1, 1, 2, 1]);
+            cache.update_and_fetch(keys, values);
+        }
+        assert!(populated.is_populated());
+        assert!(
+            populated.truncate_to(34).is_err(),
+            "an empty-layer no-op must not become a blanket bypass"
+        );
+    }
+
+    #[test]
+    #[ignore = "requires serial MLX execution"]
+    fn gemma4_truncated_restore_matches_a_cold_prefill_of_the_same_prefix() {
+        // The correctness bar for issue #1145: adopting a snapshot truncated
+        // to N tokens must decode identically to having only ever prefilled
+        // those N tokens. Anything less makes the optimization a correctness
+        // bug that only shows up as degraded output.
+        let source = super::build_synthetic_wrapper();
+        let seq_full = SequenceId::from_raw(940);
+        prefill(&source, seq_full, &[1, 2, 3, 4, 5]);
+        let snap = source
+            .snapshot_sequence_state(seq_full, 5)
+            .expect("snapshot");
+
+        let adopted = super::build_synthetic_wrapper();
+        let seq_adopted = SequenceId::from_raw(941);
+        adopted.prepare_sequence_state(seq_adopted);
+        adopted
+            .restore_sequence_state_truncated(seq_adopted, &snap, 3)
+            .expect("truncating restore must succeed for an unwrapped ring");
+
+        let control = super::build_synthetic_wrapper();
+        let seq_control = SequenceId::from_raw(942);
+        prefill(&control, seq_control, &[1, 2, 3]);
+
+        let decode = mlxcel_core::from_slice_i32(&[6], &[1, 1]);
+        let adopted_logits =
+            adopted.forward_with_sequence_id(&decode, Some(seq_adopted), &mut [], None);
+        let control_logits =
+            control.forward_with_sequence_id(&decode, Some(seq_control), &mut [], None);
+        let got = to_vec_f32(adopted_logits.as_ref().unwrap());
+        let want = to_vec_f32(control_logits.as_ref().unwrap());
+        assert_eq!(got.len(), want.len());
+        for (i, (&g, &w)) in got.iter().zip(want.iter()).enumerate() {
+            let abs = (g - w).abs();
+            let rel = abs / w.abs().max(1.0);
+            assert!(
+                abs < 1e-3 || rel < 1e-3,
+                "logit[{i}] differs between an adopted truncated prefix and a cold prefill of the same prefix: adopted={g}, cold={w}, abs={abs}, rel={rel}"
+            );
+        }
+    }
 }
 
 // -----------------------------------------------------------------

--- a/src/server/batch/scheduler.rs
+++ b/src/server/batch/scheduler.rs
@@ -1805,7 +1805,14 @@ impl BatchScheduler {
         let store = self.prompt_cache.as_ref()?.clone();
         let key = Self::compose_prompt_cache_key(ctx, tokens);
         let snapshot_outcome = if self.model.supports_snapshot_reuse() {
-            store.lookup_snapshot_outcome(&key, tokens)
+            // The truncation capability is the model's own answer (#1145):
+            // rotating-attention families can restore to the longest common
+            // prefix while their sliding layers are unwrapped, and every
+            // family whose recurrent state cannot be rewound returns false
+            // here and keeps exact-prefix semantics.
+            store.lookup_snapshot_outcome(&key, tokens, |snapshot, target_len| {
+                self.model.snapshot_truncatable_to(snapshot, target_len)
+            })
         } else {
             SnapshotLookupOutcome::NoCandidate
         };
@@ -1844,14 +1851,26 @@ impl BatchScheduler {
                     return None;
                 }
             };
-            let restore = snapshot_entry
-                .with_snapshot(|snapshot| self.model.restore_sequence_state(seq_id, snapshot));
+            // A `matched_len` shorter than the stored entry means the store
+            // adopted at the longest common prefix, which only happens when
+            // the model agreed it could truncate there (#1145).
+            let partial = matched_len < snapshot_entry.tokens.len();
+            let restore = snapshot_entry.with_snapshot(|snapshot| {
+                if partial {
+                    self.model
+                        .restore_sequence_state_truncated(seq_id, snapshot, matched_len)
+                } else {
+                    self.model.restore_sequence_state(seq_id, snapshot)
+                }
+            });
             match restore {
                 Ok(()) => {
                     tracing::debug!(
                         seq_id = %seq_id,
                         matched = matched_len,
+                        stored = snapshot_entry.tokens.len(),
                         total = tokens.len(),
+                        partial,
                         "prompt-cache snapshot hit: restored {matched_len}/{} tokens",
                         tokens.len()
                     );

--- a/src/server/prompt_cache/snapshot_divergence_tests.rs
+++ b/src/server/prompt_cache/snapshot_divergence_tests.rs
@@ -87,6 +87,17 @@ fn insert(store: &PromptCacheStore, family: &str, tokens: &[i32]) {
         .expect("snapshot insert succeeds");
 }
 
+/// Exact-prefix lookup: the truncation capability is refused, which is what
+/// every family whose recurrent state cannot be rewound reports (issue #1145).
+/// The partial-adoption path has its own tests below.
+fn outcome(
+    store: &PromptCacheStore,
+    k: &PromptCacheKey<'_>,
+    tokens: &[i32],
+) -> SnapshotLookupOutcome {
+    store.lookup_snapshot_outcome(k, tokens, |_, _| false)
+}
+
 fn diverged(outcome: SnapshotLookupOutcome) -> SnapshotDivergence {
     match outcome {
         SnapshotLookupOutcome::Diverged(d) => d,
@@ -123,8 +134,11 @@ fn generation_prompt_scaffold_divergence_is_classified_with_its_geometry() {
     request.extend(run(5_000, 45));
     request.extend(run(7_000, 30));
 
-    let report =
-        diverged(store.lookup_snapshot_outcome(&key("m", Some(SESSION), &request), &request));
+    let report = diverged(outcome(
+        &store,
+        &key("m", Some(SESSION), &request),
+        &request,
+    ));
     assert_eq!(
         report.common_prefix_len, 90,
         "the classification must carry how far the vectors agreed"
@@ -159,8 +173,11 @@ fn thinking_stripped_from_history_divergence_is_classified() {
     request.extend(run(4_100, 40)); // answer only, no reasoning
     request.extend(run(8_000, 22)); // new user turn
 
-    let report =
-        diverged(store.lookup_snapshot_outcome(&key("m", Some(SESSION), &request), &request));
+    let report = diverged(outcome(
+        &store,
+        &key("m", Some(SESSION), &request),
+        &request,
+    ));
     assert_eq!(report.common_prefix_len, header.len());
     assert_eq!(report.stored_len, stored.len());
 }
@@ -186,8 +203,11 @@ fn retokenization_drift_divergence_is_classified() {
     request.extend(run(9_500, 18)); // same text, 18 tokens after re-tokenizing
     request.extend(run(11_000, 25));
 
-    let report =
-        diverged(store.lookup_snapshot_outcome(&key("m", Some(SESSION), &request), &request));
+    let report = diverged(outcome(
+        &store,
+        &key("m", Some(SESSION), &request),
+        &request,
+    ));
     assert_eq!(report.common_prefix_len, 230);
     assert_eq!(report.stored_len, 250);
     assert!(
@@ -203,7 +223,7 @@ fn cold_store_reports_no_candidate_not_a_divergence() {
     let store = store_with_snapshots();
     let request = run(1_000, 40);
     assert!(matches!(
-        store.lookup_snapshot_outcome(&key("m", Some(SESSION), &request), &request),
+        outcome(&store, &key("m", Some(SESSION), &request), &request),
         SnapshotLookupOutcome::NoCandidate
     ));
 }
@@ -219,12 +239,12 @@ fn foreign_session_bucket_reports_no_candidate_not_a_divergence() {
     // Same tokens, different session: the candidate is not this caller's to
     // diverge from, so classifying it would be a false positive.
     assert!(matches!(
-        store.lookup_snapshot_outcome(&key("m", Some("chat-2"), &request), &request),
+        outcome(&store, &key("m", Some("chat-2"), &request), &request),
         SnapshotLookupOutcome::NoCandidate
     ));
     // A sessionless caller must not see the session-bound entry either.
     assert!(matches!(
-        store.lookup_snapshot_outcome(&key("m", None, &request), &request),
+        outcome(&store, &key("m", None, &request), &request),
         SnapshotLookupOutcome::NoCandidate
     ));
 }
@@ -238,7 +258,11 @@ fn foreign_model_bucket_reports_no_candidate_not_a_divergence() {
     let mut request = run(1_000, 30);
     request.extend(run(20_000, 12));
     assert!(matches!(
-        store.lookup_snapshot_outcome(&key("other-model", Some(SESSION), &request), &request),
+        outcome(
+            &store,
+            &key("other-model", Some(SESSION), &request),
+            &request
+        ),
         SnapshotLookupOutcome::NoCandidate
     ));
 }
@@ -251,7 +275,7 @@ fn exact_prefix_still_hits_and_reports_no_divergence() {
 
     let mut request = stored.clone();
     request.extend(run(20_000, 12));
-    match store.lookup_snapshot_outcome(&key("m", Some(SESSION), &request), &request) {
+    match outcome(&store, &key("m", Some(SESSION), &request), &request) {
         SnapshotLookupOutcome::Hit { matched_len, entry } => {
             assert_eq!(matched_len, stored.len());
             assert_eq!(entry.tokens, stored);
@@ -275,7 +299,7 @@ fn a_hit_wins_over_a_sibling_divergence() {
     let mut request = usable.clone();
     request.extend(run(20_000, 12));
     assert!(matches!(
-        store.lookup_snapshot_outcome(&key("m", Some(SESSION), &request), &request),
+        outcome(&store, &key("m", Some(SESSION), &request), &request),
         SnapshotLookupOutcome::Hit { .. }
     ));
 }
@@ -293,8 +317,11 @@ fn the_longest_common_prefix_candidate_is_the_one_reported() {
 
     let mut request = shared.clone();
     request.extend(run(32_000, 20));
-    let report =
-        diverged(store.lookup_snapshot_outcome(&key("m", Some(SESSION), &request), &request));
+    let report = diverged(outcome(
+        &store,
+        &key("m", Some(SESSION), &request),
+        &request,
+    ));
     assert_eq!(report.common_prefix_len, 40, "best candidate is reported");
     assert_eq!(report.stored_len, deep.len());
 }
@@ -308,8 +335,11 @@ fn a_request_shorter_than_the_stored_entry_is_a_divergence() {
     insert(&store, "gemma4", &stored);
 
     let request = run(1_000, 25);
-    let report =
-        diverged(store.lookup_snapshot_outcome(&key("m", Some(SESSION), &request), &request));
+    let report = diverged(outcome(
+        &store,
+        &key("m", Some(SESSION), &request),
+        &request,
+    ));
     assert_eq!(report.common_prefix_len, 25);
     assert_eq!(report.stored_len, 40);
 }
@@ -321,7 +351,7 @@ fn a_disabled_store_reports_no_candidate() {
     let store = PromptCacheStore::with_config(cfg);
     let request = run(1_000, 40);
     assert!(matches!(
-        store.lookup_snapshot_outcome(&key("m", Some(SESSION), &request), &request),
+        outcome(&store, &key("m", Some(SESSION), &request), &request),
         SnapshotLookupOutcome::NoCandidate
     ));
 }
@@ -335,9 +365,186 @@ fn divergence_does_not_inflate_the_snapshot_hit_counters() {
 
     let mut request = run(1_000, 20);
     request.extend(run(40_000, 25));
-    let _ = store.lookup_snapshot_outcome(&key("m", Some(SESSION), &request), &request);
+    let _ = outcome(&store, &key("m", Some(SESSION), &request), &request);
 
     let stats = store.stats();
     assert_eq!(stats.snapshot_lookups, 1, "the lookup is still counted");
     assert_eq!(stats.snapshot_hits, 0, "a divergence is a miss, not a hit");
+}
+
+// -- partial adoption at the longest common prefix (issue #1145) ----------
+//
+// The store never decides truncatability itself; it asks the model. These
+// tests drive that seam directly with a stub capability, so they pin the
+// store's half of the contract: which candidate is offered, at what length,
+// and what happens when the answer is no. The rotating-cache rule the real
+// capability implements lives in `mlxcel_core::cache::rotating_truncation_tests`.
+
+/// Capability stub standing in for a rotating-attention model that can
+/// truncate anywhere (Gemma 4 with every sliding layer unwrapped).
+fn truncatable(
+    store: &PromptCacheStore,
+    k: &PromptCacheKey<'_>,
+    t: &[i32],
+) -> SnapshotLookupOutcome {
+    store.lookup_snapshot_outcome(k, t, |_, _| true)
+}
+
+#[test]
+fn a_diverging_candidate_is_adopted_at_the_longest_common_prefix() {
+    let store = store_with_snapshots();
+    let shared = run(1_000, 90);
+    let mut stored = shared.clone();
+    stored.extend([100, 45_518, 107, 101]);
+    stored.extend(run(5_000, 45));
+    insert(&store, "gemma4", &stored);
+
+    let mut request = shared.clone();
+    request.extend(run(5_000, 45));
+    request.extend(run(7_000, 30));
+
+    match truncatable(&store, &key("m", Some(SESSION), &request), &request) {
+        SnapshotLookupOutcome::Hit { matched_len, entry } => {
+            assert_eq!(matched_len, 90, "adopts exactly the common prefix");
+            assert_eq!(
+                entry.tokens.len(),
+                139,
+                "the stored entry is longer than what was adopted, which is how \
+                 the caller knows to use the truncating restore"
+            );
+        }
+        other => panic!("expected a partial adopt, got {other:?}"),
+    }
+
+    let stats = store.stats();
+    assert_eq!(stats.snapshot_hits, 1, "a partial adopt counts as a hit");
+    assert_eq!(stats.snapshot_lookups, 1);
+}
+
+#[test]
+fn recurrent_families_keep_exact_prefix_semantics() {
+    // Same store, same request, capability refused: this is the qwen3.5 /
+    // falcon-h1 side of the class, where the recurrent state cannot be
+    // rewound at all. It must stay a classified miss, never a partial adopt.
+    let store = store_with_snapshots();
+    let shared = run(1_000, 90);
+    let mut stored = shared.clone();
+    stored.extend(run(5_000, 49));
+    insert(&store, "qwen3_5", &stored);
+
+    let mut request = shared.clone();
+    request.extend(run(7_000, 30));
+
+    let report = diverged(outcome(
+        &store,
+        &key("m", Some(SESSION), &request),
+        &request,
+    ));
+    assert_eq!(report.common_prefix_len, 90);
+    assert_eq!(store.stats().snapshot_hits, 0);
+}
+
+#[test]
+fn a_declining_model_leaves_the_wrapped_case_as_a_classified_reject() {
+    // The capability is what a wrapped sliding layer reports. The decline has
+    // to surface as the divergence reject rather than a silent None, so the
+    // stats still say a candidate was there and was structurally unusable.
+    let store = store_with_snapshots();
+    let mut stored = run(1_000, 60);
+    stored.extend(run(30_000, 40));
+    insert(&store, "gemma4", &stored);
+
+    let mut request = run(1_000, 60);
+    request.extend(run(40_000, 25));
+
+    let report = diverged(store.lookup_snapshot_outcome(
+        &key("m", Some(SESSION), &request),
+        &request,
+        |_, _| false,
+    ));
+    assert_eq!(report.common_prefix_len, 60);
+    assert_eq!(report.stored_len, 100);
+    assert_eq!(store.stats().snapshot_hits, 0);
+}
+
+#[test]
+fn an_exact_prefix_candidate_wins_over_a_truncating_one() {
+    // Adopting whole is always better than adopting truncated: it covers more
+    // tokens and needs no trim. A usable exact candidate must therefore
+    // suppress the partial path even when the model would allow it.
+    let store = store_with_snapshots();
+    let usable = run(1_000, 40);
+    insert(&store, "gemma4", &usable);
+    let mut longer_but_diverging = run(1_000, 35);
+    longer_but_diverging.extend(run(30_000, 60));
+    insert(&store, "gemma4", &longer_but_diverging);
+
+    let mut request = usable.clone();
+    request.extend(run(20_000, 12));
+    match truncatable(&store, &key("m", Some(SESSION), &request), &request) {
+        SnapshotLookupOutcome::Hit { matched_len, entry } => {
+            assert_eq!(matched_len, 40);
+            assert_eq!(
+                entry.tokens.len(),
+                40,
+                "the whole-entry candidate was adopted, not the truncating one"
+            );
+        }
+        other => panic!("expected the exact-prefix hit, got {other:?}"),
+    }
+}
+
+#[test]
+fn a_common_prefix_below_min_prefix_tokens_is_not_adopted() {
+    // min_prefix_tokens is 4 in this fixture. A 2-token agreement is not
+    // worth a truncating restore, and the store must not ask the model to
+    // perform one.
+    let cfg = PromptCacheConfig::new(true, 1 << 20, 64, Duration::from_secs(3600), 8)
+        .with_snapshot_limits(1 << 20, 64, Duration::from_secs(3600));
+    let store = PromptCacheStore::with_config(cfg);
+    let mut stored = run(1_000, 5);
+    stored.extend(run(30_000, 40));
+    store
+        .insert_snapshot(
+            &key("m", Some(SESSION), &stored),
+            snapshot(stored.clone(), "gemma4"),
+        )
+        .expect("insert");
+
+    let mut request = run(1_000, 5);
+    request.extend(run(40_000, 30));
+
+    let report = diverged(truncatable(
+        &store,
+        &key("m", Some(SESSION), &request),
+        &request,
+    ));
+    assert_eq!(report.common_prefix_len, 5, "below the 8-token floor");
+    assert_eq!(store.stats().snapshot_hits, 0);
+}
+
+#[test]
+fn the_capability_is_asked_about_the_adopted_length_not_the_stored_length() {
+    // The model must be able to answer "can you truncate to N", because that
+    // is the question that decides correctness. Passing the stored length
+    // instead would make the check vacuous.
+    use std::sync::Mutex;
+    let store = store_with_snapshots();
+    let mut stored = run(1_000, 70);
+    stored.extend(run(30_000, 30));
+    insert(&store, "gemma4", &stored);
+
+    let mut request = run(1_000, 70);
+    request.extend(run(40_000, 25));
+
+    let asked: Mutex<Vec<usize>> = Mutex::new(Vec::new());
+    let _ = store.lookup_snapshot_outcome(&key("m", Some(SESSION), &request), &request, |_, n| {
+        asked.lock().expect("lock").push(n);
+        true
+    });
+    assert_eq!(
+        asked.into_inner().expect("lock"),
+        vec![70],
+        "asked about the common prefix, not the 100-token stored entry"
+    );
 }

--- a/src/server/prompt_cache/store.rs
+++ b/src/server/prompt_cache/store.rs
@@ -29,6 +29,7 @@ use std::sync::{Arc, RwLock};
 use std::time::Instant;
 
 use mlxcel_core::cache::DetachedPagedCacheSet;
+use mlxcel_core::generate::ModelStateSnapshot;
 
 use super::apc_lookup::{ApcStoreStats, apc_consistent_prefix_len};
 use super::block_hash::{ApcBlockHash, BlockHashChain};
@@ -937,14 +938,15 @@ impl PromptCacheStore {
     /// token boundary.
     ///
     /// Thin wrapper over [`Self::lookup_snapshot_outcome`] for callers that
-    /// only care about the hit. Callers that also want the structural-miss
-    /// diagnosis (issue #1147) should use the outcome form directly.
+    /// only care about the hit and cannot truncate. Callers that also want the
+    /// structural-miss diagnosis (issue #1147) or partial adoption at the
+    /// longest common prefix (issue #1145) should use the outcome form.
     pub fn lookup_snapshot_prefix(
         &self,
         key: &PromptCacheKey<'_>,
         tokens: &[i32],
     ) -> Option<(Arc<ModelSnapshotEntry>, usize)> {
-        match self.lookup_snapshot_outcome(key, tokens) {
+        match self.lookup_snapshot_outcome(key, tokens, |_, _| false) {
             SnapshotLookupOutcome::Hit { entry, matched_len } => Some((entry, matched_len)),
             SnapshotLookupOutcome::Diverged(_) | SnapshotLookupOutcome::NoCandidate => None,
         }
@@ -965,11 +967,25 @@ impl PromptCacheStore {
     /// all still report [`SnapshotLookupOutcome::NoCandidate`]. When several
     /// candidates diverge, the one with the longest common prefix is reported
     /// (ties broken by recency), matching the hit path's preference order.
-    pub fn lookup_snapshot_outcome(
+    ///
+    /// `can_truncate(snapshot, target_len)` is the model's answer to "can this
+    /// stored state be restored covering only its first `target_len` tokens"
+    /// (issue #1145). When it agrees for the best diverging candidate and the
+    /// common prefix clears `min_prefix_tokens`, the lookup adopts at that
+    /// prefix and reports a `Hit` whose `matched_len` is shorter than the
+    /// stored entry, which is how the caller knows to use the truncating
+    /// restore. Passing `|_, _| false` keeps the exact-prefix behavior, which
+    /// is what every family whose recurrent state cannot be rewound must do.
+    /// An exact-prefix candidate always wins over a truncating one.
+    pub fn lookup_snapshot_outcome<F>(
         &self,
         key: &PromptCacheKey<'_>,
         tokens: &[i32],
-    ) -> SnapshotLookupOutcome {
+        can_truncate: F,
+    ) -> SnapshotLookupOutcome
+    where
+        F: Fn(&ModelStateSnapshot, usize) -> bool,
+    {
         {
             let now = Instant::now();
             let mut guard = self.inner.write().expect("prompt cache inner lock");
@@ -990,7 +1006,7 @@ impl PromptCacheStore {
             let guard = self.inner.read().expect("prompt cache inner lock");
             let min_len = guard.config.min_prefix_tokens;
             let mut best: Option<(PromptCacheKeyDigest, usize, Instant)> = None;
-            let mut diverged: Option<(SnapshotDivergence, Instant)> = None;
+            let mut diverged: Option<(PromptCacheKeyDigest, SnapshotDivergence, Instant)> = None;
             for (digest, slot) in &guard.snapshots {
                 if slot.sessionless != sessionless {
                     continue;
@@ -1018,14 +1034,14 @@ impl PromptCacheStore {
                     };
                     let replace = match &diverged {
                         None => true,
-                        Some((existing, existing_used)) => {
+                        Some((_, existing, existing_used)) => {
                             report.common_prefix_len > existing.common_prefix_len
                                 || (report.common_prefix_len == existing.common_prefix_len
                                     && last_used > *existing_used)
                         }
                     };
                     if replace {
-                        diverged = Some((report, last_used));
+                        diverged = Some((*digest, report, last_used));
                     }
                     continue;
                 }
@@ -1042,14 +1058,38 @@ impl PromptCacheStore {
                     best = Some((*digest, len, last_used));
                 }
             }
-            (best, diverged.map(|(report, _)| report))
+            (best, diverged.map(|(digest, report, _)| (digest, report)))
+        };
+
+        // No exact-prefix candidate, but a diverging one may still be usable:
+        // a rotating-attention model can restore its state truncated to the
+        // longest common prefix as long as no sliding layer has wrapped there
+        // (issue #1145). `can_truncate` is the model's own answer, so families
+        // whose recurrent state cannot be rewound (GatedDeltaNet, Mamba and
+        // the SSM hybrids) decline here and keep exact-prefix semantics.
+        let partial = match (best.is_none(), &diverged) {
+            (true, Some((digest, report))) => {
+                let guard = self.inner.read().expect("prompt cache inner lock");
+                let min_len = guard.config.min_prefix_tokens;
+                if report.common_prefix_len < min_len {
+                    None
+                } else {
+                    guard.snapshots.get(digest).and_then(|slot| {
+                        let usable = slot.entry.with_snapshot(|snapshot| {
+                            can_truncate(snapshot, report.common_prefix_len)
+                        });
+                        usable.then_some((*digest, report.common_prefix_len))
+                    })
+                }
+            }
+            _ => None,
         };
 
         let (entry, matched_len) = {
             let mut guard = self.inner.write().expect("prompt cache inner lock");
             guard.snapshot_lookups = guard.snapshot_lookups.saturating_add(1);
-            match best {
-                Some((digest, matched, _)) => {
+            match best.map(|(d, m, _)| (d, m)).or(partial) {
+                Some((digest, matched)) => {
                     let entry = match guard.snapshots.get(&digest) {
                         Some(slot) => Arc::clone(&slot.entry),
                         None => {
@@ -1075,7 +1115,7 @@ impl PromptCacheStore {
         match entry {
             Some(entry) => SnapshotLookupOutcome::Hit { entry, matched_len },
             None => match diverged {
-                Some(report) => SnapshotLookupOutcome::Diverged(report),
+                Some((_, report)) => SnapshotLookupOutcome::Diverged(report),
                 None => SnapshotLookupOutcome::NoCandidate,
             },
         }

--- a/src/vision/gemma4_unified.rs
+++ b/src/vision/gemma4_unified.rs
@@ -656,6 +656,32 @@ impl LanguageModel for Gemma4UnifiedModel {
         )
     }
 
+    fn snapshot_truncatable_to(
+        &self,
+        snapshot: &mlxcel_core::generate::ModelStateSnapshot,
+        target_len: usize,
+    ) -> bool {
+        mlxcel_core::generate::LanguageModel::snapshot_truncatable_to(
+            &self.text_model,
+            snapshot,
+            target_len,
+        )
+    }
+
+    fn restore_sequence_state_truncated(
+        &self,
+        seq_id: SequenceId,
+        snapshot: &mlxcel_core::generate::ModelStateSnapshot,
+        target_len: usize,
+    ) -> Result<(), String> {
+        mlxcel_core::generate::LanguageModel::restore_sequence_state_truncated(
+            &self.text_model,
+            seq_id,
+            snapshot,
+            target_len,
+        )
+    }
+
     fn num_layers(&self) -> usize {
         self.text_model.num_layers_value()
     }

--- a/src/vision/gemma4_vl.rs
+++ b/src/vision/gemma4_vl.rs
@@ -632,6 +632,32 @@ impl LanguageModel for Gemma4VLModel {
         )
     }
 
+    fn snapshot_truncatable_to(
+        &self,
+        snapshot: &mlxcel_core::generate::ModelStateSnapshot,
+        target_len: usize,
+    ) -> bool {
+        mlxcel_core::generate::LanguageModel::snapshot_truncatable_to(
+            &self.text_model,
+            snapshot,
+            target_len,
+        )
+    }
+
+    fn restore_sequence_state_truncated(
+        &self,
+        seq_id: SequenceId,
+        snapshot: &mlxcel_core::generate::ModelStateSnapshot,
+        target_len: usize,
+    ) -> Result<(), String> {
+        mlxcel_core::generate::LanguageModel::restore_sequence_state_truncated(
+            &self.text_model,
+            seq_id,
+            snapshot,
+            target_len,
+        )
+    }
+
     fn num_layers(&self) -> usize {
         self.text_model.num_layers_value()
     }


### PR DESCRIPTION
## Summary

The snapshot path required a stored entry to be an exact prefix of the request, so an entry sharing a long prefix but diverging before its own end was useless. For rotating-attention families that is stricter than the hardware demands: the "cannot truncate" constraint only holds after a sliding layer's ring has wrapped. This converts exact-prefix into longest-prefix matching for Gemma 4 while leaving every recurrent family untouched, following the upstream mlx-lm `can_trim_prompt_cache` precedent.

## What changed

- `src/lib/mlxcel-core/src/cache.rs`: `RotatingKVCacheSnapshotState::is_unwrapped` / `can_truncate_to`, and `RotatingKVCache::is_trimmable` mirroring upstream on the live cache. Linearity has two independent failure modes and both are excluded: a wrapped ring (`idx` no longer tracks `offset`), and the oversized temporary buffer `update_concat` leaves for one step after an over-window prefill, which keeps `idx == offset` but whose next in-place update re-slices from the back.
- `src/lib/mlxcel-core/src/generate.rs`: `LanguageModel::snapshot_truncatable_to` and `restore_sequence_state_truncated`, defaulting to `false` / `Err` so a family opts in explicitly.
- `src/models/gemma4.rs`: per-layer capability answered from the snapshot's own scalars, `Cache::truncate_to`, and `Cache::is_populated` so a KV-shared layer that stored nothing truncates to a no-op. `restore_sequence_state_truncated` re-checks rather than trusting the caller.
- `src/server/prompt_cache/store.rs`: `lookup_snapshot_outcome` takes the capability as a closure and adopts the best diverging candidate at the longest common prefix once it clears `min_prefix_tokens`. An exact-prefix candidate always wins; a refusal stays the classified `snapshot_diverged` reject from #1147.
- `src/server/batch/scheduler.rs`: routes a `matched_len` shorter than the stored entry to the truncating restore.
- `src/loaded_model.rs`, `src/vision/gemma4_unified.rs`, `src/vision/gemma4_vl.rs`: delegation.

## A bug the checkpoint run caught

The first gemma-4-e2b run failed the partial restore with `layer15: Gemma 4 truncate: target 34 exceeds cached offset 0`. KV-shared layers compute only Q and borrow K/V from an earlier layer, so `snapshot_into` skips them and `restore_from` leaves them fresh; demanding `target_len <= offset` there failed against an offset of 0 on a restore that was actually sound. A single-layer synthetic fixture cannot reach this. Fixed with the `is_populated` guard and pinned by a test that also covers the negative half, so the no-op cannot become a blanket bypass.

## Validation

Unit tests, `cargo test --release`:

- `mlxcel-core::cache::rotating_truncation_tests`: 9 passed. Covers the inclusive boundary at `offset == max_size` (accepted) versus one token later (refused), a wrapped cache refused even for a target inside its live window, the over-window prefill trap, buffered speculative mode, non-FP16 storage, and a live cache driven through its wrap.
- `models::gemma4_tests::snapshot_prompt_cache`: 7 passed, including `gemma4_truncated_restore_matches_a_cold_prefill_of_the_same_prefix` (the correctness bar: a restore truncated to N decodes identically to having only ever prefilled those N tokens) and the KV-shared empty-layer regression.
- `server::prompt_cache`: 165 passed. Covers partial adoption at the longest common prefix, exact-prefix precedence, the `min_prefix_tokens` floor, a declining model keeping exact-prefix semantics, and that the capability is asked about the adopted length rather than the stored length.
- `cargo clippy --lib --tests -- -D warnings` and `cargo fmt --check` clean.

Real checkpoints, through the production `/v1/chat/completions` path, counter-verified on `/v1/cache/stats`:

| Checkpoint | Family path | Turn | `snapshot_lookups` / `hits` | `cached_tokens` | Scheduler log |
|---|---|---|---|---|---|
| gemma-4-e2b-it-4bit | rotating attention, `sliding_window` 512, 35 layers | turn 2 | 2 / 1 | 77 | `matched=77 stored=129 partial=true` |
| gemma-4-e2b-it-4bit | | deliberately diverged turn | 3 / 2 | 66 | `matched=66 stored=168 partial=true` |
| qwen3.5-0.8b-4bit | Attention + GatedDeltaNet | diverged turn | 3 / 0 | 0 | no truncating restore attempted |
| llama-3.2-1b-instruct | dense KV | turn 2 | 0 / 0 | 160 | dense trie path, snapshot path never entered |
| llama-3.2-1b-instruct | | diverged turn | 0 / 0 | 128 | dense trie path |

Both Gemma 4 rows adopted a prefix strictly shorter than the stored entry, which is the behavior this issue asks for and is impossible on the previous code. The qwen row is the load-bearing negative control: zero `partial=true` occurrences in its log and `snapshot_hits` pinned at 0, with the `snapshot_diverged` reject firing instead, so the recurrent path is provably unchanged. The llama rows show `snapshot_lookups = 0` throughout, so the dense-KV families never touch this code at all.

The gemma-4-31b-it-4bit scenario named in the issue is left to the orchestrator's large-model pass; gemma-4-e2b-it-4bit is the same rotating-attention family and exercises the identical code path under a 512-token window.

Closes #1145
