### PR TITLE
test: derive prompt_cache_e2e slack from the paged block size

### DIFF
--- a/TECHNICAL_REPORTS/1158-prompt-cache-e2e-block-slack-20260815.en.md
+++ b/TECHNICAL_REPORTS/1158-prompt-cache-e2e-block-slack-20260815.en.md
@@ -1,0 +1,171 @@
+# Technical Report: PR #1158 - test: derive prompt_cache_e2e slack from the paged block size
+
+**Date**: 2026-08-15
+**Author**: AI Code Reviewer
+**Status**: Completed
+**Languages**: Rust
+**Risk Level**: Low
+
+---
+
+## Executive Summary
+
+The manual multi-turn prompt-cache e2e test (`tests/prompt_cache_e2e.rs`, `#[ignore]`d, run against local qwen3-0.6b-4bit weights) failed deterministically at turn 3 because its under-allowance assertion granted only 4 tokens of slack while the APC lookup path floors cache credit to whole 16-token blocks, which can legitimately cost up to 15 tokens. This PR derives the slack from the server's own `DEFAULT_APC_BLOCK_SIZE` constant (slack = block size - 1 = 15), documents the flooring mechanism accurately, and scrubs the `APC_BLOCK_SIZE`/`APC_ENABLED` env-var fallbacks when spawning the server so the assertion's premise holds regardless of the invoking shell. Test-only change; six recorded runs with the real fixture produce identical per-turn values.
+
+---
+
+## 1. Problem Statement
+
+### 1.1 Background
+
+Issue #1156 was filed from epic #1148's integration verification. A two-arm measurement settled attribution: the pre-epic baseline `9c154ff3` fails with token-for-token identical values (cached 0/48/64/96/112 across 5 turns), so the defect is pre-existing in the test, not an epic regression.
+
+### 1.2 Existing Issues
+
+- **Issue 1**: At turn 3, `cached_tokens` is 64 against a previous prompt length of 73, and the assertion `cached + 4 >= prev_prompt_len` fails: the 4-token slack does not cover block flooring.
+- **Issue 2**: The mechanism: APC lookup credits only whole verified blocks (`apc_consistent_prefix_len` returns `consistent_blocks * block_size`, `src/server/prompt_cache/apc_lookup.rs`), and the dense adopt path truncates to exactly that. With `max_tokens=16` the qwen3 thinking model emits empty assistant content (all 16 tokens go to the unterminated think block), so the history re-render diverges right at the previous prompt boundary and the flooring loss is fully exposed: worst case `block_size - 1 = 15` tokens, which exceeds 4.
+- **Issue 3** (found during review): the spawned server inherited the parent environment, and `mlxcel-server` falls back to `APC_BLOCK_SIZE`/`APC_ENABLED` env vars when the flags are absent — an exported `APC_BLOCK_SIZE` would silently change the server's block size while the assertion kept using the compile-time constant.
+
+### 1.3 Risk Assessment
+
+| Risk | Impact | Likelihood |
+|------|--------|------------|
+| Deterministic false failure hides real cache regressions behind a known-red test | Medium | High (fails every run at turn 3) |
+| Hardcoded slack silently diverges if the block size constant changes | Low | Low |
+
+---
+
+## 2. Technical Review
+
+### 2.1 Security
+
+No security surface (test-only). The security pass verified 15 is the tight bound, arithmetic is overflow-safe (const-evaluated; `cached + 15` wrap requires `cached` near `u64::MAX` where the assertion passes either way), and surfaced the env-var inheritance finding (MEDIUM) that the orchestrator fixed with `.env_remove` in `spawn_server` (precedent: `tests/cli_help_consistency.rs`).
+
+**Issues Found:**
+| Issue | Severity | Status |
+|-------|----------|--------|
+| False justification comment: claimed the crate constant was unimportable (root package "has no lib target") — it does, and a sibling test already imports the exact path | High | Fixed (`203d1118`) |
+| Mechanism misattribution in the comment: credited "dense-trie flooring"/"whole-block donation"; donation stores exact tokens and the trie returns an exact LCP — the floor is at APC lookup | Medium | Fixed (`203d1118`) |
+| Inherited `APC_BLOCK_SIZE`/`APC_ENABLED` env vars could break the assertion's premise both ways (32 → false failure; 8 → over-permissive) | Medium | Fixed (`45d8757c`) |
+| Pre-existing doc bug in `apc_lookup.rs:46` ("input matched_len is preserved" — false, return is always block-floored) | Low | Open (production doc, out of scope; flagged on the PR) |
+
+### 2.2 Performance
+
+None; assertion arithmetic only. The prefill-latency assertion continued to pass in every recorded run (ratios 0.37-0.50 against a 1.3 upper bound).
+
+### 2.3 Compatibility & Dependencies
+
+- **Breaking Changes**: none
+- **New Dependencies**: none — the lib import adds no build surface (18 other files under `tests/` already import from the `mlxcel` lib)
+- **Compatibility**: valid only for the Dense decode backend (`--batch-size 1`); the paged backend applies a coarser 32-token floor (`DEFAULT_PAGED_BLOCK_SIZE`), now documented on the constant
+
+### 2.4 Code Quality
+
+- **Test Coverage**: the previously always-red manual test is now a usable regression gate
+- **Code Complexity**: one imported constant, one assertion change, two env removals
+- **Technical Debt**: decreased (magic number replaced with the source-of-truth constant; env-dependent premise closed)
+
+---
+
+## 3. Technical Decisions
+
+### 3.1 Derive the slack from the constant instead of widening the literal or changing the fixture
+
+**Alternatives Considered:**
+
+| Option | Pros | Cons |
+|--------|------|------|
+| Raise the literal to 15 | Minimal diff | Silently diverges if the block size changes |
+| Change the fixture (non-thinking model or larger `max_tokens`) | Avoids the empty-content divergence | Hides rather than accommodates the mechanism; the flooring loss still exists for any divergence at a non-aligned boundary |
+| **Chosen: import `DEFAULT_APC_BLOCK_SIZE`, slack = block size - 1** | Assertion tracks the source of truth; 15 is provably the tight bound | Requires the (correct) importability of the crate constant |
+
+**Rationale:** The acceptance criteria preferred derivation from the constant. The review pass proved 15 is exactly tight: a one-block regression gives `cached <= P - 16`, so `cached + 15 <= P - 1` and the assertion still fires — a full block is the smallest loss the dense APC path can express. All observed values match `floor(P/16)*16` exactly (48/64/96/112 against 50/73/96/119), confirming the flooring model empirically.
+
+### 3.2 Scrub env fallbacks in `spawn_server` rather than pass `--apc-block-size` at each call site
+
+**Rationale:** `.env_remove("APC_BLOCK_SIZE").env_remove("APC_ENABLED")` fixes every current and future spawn in the file at one point, matching the existing precedent in `tests/cli_help_consistency.rs`. Passing the flag would need repeating at each call site and still leave `APC_ENABLED` inherited.
+
+---
+
+## 4. Implementation Details
+
+### 4.2 Key Code Changes
+
+**File: `tests/prompt_cache_e2e.rs`**
+```rust
+// Before
+assert!(
+    cached + 4 >= prev_prompt_len,
+    ...
+);
+
+// After
+use mlxcel::server::prompt_cache::DEFAULT_APC_BLOCK_SIZE;
+const APC_BLOCK_SIZE: u64 = DEFAULT_APC_BLOCK_SIZE as u64;
+...
+assert!(
+    cached + (APC_BLOCK_SIZE - 1) >= prev_prompt_len,
+    ...
+);
+```
+
+**Reason for change:** APC lookup credits only whole verified blocks, so a re-render divergence at the previous prompt boundary can cost up to `block_size - 1` tokens; the assertion must allow exactly that and no more. The doc comment records both preconditions: Dense backend via `--batch-size 1` (paged floors at 32), and the env scrub in `spawn_server`.
+
+---
+
+## 7. Change Summary
+
+### Statistics
+| Item | Value |
+|------|-------|
+| Files changed | 1 |
+| Lines added | +44 |
+| Lines deleted | -2 |
+| Tests added | 0 (1 existing manual test repaired) |
+
+### Changes by Category
+
+| Category | Count | Summary |
+|----------|-------|---------|
+| Code Quality | 3 | Constant-derived slack, accurate mechanism docs, env-fallback scrub |
+
+### Related Commits
+| Hash | Type | Message |
+|------|------|---------|
+| `c3b33cd8` | test | derive prompt_cache_e2e slack from the paged block size |
+| `203d1118` | test | import the APC block size instead of mirroring it |
+| `45d8757c` | test | scrub APC env fallbacks when spawning the e2e server |
+
+---
+
+## 8. Follow-up Actions
+
+### Required
+- [ ] None; all three acceptance criteria are met with real-model evidence
+
+### Future Improvements
+- Fix the `apc_lookup.rs:46` doc comment ("input matched_len is preserved" is false; the return is always `consistent_blocks * block_size`) — pre-existing production doc bug flagged on the PR
+- If the test ever raises `--batch-size`, the slack must widen to `DEFAULT_PAGED_BLOCK_SIZE - 1` (documented on the constant)
+
+---
+
+## Appendix
+
+### A. Test Results
+
+Six recorded runs of `cargo test --release --features metal,accelerate --test prompt_cache_e2e multi_turn -- --ignored` with the local qwen3-0.6b-4bit fixture (2 by the implementer, 2 by the reviewer, 1 by the security pass baseline evidence, 1 by the finalizer post-env-scrub), all with identical per-turn values:
+
+| Turn | prompt_tokens | cached_tokens | flooring check |
+|------|---------------|---------------|----------------|
+| 1 | 50 | 0 | cold start |
+| 2 | 73 | 48 | floor(50/16)*16 = 48 |
+| 3 | 96 | 64 | floor(73/16)*16 = 64 (the previously failing case: 64 + 15 >= 73) |
+| 4 | 119 | 96 | floor(96/16)*16 = 96 |
+| 5 | 142 | 112 | floor(119/16)*16 = 112 |
+
+Observed slack consumption per turn: 2/9/0/7 of the 15 allowed. Strict assertions (cached > 0 from turn 2, monotonic growth) unchanged and passing.
+
+### C. References
+- Issue #1156 (specification), epic #1148 (integration verification, full turn table in its summary comment)
+- `src/server/prompt_cache/apc_lookup.rs` (flooring site), `src/server/prompt_cache/block_hash.rs` (`DEFAULT_APC_BLOCK_SIZE`), `src/server/batch/scheduler.rs` (dense adopt truncation, `DEFAULT_PAGED_BLOCK_SIZE`)
+- PR #1158 review and security comments

