### PR TITLE
fix(cli): reject a DFlash drafter before the offline standalone load

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## [Unreleased]
+
+### Fixed
+
+- **`mlxcel generate --draft-model <dflash-drafter>` now fails with a named error instead of a misleading `Weight not found: model.embed_tokens.weight`** (#1168). A DFlash drafter borrows `embed_tokens` and `lm_head` from its target when it binds, so it ships neither, but its `config.json` still declares an ordinary `model_type` (`qwen3`, say), so the offline path classified it as a standalone model and drove it through the full `LoadedModel` loader, which failed on the first missing tensor with a message that named a tensor rather than the problem. Detection now rejects a directory that is structurally a DFlash drafter (a nested `dflash_config` object and/or `architectures: ["DFlashDraftModel"]`) before dispatch, both for `-m/--model` (`get_model_type`, which also covers server startup and the distributed stage loaders) and for offline `--draft-model` (a new pre-load check in `mlxcel generate`), and points at `mlxcel-server --draft-kind dflash` instead. The discriminator is the checkpoint's own markers, not the resolved `DrafterKind`: an ordinary small full model still auto-resolves to `DrafterKind::Dflash` by default (`DEFAULT_DRAFTER_KIND`) and keeps loading through the classic `SpeculativeGenerator` path unaffected, confirmed by a non-regression run (`qwen3-0.6b-4bit` as both target and drafter, acceptance_rate 1.0000, 137.54 tok/s). `docs/supported-models.md` and `docs/speculative-acceptance.md` are corrected to match: DFlash's offline entry is `mlxcel-server` only.
+
 ## [v0.5.1] - 2026-08-15
 
 ### Added

--- a/TECHNICAL_REPORTS/1170-dflash-drafter-cli-load-20260816.en.md
+++ b/TECHNICAL_REPORTS/1170-dflash-drafter-cli-load-20260816.en.md
@@ -1,0 +1,195 @@
+# Technical Report: PR #1170 - fix(cli): reject a DFlash drafter before the offline standalone load
+
+**Date**: 2026-08-16
+**Author**: AI Code Reviewer
+**Status**: Completed
+**Languages**: Rust
+**Risk Level**: Low
+
+---
+
+## Executive Summary
+
+`mlxcel generate --draft-model <dflash-drafter>` failed for every DFlash drafter and every target with `Error: Weight not found: model.embed_tokens.weight`, a message that names a tensor instead of the actual problem. A DFlash checkpoint borrows `embed_tokens` and `lm_head` from its target when it binds, so it ships neither, but its `config.json` still declares an ordinary `model_type` (`qwen3`), which routed it through the full standalone `LoadedModel` loader. This PR adds a structural probe, keyed on the checkpoint's own DFlash markers (a nested `dflash_config` object and/or `architectures: ["DFlashDraftModel"]`) rather than on the resolved `DrafterKind` (which defaults to `Dflash` for any non-Gemma-4-assistant drafter, including ordinary full models used as classic drafters), and rejects a DFlash drafter before both the `-m/--model` detection path and the offline `--draft-model` load, with a message that names the real problem and points at `mlxcel-server --draft-kind dflash`. The server path, which never reaches `get_model_type` for a drafter, is unaffected and pinned by a non-regression test. The finalization pass additionally fixed a predictable-temp-directory test hygiene finding (M3) in the new test fixtures.
+
+---
+
+## 1. Problem Statement
+
+### 1.1 Background
+
+Issue #1168: offline speculative decoding with a DFlash drafter could never succeed, with or without `--draft-kind`, because the offline entry point has no `DFlashGenerator` round loop and instead drives the drafter through the same loader used for a full standalone model.
+
+### 1.2 Existing Issues
+
+- **Issue 1**: `get_model_type` classified a DFlash drafter's `config.json` as `ModelType::Qwen3` (or whatever ordinary `model_type` the checkpoint's config declares), so `model_metadata` routed it to the matching family loader, which failed on the first missing tensor (`UnifiedEmbedding::from_weights` looking for `model.embed_tokens.weight`) rather than reporting that the directory is a drafter.
+- **Issue 2**: The obvious fix, rejecting on the resolved `DrafterKind`, would have broken a working workflow: `DEFAULT_DRAFTER_KIND` is `Dflash` and `drafter_kind_by_model_type()` maps only the two Gemma 4 assistant model types, so an ordinary small full model used as a classic `--draft-model` drafter (a Qwen3 0.6B, for example) also auto-resolves to `Dflash` and runs fine today on the classic `SpeculativeGenerator` path.
+- **Issue 3** (found during this finalization pass, security finding M3): `drafter_fixture_dir` in the new `src/commands/generate_tests.rs` tests built a predictable directory name under `env::temp_dir()` and created it with `create_dir_all`, which succeeds against a pre-existing directory or symlink there (CWE-377/379 class), and cleaned up only on the success path, leaking the fixture on an assertion failure. CI-relevant on Linux, where `TMPDIR` is shared across jobs.
+
+### 1.3 Risk Assessment
+
+| Risk | Impact | Likelihood |
+|------|--------|------------|
+| Offline DFlash `--draft-model` stays permanently broken with a misleading error | Medium (every DFlash drafter, every target) | Certain before this fix |
+| Rejecting on the wrong discriminator breaks the classic small-model drafter workflow | High if mis-keyed | Avoided by keying on checkpoint structure, confirmed by a dedicated control test |
+| Predictable temp-dir fixture is squatted or symlinked in a shared `TMPDIR` (M3) | Low (test-only, no production surface) | Low, but real on shared Linux CI runners |
+
+---
+
+## 2. Technical Review
+
+### 2.1 Security
+
+Review and security passes were completed by the orchestrator and reviewer before finalization: no CRITICAL, no HIGH findings. One MEDIUM finding (M3) was raised against the test-only fixture helper added in this PR.
+
+**Issues Found:**
+
+| Issue | Severity | Status |
+|-------|----------|--------|
+| `drafter_fixture_dir` built a predictable path under `env::temp_dir()` with `create_dir_all` (CWE-377/379) and leaked on assertion failure | Medium | Fixed (`37136aa6`) |
+
+The fix replaces the helper, and the identical inline pattern in the missing-config fixture, with `tempfile::tempdir()`, which mints a randomly-named, securely-permissioned directory and removes it on drop regardless of how the test exits. This is the same pattern the `mlxcel-core` `drafter::dflash::config` tests already use, so the PR is now internally consistent on this point.
+
+### 2.2 Performance
+
+None. This is a pre-load guard on the config-inspection path (a `serde_json` parse of `config.json`), not a hot inference path. No benchmark was required or run.
+
+### 2.3 Compatibility & Dependencies
+
+- **Breaking Changes**: an offline `--draft-model <dflash-drafter>` invocation that previously failed with a misleading `Weight not found` error now fails earlier with an explanatory one. No previously-working invocation is affected: no test or documented workflow constructed the offline DFlash round loop, since it does not exist.
+- **New Dependencies**: none in the fix itself. `tempfile` (already a dev-dependency, used elsewhere in this same PR) backs the corrected test fixtures.
+- **Compatibility**: the server path (`DFlashDrafter::load`, `resolve_drafter_kind`) never calls `get_model_type` for a drafter path, confirmed by re-checking every `get_model_type` call site in the tree; a new integration test pins that `SpeculativeDispatch::resolve` still returns the DFlash variant for the same fixture directory that detection now rejects.
+
+### 2.4 Code Quality
+
+- **Test Coverage**: new tests across four locations (`src/commands/generate_tests.rs`, `src/models/detection_tests.rs`, `src/lib/mlxcel-core/src/drafter/dflash/config.rs`, `tests/speculative_dispatch.rs`), each carrying an ordinary-full-model control that must keep resolving through the classic path. A mutation test (guarding the new detection arm as `if false && ...`) confirmed the new tests are real assertions rather than tautologies: both the `-m` and `--draft-model` rejection tests failed with the pre-fix classification.
+- **Code Complexity**: the structural probe is two small pure functions (`is_dflash_drafter_config`, `is_dflash_drafter_dir`) plus one shared error constructor; no control flow changes to any existing load path.
+- **Technical Debt**: decreased on both counts addressed here — the CI-relevant test hygiene inconsistency (M3) is closed, and the offline entry point no longer silently misroutes a class of checkpoint it was never built to run.
+
+---
+
+## 3. Technical Decisions
+
+### 3.1 Key on checkpoint structure, not on the resolved `DrafterKind`
+
+**Alternatives Considered:**
+
+| Option | Pros | Cons |
+|--------|------|------|
+| Reject when `DrafterKind::Dflash` is resolved | Minimal code, reuses existing resolution | Breaks the classic small-full-model drafter workflow, which also resolves to `Dflash` by default |
+| **Chosen: probe `config.json` for `dflash_config` and/or `architectures: ["DFlashDraftModel"]`** | Matches exactly what `DFlashConfig::from_json` and HuggingFace `AutoModel` dispatch each read; an ordinary full model has neither marker | Two independent markers to check instead of one resolved enum value |
+
+**Rationale:** the resolved kind is a fallback default, not a structural fact about the checkpoint. The checkpoint's own markers are what the DFlash loader and the HuggingFace ecosystem both already treat as authoritative, so keying on them cannot misclassify an ordinary drafter.
+
+### 3.2 Fix M3 by adopting `tempfile::tempdir()` rather than tightening the ad hoc path
+
+**Rationale:** the PR already establishes the `tempfile::tempdir()` pattern in `mlxcel-core`'s own new tests. Hardening the ad hoc `env::temp_dir()` path (unique suffix, permission checks, explicit cleanup on every exit path including panics) would have reimplemented what `tempfile` already provides as an RAII guard, at higher risk of missing an exit path than reusing the proven crate.
+
+---
+
+## 4. Implementation Details
+
+### 4.1 Detection (`src/models/detection.rs`, `src/lib/mlxcel-core/src/drafter/dflash/config.rs`)
+
+`get_model_type` now rejects a structurally-DFlash directory before any `model_type` dispatch, through a shared `dflash_drafter_not_standalone_error`, covering the `-m` case, server startup, and the distributed stage loaders from one call site.
+
+### 4.2 Offline CLI (`src/commands/generate.rs`)
+
+New `reject_dflash_drafter_offline`, called in `run_generation_mode` immediately before `load_model(draft_model_path)`. Fires with no `--draft-kind` and with `--draft-kind dflash`; `--draft-kind mtp` is a separate, already-handled request routed to `run_offline_mtp`.
+
+### 4.3 Test fixture hygiene fix (`src/commands/generate_tests.rs`, commit `37136aa6`)
+
+```rust
+// Before
+fn drafter_fixture_dir(name: &str, config: &str) -> PathBuf {
+    let dir = std::env::temp_dir().join(format!(
+        "mlxcel_generate_drafter_{name}_{}",
+        std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_nanos()
+    ));
+    fs::create_dir_all(&dir).unwrap();
+    fs::write(dir.join("config.json"), config).unwrap();
+    dir
+}
+// ... each call site manually `fs::remove_dir_all(dir).unwrap()`s on the success path only
+
+// After
+fn drafter_fixture_dir(config: &str) -> tempfile::TempDir {
+    let dir = tempfile::tempdir().expect("temp dir");
+    fs::write(dir.path().join("config.json"), config).unwrap();
+    dir
+}
+// call sites use dir.path(); TempDir removes the directory on drop, on every exit path
+```
+
+The `name` parameter was dropped: it existed only to build a unique-ish path segment, which `tempfile::tempdir()` already guarantees by construction. The identical inline pattern in `offline_draft_model_check_defers_missing_or_broken_configs_to_the_loader`'s `empty` fixture was fixed the same way.
+
+---
+
+## 7. Change Summary
+
+### Statistics
+
+| Item | Value |
+|------|-------|
+| Files changed (feature commit `82096193`) | 9 |
+| Files changed (M3 fix commit `37136aa6`) | 1 |
+| Lines added / removed (feature) | +645 / -5 |
+| Lines added / removed (M3 fix) | +19 / -34 |
+| Tests added | 4 (`commands::generate`) + 3 (`models::detection`) + 3 (`drafter::dflash::config`, plus existing coverage extended) + 2 (`speculative_dispatch`) |
+
+### Changes by Category
+
+| Category | Count | Summary |
+|----------|-------|---------|
+| Detection / loading | 3 | `is_dflash_drafter_config`, `is_dflash_drafter_dir`, `get_model_type` rejection, shared error text |
+| CLI | 1 | `reject_dflash_drafter_offline` pre-load guard in `run_generation_mode` |
+| Docs | 2 | `docs/supported-models.md`, `docs/speculative-acceptance.md` corrected to state the offline limitation |
+| Test hygiene (this finalization pass) | 1 | `drafter_fixture_dir` and the inline `empty` fixture moved to `tempfile::tempdir()` |
+
+### Related Commits
+
+| Hash | Type | Message |
+|------|------|---------|
+| `82096193` | fix | reject a DFlash drafter before the offline standalone load |
+| `37136aa6` | fix | back drafter test fixtures with `tempfile::tempdir()` |
+
+---
+
+## 8. Follow-up Actions
+
+### Required
+
+- [ ] None; the security and review passes reported no CRITICAL or HIGH findings, and the one MEDIUM finding (M3) is fixed in this pass.
+
+### Future Improvements (recorded as known limitations, not fixed here)
+
+- The precheck fires only after the target model finishes loading, so an operator with a large target waits through the full load before seeing the error. Moving it earlier would also intercept `--draft-kind mtp`, which is deliberately routed elsewhere.
+- `--draft-model <dir>/config.json` (pointing at the config file rather than the directory) bypasses the precheck and falls through to the detection error with `-m` phrasing, because the precheck does not apply `resolve_model_dir`.
+- The probe uses raw `serde_json::from_slice`, while `get_model_type` applies `sanitize_config_json` first; a config with bare `NaN`/`Infinity` literals would fail the precheck open. No current checkpoint is affected, and closing this gap is a cross-crate change (the sanitizer lives in the root crate, the probe in `mlxcel-core`).
+- Building the actual offline `DFlashGenerator` round loop remains out of scope, as stated in the PR summary; the CLI directs an operator who needs this today at `mlxcel-server --draft-kind dflash`.
+
+---
+
+## Appendix
+
+### A. Test Results
+
+- `cargo test --release --workspace --features metal,accelerate --no-fail-fast`: every target passes except `-p mlxcel --lib`, which reports 5621 passed / 3 failed. All 3 failures are `multimodal::video::tests::*`, proven unrelated to this PR (0 lines touched in `src/multimodal/video.rs`; a PATH-controlled experiment on the same binary gives 34 passed / 0 failed with ffmpeg hidden versus 31 passed / 3 failed with ffmpeg 9.0.1 present; root cause is `src/multimodal/video.rs:1123` passing `-vsync`, which ffmpeg 9 removed). Filed separately as #1172.
+- The four `commands::generate::tests::offline_draft_model_*` precheck tests compile into `--bin mlxcel`, not `--lib`, so they were not part of the `--lib` run above. Run separately (`cargo test --release --bin mlxcel --features metal,accelerate commands::generate`): 82 passed, including all four.
+- `cargo test --release -p mlxcel-core --lib --features metal,accelerate drafter::dflash::config`: 16 passed.
+- `cargo test --release --test speculative_dispatch --features metal,accelerate`: 22 passed.
+- `cargo test --release --lib --features metal,accelerate models::detection`: 30 passed.
+- `cargo clippy --release --workspace --features metal,accelerate --tests -- -D warnings`: clean.
+- `cargo fmt --check`: clean.
+- Classic-path non-regression, executed against a real checkpoint: `-m qwen3-0.6b-4bit --draft-model qwen3-0.6b-4bit` runs `SpeculativeGenerator`, 24 tokens, acceptance_rate 1.0000, 137.54 tok/s.
+- Mutation test: guarding the new detection arm as `if false && ...` makes both the `-m` and `--draft-model` rejection tests fail with the pre-fix classification, on both markers.
+
+### B. References
+
+- Issue #1168 (specification)
+- Issue #1172 (pre-existing, unrelated ffmpeg 9 `-vsync` regression surfaced by the full workspace test run)
+- `src/lib/mlxcel-core/src/drafter/dflash/config.rs` (structural probe), `src/models/detection.rs` (`get_model_type` rejection), `src/commands/generate.rs` (`reject_dflash_drafter_offline`)
+- PR #1170 review and security comments