--- a/TECHNICAL_REPORTS/1158-prompt-cache-e2e-block-slack-20260815.ko.md
+++ b/TECHNICAL_REPORTS/1158-prompt-cache-e2e-block-slack-20260815.ko.md
@@ -1,0 +1,171 @@
+# 기술 보고서: PR #1158 - test: derive prompt_cache_e2e slack from the paged block size
+
+**작성일**: 2026-08-15
+**작성자**: AI Code Reviewer
+**상태**: 완료
+**언어**: Rust
+**위험도**: Low
+
+---
+
+## 요약
+
+수동 실행 multi-turn prompt-cache e2e 테스트(`tests/prompt_cache_e2e.rs`, `#[ignore]`, 로컬 qwen3-0.6b-4bit 사용)가 turn 3에서 결정적으로 실패했다. under-allowance 어서션의 slack이 4토큰뿐인데, APC lookup 경로는 캐시 크레딧을 16토큰 블록 단위로 내림(floor)하므로 최대 15토큰의 정당한 손실이 발생한다. 이 PR은 slack을 서버 자체의 `DEFAULT_APC_BLOCK_SIZE` 상수에서 유도하고(slack = block size - 1 = 15), flooring 메커니즘을 정확하게 문서화하며, 서버 spawn 시 `APC_BLOCK_SIZE`/`APC_ENABLED` env 폴백을 제거해 어서션의 전제가 호출 셸과 무관하게 성립하도록 한다. 테스트 전용 변경이며, 실물 fixture로 6회 실측 모두 turn별 값이 완전히 동일하다.
+
+---
+
+## 1. 문제 정의
+
+### 1.1 배경
+
+이슈 #1156은 에픽 #1148 통합 검증에서 발행됐다. 양팔 실측으로 귀속이 확정됐다: 에픽 이전 기준선 `9c154ff3`이 토큰 단위까지 동일한 값(5턴에 걸쳐 cached 0/48/64/96/112)으로 실패하므로, 에픽 회귀가 아니라 테스트의 선재 결함이다.
+
+### 1.2 기존 문제점
+
+- **문제 1**: turn 3에서 `cached_tokens`가 64인데 이전 프롬프트 길이가 73이고, 어서션 `cached + 4 >= prev_prompt_len`이 실패. 4토큰 slack은 블록 flooring을 감당하지 못한다.
+- **문제 2**: 메커니즘. APC lookup은 검증된 전체 블록만 인정하고(`apc_consistent_prefix_len`이 `consistent_blocks * block_size` 반환, `src/server/prompt_cache/apc_lookup.rs`), dense adopt 경로는 정확히 그 값으로 잘라낸다. `max_tokens=16`이면 qwen3 thinking 모델의 assistant content가 비어(16토큰 전부 미종결 think 블록으로 소진), 히스토리 재렌더가 이전 프롬프트 경계 바로 그 지점에서 갈라져 flooring 손실이 그대로 노출된다: 최악 `block_size - 1 = 15`토큰으로 4를 초과.
+- **문제 3** (리뷰 중 발견): spawn된 서버가 부모 환경을 상속하는데 `mlxcel-server`는 플래그 부재 시 `APC_BLOCK_SIZE`/`APC_ENABLED` env var로 폴백한다. 셸에 export된 `APC_BLOCK_SIZE`가 있으면 어서션은 컴파일 타임 상수를 쓰는데 서버 블록 크기는 조용히 달라진다.
+
+### 1.3 위험성
+
+| 위험 | 영향도 | 발생 가능성 |
+|-----|-------|-----------|
+| 결정적 거짓 실패가 항상 붉은 테스트 뒤로 실제 캐시 회귀를 숨김 | Medium | High (매 실행 turn 3 실패) |
+| 하드코딩 slack이 블록 크기 상수 변경 시 조용히 어긋남 | Low | Low |
+
+---
+
+## 2. 기술적 검토 사항
+
+### 2.1 보안 관점
+
+보안 표면 없음(테스트 전용). 보안 검토에서 15가 tight bound임을 검증했고, 산술은 오버플로 안전(const 평가, `cached + 15` wrap은 `cached`가 `u64::MAX` 근방일 때뿐이며 그 경우 어서션은 어차피 통과)하며, env var 상속 발견(MEDIUM)은 오케스트레이터가 `spawn_server`의 `.env_remove`로 수정했다(선례: `tests/cli_help_consistency.rs`).
+
+**발견된 이슈:**
+| 이슈 | 심각도 | 상태 |
+|-----|-------|-----|
+| 거짓 정당화 주석: crate 상수를 import할 수 없다고 주장(루트 패키지에 "lib 타깃 없음") — 실제로는 있고, 형제 테스트가 이미 같은 경로를 import | High | Fixed (`203d1118`) |
+| 주석의 메커니즘 오귀속: "dense-trie flooring"/"전체 블록 donation" — donation은 정확한 토큰을 저장하고 trie는 정확한 LCP를 반환하며, floor는 APC lookup에 있다 | Medium | Fixed (`203d1118`) |
+| 상속된 `APC_BLOCK_SIZE`/`APC_ENABLED`가 어서션 전제를 양방향으로 깨뜨림(32 → 거짓 실패, 8 → 과잉 허용) | Medium | Fixed (`45d8757c`) |
+| `apc_lookup.rs:46`의 선재 doc 결함("input matched_len은 보존된다" — 거짓, 반환은 항상 블록 내림) | Low | Open (프로덕션 doc, 스코프 밖, PR에 기록) |
+
+### 2.2 성능 관점
+
+없음. 어서션 산술만 변경. prefill-latency 어서션은 매 실측에서 통과(비율 0.37~0.50, 상한 1.3).
+
+### 2.3 호환성/의존성 관점
+
+- **Breaking Changes**: 없음
+- **새로운 의존성**: 없음. lib import는 빌드 표면을 추가하지 않는다(`tests/` 아래 18개 파일이 이미 `mlxcel` lib을 import)
+- **호환성**: Dense 디코드 백엔드(`--batch-size 1`) 전제에서만 유효. paged 백엔드는 더 굵은 32토큰 floor(`DEFAULT_PAGED_BLOCK_SIZE`)를 적용하며, 상수 주석에 문서화됨
+
+### 2.4 코드 품질 관점
+
+- **테스트 커버리지**: 항상 붉던 수동 테스트가 사용 가능한 회귀 게이트로 복원됨
+- **코드 복잡도**: 상수 import 1건, 어서션 변경 1건, env 제거 2건
+- **기술 부채**: 감소 (매직 넘버를 source-of-truth 상수로 대체, env 의존 전제 봉쇄)
+
+---
+
+## 3. 기술적 선택과 그 이유
+
+### 3.1 리터럴 확대나 fixture 변경 대신 상수에서 slack 유도
+
+**고려한 대안:**
+
+| 옵션 | 장점 | 단점 |
+|-----|-----|-----|
+| 리터럴을 15로 확대 | 최소 diff | 블록 크기 상수가 바뀌면 조용히 어긋남 |
+| fixture 변경(non-thinking 모델 또는 더 큰 `max_tokens`) | empty-content 분기 회피 | 메커니즘을 수용하는 대신 숨김. 비정렬 경계에서 갈라지는 어떤 경우에도 flooring 손실은 여전히 존재 |
+| **선택: `DEFAULT_APC_BLOCK_SIZE` import, slack = block size - 1** | 어서션이 source of truth를 추적. 15가 tight bound임을 증명 가능 | crate 상수의 (실제로 성립하는) import 가능성 필요 |
+
+**선택 이유:** 수용 기준이 상수 유도를 선호했다. 리뷰 단계에서 15가 정확히 tight함을 증명했다: 블록 하나를 잃는 회귀는 `cached <= P - 16`이므로 `cached + 15 <= P - 1`이 되어 어서션이 여전히 발화하며, 전체 블록 하나가 dense APC 경로가 표현할 수 있는 최소 손실이다. 관측된 모든 값이 `floor(P/16)*16`과 정확히 일치(50→48, 73→64, 96→96, 119→112)해 flooring 모델이 실증적으로 확인됐다.
+
+### 3.2 각 호출 지점에 `--apc-block-size`를 넘기는 대신 `spawn_server`에서 env 폴백 제거
+
+**선택 이유:** `.env_remove("APC_BLOCK_SIZE").env_remove("APC_ENABLED")`는 파일 내 현재·미래의 모든 spawn을 한 지점에서 고치며, `tests/cli_help_consistency.rs`의 기존 선례와 일치한다. 플래그 전달 방식은 호출 지점마다 반복해야 하고 `APC_ENABLED`는 여전히 상속된다.
+
+---
+
+## 4. 구현 상세
+
+### 4.2 주요 코드 변경
+
+**파일: `tests/prompt_cache_e2e.rs`**
+```rust
+// 변경 전
+assert!(
+    cached + 4 >= prev_prompt_len,
+    ...
+);
+
+// 변경 후
+use mlxcel::server::prompt_cache::DEFAULT_APC_BLOCK_SIZE;
+const APC_BLOCK_SIZE: u64 = DEFAULT_APC_BLOCK_SIZE as u64;
+...
+assert!(
+    cached + (APC_BLOCK_SIZE - 1) >= prev_prompt_len,
+    ...
+);
+```
+
+**변경 이유:** APC lookup은 검증된 전체 블록만 인정하므로 이전 프롬프트 경계에서의 재렌더 분기는 최대 `block_size - 1`토큰을 잃을 수 있다. 어서션은 정확히 그만큼만 허용해야 한다. doc 주석에 두 전제조건을 기록했다: `--batch-size 1`을 통한 Dense 백엔드(paged는 32에서 floor), 그리고 `spawn_server`의 env 스크럽.
+
+---
+
+## 7. 변경 요약
+
+### 통계
+| 항목 | 값 |
+|-----|---|
+| 변경된 파일 수 | 1 |
+| 추가된 라인 | +44 |
+| 삭제된 라인 | -2 |
+| 테스트 추가 | 0 (기존 수동 테스트 1건 수리) |
+
+### 카테고리별 변경
+
+| 카테고리 | 변경 수 | 주요 내용 |
+|---------|--------|----------|
+| Code Quality | 3 | 상수 유도 slack, 정확한 메커니즘 문서화, env 폴백 스크럽 |
+
+### 관련 커밋
+| Hash | Type | Message |
+|------|------|---------|
+| `c3b33cd8` | test | derive prompt_cache_e2e slack from the paged block size |
+| `203d1118` | test | import the APC block size instead of mirroring it |
+| `45d8757c` | test | scrub APC env fallbacks when spawning the e2e server |
+
+---
+
+## 8. 후속 조치
+
+### 완료 필요
+- [ ] 없음. 세 수용 기준 모두 실물 모델 증거로 충족
+
+### 향후 개선 사항
+- `apc_lookup.rs:46` doc 주석 수정("input matched_len은 보존된다"는 거짓, 반환은 항상 `consistent_blocks * block_size`) — PR에 기록된 선재 프로덕션 doc 결함
+- 테스트가 `--batch-size`를 올리게 되면 slack을 `DEFAULT_PAGED_BLOCK_SIZE - 1`로 넓혀야 함(상수 주석에 문서화됨)
+
+---
+
+## 부록
+
+### A. 테스트 결과
+
+로컬 qwen3-0.6b-4bit fixture로 `cargo test --release --features metal,accelerate --test prompt_cache_e2e multi_turn -- --ignored` 6회 실측(구현자 2회, 리뷰어 2회, 보안 검토 기준 증거 1회, finalizer의 env 스크럽 이후 1회), 전부 turn별 값 동일:
+
+| Turn | prompt_tokens | cached_tokens | flooring 검산 |
+|------|---------------|---------------|----------------|
+| 1 | 50 | 0 | cold start |
+| 2 | 73 | 48 | floor(50/16)*16 = 48 |
+| 3 | 96 | 64 | floor(73/16)*16 = 64 (기존 실패 지점: 64 + 15 >= 73) |
+| 4 | 119 | 96 | floor(96/16)*16 = 96 |
+| 5 | 142 | 112 | floor(119/16)*16 = 112 |
+
+턴별 slack 소비량: 허용 15 중 2/9/0/7. 엄격 어서션(turn 2부터 cached > 0, 단조 증가)은 불변·통과.
+
+### C. 참고 자료
+- 이슈 #1156 (사양), 에픽 #1148 (통합 검증, 요약 코멘트에 전체 턴 테이블)
+- `src/server/prompt_cache/apc_lookup.rs` (flooring 지점), `src/server/prompt_cache/block_hash.rs` (`DEFAULT_APC_BLOCK_SIZE`), `src/server/batch/scheduler.rs` (dense adopt 절단, `DEFAULT_PAGED_BLOCK_SIZE`)
+- PR #1158의 리뷰·보안 코멘트

--- a/tests/prompt_cache_e2e.rs
+++ b/tests/prompt_cache_e2e.rs
@@ -49,6 +49,7 @@ use std::process::{Child, Command, Stdio};
 use std::time::{Duration, Instant};
 
 use common::{repo_binary_path, repo_model_dir};
+use mlxcel::server::prompt_cache::DEFAULT_APC_BLOCK_SIZE;
 
 /// Smallest Qwen3 weight bundle we keep locally.
 const QWEN3_MODEL: &str = "qwen3-0.6b-4bit";
@@ -61,13 +62,19 @@ const NUM_TURNS: usize = 5;
 /// future tightening happens in one place.
 const PREFILL_LATENCY_UPPER_RATIO: f64 = 1.3;
 
-/// Mirror of `DEFAULT_APC_BLOCK_SIZE` in
-/// `src/server/prompt_cache/block_hash.rs`. This integration test crate has
-/// no `[lib]` dependency edge to `mlxcel-core` (the root `mlxcel` package
-/// carries no `[lib]` target either, only `[[bin]]`s), so the crate-internal
-/// constant is not importable here; keep this value in sync with the source
-/// of truth if the paged block size ever changes.
-const APC_BLOCK_SIZE: u64 = 16;
+/// Tokens per APC block, taken from the server's own default
+/// (`DEFAULT_APC_BLOCK_SIZE` in `src/server/prompt_cache/block_hash.rs`) so
+/// the under-allowance slack below follows the constant instead of a
+/// literal. `mlxcel-server` turns APC on by default
+/// (`--apc-enabled` defaults to `true`) and this test passes no
+/// `--apc-block-size`, so this is the block size the server under test uses.
+///
+/// This is the right constant only because the test spawns the server with
+/// `--batch-size 1`, which resolves the decode backend to Dense. On the paged
+/// backend the adopt path applies a second, coarser floor at the pool block
+/// size (`DEFAULT_PAGED_BLOCK_SIZE` = 32 in `src/server/batch/scheduler.rs`),
+/// so raising `--batch-size` here would also mean widening the slack below.
+const APC_BLOCK_SIZE: u64 = DEFAULT_APC_BLOCK_SIZE as u64;
 
 fn reserve_port() -> u16 {
     let listener = TcpListener::bind("127.0.0.1:0").expect("bind ephemeral port");
@@ -365,22 +372,26 @@ async fn multi_turn_chat_reports_cached_tokens_and_lowers_prefill_latency() {
         // (min_prefix gate, template boundary) but flag regressions that
         // drop below the previous prompt length.
         //
-        // The slack must cover one full block of dense-trie flooring, not
-        // just a template-boundary fudge factor: `cached_tokens` is
-        // block-floored to multiples of `APC_BLOCK_SIZE` (paged prefix-cache
-        // adoption only donates back whole blocks), so a re-render that
-        // diverges from the previous turn just past a block boundary can
-        // legitimately cost up to `APC_BLOCK_SIZE - 1` tokens versus the raw
-        // previous prompt length. This is exercised by the qwen3 thinking
-        // model at `max_tokens=16`, where the whole turn is consumed by an
-        // unterminated `<think>` block, the assistant content re-renders as
-        // empty, and the history text diverges right at the previous
-        // prompt's boundary.
+        // The slack must cover one full APC block, not just a
+        // template-boundary fudge factor. APC lookup credits only whole
+        // verified blocks: `apc_consistent_prefix_len` returns
+        // `consistent_blocks * block_size`
+        // (`src/server/prompt_cache/apc_lookup.rs`), and the adopt path then
+        // truncates the detached KV set to exactly that length
+        // (`Scheduler::try_adopt_cached_prefix` in
+        // `src/server/batch/scheduler.rs`). So `cached_tokens` is floored to
+        // a multiple of `APC_BLOCK_SIZE`, and a re-render that diverges from
+        // the previous turn just past a block boundary can legitimately cost
+        // up to `APC_BLOCK_SIZE - 1` tokens against the raw previous prompt
+        // length. The qwen3 thinking model at `max_tokens=16` exercises
+        // exactly that: the whole turn is consumed by an unterminated
+        // `<think>` block, the assistant content re-renders as empty, and the
+        // history text diverges right at the previous prompt's boundary.
         assert!(
             cached + (APC_BLOCK_SIZE - 1) >= prev_prompt_len,
             "turn {turn_number}: cached_tokens ({cached}) should cover at least the \
              previous turn's prompt length ({prev_prompt_len}) minus one block's worth \
-             ({}) of dense-trie flooring slack",
+             ({}) of APC block-flooring slack",
             APC_BLOCK_SIZE - 1,
         );
         prev_cached = cached;

--- a/tests/prompt_cache_e2e.rs
+++ b/tests/prompt_cache_e2e.rs
@@ -66,8 +66,10 @@ const PREFILL_LATENCY_UPPER_RATIO: f64 = 1.3;
 /// (`DEFAULT_APC_BLOCK_SIZE` in `src/server/prompt_cache/block_hash.rs`) so
 /// the under-allowance slack below follows the constant instead of a
 /// literal. `mlxcel-server` turns APC on by default
-/// (`--apc-enabled` defaults to `true`) and this test passes no
-/// `--apc-block-size`, so this is the block size the server under test uses.
+/// (`--apc-enabled` defaults to `true`), this test passes no
+/// `--apc-block-size`, and `spawn_server` scrubs the `APC_BLOCK_SIZE` /
+/// `APC_ENABLED` env fallbacks, so this is the block size the server under
+/// test uses.
 ///
 /// This is the right constant only because the test spawns the server with
 /// `--batch-size 1`, which resolves the decode backend to Dense. On the paged
@@ -103,6 +105,13 @@ async fn wait_for_health_soft(client: &reqwest::Client, base_url: &str, timeout:
 fn spawn_server(args: &[&str]) -> Child {
     Command::new(repo_binary_path("mlxcel-server"))
         .args(args)
+        // The server falls back to these env vars when the matching flags are
+        // absent. Scrub them so an exported APC_BLOCK_SIZE / APC_ENABLED in
+        // the invoking shell cannot silently change the block size (or
+        // disable APC) out from under the `APC_BLOCK_SIZE`-derived slack
+        // assertion below.
+        .env_remove("APC_BLOCK_SIZE")
+        .env_remove("APC_ENABLED")
         .stdout(Stdio::null())
         .stderr(Stdio::null())
         .spawn()

--- a/tests/prompt_cache_e2e.rs
+++ b/tests/prompt_cache_e2e.rs
@@ -61,6 +61,14 @@ const NUM_TURNS: usize = 5;
 /// future tightening happens in one place.
 const PREFILL_LATENCY_UPPER_RATIO: f64 = 1.3;
 
+/// Mirror of `DEFAULT_APC_BLOCK_SIZE` in
+/// `src/server/prompt_cache/block_hash.rs`. This integration test crate has
+/// no `[lib]` dependency edge to `mlxcel-core` (the root `mlxcel` package
+/// carries no `[lib]` target either, only `[[bin]]`s), so the crate-internal
+/// constant is not importable here; keep this value in sync with the source
+/// of truth if the paged block size ever changes.
+const APC_BLOCK_SIZE: u64 = 16;
+
 fn reserve_port() -> u16 {
     let listener = TcpListener::bind("127.0.0.1:0").expect("bind ephemeral port");
     let port = listener.local_addr().expect("local addr").port();
@@ -356,10 +364,24 @@ async fn multi_turn_chat_reports_cached_tokens_and_lowers_prefill_latency() {
         // prompt, up to the min_prefix_tokens cap. Allow a small slack
         // (min_prefix gate, template boundary) but flag regressions that
         // drop below the previous prompt length.
+        //
+        // The slack must cover one full block of dense-trie flooring, not
+        // just a template-boundary fudge factor: `cached_tokens` is
+        // block-floored to multiples of `APC_BLOCK_SIZE` (paged prefix-cache
+        // adoption only donates back whole blocks), so a re-render that
+        // diverges from the previous turn just past a block boundary can
+        // legitimately cost up to `APC_BLOCK_SIZE - 1` tokens versus the raw
+        // previous prompt length. This is exercised by the qwen3 thinking
+        // model at `max_tokens=16`, where the whole turn is consumed by an
+        // unterminated `<think>` block, the assistant content re-renders as
+        // empty, and the history text diverges right at the previous
+        // prompt's boundary.
         assert!(
-            cached + 4 >= prev_prompt_len,
+            cached + (APC_BLOCK_SIZE - 1) >= prev_prompt_len,
             "turn {turn_number}: cached_tokens ({cached}) should cover at least the \
-             previous turn's prompt length ({prev_prompt_len}) minus the min-prefix slack",
+             previous turn's prompt length ({prev_prompt_len}) minus one block's worth \
+             ({}) of dense-trie flooring slack",
+            APC_BLOCK_SIZE - 1,
         );
         prev_cached = cached;
     }


### PR DESCRIPTION
## Summary

Fixes the deterministic failure in the ignored `prompt_cache_e2e::multi_turn_chat_reports_cached_tokens_and_lowers_prefill_latency` test, where the turn-3 under-allowance assertion allowed only 4 tokens of slack between `cached_tokens` and the previous turn's prompt length. APC lookup can only credit whole verified blocks, so `cached_tokens` is floored to a multiple of the APC block size (16 by default), which legitimately costs up to 15 tokens when a re-render diverges just past a block boundary.

## What changed

- `tests/prompt_cache_e2e.rs`: the turn-3+ under-allowance assertion changes from a hardcoded `cached + 4 >= prev_prompt_len` to `cached + (APC_BLOCK_SIZE - 1) >= prev_prompt_len`, where `APC_BLOCK_SIZE` is `mlxcel::server::prompt_cache::DEFAULT_APC_BLOCK_SIZE` imported directly, so the assertion tracks the constant rather than a copied literal.
- `tests/prompt_cache_e2e.rs`: expanded comments record where the flooring actually comes from (`apc_consistent_prefix_len` in `src/server/prompt_cache/apc_lookup.rs` returns `consistent_blocks * block_size`; the dense adopt path in `Scheduler::try_adopt_cached_prefix` then truncates to exactly that length), why 16 is the right constant for this test (`--apc-enabled` defaults to `true`, and `--batch-size 1` resolves the decode backend to Dense), and that the paged backend floors to the coarser 32-token pool block so raising `--batch-size` here would require widening the slack.
- `tests/prompt_cache_e2e.rs`: `spawn_server` now scrubs the `APC_BLOCK_SIZE` / `APC_ENABLED` env vars before spawning `mlxcel-server`, so an exported `APC_BLOCK_SIZE` in the invoking shell cannot silently change the block size the server uses out from under the `DEFAULT_APC_BLOCK_SIZE`-derived slack assertion, which would otherwise break the bound in either direction.
- The strict assertions (`cached_tokens > 0` from turn 2 onward, monotonic growth across turns) are unchanged.
- This is a test-only change; no production code paths are touched.

## Test plan

- [x] `cargo fmt --check -- tests/prompt_cache_e2e.rs`
- [x] `cargo test --release --features metal,accelerate --test prompt_cache_e2e multi_turn -- --ignored --nocapture` run five times against the local `qwen3-0.6b-4bit` checkpoint (twice before the import fix, twice after, once more after the `spawn_server` env-var scrub); every run passed with identical `cached_tokens` across all 5 turns (0/48/64/96/112 against prompts 50/73/96/119/142), confirming the assertion fix, the constant import, and the env-var hardening are all deterministic.

Closes #1156