--- a/TECHNICAL_REPORTS/1170-dflash-drafter-cli-load-20260816.en.md
+++ b/TECHNICAL_REPORTS/1170-dflash-drafter-cli-load-20260816.en.md
@@ -64,7 +64,7 @@ None. This is a pre-load guard on the config-inspection path (a `serde_json` par
 
 - **Test Coverage**: new tests across four locations (`src/commands/generate_tests.rs`, `src/models/detection_tests.rs`, `src/lib/mlxcel-core/src/drafter/dflash/config.rs`, `tests/speculative_dispatch.rs`), each carrying an ordinary-full-model control that must keep resolving through the classic path. A mutation test (guarding the new detection arm as `if false && ...`) confirmed the new tests are real assertions rather than tautologies: both the `-m` and `--draft-model` rejection tests failed with the pre-fix classification.
 - **Code Complexity**: the structural probe is two small pure functions (`is_dflash_drafter_config`, `is_dflash_drafter_dir`) plus one shared error constructor; no control flow changes to any existing load path.
-- **Technical Debt**: decreased on both counts addressed here — the CI-relevant test hygiene inconsistency (M3) is closed, and the offline entry point no longer silently misroutes a class of checkpoint it was never built to run.
+- **Technical Debt**: decreased on both counts addressed here: the CI-relevant test hygiene inconsistency (M3) is closed, and the offline entry point no longer silently misroutes a class of checkpoint it was never built to run.
 
 ---
 

--- a/TECHNICAL_REPORTS/1170-dflash-drafter-cli-load-20260816.ko.md
+++ b/TECHNICAL_REPORTS/1170-dflash-drafter-cli-load-20260816.ko.md
@@ -1,0 +1,195 @@
+# 기술 보고서: PR #1170 - fix(cli): reject a DFlash drafter before the offline standalone load
+
+**작성일**: 2026-08-16
+**작성자**: AI Code Reviewer
+**상태**: 완료
+**언어**: Rust
+**위험도**: Low
+
+---
+
+## 요약
+
+`mlxcel generate --draft-model <dflash-drafter>`는 모든 DFlash drafter와 모든 target 조합에서 `Error: Weight not found: model.embed_tokens.weight`로 실패했다. 이 메시지는 실제 원인이 아니라 텐서 이름 하나만 지목한다. DFlash 체크포인트는 바인딩 시점에 target으로부터 `embed_tokens`와 `lm_head`를 빌려 쓰므로 둘 다 자체 보유하지 않는데, `config.json`은 여전히 평범한 `model_type`(`qwen3`)을 선언하고 있어 전체 standalone `LoadedModel` 로더로 그대로 라우팅됐다. 이번 PR은 체크포인트 자체가 갖는 DFlash 마커(중첩된 `dflash_config` 객체와 `architectures: ["DFlashDraftModel"]`)를 기준으로 구조적 프로브를 추가한다. resolve된 `DrafterKind`를 기준으로 삼지 않은 이유는, Gemma 4 assistant가 아닌 모든 drafter가 기본값으로 `Dflash`로 resolve되기 때문이다. classic drafter로 쓰이는 평범한 full model도 여기 포함된다. 이 프로브는 `-m/--model` detection 경로와 offline `--draft-model` 로드 경로 양쪽에서 DFlash drafter를 사전에 거부하며, 실제 문제를 지목하고 `mlxcel-server --draft-kind dflash`를 대안으로 안내하는 메시지를 낸다. 서버 경로는 drafter에 대해 애초에 `get_model_type`을 호출하지 않으므로 영향이 없고, 이는 non-regression 테스트로 고정됐다. 이번 finalization 단계에서는 새로 추가된 테스트 fixture의 예측 가능한 임시 디렉터리 사용 문제(M3)도 함께 수정했다.
+
+---
+
+## 1. 문제 정의
+
+### 1.1 배경
+
+이슈 #1168: DFlash drafter로 offline speculative decoding을 시도하면 `--draft-kind` 유무와 무관하게 항상 실패했다. offline 진입점에는 `DFlashGenerator` round loop이 없고, standalone 모델과 동일한 로더로 drafter를 그대로 밀어넣기 때문이다.
+
+### 1.2 기존 문제점
+
+- **문제 1**: `get_model_type`이 DFlash drafter의 `config.json`을 (체크포인트가 선언한 평범한 `model_type` 그대로) `ModelType::Qwen3` 등으로 분류했다. `model_metadata`는 이를 해당 family 로더로 라우팅했고, 로더는 첫 번째로 찾는 텐서(`UnifiedEmbedding::from_weights`가 찾는 `model.embed_tokens.weight`)가 없다는 이유로 실패했다. 정작 "이 디렉터리는 drafter다"라는 사실은 어디에도 보고되지 않았다.
+- **문제 2**: 가장 단순해 보이는 해법인 resolve된 `DrafterKind` 기준 거부는 기존에 정상 동작하던 워크플로를 깨뜨렸을 것이다. `DEFAULT_DRAFTER_KIND`는 `Dflash`이고 `drafter_kind_by_model_type()`은 두 Gemma 4 assistant model_type만 매핑하므로, classic `--draft-model` drafter로 쓰이는 평범한 소형 full model(예: Qwen3 0.6B)도 자동으로 `Dflash`로 resolve된다. 이 조합은 현재 classic `SpeculativeGenerator` 경로에서 정상 동작한다.
+- **문제 3** (이번 finalization 단계에서 발견, 보안 항목 M3): 새로 추가된 `src/commands/generate_tests.rs`의 `drafter_fixture_dir`가 `env::temp_dir()` 아래 예측 가능한 경로명을 만들고 `create_dir_all`로 생성했다. 이 방식은 이미 존재하는 디렉터리나 심볼릭 링크에 대해서도 성공해버리는 CWE-377/379 계열 문제이며, 정리(cleanup)도 성공 경로에서만 이루어져 어서션이 실패하면 fixture가 남는다. `TMPDIR`을 여러 job이 공유하는 Linux CI에서 특히 문제가 된다.
+
+### 1.3 위험성
+
+| 위험 | 영향도 | 발생 가능성 |
+|-----|-------|-----------|
+| offline DFlash `--draft-model`이 오도하는 오류 메시지와 함께 영구적으로 동작 불능 상태로 남음 | Medium (모든 DFlash drafter, 모든 target) | 수정 전 확정적 |
+| 잘못된 판별 기준으로 거부하면 classic 소형 모델 drafter 워크플로가 깨짐 | High (판별 기준을 잘못 잡을 경우) | 체크포인트 구조를 기준으로 판별해 회피, 전용 control 테스트로 확인 |
+| 공유 `TMPDIR` 환경에서 예측 가능한 임시 디렉터리 fixture가 선점되거나 심볼릭 링크로 악용됨 (M3) | Low (테스트 전용, 프로덕션 표면 없음) | Low이지만 공유 Linux CI 러너에서는 실재 |
+
+---
+
+## 2. 기술적 검토 사항
+
+### 2.1 보안 관점
+
+리뷰와 보안 검토는 오케스트레이터와 리뷰어가 finalization 이전에 완료했다. CRITICAL, HIGH 항목은 없었다. 이번 PR에서 새로 추가한 테스트 전용 fixture 헬퍼에 대해 MEDIUM 항목 하나(M3)가 지적됐다.
+
+**발견된 이슈:**
+
+| 이슈 | 심각도 | 상태 |
+|-----|-------|-----|
+| `drafter_fixture_dir`가 `env::temp_dir()` 아래 `create_dir_all`로 예측 가능한 경로를 생성(CWE-377/379), 어서션 실패 시 fixture가 남음 | Medium | Fixed (`37136aa6`) |
+
+수정은 이 헬퍼와, 바로 아래에 있던 missing-config fixture의 동일한 인라인 패턴을 모두 `tempfile::tempdir()`로 교체한다. 이 함수는 무작위 이름의 안전한 권한을 가진 디렉터리를 만들고, 테스트가 어떤 경로로 종료되든 drop 시점에 그 디렉터리를 제거한다. 같은 PR에 포함된 `mlxcel-core`의 `drafter::dflash::config` 테스트가 이미 쓰던 패턴과 동일하며, 이로써 PR 내부의 불일치가 해소됐다.
+
+### 2.2 성능 관점
+
+없음. 이 변경은 hot inference 경로가 아니라 `config.json`을 `serde_json`으로 파싱하는 사전 로드 가드에 해당한다. 벤치마크는 필요하지 않았고 실행하지도 않았다.
+
+### 2.3 호환성/의존성 관점
+
+- **Breaking Changes**: offline `--draft-model <dflash-drafter>` 호출은 이전에도 실패했지만, 이제는 더 이른 시점에 설명이 담긴 오류로 실패한다. 이전에 정상 동작하던 호출 방식은 영향을 받지 않는다. offline DFlash round loop을 구성하는 테스트나 문서화된 워크플로는 애초에 존재하지 않았다.
+- **새로운 의존성**: 수정 자체에는 없다. 같은 PR에서 이미 dev-dependency로 존재하던 `tempfile`이 수정된 테스트 fixture를 뒷받침한다.
+- **호환성**: 서버 경로(`DFlashDrafter::load`, `resolve_drafter_kind`)는 drafter 경로에 대해 `get_model_type`을 전혀 호출하지 않는다. 트리 내 모든 `get_model_type` 호출 지점을 다시 확인해 이를 검증했다. 새로 추가된 통합 테스트는 detection이 이제 거부하는 것과 같은 fixture 디렉터리에 대해 `SpeculativeDispatch::resolve`가 여전히 DFlash variant를 반환함을 고정한다.
+
+### 2.4 코드 품질 관점
+
+- **테스트 커버리지**: 네 곳(`src/commands/generate_tests.rs`, `src/models/detection_tests.rs`, `src/lib/mlxcel-core/src/drafter/dflash/config.rs`, `tests/speculative_dispatch.rs`)에 새 테스트가 추가됐고, 각각 classic 경로가 계속 resolve되어야 함을 확인하는 평범한 full model control을 포함한다. mutation 테스트(새 detection 분기를 `if false && ...`로 막음)로 새 테스트들이 항진명제가 아니라 실제 어서션임을 확인했다. `-m`과 `--draft-model` 거부 테스트 모두 수정 전 분류로 실패했다.
+- **코드 복잡도**: 구조적 프로브는 작은 순수 함수 두 개(`is_dflash_drafter_config`, `is_dflash_drafter_dir`)와 공유 오류 생성 함수 하나로 이루어진다. 기존 로드 경로의 제어 흐름은 바뀌지 않았다.
+- **기술 부채**: 두 항목 모두 감소했다. CI에 영향을 주던 테스트 위생 불일치(M3)가 해소됐고, offline 진입점이 애초에 지원하도록 만들어지지 않은 종류의 체크포인트를 조용히 잘못 라우팅하는 문제도 사라졌다.
+
+---
+
+## 3. 기술적 선택과 그 이유
+
+### 3.1 resolve된 `DrafterKind`가 아니라 체크포인트 구조를 판별 기준으로 삼음
+
+**고려한 대안:**
+
+| 옵션 | 장점 | 단점 |
+|-----|-----|-----|
+| `DrafterKind::Dflash`가 resolve되면 거부 | 코드가 적고 기존 resolve 로직을 재사용 | classic 소형 full model drafter 워크플로도 기본값으로 `Dflash`에 resolve되므로 이를 깨뜨림 |
+| **선택: `config.json`에서 `dflash_config`와 `architectures: ["DFlashDraftModel"]` 존재 여부를 확인** | `DFlashConfig::from_json`과 HuggingFace `AutoModel` dispatch가 실제로 읽는 값과 정확히 일치. 평범한 full model에는 둘 다 없음 | resolve된 enum 값 하나 대신 독립적인 마커 두 개를 확인해야 함 |
+
+**선택 이유**: resolve된 kind는 체크포인트에 대한 구조적 사실이 아니라 fallback 기본값일 뿐이다. 체크포인트 자체의 마커는 DFlash 로더와 HuggingFace 생태계 양쪽이 이미 권위 있는 값으로 취급하는 정보이므로, 이를 기준으로 삼으면 평범한 drafter를 오분류할 수 없다.
+
+### 3.2 M3 수정: 임시 경로를 강화하는 대신 `tempfile::tempdir()`를 채택
+
+**선택 이유**: 이 PR은 이미 `mlxcel-core`의 새 테스트에서 `tempfile::tempdir()` 패턴을 확립해 두었다. 기존 `env::temp_dir()` 경로를 강화하는 방법(고유 접미사, 권한 검사, panic을 포함한 모든 종료 경로에서의 명시적 정리)은 이미 검증된 crate가 RAII 가드로 제공하는 것을 재구현하는 셈이고, 종료 경로 하나를 놓칠 위험도 더 크다.
+
+---
+
+## 4. 구현 상세
+
+### 4.1 Detection (`src/models/detection.rs`, `src/lib/mlxcel-core/src/drafter/dflash/config.rs`)
+
+`get_model_type`은 이제 `model_type` 기반 dispatch보다 먼저, 공유 함수 `dflash_drafter_not_standalone_error`를 통해 구조적으로 DFlash인 디렉터리를 거부한다. 이 한 곳의 호출 지점이 `-m` 케이스, 서버 startup, distributed stage 로더를 모두 커버한다.
+
+### 4.2 Offline CLI (`src/commands/generate.rs`)
+
+새 함수 `reject_dflash_drafter_offline`이 `run_generation_mode`에서 `load_model(draft_model_path)` 바로 직전에 호출된다. `--draft-kind` 없이 호출한 경우와 `--draft-kind dflash`로 명시한 경우 모두 발화하며, `--draft-kind mtp`는 별도의 요청으로 이미 `run_offline_mtp`가 처리한다.
+
+### 4.3 테스트 fixture 위생 수정 (`src/commands/generate_tests.rs`, 커밋 `37136aa6`)
+
+```rust
+// 변경 전
+fn drafter_fixture_dir(name: &str, config: &str) -> PathBuf {
+    let dir = std::env::temp_dir().join(format!(
+        "mlxcel_generate_drafter_{name}_{}",
+        std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_nanos()
+    ));
+    fs::create_dir_all(&dir).unwrap();
+    fs::write(dir.join("config.json"), config).unwrap();
+    dir
+}
+// 각 호출 지점이 성공 경로에서만 fs::remove_dir_all(dir).unwrap()을 수동 호출
+
+// 변경 후
+fn drafter_fixture_dir(config: &str) -> tempfile::TempDir {
+    let dir = tempfile::tempdir().expect("temp dir");
+    fs::write(dir.path().join("config.json"), config).unwrap();
+    dir
+}
+// 호출 지점은 dir.path()를 사용. TempDir이 모든 종료 경로에서 drop 시 디렉터리를 제거
+```
+
+`name` 매개변수는 제거했다. 이 값은 경로 세그먼트를 어느 정도 고유하게 만드는 용도로만 쓰였는데, `tempfile::tempdir()`가 구조적으로 이미 이를 보장한다. `offline_draft_model_check_defers_missing_or_broken_configs_to_the_loader`의 `empty` fixture에 있던 동일한 인라인 패턴도 같은 방식으로 고쳤다.
+
+---
+
+## 7. 변경 요약
+
+### 통계
+
+| 항목 | 값 |
+|-----|---|
+| 변경된 파일 수 (기능 커밋 `82096193`) | 9 |
+| 변경된 파일 수 (M3 수정 커밋 `37136aa6`) | 1 |
+| 추가/삭제 라인 (기능) | +645 / -5 |
+| 추가/삭제 라인 (M3 수정) | +19 / -34 |
+| 테스트 추가 | `commands::generate` 4건, `models::detection` 3건, `drafter::dflash::config` 3건(기존 커버리지 확장 포함), `speculative_dispatch` 2건 |
+
+### 카테고리별 변경
+
+| 카테고리 | 변경 수 | 주요 내용 |
+|---------|--------|----------|
+| Detection / 로딩 | 3 | `is_dflash_drafter_config`, `is_dflash_drafter_dir`, `get_model_type` 거부, 공유 오류 메시지 |
+| CLI | 1 | `run_generation_mode`의 `reject_dflash_drafter_offline` 사전 로드 가드 |
+| 문서 | 2 | `docs/supported-models.md`, `docs/speculative-acceptance.md`에 offline 제약 명시 |
+| 테스트 위생 (이번 finalization) | 1 | `drafter_fixture_dir`와 인라인 `empty` fixture를 `tempfile::tempdir()`로 전환 |
+
+### 관련 커밋
+
+| Hash | Type | Message |
+|------|------|---------|
+| `82096193` | fix | reject a DFlash drafter before the offline standalone load |
+| `37136aa6` | fix | back drafter test fixtures with `tempfile::tempdir()` |
+
+---
+
+## 8. 후속 조치
+
+### 완료 필요
+
+- [ ] 없음. 리뷰와 보안 검토에서 CRITICAL이나 HIGH 항목은 보고되지 않았고, MEDIUM 항목(M3) 하나는 이번 finalization에서 수정했다.
+
+### 향후 개선 사항 (알려진 제약으로 기록, 이번 PR에서는 수정하지 않음)
+
+- 이 사전 검사는 target 모델 로드가 끝난 뒤에야 발화한다. target이 큰 경우 오퍼레이터는 전체 로드가 끝날 때까지 기다려야 오류를 보게 된다. 검사를 더 이른 시점으로 옮기면 별도로 라우팅되는 `--draft-kind mtp`까지 가로챌 수 있어 그대로 두었다.
+- `--draft-model <dir>/config.json`처럼 디렉터리가 아니라 config 파일 자체를 직접 가리키면 이 사전 검사를 우회하고, 로딩 경로의 나머지 부분이 적용하는 `resolve_model_dir`를 이 검사가 적용하지 않기 때문에 `-m` 문구가 섞인 detection 오류로 떨어진다.
+- 이 프로브는 `config.json`을 원시 `serde_json::from_slice`로 파싱하는 반면 `get_model_type`은 먼저 `sanitize_config_json`을 적용한다. 순수 `NaN`이나 `Infinity` 리터럴을 담은 config는 이 사전 검사를 그냥 통과해버릴 수 있다. 현재 어떤 체크포인트도 영향을 받지 않으며, sanitizer는 루트 crate에 있고 프로브는 `mlxcel-core`에 있어 이 간극을 메우려면 crate 경계를 넘는 변경이 필요하므로 남겨두었다.
+- 실제 offline `DFlashGenerator` round loop 구현은 PR 요약에서 밝힌 대로 여전히 범위 밖이다. 오늘 이 기능이 필요한 오퍼레이터는 CLI 오류 메시지가 안내하는 대로 `mlxcel-server --draft-kind dflash`를 사용해야 한다.
+
+---
+
+## 부록
+
+### A. 테스트 결과
+
+- `cargo test --release --workspace --features metal,accelerate --no-fail-fast`: `-p mlxcel --lib`를 제외한 모든 타깃 통과. 이 타깃은 5621 passed / 3 failed를 보고했고 실패한 3건은 모두 `multimodal::video::tests::*`다. 이 PR과는 무관함이 확인됐다. `src/multimodal/video.rs`는 이 브랜치에서 단 한 줄도 건드리지 않았고, 같은 바이너리로 PATH를 제어한 실험에서 ffmpeg를 숨기면 34 passed / 0 failed, ffmpeg 9.0.1이 있으면 31 passed / 3 failed가 나온다. 근본 원인은 `src/multimodal/video.rs:1123`가 넘기는 `-vsync` 인자로, ffmpeg 9에서 제거됐다. 별도로 #1172로 등록됐다.
+- 새로 추가된 `commands::generate::tests::offline_draft_model_*` 사전 검사 테스트 4건은 `--lib`이 아니라 `--bin mlxcel`로 컴파일되므로 위 `--lib` 실행에는 포함되지 않았다. 별도로 `cargo test --release --bin mlxcel --features metal,accelerate commands::generate`를 실행해 82건 모두 통과했고 그중 4건이 이 테스트다.
+- `cargo test --release -p mlxcel-core --lib --features metal,accelerate drafter::dflash::config`: 16건 통과.
+- `cargo test --release --test speculative_dispatch --features metal,accelerate`: 22건 통과.
+- `cargo test --release --lib --features metal,accelerate models::detection`: 30건 통과.
+- `cargo clippy --release --workspace --features metal,accelerate --tests -- -D warnings`: 클린.
+- `cargo fmt --check`: 클린.
+- classic 경로 non-regression을 실물 체크포인트로 실행: `-m qwen3-0.6b-4bit --draft-model qwen3-0.6b-4bit`가 `SpeculativeGenerator`를 통해 24토큰을 생성했고, acceptance_rate 1.0000, 137.54 tok/s를 기록했다.
+- mutation 테스트: 새 detection 분기를 `if false && ...`로 막으면 `-m`과 `--draft-model` 거부 테스트가 두 마커 모두에서 수정 전 분류로 실패한다.
+
+### B. 참고 자료
+
+- 이슈 #1168 (사양)
+- 이슈 #1172 (선재하던, 이 PR과 무관한 ffmpeg 9 `-vsync` 회귀. 전체 workspace 테스트 실행 중 드러남)
+- `src/lib/mlxcel-core/src/drafter/dflash/config.rs` (구조적 프로브), `src/models/detection.rs` (`get_model_type` 거부), `src/commands/generate.rs` (`reject_dflash_drafter_offline`)
+- PR #1170의 리뷰·보안 코멘트

--- a/docs/speculative-acceptance.md
+++ b/docs/speculative-acceptance.md
@@ -274,6 +274,25 @@ Passing `--draft-kind` explicitly does **not** get you a DFlash round loop in
 `mlxcel generate`; it returns an error saying the offline path does not
 construct one.
 
+**A real DFlash drafter is rejected before the load.** The auto-detected
+`dflash` above is the `DEFAULT_DRAFTER_KIND` fallback applied to an ordinary
+small full model, which is exactly what the classic `SpeculativeGenerator`
+wants, so that pairing keeps working. An actual DFlash drafter checkpoint is a
+different object: it ships no `embed_tokens` and no `lm_head` because it borrows
+both from the target when it binds, so the classic path cannot load it as a
+`LoadedModel` at all. The CLI now refuses it up front, with or without
+`--draft-kind`, and names `mlxcel-server` as the path that does drive the DFlash
+round loop (#1168). Before that check existed, the drafter's ordinary
+`"model_type": "qwen3"` sent it to the Qwen 3 loader, which failed with
+`Weight not found: model.embed_tokens.weight`.
+
+The discriminator is structural (a `dflash_config` block and/or
+`architectures: ["DFlashDraftModel"]` in the drafter's `config.json`), not the
+resolved `DrafterKind`. Keying on the resolved kind would reject every ordinary
+classic drafter along with it, since they all auto-resolve to `dflash`. The same
+structural check runs inside `get_model_type`, so `mlxcel generate -m
+<dflash-dir>` is rejected as "not a standalone model" too.
+
 ## Regression guards
 
 In `src/lib/mlxcel-core/src/speculative/`:

--- a/docs/supported-models.md
+++ b/docs/supported-models.md
@@ -519,11 +519,17 @@ until each path has explicit mixed-cache and multimodal validation.
 
 | Drafter | Target families | Notes |
 |---------|-----------------|-------|
-| MTP | Gemma 4 target paths | Available through shared speculative decoding flags. |
-| DFlash | Qwen 3.5 text/VLM paths | Available through shared speculative decoding flags. |
+| MTP | Gemma 4 target paths | Available through shared speculative decoding flags, on `mlxcel-server` and on offline `mlxcel generate --draft-kind mtp`. |
+| DFlash | Qwen 3.5 text/VLM paths | `mlxcel-server` only. Available through shared speculative decoding flags there; offline `mlxcel generate` rejects a DFlash drafter with a named error because it does not construct the DFlash round loop. |
 
 Use auto-detection by default. Override only when you know the target and drafter
 checkpoint pair are compatible.
+
+A DFlash drafter checkpoint is not a standalone model: it ships no `embed_tokens`
+and no `lm_head`, borrowing both from the target when it binds. Passing one to
+`-m` is rejected with that explanation rather than with a weight-lookup failure.
+See [`speculative-acceptance.md`](speculative-acceptance.md) for what the offline
+path does and does not construct.
 
 Muse Glimmer is not a speculative or DFlash target in this baseline.
 

--- a/src/commands/generate.rs
+++ b/src/commands/generate.rs
@@ -1437,6 +1437,12 @@ pub(super) fn run_generation_mode(
             );
         }
 
+        // The classic `SpeculativeGenerator` below needs a full `LoadedModel`
+        // for the drafter, which a DFlash checkpoint is not. Reject it here,
+        // before the load prints a "Loading draft model" line it cannot honor
+        // (#1168).
+        reject_dflash_drafter_offline(draft_model_path)?;
+
         println!("Loading draft model from {:?}...", draft_model_path);
         let (draft_model, _draft_tokenizer) = select_backend().load_model(draft_model_path)?;
         println!("Draft model loaded.");
@@ -1581,6 +1587,52 @@ fn should_route_offline_mtp(
     resolved_kind: DrafterKind,
 ) -> bool {
     user_requested_explicit_kind && resolved_kind == DrafterKind::Mtp
+}
+
+/// Reject a DFlash speculative drafter before the offline path tries to load
+/// it as a full standalone model (#1168).
+///
+/// The offline `--draft-model` path has always called `load_model` on the
+/// drafter directory, because the classic `SpeculativeGenerator` it falls
+/// through to drives a full `LoadedModel`. A DFlash checkpoint is not one: it
+/// ships no `embed_tokens` and no `lm_head`, and its tensors carry no `model.`
+/// prefix. It nevertheless declares `"model_type": "qwen3"`, so it used to be
+/// classified as an ordinary Qwen 3 model and die on
+/// `Weight not found: model.embed_tokens.weight`, naming a tensor instead of
+/// the problem. The same pair works on `mlxcel-server`, which routes the
+/// drafter through `load_drafter` and drives the DFlash round loop.
+///
+/// The gate is [`mlxcel_core::drafter::dflash::is_dflash_drafter_dir`], a
+/// **structural** probe of the drafter's `config.json`, not the resolved
+/// [`DrafterKind`]. `DEFAULT_DRAFTER_KIND` is `Dflash`, so every drafter that
+/// is not a Gemma 4 assistant auto-resolves to `Dflash`, including an ordinary
+/// small full model used as a classic drafter. Rejecting on the resolved kind
+/// would break that legitimate, currently-working pairing; rejecting on the
+/// checkpoint's own DFlash markers does not.
+///
+/// Called after the explicit `--draft-kind mtp` gate, which is a different
+/// request with its own targeted errors, and before `load_model`. Everything
+/// that reaches `load_model` here (no `--draft-kind`, or an explicit
+/// `--draft-kind dflash`) passes through this check.
+fn reject_dflash_drafter_offline(draft_model_path: &Path) -> Result<()> {
+    if !mlxcel_core::drafter::dflash::is_dflash_drafter_dir(draft_model_path) {
+        return Ok(());
+    }
+
+    Err(anyhow!(
+        "--draft-model {path} is a DFlash speculative drafter, not a standalone \
+         model, and the offline `mlxcel generate` path does not construct the \
+         `DFlashGenerator` round loop. Loading it here would route it through the \
+         standalone model loader, which fails on the drafter's missing \
+         embed_tokens (a DFlash drafter borrows embed_tokens and lm_head from the \
+         target when it binds). The offline runtime wiring lands with the \
+         DFlashGenerator round loop and the per-target SpeculativeTarget impls. \
+         To use this drafter today, run `mlxcel-server` with the same -m target \
+         and `--draft-model {path} --draft-kind dflash`. For an offline \
+         speculative run, pass a small full model as --draft-model instead, which \
+         keeps the classic SpeculativeGenerator path.",
+        path = draft_model_path.display(),
+    ))
 }
 
 /// Drive a constructed [`mlxcel_core::speculative::mtp::target::MtpTarget`]

--- a/src/commands/generate_tests.rs
+++ b/src/commands/generate_tests.rs
@@ -96,16 +96,17 @@ fn should_route_offline_mtp_rejects_other_explicit_kinds() {
 // =============================================================================
 
 /// Write a drafter fixture directory carrying `config`, and return it.
-fn drafter_fixture_dir(name: &str, config: &str) -> PathBuf {
-    let dir = std::env::temp_dir().join(format!(
-        "mlxcel_generate_drafter_{name}_{}",
-        std::time::SystemTime::now()
-            .duration_since(std::time::UNIX_EPOCH)
-            .unwrap()
-            .as_nanos()
-    ));
-    fs::create_dir_all(&dir).unwrap();
-    fs::write(dir.join("config.json"), config).unwrap();
+///
+/// Backed by `tempfile::tempdir()` rather than a predictable path under
+/// `env::temp_dir()`: the latter is a symlink/pre-existing-directory hazard
+/// (CWE-377/379) on a shared `TMPDIR`, and only cleans up on the success path,
+/// leaking the fixture on an assertion failure. `TempDir` removes the
+/// directory on drop regardless of how the test exits, matching the pattern
+/// the `mlxcel-core` `drafter::dflash::config` tests added in this same PR
+/// already use.
+fn drafter_fixture_dir(config: &str) -> tempfile::TempDir {
+    let dir = tempfile::tempdir().expect("temp dir");
+    fs::write(dir.path().join("config.json"), config).unwrap();
     dir
 }
 
@@ -115,7 +116,6 @@ fn offline_draft_model_rejects_a_dflash_drafter_directory() {
     // only honest markers are the DFlashDraftModel architecture and the nested
     // `dflash_config` block.
     let dir = drafter_fixture_dir(
-        "dflash",
         r#"{
             "architectures": ["DFlashDraftModel"],
             "auto_map": {"AutoModel": "dflash.DFlashDraftModel"},
@@ -126,7 +126,7 @@ fn offline_draft_model_rejects_a_dflash_drafter_directory() {
         }"#,
     );
 
-    let error = reject_dflash_drafter_offline(&dir)
+    let error = reject_dflash_drafter_offline(dir.path())
         .expect_err("a DFlash drafter cannot be loaded as a standalone model")
         .to_string();
 
@@ -146,8 +146,6 @@ fn offline_draft_model_rejects_a_dflash_drafter_directory() {
         !error.contains("Weight not found"),
         "the weight-lookup symptom must not reach the user, got: {error}",
     );
-
-    fs::remove_dir_all(dir).unwrap();
 }
 
 #[test]
@@ -162,12 +160,11 @@ fn offline_draft_model_rejects_a_dflash_drafter_on_either_marker_alone() {
             r#"{"model_type": "qwen3", "dflash_config": {"mask_token_id": 248070}}"#,
         ),
     ] {
-        let dir = drafter_fixture_dir(name, config);
+        let dir = drafter_fixture_dir(config);
         assert!(
-            reject_dflash_drafter_offline(&dir).is_err(),
+            reject_dflash_drafter_offline(dir.path()).is_err(),
             "{name} must be rejected",
         );
-        fs::remove_dir_all(dir).unwrap();
     }
 }
 
@@ -178,7 +175,6 @@ fn offline_draft_model_still_accepts_an_ordinary_full_model_drafter() {
     // (`DEFAULT_DRAFTER_KIND`), so a rejection keyed on the resolved kind would
     // break it. Keyed on checkpoint structure, it passes through untouched.
     let dir = drafter_fixture_dir(
-        "ordinary",
         r#"{
             "architectures": ["Qwen3ForCausalLM"],
             "model_type": "qwen3",
@@ -188,11 +184,9 @@ fn offline_draft_model_still_accepts_an_ordinary_full_model_drafter() {
     );
 
     assert!(
-        reject_dflash_drafter_offline(&dir).is_ok(),
+        reject_dflash_drafter_offline(dir.path()).is_ok(),
         "an ordinary full model must keep loading as a classic drafter",
     );
-
-    fs::remove_dir_all(dir).unwrap();
 }
 
 #[test]
@@ -200,20 +194,11 @@ fn offline_draft_model_check_defers_missing_or_broken_configs_to_the_loader() {
     // The probe is a pre-load guard, not a config validator: a directory with
     // no `config.json` (or an unparseable one) must fall through to the real
     // loader, which reports the I/O or parse error with its own diagnostics.
-    let empty = std::env::temp_dir().join(format!(
-        "mlxcel_generate_drafter_empty_{}",
-        std::time::SystemTime::now()
-            .duration_since(std::time::UNIX_EPOCH)
-            .unwrap()
-            .as_nanos()
-    ));
-    fs::create_dir_all(&empty).unwrap();
-    assert!(reject_dflash_drafter_offline(&empty).is_ok());
-    fs::remove_dir_all(&empty).unwrap();
+    let empty = tempfile::tempdir().expect("temp dir");
+    assert!(reject_dflash_drafter_offline(empty.path()).is_ok());
 
-    let broken = drafter_fixture_dir("broken", "{ not json");
-    assert!(reject_dflash_drafter_offline(&broken).is_ok());
-    fs::remove_dir_all(broken).unwrap();
+    let broken = drafter_fixture_dir("{ not json");
+    assert!(reject_dflash_drafter_offline(broken.path()).is_ok());
 }
 
 // issue #166: the offline MTP loop must exclude the terminal EOS / stop token so

--- a/src/commands/generate_tests.rs
+++ b/src/commands/generate_tests.rs
@@ -18,8 +18,8 @@ use super::{
     CliSamplingFlagState, apply_user_chat_template, apply_vlm_chat_template,
     build_cli_sampling_config_with_flags, cli_pipeline_requested, estimate_delta_label_and_bytes,
     generated_suffix, generation_stats_from_duration, memory_preflight_ctx_len,
-    resolve_cli_pipeline_assignments, resolve_cli_prompt, should_route_offline_mtp,
-    strip_trailing_eos, validate_muse_glimmer_cli_unsupported_options,
+    reject_dflash_drafter_offline, resolve_cli_pipeline_assignments, resolve_cli_prompt,
+    should_route_offline_mtp, strip_trailing_eos, validate_muse_glimmer_cli_unsupported_options,
     validate_pipeline_parallel_args, validate_tensor_parallel_args,
     validate_xla_cli_image_cardinality, validate_xla_output_audio,
 };
@@ -89,6 +89,131 @@ fn should_route_offline_mtp_rejects_other_explicit_kinds() {
     assert!(!should_route_offline_mtp(true, DrafterKind::Dflash));
     assert!(!should_route_offline_mtp(true, DrafterKind::InternalMtp));
     assert!(!should_route_offline_mtp(false, DrafterKind::Dflash));
+}
+
+// =============================================================================
+// Offline `--draft-model <dflash-drafter>` rejection (#1168)
+// =============================================================================
+
+/// Write a drafter fixture directory carrying `config`, and return it.
+fn drafter_fixture_dir(name: &str, config: &str) -> PathBuf {
+    let dir = std::env::temp_dir().join(format!(
+        "mlxcel_generate_drafter_{name}_{}",
+        std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_nanos()
+    ));
+    fs::create_dir_all(&dir).unwrap();
+    fs::write(dir.join("config.json"), config).unwrap();
+    dir
+}
+
+#[test]
+fn offline_draft_model_rejects_a_dflash_drafter_directory() {
+    // The published drafter shape: `model_type` is an ordinary `qwen3`, and the
+    // only honest markers are the DFlashDraftModel architecture and the nested
+    // `dflash_config` block.
+    let dir = drafter_fixture_dir(
+        "dflash",
+        r#"{
+            "architectures": ["DFlashDraftModel"],
+            "auto_map": {"AutoModel": "dflash.DFlashDraftModel"},
+            "block_size": 16,
+            "dflash_config": {"mask_token_id": 248070, "target_layer_ids": [1, 16, 31, 46, 61]},
+            "model_type": "qwen3",
+            "num_hidden_layers": 5
+        }"#,
+    );
+
+    let error = reject_dflash_drafter_offline(&dir)
+        .expect_err("a DFlash drafter cannot be loaded as a standalone model")
+        .to_string();
+
+    assert!(
+        error.contains("DFlash speculative drafter"),
+        "the error must say what the directory is, got: {error}",
+    );
+    assert!(
+        error.contains("does not construct the `DFlashGenerator` round loop"),
+        "the error must say why the offline path refuses it, got: {error}",
+    );
+    assert!(
+        error.contains("mlxcel-server"),
+        "the error must point at the path that does run this drafter, got: {error}",
+    );
+    assert!(
+        !error.contains("Weight not found"),
+        "the weight-lookup symptom must not reach the user, got: {error}",
+    );
+
+    fs::remove_dir_all(dir).unwrap();
+}
+
+#[test]
+fn offline_draft_model_rejects_a_dflash_drafter_on_either_marker_alone() {
+    for (name, config) in [
+        (
+            "arch-only",
+            r#"{"architectures": ["DFlashDraftModel"], "model_type": "qwen3"}"#,
+        ),
+        (
+            "dflash-config-only",
+            r#"{"model_type": "qwen3", "dflash_config": {"mask_token_id": 248070}}"#,
+        ),
+    ] {
+        let dir = drafter_fixture_dir(name, config);
+        assert!(
+            reject_dflash_drafter_offline(&dir).is_err(),
+            "{name} must be rejected",
+        );
+        fs::remove_dir_all(dir).unwrap();
+    }
+}
+
+#[test]
+fn offline_draft_model_still_accepts_an_ordinary_full_model_drafter() {
+    // Non-regression guard for the classic `SpeculativeGenerator` workflow.
+    // An ordinary small full model auto-resolves to `DrafterKind::Dflash`
+    // (`DEFAULT_DRAFTER_KIND`), so a rejection keyed on the resolved kind would
+    // break it. Keyed on checkpoint structure, it passes through untouched.
+    let dir = drafter_fixture_dir(
+        "ordinary",
+        r#"{
+            "architectures": ["Qwen3ForCausalLM"],
+            "model_type": "qwen3",
+            "hidden_size": 1024,
+            "num_hidden_layers": 28
+        }"#,
+    );
+
+    assert!(
+        reject_dflash_drafter_offline(&dir).is_ok(),
+        "an ordinary full model must keep loading as a classic drafter",
+    );
+
+    fs::remove_dir_all(dir).unwrap();
+}
+
+#[test]
+fn offline_draft_model_check_defers_missing_or_broken_configs_to_the_loader() {
+    // The probe is a pre-load guard, not a config validator: a directory with
+    // no `config.json` (or an unparseable one) must fall through to the real
+    // loader, which reports the I/O or parse error with its own diagnostics.
+    let empty = std::env::temp_dir().join(format!(
+        "mlxcel_generate_drafter_empty_{}",
+        std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_nanos()
+    ));
+    fs::create_dir_all(&empty).unwrap();
+    assert!(reject_dflash_drafter_offline(&empty).is_ok());
+    fs::remove_dir_all(&empty).unwrap();
+
+    let broken = drafter_fixture_dir("broken", "{ not json");
+    assert!(reject_dflash_drafter_offline(&broken).is_ok());
+    fs::remove_dir_all(broken).unwrap();
 }
 
 // issue #166: the offline MTP loop must exclude the terminal EOS / stop token so

--- a/src/lib/mlxcel-core/src/drafter/dflash/config.rs
+++ b/src/lib/mlxcel-core/src/drafter/dflash/config.rs
@@ -37,6 +37,7 @@
 //! `mask_token_id` and `target_layer_ids`.
 
 use serde::{Deserialize, Serialize};
+use std::path::Path;
 
 /// Upstream DFlash default target-layer capture list.
 ///
@@ -242,6 +243,69 @@ impl DFlashConfig {
     }
 }
 
+/// Architecture name every published DFlash drafter declares in the
+/// `architectures` array of its `config.json`, and the class the checkpoint's
+/// `auto_map` points `AutoModel` at (`dflash.DFlashDraftModel`).
+pub const DFLASH_DRAFT_ARCHITECTURE: &str = "DFlashDraftModel";
+
+/// Whether a parsed `config.json` describes a DFlash speculative drafter
+/// rather than a standalone model.
+///
+/// The discriminator is deliberately **structural**. Two tempting
+/// alternatives are both wrong:
+///
+/// - **`model_type` is not a discriminator.** The published z-lab DFlash
+///   checkpoints declare `"model_type": "qwen3"`, byte-identical to what an
+///   ordinary Qwen 3 full model declares. That is precisely how a drafter
+///   directory reaches `Qwen3Model::load` and dies on `model.embed_tokens`.
+/// - **The resolved [`DrafterKind`](crate::drafter::DrafterKind) is worse.**
+///   [`DEFAULT_DRAFTER_KIND`](crate::drafter::DEFAULT_DRAFTER_KIND) is
+///   `Dflash` and `drafter_kind_by_model_type` maps only the two Gemma 4
+///   assistant types, so *every* drafter that is not a Gemma 4 assistant
+///   auto-resolves to `Dflash`, including an ordinary small full model used as
+///   a classic drafter. Keying on the resolved kind would reject that
+///   legitimate, currently-working pairing.
+///
+/// What a DFlash drafter really carries is a nested `dflash_config` object
+/// and/or `architectures: ["DFlashDraftModel"]`. Either marker alone is
+/// sufficient: `dflash_config` is what [`DFlashConfig::from_json`] itself
+/// keys on, and `architectures` is what HuggingFace `AutoModel` dispatch keys
+/// on. A checkpoint carrying neither is not a DFlash drafter.
+pub fn is_dflash_drafter_config(config: &serde_json::Value) -> bool {
+    if config
+        .get("dflash_config")
+        .is_some_and(serde_json::Value::is_object)
+    {
+        return true;
+    }
+
+    config
+        .get("architectures")
+        .and_then(serde_json::Value::as_array)
+        .is_some_and(|architectures| {
+            architectures
+                .iter()
+                .any(|arch| arch.as_str() == Some(DFLASH_DRAFT_ARCHITECTURE))
+        })
+}
+
+/// Whether `path` holds a DFlash speculative drafter checkpoint.
+///
+/// Reads `path/config.json` and applies [`is_dflash_drafter_config`].
+///
+/// Returns `false` when the config is missing or unparseable: this is a
+/// pre-load guard, and a config that cannot be read is the general loader's
+/// error to report with its own diagnostics, not this probe's to swallow.
+pub fn is_dflash_drafter_dir(path: &Path) -> bool {
+    let Ok(bytes) = std::fs::read(path.join("config.json")) else {
+        return false;
+    };
+    let Ok(config) = serde_json::from_slice::<serde_json::Value>(&bytes) else {
+        return false;
+    };
+    is_dflash_drafter_config(&config)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -388,6 +452,105 @@ mod tests {
             cfg.hidden_size,
             "default DFlashConfig is asymmetric: q out (4096) != hidden_size (2560). \
              A future patch that 'fixes' this is a regression."
+        );
+    }
+
+    // =========================================================================
+    // Structural DFlash-drafter probe (#1168)
+    // =========================================================================
+
+    /// The `config.json` of the published `qwen3.5-27b-dflash` drafter,
+    /// trimmed to the fields the probe and its negative controls care about.
+    fn published_dflash_config() -> serde_json::Value {
+        json!({
+            "architectures": ["DFlashDraftModel"],
+            "auto_map": {"AutoModel": "dflash.DFlashDraftModel"},
+            "block_size": 16,
+            "dflash_config": {
+                "mask_token_id": 248070,
+                "target_layer_ids": [1, 16, 31, 46, 61],
+            },
+            "hidden_size": 5120,
+            "model_type": "qwen3",
+            "num_hidden_layers": 5,
+            "num_target_layers": 64,
+            "vocab_size": 248320,
+        })
+    }
+
+    #[test]
+    fn probe_accepts_the_published_dflash_drafter_config() {
+        assert!(is_dflash_drafter_config(&published_dflash_config()));
+    }
+
+    #[test]
+    fn probe_accepts_either_marker_on_its_own() {
+        // `architectures` alone (a drafter export that inlines its DFlash
+        // fields at the top level instead of nesting them).
+        assert!(is_dflash_drafter_config(&json!({
+            "architectures": ["DFlashDraftModel"],
+            "model_type": "qwen3",
+            "mask_token_id": 248070,
+        })));
+
+        // `dflash_config` alone (an export that omits `architectures`, which
+        // `DFlashConfig::from_json` still loads because it keys on this block).
+        assert!(is_dflash_drafter_config(&json!({
+            "model_type": "qwen3",
+            "dflash_config": {"mask_token_id": 248070},
+        })));
+    }
+
+    #[test]
+    fn probe_rejects_an_ordinary_qwen3_full_model() {
+        // The regression this whole probe exists to avoid: an ordinary small
+        // full model used as a classic `--draft-model` drafter resolves to
+        // `DrafterKind::Dflash` by default, but it is NOT a DFlash drafter and
+        // must keep loading through the standalone model loader.
+        assert!(!is_dflash_drafter_config(&json!({
+            "architectures": ["Qwen3ForCausalLM"],
+            "model_type": "qwen3",
+            "hidden_size": 1024,
+            "num_hidden_layers": 28,
+        })));
+    }
+
+    #[test]
+    fn probe_rejects_non_object_and_non_array_marker_shapes() {
+        // A scalar `dflash_config` is not the nested block the loader reads,
+        // and a string `architectures` is not the HuggingFace array shape.
+        assert!(!is_dflash_drafter_config(&json!({"dflash_config": true})));
+        assert!(!is_dflash_drafter_config(&json!({"dflash_config": null})));
+        assert!(!is_dflash_drafter_config(&json!({
+            "architectures": "DFlashDraftModel",
+        })));
+        assert!(!is_dflash_drafter_config(&json!({})));
+    }
+
+    #[test]
+    fn probe_reads_config_json_from_a_directory() {
+        let dir = tempfile::tempdir().expect("temp dir");
+        std::fs::write(
+            dir.path().join("config.json"),
+            serde_json::to_string(&published_dflash_config()).unwrap(),
+        )
+        .expect("write config.json");
+        assert!(is_dflash_drafter_dir(dir.path()));
+    }
+
+    #[test]
+    fn probe_returns_false_for_missing_or_unparseable_config() {
+        let empty = tempfile::tempdir().expect("temp dir");
+        assert!(
+            !is_dflash_drafter_dir(empty.path()),
+            "a directory without config.json is not this probe's error to report",
+        );
+
+        let broken = tempfile::tempdir().expect("temp dir");
+        std::fs::write(broken.path().join("config.json"), "{ not json").expect("write");
+        assert!(
+            !is_dflash_drafter_dir(broken.path()),
+            "an unparseable config is the general loader's error to report",
         );
     }
 }

--- a/src/lib/mlxcel-core/src/drafter/dflash/mod.rs
+++ b/src/lib/mlxcel-core/src/drafter/dflash/mod.rs
@@ -72,7 +72,9 @@ pub mod round_loop_batched;
 
 pub use attention::DFlashAttention;
 pub use cache::DFlashKVCache;
-pub use config::DFlashConfig;
+pub use config::{
+    DFLASH_DRAFT_ARCHITECTURE, DFlashConfig, is_dflash_drafter_config, is_dflash_drafter_dir,
+};
 pub use drafter::DFlashDrafter;
 pub use layer::DFlashDecoderLayer;
 pub use mlp::DFlashMlp;

--- a/src/models/detection.rs
+++ b/src/models/detection.rs
@@ -19,11 +19,38 @@
 //! model implementations and exported types.
 
 use anyhow::Result;
+use mlxcel_core::drafter::dflash::is_dflash_drafter_config;
 use serde_json::Value;
 use std::path::Path;
 
 use super::ModelType;
 use super::sanitize::sanitize_config_json;
+
+/// Canonical error for "this directory is a DFlash speculative drafter, not a
+/// model you can load standalone" (#1168).
+///
+/// Every entry point that resolves a checkpoint directory goes through
+/// [`get_model_type`], so raising the rejection there gives the offline
+/// `mlxcel generate -m`, server startup, and the distributed stage loaders one
+/// shared message instead of each one surfacing a different weight-map symptom.
+///
+/// Before this arm existed, a DFlash drafter passed to `-m` (or reached by the
+/// offline `--draft-model` path, which loads the drafter as a full model) was
+/// classified `ModelType::Qwen3` from its `"model_type": "qwen3"`, routed to
+/// `Qwen3Model::load`, and died on its first weight lookup with
+/// `Weight not found: model.embed_tokens.weight`. That message names a tensor,
+/// not the problem.
+fn dflash_drafter_not_standalone_error(model_path: &Path) -> anyhow::Error {
+    anyhow::anyhow!(
+        "{path} is a DFlash speculative drafter checkpoint, not a standalone model. \
+         Its config.json declares the DFlashDraftModel architecture and/or a \
+         dflash_config block, and its weights carry no embed_tokens and no lm_head \
+         because a DFlash drafter borrows both from the target model when it binds. \
+         Pass a full model to -m, and pass this directory to --draft-model on \
+         `mlxcel-server` (with --draft-kind dflash) to use it as a drafter.",
+        path = model_path.display(),
+    )
+}
 
 pub(crate) fn has_vision_config(config: &serde_json::Value) -> bool {
     config.get("vision_config").is_some()
@@ -99,6 +126,18 @@ pub fn get_model_type(model_path: &Path) -> Result<ModelType> {
     let config_str = std::fs::read_to_string(config_path)?;
     let config_str = sanitize_config_json(&config_str);
     let v: serde_json::Value = serde_json::from_str(&config_str)?;
+
+    // A DFlash speculative drafter is structurally not a standalone model, but
+    // it declares an ordinary `"model_type": "qwen3"`, so it would otherwise
+    // fall through to the Qwen 3 arm below (#1168). Reject it before any
+    // `model_type` dispatch runs. The discriminator is structural (a
+    // `dflash_config` block and/or the `DFlashDraftModel` architecture) rather
+    // than the resolved `DrafterKind`, because `DEFAULT_DRAFTER_KIND` is
+    // `Dflash`: keying on the resolved kind would also reject an ordinary small
+    // full model used as a classic drafter, which loads and runs fine.
+    if is_dflash_drafter_config(&v) {
+        return Err(dflash_drafter_not_standalone_error(model_path));
+    }
 
     // Kokoro TTS checkpoints carry no top-level `model_type`, so detect them by
     // architecture signal (the `istftnet` config block or the canonical weight

--- a/src/models/detection_tests.rs
+++ b/src/models/detection_tests.rs
@@ -759,3 +759,104 @@ fn llava_next_without_granite_stays_llava() {
 
     fs::remove_dir_all(model_dir).unwrap();
 }
+
+// =============================================================================
+// DFlash speculative drafter rejection (#1168)
+// =============================================================================
+
+/// `config.json` of the published `qwen3.5-27b-dflash` drafter, trimmed to the
+/// fields detection reads. The point of the fixture is that `model_type` says
+/// `qwen3`: without the structural DFlash arm this routes to `ModelType::Qwen3`
+/// and then to `Qwen3Model::load`, which dies on
+/// `Weight not found: model.embed_tokens.weight`.
+const DFLASH_DRAFTER_CONFIG: &str = r#"{
+    "architectures": ["DFlashDraftModel"],
+    "auto_map": {"AutoModel": "dflash.DFlashDraftModel"},
+    "block_size": 16,
+    "dflash_config": {"mask_token_id": 248070, "target_layer_ids": [1, 16, 31, 46, 61]},
+    "hidden_size": 5120,
+    "model_type": "qwen3",
+    "num_hidden_layers": 5,
+    "num_target_layers": 64,
+    "vocab_size": 248320
+}"#;
+
+#[test]
+fn dflash_drafter_is_rejected_as_a_standalone_model() {
+    let model_dir = temp_path("dflash_drafter");
+    fs::create_dir_all(&model_dir).unwrap();
+    fs::write(model_dir.join("config.json"), DFLASH_DRAFTER_CONFIG).unwrap();
+
+    let error = super::detection::get_model_type(&model_dir)
+        .expect_err("a DFlash drafter is not a standalone model")
+        .to_string();
+
+    assert!(
+        error.contains("DFlash speculative drafter"),
+        "the error must name the real problem, got: {error}",
+    );
+    assert!(
+        error.contains("--draft-model"),
+        "the error must point at the flag that does take a drafter, got: {error}",
+    );
+    assert!(
+        !error.contains("Weight not found"),
+        "the weight-lookup symptom must not be what a user sees, got: {error}",
+    );
+
+    fs::remove_dir_all(model_dir).unwrap();
+}
+
+#[test]
+fn dflash_drafter_is_rejected_on_either_marker_alone() {
+    for (name, config) in [
+        (
+            "architectures_only",
+            r#"{"architectures": ["DFlashDraftModel"], "model_type": "qwen3"}"#,
+        ),
+        (
+            "dflash_config_only",
+            r#"{"model_type": "qwen3", "dflash_config": {"mask_token_id": 248070}}"#,
+        ),
+    ] {
+        let model_dir = temp_path(name);
+        fs::create_dir_all(&model_dir).unwrap();
+        fs::write(model_dir.join("config.json"), config).unwrap();
+
+        let error = super::detection::get_model_type(&model_dir)
+            .expect_err("marker alone is sufficient")
+            .to_string();
+        assert!(
+            error.contains("DFlash speculative drafter"),
+            "{name}: {error}"
+        );
+
+        fs::remove_dir_all(model_dir).unwrap();
+    }
+}
+
+#[test]
+fn ordinary_qwen3_full_model_still_detects_as_qwen3() {
+    // Non-regression control for the classic `--draft-model` path: a small
+    // Qwen 3 full model used as a classic drafter carries neither DFlash
+    // marker and must keep loading exactly as before. It resolves to
+    // `DrafterKind::Dflash` by default, which is why the rejection above keys
+    // on checkpoint structure and not on the resolved drafter kind.
+    let model_dir = temp_path("ordinary_qwen3_drafter");
+    fs::create_dir_all(&model_dir).unwrap();
+    fs::write(
+        model_dir.join("config.json"),
+        r#"{
+            "architectures": ["Qwen3ForCausalLM"],
+            "model_type": "qwen3",
+            "hidden_size": 1024,
+            "num_hidden_layers": 28
+        }"#,
+    )
+    .unwrap();
+
+    let detected = super::detection::get_model_type(&model_dir).unwrap();
+    assert_eq!(detected, ModelType::Qwen3);
+
+    fs::remove_dir_all(model_dir).unwrap();
+}

--- a/tests/speculative_dispatch.rs
+++ b/tests/speculative_dispatch.rs
@@ -63,6 +63,49 @@ fn make_drafter_dir(model_type: Option<&str>) -> (TempDir, PathBuf) {
     (dir, path)
 }
 
+/// Structurally-DFlash drafter fixture: the shape of the published
+/// `qwen3.5-27b-dflash` `config.json`, trimmed to what detection and the
+/// structural probe read. Note that `model_type` is an ordinary `"qwen3"`;
+/// the DFlash markers are `architectures` and the nested `dflash_config`.
+fn make_dflash_drafter_dir() -> (TempDir, PathBuf) {
+    let dir = tempfile::tempdir().expect("create temp dir");
+    std::fs::write(
+        dir.path().join("config.json"),
+        r#"{
+            "architectures": ["DFlashDraftModel"],
+            "auto_map": {"AutoModel": "dflash.DFlashDraftModel"},
+            "block_size": 16,
+            "dflash_config": {"mask_token_id": 248070, "target_layer_ids": [1, 16, 31, 46, 61]},
+            "hidden_size": 5120,
+            "model_type": "qwen3",
+            "num_hidden_layers": 5,
+            "num_target_layers": 64,
+            "vocab_size": 248320
+        }"#,
+    )
+    .expect("write config.json");
+    let path = dir.path().to_path_buf();
+    (dir, path)
+}
+
+/// Ordinary small full model used as a classic `--draft-model` drafter. It
+/// carries no DFlash marker, and it must stay loadable as a standalone model.
+fn make_ordinary_full_model_dir() -> (TempDir, PathBuf) {
+    let dir = tempfile::tempdir().expect("create temp dir");
+    std::fs::write(
+        dir.path().join("config.json"),
+        r#"{
+            "architectures": ["Qwen3ForCausalLM"],
+            "model_type": "qwen3",
+            "hidden_size": 1024,
+            "num_hidden_layers": 28
+        }"#,
+    )
+    .expect("write config.json");
+    let path = dir.path().to_path_buf();
+    (dir, path)
+}
+
 fn base_server_config() -> ServerConfig {
     ServerConfig::default()
 }
@@ -387,4 +430,94 @@ fn dispatch_classic_fallback_is_not_burstable() {
     let cfg = base_server_config();
     let dispatch = SpeculativeDispatch::resolve(&cfg).expect("resolve");
     assert!(!dispatch.is_kind_specific());
+}
+
+// =============================================================================
+// DFlash drafter is not a standalone model (#1168)
+//
+// `mlxcel generate --draft-model <dflash-dir>` used to load the drafter as a
+// full standalone model and die on `Weight not found:
+// model.embed_tokens.weight`, and `mlxcel generate -m <dflash-dir>` died the
+// same way, because the published drafter declares `"model_type": "qwen3"`.
+// These tests pin the two halves of the fix: the structural discriminator the
+// CLI precheck keys on, and the detection-level rejection every `-m` entry
+// point shares. They also pin that the server dispatch, which never routes a
+// drafter through `get_model_type`, is unaffected.
+// =============================================================================
+
+#[test]
+fn dflash_drafter_directory_is_structurally_identifiable() {
+    let (_dir, dflash) = make_dflash_drafter_dir();
+    assert!(
+        mlxcel_core::drafter::dflash::is_dflash_drafter_dir(&dflash),
+        "the published drafter shape must be recognized",
+    );
+}
+
+#[test]
+fn ordinary_full_model_is_not_mistaken_for_a_dflash_drafter() {
+    // The regression this discriminator exists to avoid. `DEFAULT_DRAFTER_KIND`
+    // is `Dflash`, so this directory resolves to `DrafterKind::Dflash` even
+    // though it is an ordinary full model: a check keyed on the resolved kind
+    // would reject a working classic-drafter pairing.
+    let (_dir, ordinary) = make_ordinary_full_model_dir();
+    assert_eq!(
+        mlxcel_core::drafter::resolve_drafter_kind(&ordinary, None).expect("resolve"),
+        DrafterKind::Dflash,
+        "an ordinary full model auto-resolves to Dflash; that is why the \
+         discriminator must be structural",
+    );
+    assert!(
+        !mlxcel_core::drafter::dflash::is_dflash_drafter_dir(&ordinary),
+        "an ordinary full model is not a DFlash drafter",
+    );
+}
+
+#[test]
+fn dflash_drafter_passed_to_dash_m_is_rejected_as_not_a_standalone_model() {
+    let (_dir, dflash) = make_dflash_drafter_dir();
+
+    let error = mlxcel::models::get_model_type(&dflash)
+        .expect_err("a DFlash drafter is not a standalone model")
+        .to_string();
+
+    assert!(
+        error.contains("DFlash speculative drafter"),
+        "the error must name the real problem, got: {error}",
+    );
+    assert!(
+        !error.contains("Weight not found"),
+        "the weight-lookup symptom must not be what a user sees, got: {error}",
+    );
+}
+
+#[test]
+fn ordinary_full_model_still_detects_as_a_standalone_model() {
+    let (_dir, ordinary) = make_ordinary_full_model_dir();
+    assert_eq!(
+        mlxcel::models::get_model_type(&ordinary).expect("ordinary full model still detects"),
+        mlxcel::models::ModelType::Qwen3,
+    );
+}
+
+#[test]
+fn server_dispatch_still_accepts_a_real_dflash_drafter_directory() {
+    // Non-regression guard for the path that works: the server resolves the
+    // drafter through `resolve_drafter_kind` / `load_drafter` and never calls
+    // `get_model_type` on it, so the detection-level rejection above must not
+    // change server dispatch for the same directory.
+    let (_dir, dflash) = make_dflash_drafter_dir();
+    let mut cfg = base_server_config();
+    cfg.draft_model_path = Some(dflash.clone());
+    cfg.draft_kind = Some("dflash".to_string());
+
+    let dispatch = SpeculativeDispatch::resolve(&cfg).expect("resolve");
+    assert!(dispatch.is_kind_specific());
+    assert_eq!(dispatch.drafter_kind(), Some(DrafterKind::Dflash));
+    assert_eq!(dispatch.draft_model_path(), Some(dflash.as_path()));
+
+    // Auto-detect (no `--draft-kind`) must reach the same DFlash dispatch.
+    cfg.draft_kind = None;
+    let auto = SpeculativeDispatch::resolve(&cfg).expect("resolve");
+    assert_eq!(auto.drafter_kind(), Some(DrafterKind::Dflash));
 }


### PR DESCRIPTION
## Summary

`mlxcel generate --draft-model <dflash-drafter>` failed with `Error: Weight not found: model.embed_tokens.weight`, with and without `--draft-kind`, for every DFlash drafter and every target. The offline path calls `load_model` on the drafter directory because the classic `SpeculativeGenerator` it falls through to drives a full `LoadedModel`, and a DFlash checkpoint is not one: it ships no `embed_tokens` and no `lm_head` because it borrows both from the target when it binds, and its tensors carry no `model.` prefix. Its `config.json` nevertheless declares an ordinary `"model_type": "qwen3"`, so `get_model_type` classified it `ModelType::Qwen3`, `model_metadata` routed it to `Qwen3Model::load`, and the first `UnifiedEmbedding::from_weights` lookup failed with a message naming a tensor rather than the problem. This PR makes both offline entry points fail where it makes sense, with a message that names the real problem, and corrects the docs that overstated CLI support.

This deliberately does not build an offline DFlash round loop. That remains out of scope and is still described by the existing `--draft-kind` message in `generate.rs` and by `docs/speculative-acceptance.md`.

## The discriminator is structural, not the resolved drafter kind

`DEFAULT_DRAFTER_KIND` is `DrafterKind::Dflash` and `drafter_kind_by_model_type()` maps only `gemma4_assistant` and `gemma4_unified_assistant`, so **every** drafter that is not a Gemma 4 assistant auto-resolves to `Dflash`, including an ordinary small full model (a Qwen3 0.6B, say) used as a classic drafter. That pairing loads and runs fine today on the classic `SpeculativeGenerator` path, so rejecting on the resolved kind would have broken a working workflow. The new probe keys on the checkpoint's own DFlash markers instead: a nested `dflash_config` object (what `DFlashConfig::from_json` itself reads) and/or `architectures: ["DFlashDraftModel"]` (what HuggingFace `AutoModel` dispatch reads). Every test added here carries an ordinary-full-model control asserting the classic path still resolves.

## The server path is unaffected

`DFlashDrafter::load` reads `config.json` into `DFlashConfig::from_json` directly and `resolve_drafter_kind` peeks `model_type` through its own reader, so neither reaches `get_model_type`. Re-confirmed on this branch that every `get_model_type` call site in the tree takes a target or model path and never a drafter path (`src/loading/mod.rs`, `src/distributed/pipeline/stage_executor/mod.rs`, `src/distributed/tensor_parallel/inference.rs`, `src/server/chat_template.rs`, `src/server/startup.rs`, `src/server/model_provider.rs`, `src/server/batch/xla_worker.rs`, `src/multimodal/host_preprocessor.rs`, and the three target-path uses in `src/commands/generate.rs`). The drafter reaches `load_drafter` through `SpeculativeDispatch` and `DrafterSlot::ensure_loaded`, neither of which touches detection. `src/bin/speculative_bench.rs` likewise passes only the target to `load_model`. A new test in `tests/speculative_dispatch.rs` pins that `SpeculativeDispatch::resolve` still returns the DFlash variant for the same fixture directory that detection now rejects, with and without an explicit `--draft-kind`.

For the record, the working reference this issue measured on `main` @ `6e781fcf` (Qwen 3.5 27B 4-bit target, which loads as `ModelType::Qwen35VLM`, plus the 27B DFlash drafter, 120-token completion): rounds 24, proposed_tokens 347, accepted_tokens 95, acceptance_rate 0.274, emitted_per_verify 4.96. That also backs the "VLM paths" claim the supported-models table makes for DFlash, which is why this PR keeps it.

## What changed

- `src/lib/mlxcel-core/src/drafter/dflash/config.rs`: new `DFLASH_DRAFT_ARCHITECTURE` constant, `is_dflash_drafter_config(&Value)`, and `is_dflash_drafter_dir(&Path)`, placed next to the parser that consumes `dflash_config` so the structural definition lives with the loader that keys on it. The doc comment records why `model_type` and the resolved `DrafterKind` are both wrong discriminators. An unreadable or missing `config.json` returns `false` so the general loader keeps reporting its own I/O and parse diagnostics.
- `src/lib/mlxcel-core/src/drafter/dflash/mod.rs`: re-exports the three new items.
- `src/models/detection.rs`: `get_model_type` rejects a structurally-DFlash directory before any `model_type` dispatch, via a shared `dflash_drafter_not_standalone_error`. This is the single source of truth for the `-m` case and covers server startup and the distributed stage loaders at the same time.
- `src/commands/generate.rs`: new `reject_dflash_drafter_offline`, called in `run_generation_mode` immediately before `load_model(draft_model_path)`. The error says the directory is a DFlash drafter, that the offline path does not construct the `DFlashGenerator` round loop, and that `mlxcel-server` with `--draft-kind dflash` does. It fires with no `--draft-kind` and with `--draft-kind dflash`; an explicit `--draft-kind mtp` is a different request that keeps its own targeted errors from `run_offline_mtp`.
- `docs/supported-models.md`: the DFlash row now reads `mlxcel-server` only and explains that offline `mlxcel generate` rejects a DFlash drafter with a named error, so it no longer contradicts `docs/speculative-acceptance.md` by omission. The MTP row gained the matching detail that it does work offline under `--draft-kind mtp`. A following paragraph explains why a DFlash checkpoint is not a standalone model.
- `docs/speculative-acceptance.md`: the "note on the drafter-kind line" section now distinguishes the auto-detected `dflash` fallback applied to an ordinary full model (which still runs the classic path) from a real DFlash drafter (which is now refused up front), and records the structural discriminator.
- `src/commands/generate_tests.rs` (finalization pass, security finding M3): `drafter_fixture_dir` and the identical inline `empty`-fixture pattern built a predictable path under `env::temp_dir()` with `create_dir_all` and cleaned up only on the success path (CWE-377/379 class, CI-relevant on shared-`TMPDIR` Linux runners). Both now use `tempfile::tempdir()`, matching the pattern the `mlxcel-core` tests added in this PR already use.
- `CHANGELOG.md`, `TECHNICAL_REPORTS/1170-dflash-drafter-cli-load-20260816.en.md` (finalization pass): the `## [Unreleased]` entry and technical report this repository's convention expects for every merged PR.

## Test plan

New coverage, all on synthetic fixtures. No test previously invoked `mlxcel generate --draft-model` at any level, which is why a path that could never work for any DFlash drafter stayed green. All of the below has now actually been executed (by the orchestrator and by review), not just written.

- [x] `cargo test --release --workspace --features metal,accelerate --no-fail-fast`: every target passes except `-p mlxcel --lib`, which reports 5621 passed / 3 failed. All 3 failures are `multimodal::video::tests::*` and are unrelated to this PR: this branch touches 0 lines of `src/multimodal/video.rs`, and a PATH-controlled experiment on the same binary gives 34 passed / 0 failed with ffmpeg hidden from `PATH` versus 31 passed / 3 failed with ffmpeg 9.0.1 present. Root cause is `src/multimodal/video.rs:1123` passing `-vsync`, an argument ffmpeg 9 removed. Filed as #1172.
- [x] Gotcha for the next person: the four new `commands::generate::tests::*` precheck tests compile into `--bin mlxcel`, not `--lib`, so they were **not** part of the `--lib` run above. They were run separately with `cargo test --release --bin mlxcel --features metal,accelerate commands::generate`: 4 passed.
- [x] `cargo clippy -- -D warnings` clean on both crates (`mlxcel`, `mlxcel-core`).
- [x] `cargo fmt --check` clean.
- [x] Classic-path non-regression, executed rather than reasoned about: `-m qwen3-0.6b-4bit --draft-model qwen3-0.6b-4bit` still runs `SpeculativeGenerator` end to end, 24 tokens, acceptance_rate 1.0000, 137.54 tok/s.
- [x] Mutation test confirming the new detection tests are real assertions, not tautologies: guarding the new arm as `if false && ...` makes `models::detection` and `commands::generate` fail with the pre-fix classification, on both markers.

Not verified here: an end-to-end run of `mlxcel generate --draft-model models/qwen3.5-27b-dflash` against a real 27B target. The change is a pre-load guard, so the reproduction is a one-line error rather than a load, but that confirmation has not been re-run on this branch.

## Known limitations

Reported and deliberately not fixed in this PR:

- The precheck fires only after the target model finishes loading, so an operator with a large target waits through the full load before seeing the error. Moving the check earlier would also intercept `--draft-kind mtp`, which is deliberately routed elsewhere and must keep its own targeted errors from `run_offline_mtp`.
- `--draft-model <dir>/config.json` (pointing directly at the config file rather than the directory) bypasses the precheck and falls through to the detection error with `-m` phrasing, because the precheck does not apply `resolve_model_dir` the way the rest of the loading path does.
- The probe uses raw `serde_json::from_slice` on `config.json`, while `get_model_type` applies `sanitize_config_json` first. A config containing bare `NaN`/`Infinity` literals (invalid JSON, but occasionally emitted by some tooling) would therefore fail the precheck open. No current checkpoint is affected, and the sanitizer lives in the root crate while the probe lives in `mlxcel-core`, so closing this gap is a cross-crate change left for later.

Closes #1168
