### PR TITLE
fix(test): skip partial Muse Glimmer checkpoints instead of panicking

### DIFF
--- a/TECHNICAL_REPORTS/1173-pinned-checkpoint-skip-guard-20260816.en.md
+++ b/TECHNICAL_REPORTS/1173-pinned-checkpoint-skip-guard-20260816.en.md
@@ -1,0 +1,203 @@
+# Technical Report: PR #1173 - fix(test): skip partial Muse Glimmer checkpoints instead of panicking
+
+**Date**: 2026-08-16
+**Author**: AI Code Reviewer
+**Status**: Completed
+**Languages**: Rust
+**Risk Level**: Low
+
+---
+
+## Executive Summary
+
+`pinned_post_tower_weight_roots_and_shapes_match_published_contract` skipped gracefully only when the pinned checkpoint's index file was absent. With the index present but anything else missing or corrupt, an interrupted `hf download` or `mlxcel download`, it panicked on an opaque `unwrap` instead of skipping with a reason. This PR adds an availability pre-check that skips with a message naming the offending file, while keeping every genuine contract violation a hard failure.
+
+The governing constraint was that turning a wrong checkpoint into a silent skip would be strictly worse than the panic being fixed, because it would permanently disable the contract this test exists to enforce. The implementation separates the two categories structurally rather than by convention: `load_pinned_checkpoint` may only veto on availability, and `assert_post_tower_contract` holds the assertions with no skip path except for an unreadable shard header.
+
+Two defects were found in review and fixed before merge, both of them cases where the first implementation put something on the wrong side of that line or left a hazard behind it.
+
+---
+
+## 1. Problem Statement
+
+### 1.1 Background
+
+Issue #1161 came from the security review LOW findings on PR #1157 (implementation of #1155). That PR added the index-absent guard and deliberately left the partial-checkpoint case out of scope. The sibling loading test `pinned_weight_index_classifies_each_source_weight_once` does not share the gap, because it reads only the index file itself.
+
+### 1.2 Existing Issues
+
+- **Issue 1**: past the index-existence guard, the test unwrapped every read: `config.json`, the index contents, `index["weight_map"].as_object()`, and every referenced shard through `safetensors_shape`, which itself unwrapped `File::open`, two `read_exact` calls, and the header parse.
+- **Issue 2** (found in review): the availability pre-check deserialized `config.json` straight into `MuseGlimmerConfig`, so a config that was valid JSON but did not fit the schema was reported as unavailable and skipped. Schema drift in the pinned config, or a different model dropped into the pinned directory, is precisely the divergence this contract test exists to catch, so it belongs on the failing side.
+- **Issue 3** (found in the security pass): the new header-length guard was file-relative only. `header_len > file_len.saturating_sub(8)` permits a declared header as large as the whole file, and the pinned shards are 50 GB and 9.6 GB, so a corrupt eight-byte prefix passed the check and reached `vec![0u8; header_len as usize]`. The outcome is either a `handle_alloc_error` abort, which is uncatchable and prints no reason, or gigabytes of tensor payload pulled into host memory, on the one machine that owns the checkpoint. An abort is strictly worse than the opaque unwrap this PR removes.
+
+### 1.3 Risk Assessment
+
+| Risk | Impact | Likelihood |
+|------|--------|------------|
+| Opaque panic on a partially materialized checkpoint, misread as a code defect | Low | Medium (any interrupted download) |
+| A wrong checkpoint silently skipping, disabling the contract check permanently | Medium | Low (closed by the boundary design and by issue 2's fix) |
+| Uncatchable allocation abort from a corrupt header on the checkpoint-owning machine | Medium | Low (closed by the absolute ceiling) |
+
+---
+
+## 2. Technical Review
+
+### 2.1 Security
+
+The security pass filed one MEDIUM (issue 3 above) and fixed it by mirroring the guard the production reader already uses: `read_safetensors_header_bytes` (`src/lib/mlxcel-core/src/weights.rs:196`) caps the identical eight-byte prefix at `MAX_HEADER_BYTES = 256 * 1024 * 1024` with the rationale "reject absurdly large headers to avoid OOM". This test reader was the only header reader in the tree without such a cap. The mirrored constant is checked before the file-relative bound, and `safetensors_shape_refuses_a_header_over_the_allocation_ceiling` declares `u64::MAX` in a tiny temp file so the test itself allocates nothing large. The real pinned shard records an 11,720-byte header against a 9.6 GB file, roughly four orders of magnitude of margin, so no genuine checkpoint can be rejected.
+
+Everything else was verified clean. The boundary holds on every traced path: an absent or non-object `weight_map` becomes an empty map that fails the weight-root assertion; a pinned key missing from a well-formed map is skipped past in the loop and reported by that same assertion; a key mapped to a non-string hits the "must name a shard" panic; a header that parses without a shaped entry for the key panics rather than returning `Err`. The env-var read holds the crate-wide env lock in a scoped block and drops it before the `assert!`, so a failing assertion cannot poison it, and nothing reachable from that function re-acquires the non-reentrant mutex. Only file headers are read, never tensor payloads, and every `TempDir` is bound to a live local so the `should_panic` tests still clean up on unwind.
+
+**Issues Found:**
+| Issue | Severity | Status |
+|-------|----------|--------|
+| Schema-mismatched `config.json` skipped instead of failing | Medium | Fixed (`3336732c`) |
+| Header allocation bounded only by file size, so a corrupt length in a 50 GB shard could abort the process | Medium | Fixed (`3c61dd21`) |
+| `contract_assertion_still_fails_on_a_wrong_recorded_shape` expected a bare key name that three different panics emit | Low | Fixed (`3336732c`) |
+| `pinned_precheck_leaves_an_absent_weight_map_...` had no `should_panic` companion, unlike its missing-weight-root sibling | Low | Fixed (`3336732c`) |
+
+### 2.2 Performance
+
+No production path is touched. The pinned check reads only file headers, so it stays fast despite the 60 GB checkpoint: the full module runs in about 0.01 s.
+
+### 2.3 Compatibility & Dependencies
+
+- **Breaking Changes**: none
+- **New Dependencies**: none; `tempfile` was already a dev-dependency (`Cargo.toml:308`)
+- **Compatibility**: no production loading path is affected
+
+### 2.4 Code Quality
+
+- **Test Coverage**: 5 tests became 23 in the module, adding synthetic coverage for every skip branch plus executable proof that contract violations still fail
+- **Code Complexity**: the pinned check is now three named functions with one responsibility each instead of one unwrap-laden body
+- **Technical Debt**: decreased
+
+---
+
+## 3. Technical Decisions
+
+### 3.1 Hybrid pre-check rather than either option the issue offered
+
+**Alternatives Considered:**
+
+| Option | Pros | Cons |
+|--------|------|------|
+| Option 1: existence pre-check only | Simple | Cannot see a shard that exists but whose header was truncated mid-download |
+| Option 2: convert every unwrap into skip-with-reason | Covers corruption | Reads the index twice, which the issue explicitly ruled out |
+| **Chosen: hybrid** | Single index parse shared with the assertions, and corruption coverage | Slightly more structure |
+
+**Rationale:** `load_pinned_checkpoint` parses the index once and hands the parsed `weight_map` to the assertion body, and `safetensors_shape` returns `Result` so header corruption is covered too.
+
+### 3.2 Separate availability from contract structurally, not by convention
+
+**Rationale:** The assertions live in `assert_post_tower_contract`, which takes an already-validated `PinnedCheckpoint`. Reaching it means every file it needs was confirmed readable, so anything failing there is the checkpoint disagreeing with the contract. The one skip inside it, an unreadable shard header, is scoped to availability by construction: the only `Err` producers in `safetensors_shape` are open failure, metadata failure, truncation, an over-ceiling or over-file declared length, and a non-JSON header. A header that parses but records no shape, or a non-integer dimension, panics.
+
+### 3.3 Defer `MuseGlimmerConfig` deserialization into the assertion body
+
+**Rationale:** This is the fix for issue 2. The pre-check now parses `config.json` as plain JSON only, so a truncated config, which is a syntax error and a real availability problem, still skips, while a config that parses and does not fit the schema reaches `serde_json::from_value::<MuseGlimmerConfig>` in the assertion body and panics. `PinnedCheckpoint` carries the raw `Value` to make the split explicit. The fix has teeth rather than passing vacuously: `MuseGlimmerConfig.text_config` and its inner fields carry no serde defaults (`src/models/muse_glimmer_config.rs:26`), so a mismatched config genuinely fails to deserialize.
+
+### 3.4 Implement the optional env gate
+
+**Rationale:** `MLXCEL_REQUIRE_PINNED_CHECKPOINTS=1` turns every skip into a failure, so a corrupted checkpoint cannot quietly disable the contract check forever on the machine positioned to enforce it. It is read under the crate-wide env lock, matching the convention `muse_glimmer_startup_guard_tests` established, because this crate is edition 2024 and a sibling test mutates the environment with `unsafe set_var` under that same lock. It also turned out to be the cleanest way to prove the happy path: see the appendix.
+
+### 3.5 Split into a separate file
+
+**Rationale:** the pinned check plus its synthetic coverage is a distinct concern from the fusion math tests, and the `#[cfg(test)] #[path = "..."] mod` sibling pattern is already used throughout `src/vision/`. Note that the PR and commit bodies justify the split with a "500-line limit"; the repo's own code-structure guidance actually puts the threshold at 800 lines, so that stated reason is wrong even though the split itself is sound.
+
+---
+
+## 4. Implementation Details
+
+### 4.1 Key Code Changes
+
+**File: `src/vision/encoders/muse_glimmer_fusion_pinned_tests.rs`** (new)
+```rust
+// The availability veto, which may never see a contract violation.
+fn load_pinned_checkpoint(model_dir: &Path) -> Result<PinnedCheckpoint, String> {
+    let index_text = read_checkpoint_file(&index_path)?;
+    let index: Value = serde_json::from_str(&index_text)
+        .map_err(|err| format!("{} does not parse as JSON: {err}", index_path.display()))?;
+    // ... config parsed as plain JSON only ...
+    // A missing or non-object `weight_map` is a malformed index rather than a
+    // missing file: hand the caller an empty map so the weight-root assertion
+    // reports it as the contract violation it is.
+    let weight_map = index["weight_map"].as_object().cloned().unwrap_or_default();
+    // ... each referenced shard checked for presence, naming any that is missing ...
+}
+```
+
+```rust
+// Bound the declared header before allocating.
+if header_len > MAX_SAFETENSORS_HEADER_BYTES { /* Err */ }
+if header_len > file_len.saturating_sub(8) { /* Err */ }
+let mut header = vec![0u8; header_len as usize];
+```
+
+**Reason for change:** the original `safetensors_shape` did `vec![0u8; header_len]` straight from an unvalidated eight-byte little-endian read.
+
+---
+
+## 7. Change Summary
+
+### Statistics
+| Item | Value |
+|------|-------|
+| Files changed | 3 |
+| Lines added | +609 |
+| Lines deleted | -79 |
+| Tests added | 18 (module went from 5 to 23) |
+
+### Changes by Category
+
+| Category | Count | Summary |
+|----------|-------|---------|
+| Test Robustness | 1 | Partial checkpoints skip with a named reason instead of panicking |
+| Test Correctness | 4 | Contract violations proven still failing; two `should_panic` tests tightened |
+| Security | 1 | Absolute ceiling on the declared safetensors header before allocation |
+| Tooling | 1 | `MLXCEL_REQUIRE_PINNED_CHECKPOINTS=1` turns skips into failures |
+
+### Related Commits
+| Hash | Type | Message |
+|------|------|---------|
+| `5274e7e5` | fix(test) | skip partial Muse Glimmer checkpoints instead of panicking |
+| `3336732c` | test | fail rather than skip on a schema-mismatched pinned config |
+| `3c61dd21` | fix(test) | cap the safetensors header this reader will allocate |
+
+---
+
+## 8. Follow-up Actions
+
+### Required
+- [ ] None; all four acceptance criteria are met, including the optional one
+
+### Future Improvements
+- `pinned_weight_index_classifies_each_source_weight_once` (`src/loading/vlm_muse_glimmer_tests.rs:473`) does not honor `MLXCEL_REQUIRE_PINNED_CHECKPOINTS`, so only one of the two pinned guards is hardened on the checkpoint-owning machine. Worth filing separately; explicitly out of scope for #1161.
+- The mid-loop skip on an unreadable shard returns early over a `BTreeMap`, so an unreadable `fc1` shard hides a wrong shape on `fc2` or `vision_projection`. Inherent to skip semantics and bounded by the env gate. Asserting readable keys first and skipping at the end would be strictly better.
+- Two `should_panic` tests still expect a bare key name that the "must name a shard" panic also emits. Both alternatives are failures rather than skips, so the invariant holds; tightening would mean depending on more of `assert_eq!`'s output formatting.
+
+---
+
+## Appendix
+
+### A. Test Results
+
+| Command | Result |
+|---------|--------|
+| `cargo test --lib vision::encoders::muse_glimmer_fusion` | 23 passed, 0 failed |
+| `MLXCEL_REQUIRE_PINNED_CHECKPOINTS=1 cargo test --lib vision::encoders::muse_glimmer_fusion` | 23 passed, 0 failed |
+| `cargo clippy --lib --tests -- -D warnings` | clean |
+| `cargo fmt --check` | clean |
+
+### B. How the acceptance criteria were proven
+
+The pinned checkpoint is fully materialized on the machine used here (`models` is a gitignored symlink to `/home/inureyes/models`; `config.json`, the index, and both shards at 50 GB and 9.6 GB are all present), which made every criterion directly testable.
+
+- **Criterion 2, full checkpoint still validates the contract.** The env gate is the proof. Running with `MLXCEL_REQUIRE_PINNED_CHECKPOINTS=1` converts any skip into a failure, so the pinned test passing under that gate means it actually read the genuine checkpoint and asserted the weight-root and shape contract rather than skipping.
+- **Criterion 3, index absent behaves as before.** The test binary was run from a directory containing no `models/`, and skipped with `models/mlx/muse-glimmer-30b/model.safetensors.index.json is not present`.
+- **Optional criterion 4.** The same run with the gate set failed instead of skipping.
+- **Criterion 1, partial checkpoint skips with a named reason.** Covered by the synthetic tests, which build throwaway checkpoints in `tempfile::tempdir()`. Nothing under `models/` was moved, renamed, deleted, truncated, or written at any point; both shards were verified intact with their original timestamps afterwards.
+
+### C. References
+- Issue #1161 (specification), PR #1157 (added the index-absent guard, and whose review filed this issue), #1116
+- `src/vision/encoders/muse_glimmer_fusion_pinned_tests.rs` (the new module), `src/lib/mlxcel-core/src/weights.rs:196` (the production header cap this mirrors), `src/models/muse_glimmer_config.rs:26` (why the schema check has teeth)
+- PR #1173 review and security comments

--- a/TECHNICAL_REPORTS/1173-pinned-checkpoint-skip-guard-20260816.ko.md
+++ b/TECHNICAL_REPORTS/1173-pinned-checkpoint-skip-guard-20260816.ko.md
@@ -1,0 +1,202 @@
+# 기술 보고서: PR #1173 - fix(test): skip partial Muse Glimmer checkpoints instead of panicking
+
+**작성일**: 2026-08-16
+**작성자**: AI Code Reviewer
+**상태**: 완료
+**언어**: Rust
+**위험도**: Low
+
+---
+
+## 요약
+
+`pinned_post_tower_weight_roots_and_shapes_match_published_contract`는 고정 체크포인트의 인덱스 파일이 없을 때만 온전히 건너뛰었다. 인덱스는 있는데 나머지가 없거나 깨진 경우, 즉 `hf download`나 `mlxcel download`가 중단된 상태에서는 이유를 알려주며 건너뛰는 대신 불투명한 `unwrap`으로 패닉했다. 이 PR은 문제가 된 파일 이름을 담아 건너뛰는 가용성 사전 검사를 추가하되, 진짜 계약 위반은 전부 실패로 남긴다.
+
+핵심 제약은 이것이었다. 잘못된 체크포인트를 조용한 skip으로 바꾸면 고치려던 패닉보다 엄격히 더 나쁘다. 이 테스트가 강제하려는 계약을 영구히 무력화하기 때문이다. 그래서 구현은 두 범주를 관례가 아니라 구조로 분리한다. `load_pinned_checkpoint`는 가용성 문제로만 거부할 수 있고, `assert_post_tower_contract`는 읽을 수 없는 shard 헤더를 제외하면 skip 경로가 없는 어서션 본문이다.
+
+리뷰에서 결함 두 건을 찾아 머지 전에 고쳤다. 둘 다 최초 구현이 무언가를 그 경계의 잘못된 쪽에 두었거나 뒤에 위험을 남긴 경우였다.
+
+---
+
+## 1. 문제 정의
+
+### 1.1 배경
+
+이슈 #1161은 PR #1157(#1155 구현)의 보안 리뷰 LOW 지적에서 나왔다. 그 PR은 인덱스 부재 가드를 추가하면서 부분 체크포인트 경우는 의도적으로 범위 밖에 뒀다. 형제 로딩 테스트 `pinned_weight_index_classifies_each_source_weight_once`는 인덱스 파일 자체만 읽으므로 같은 빈틈이 없다.
+
+### 1.2 기존 문제점
+
+- **문제 1**: 인덱스 존재 가드를 지나면 테스트는 모든 읽기를 unwrap했다. `config.json`, 인덱스 내용, `index["weight_map"].as_object()`, 그리고 `safetensors_shape`를 통한 모든 참조 shard. 그 헬퍼 자체도 `File::open`, `read_exact` 두 번, 헤더 파싱을 unwrap했다.
+- **문제 2** (리뷰에서 발견): 가용성 사전 검사가 `config.json`을 곧바로 `MuseGlimmerConfig`로 역직렬화했다. 그래서 JSON으로는 유효하지만 스키마에 맞지 않는 config가 "사용 불가"로 보고되어 skip됐다. 고정 config의 스키마 드리프트나 고정 디렉터리에 다른 모델이 들어온 상황이야말로 이 계약 테스트가 잡아야 할 괴리이므로, 실패하는 쪽에 있어야 한다.
+- **문제 3** (보안 검토에서 발견): 새 헤더 길이 가드가 파일 크기 기준뿐이었다. `header_len > file_len.saturating_sub(8)`은 파일 전체 크기만 한 헤더 선언도 허용하는데 고정 shard는 50 GB와 9.6 GB다. 따라서 손상된 8바이트 접두부가 검사를 통과해 `vec![0u8; header_len as usize]`에 도달할 수 있다. 결과는 이유도 출력하지 않고 잡을 수도 없는 `handle_alloc_error` abort이거나, 체크포인트를 보유한 바로 그 장비에서 수 기가바이트의 텐서 페이로드를 호스트 메모리로 끌어오는 것이다. abort는 이 PR이 없애려는 불투명한 unwrap보다 엄격히 더 나쁘다.
+
+### 1.3 위험성
+
+| 위험 | 영향 | 발생 가능성 |
+|------|------|------------|
+| 부분 체크포인트에서 불투명한 패닉이 나고 코드 결함으로 오독됨 | Low | Medium (중단된 다운로드마다) |
+| 잘못된 체크포인트가 조용히 skip되어 계약 검사가 영구 무력화 | Medium | Low (경계 설계와 문제 2 수정으로 차단) |
+| 손상된 헤더가 체크포인트 보유 장비에서 잡을 수 없는 할당 abort 유발 | Medium | Low (절대 상한으로 차단) |
+
+---
+
+## 2. 기술적 검토 사항
+
+### 2.1 보안 관점
+
+보안 검토는 MEDIUM 1건(위 문제 3)을 제기하고, 프로덕션 리더가 이미 쓰는 가드를 그대로 옮겨 고쳤다. `read_safetensors_header_bytes`(`src/lib/mlxcel-core/src/weights.rs:196`)는 동일한 8바이트 접두부를 `MAX_HEADER_BYTES = 256 * 1024 * 1024`로 제한하며 "reject absurdly large headers to avoid OOM"이라는 근거를 단다. 이 테스트 리더가 트리에서 그런 상한이 없는 유일한 헤더 리더였다. 옮겨온 상수는 파일 기준 경계보다 먼저 검사하고, `safetensors_shape_refuses_a_header_over_the_allocation_ceiling`은 작은 임시 파일에 `u64::MAX`를 선언하므로 테스트 자체는 큰 할당을 하지 않는다. 실제 고정 shard는 9.6 GB 파일에 11,720바이트 헤더를 기록하므로 약 네 자릿수의 여유가 있어 정상 체크포인트가 거부될 일은 없다.
+
+나머지는 모두 깨끗함을 확인했다. 추적한 모든 경로에서 경계가 유지된다. `weight_map`이 없거나 객체가 아니면 빈 맵이 되어 weight-root 어서션이 실패하고, 정상 파싱된 맵에서 고정 키가 빠지면 루프에서 건너뛴 뒤 같은 어서션이 보고하며, 키가 문자열이 아닌 값에 매핑되면 "must name a shard" 패닉에 걸리고, 헤더가 파싱되지만 해당 키의 shape 항목이 없으면 `Err`가 아니라 패닉한다. 환경변수 읽기는 크레이트 전역 env 락을 블록 스코프로 잡고 `assert!` 전에 해제하므로 실패하는 어서션이 락을 오염시킬 수 없고, 그 함수에서 도달 가능한 어떤 코드도 비재진입 뮤텍스를 다시 잡지 않는다. 파일 헤더만 읽고 텐서 페이로드는 절대 읽지 않으며, 모든 `TempDir`이 살아 있는 지역 변수에 묶여 있어 `should_panic` 테스트도 되감기 시 정리된다.
+
+**발견된 이슈:**
+| 이슈 | 심각도 | 상태 |
+|------|--------|------|
+| 스키마 불일치 `config.json`이 실패가 아니라 skip | Medium | 수정 (`3336732c`) |
+| 헤더 할당이 파일 크기로만 제한되어 50 GB shard의 손상된 길이가 프로세스를 abort시킬 수 있음 | Medium | 수정 (`3c61dd21`) |
+| `contract_assertion_still_fails_on_a_wrong_recorded_shape`가 세 가지 패닉이 모두 내는 맨 키 이름을 기대 | Low | 수정 (`3336732c`) |
+| `pinned_precheck_leaves_an_absent_weight_map_...`에 형제 케이스와 달리 `should_panic` 짝이 없었음 | Low | 수정 (`3336732c`) |
+
+### 2.2 성능 관점
+
+프로덕션 경로를 건드리지 않는다. 고정 검사는 파일 헤더만 읽으므로 60 GB 체크포인트에도 빠르다. 모듈 전체가 약 0.01초에 끝난다.
+
+### 2.3 호환성/의존성 관점
+
+- **호환성 파괴**: 없음
+- **신규 의존성**: 없음. `tempfile`은 이미 dev-dependency였다(`Cargo.toml:308`)
+- **호환성**: 프로덕션 로딩 경로에 영향 없음
+
+### 2.4 코드 품질 관점
+
+- **테스트 커버리지**: 모듈 기준 5개에서 23개로. 모든 skip 분기에 대한 합성 커버리지와 계약 위반이 여전히 실패한다는 실행 가능한 증명이 추가됐다
+- **코드 복잡도**: unwrap으로 채워진 본문 하나 대신 책임이 하나씩인 명명된 함수 셋
+- **기술 부채**: 감소
+
+---
+
+## 3. 기술적 선택과 그 이유
+
+### 3.1 이슈가 제시한 두 선택지 대신 하이브리드
+
+**고려한 대안:**
+
+| 선택지 | 장점 | 단점 |
+|--------|------|------|
+| 선택지 1: 존재 여부 사전 검사만 | 단순 | 존재하지만 다운로드 중 헤더가 잘린 shard를 못 봄 |
+| 선택지 2: 모든 unwrap을 skip-with-reason으로 | 손상까지 커버 | 인덱스를 두 번 읽게 되어 이슈가 명시적으로 배제한 방식 |
+| **채택: 하이브리드** | 인덱스 1회 파싱을 어서션과 공유하면서 손상까지 커버 | 구조가 조금 늘어남 |
+
+**선택 이유:** `load_pinned_checkpoint`가 인덱스를 한 번 파싱해 `weight_map`을 어서션 본문에 넘기고, `safetensors_shape`는 `Result`를 반환해 헤더 손상도 덮는다.
+
+### 3.2 가용성과 계약을 관례가 아니라 구조로 분리
+
+**선택 이유:** 어서션은 이미 검증된 `PinnedCheckpoint`를 받는 `assert_post_tower_contract`에 있다. 이 함수에 도달했다는 것은 필요한 모든 파일이 읽을 수 있음이 확인됐다는 뜻이므로, 여기서 실패하는 것은 체크포인트가 계약과 어긋난다는 의미다. 그 안의 유일한 skip인 "읽을 수 없는 shard 헤더"는 구성상 가용성에 한정된다. `safetensors_shape`가 `Err`를 내는 경우는 열기 실패, 메타데이터 실패, 잘림, 상한이나 파일 크기를 넘는 선언 길이, JSON이 아닌 헤더뿐이다. 헤더가 파싱되지만 shape가 없거나 차원이 정수가 아니면 패닉한다.
+
+### 3.3 `MuseGlimmerConfig` 역직렬화를 어서션 본문으로 미룸
+
+**선택 이유:** 문제 2의 수정이다. 사전 검사는 이제 `config.json`을 순수 JSON으로만 파싱하므로, 중단된 다운로드가 남기는 잘린 config는 문법 오류이자 실제 가용성 문제로 여전히 skip된다. 반면 파싱은 되지만 스키마에 맞지 않는 config는 어서션 본문의 `serde_json::from_value::<MuseGlimmerConfig>`에 도달해 패닉한다. 분리를 명시하려고 `PinnedCheckpoint`가 원본 `Value`를 들고 다닌다. 이 수정은 헛돌지 않는다. `MuseGlimmerConfig.text_config`와 그 내부 필드에는 serde 기본값이 없어서(`src/models/muse_glimmer_config.rs:26`) 불일치 config는 실제로 역직렬화에 실패한다.
+
+### 3.4 선택 항목이던 환경변수 게이트를 구현
+
+**선택 이유:** `MLXCEL_REQUIRE_PINNED_CHECKPOINTS=1`은 모든 skip을 실패로 바꾸므로, 손상된 체크포인트가 이를 강제할 수 있는 유일한 장비에서 계약 검사를 영구히 무력화하는 일을 막는다. 크레이트 전역 env 락 아래에서 읽어 `muse_glimmer_startup_guard_tests`가 세운 관례를 따른다. 이 크레이트는 edition 2024이고 형제 테스트가 같은 락 아래 `unsafe set_var`로 환경을 바꾸기 때문이다. 결과적으로 정상 경로를 증명하는 가장 깔끔한 수단이 되기도 했다. 부록 참고.
+
+### 3.5 별도 파일로 분리
+
+**선택 이유:** 고정 검사와 그 합성 커버리지는 fusion 수치 테스트와 별개 관심사이고, `#[cfg(test)] #[path = "..."] mod` 형제 패턴은 이미 `src/vision/` 전반에서 쓰인다. 다만 PR과 커밋 본문은 분리 근거로 "500줄 제한"을 들었는데, 저장소 자체 코드 구조 지침의 기준은 800줄이므로 그 근거 서술은 틀렸다. 분리 자체는 타당하다.
+
+---
+
+## 4. 구현 상세
+
+### 4.1 주요 코드 변경
+
+**파일: `src/vision/encoders/muse_glimmer_fusion_pinned_tests.rs`** (신규)
+```rust
+// 계약 위반을 절대 보아서는 안 되는 가용성 거부 지점.
+fn load_pinned_checkpoint(model_dir: &Path) -> Result<PinnedCheckpoint, String> {
+    let index_text = read_checkpoint_file(&index_path)?;
+    let index: Value = serde_json::from_str(&index_text)
+        .map_err(|err| format!("{} does not parse as JSON: {err}", index_path.display()))?;
+    // ... config는 순수 JSON으로만 파싱 ...
+    // `weight_map`이 없거나 객체가 아니면 파일 누락이 아니라 잘못된 인덱스다.
+    // 빈 맵을 넘겨 weight-root 어서션이 계약 위반으로 보고하게 한다.
+    let weight_map = index["weight_map"].as_object().cloned().unwrap_or_default();
+    // ... 참조된 각 shard의 존재를 확인하고, 없으면 그 이름을 담아 반환 ...
+}
+```
+
+```rust
+// 할당 전에 선언된 헤더 길이를 제한한다.
+if header_len > MAX_SAFETENSORS_HEADER_BYTES { /* Err */ }
+if header_len > file_len.saturating_sub(8) { /* Err */ }
+let mut header = vec![0u8; header_len as usize];
+```
+
+**변경 이유:** 기존 `safetensors_shape`는 검증되지 않은 8바이트 리틀엔디언 읽기 결과로 곧장 `vec![0u8; header_len]`을 했다.
+
+---
+
+## 7. 변경 요약
+
+### 통계
+| 항목 | 값 |
+|------|-----|
+| 변경 파일 | 3 |
+| 추가 줄 | +609 |
+| 삭제 줄 | -79 |
+| 추가 테스트 | 18 (모듈 기준 5 → 23) |
+
+### 카테고리별 변경
+
+| 카테고리 | 개수 | 요약 |
+|----------|------|------|
+| 테스트 견고성 | 1 | 부분 체크포인트가 패닉 대신 이유를 담아 skip |
+| 테스트 정확성 | 4 | 계약 위반이 여전히 실패함을 증명, `should_panic` 2건 조임 |
+| 보안 | 1 | 할당 전 safetensors 헤더 절대 상한 |
+| 도구 | 1 | `MLXCEL_REQUIRE_PINNED_CHECKPOINTS=1`이 skip을 실패로 전환 |
+
+### 관련 커밋
+| 해시 | 유형 | 메시지 |
+|------|------|--------|
+| `5274e7e5` | fix(test) | skip partial Muse Glimmer checkpoints instead of panicking |
+| `3336732c` | test | fail rather than skip on a schema-mismatched pinned config |
+| `3c61dd21` | fix(test) | cap the safetensors header this reader will allocate |
+
+---
+
+## 8. 후속 조치
+
+### 완료 필요
+- [ ] 없음. 선택 항목을 포함한 수용 기준 네 가지 모두 충족
+
+### 향후 개선 사항
+- `pinned_weight_index_classifies_each_source_weight_once`(`src/loading/vlm_muse_glimmer_tests.rs:473`)는 `MLXCEL_REQUIRE_PINNED_CHECKPOINTS`를 따르지 않으므로, 체크포인트 보유 장비에서 두 고정 가드 중 하나만 강화된 상태다. 별도 이슈로 발행할 만하며 #1161 범위 밖이다.
+- 읽을 수 없는 shard에서 루프 중간에 조기 반환하므로, `fc1` shard를 읽지 못하면 `fc2`나 `vision_projection`의 잘못된 shape가 가려진다. skip 의미상 내재적이고 환경변수 게이트로 한정된다. 읽기 가능 여부를 먼저 확인하고 마지막에 skip하면 더 낫다.
+- `should_panic` 테스트 두 건은 여전히 "must name a shard" 패닉도 내는 맨 키 이름을 기대한다. 두 대안 모두 skip이 아니라 실패이므로 불변식은 유지된다. 더 조이려면 `assert_eq!` 출력 형식에 더 의존해야 한다.
+
+---
+
+## 부록
+
+### A. 테스트 결과
+
+| 명령 | 결과 |
+|------|------|
+| `cargo test --lib vision::encoders::muse_glimmer_fusion` | 23 passed, 0 failed |
+| `MLXCEL_REQUIRE_PINNED_CHECKPOINTS=1 cargo test --lib vision::encoders::muse_glimmer_fusion` | 23 passed, 0 failed |
+| `cargo clippy --lib --tests -- -D warnings` | clean |
+| `cargo fmt --check` | clean |
+
+### B. 수용 기준을 증명한 방법
+
+여기서 쓴 장비에는 고정 체크포인트가 완전히 준비돼 있어(`models`는 `/home/inureyes/models`를 가리키는 gitignore된 심볼릭 링크이고 `config.json`, 인덱스, 50 GB와 9.6 GB 두 shard가 모두 있음) 모든 기준을 직접 시험할 수 있었다.
+
+- **기준 2, 완전한 체크포인트에서 계약이 그대로 검증됨.** 환경변수 게이트가 증거다. `MLXCEL_REQUIRE_PINNED_CHECKPOINTS=1`로 실행하면 모든 skip이 실패로 바뀌므로, 그 상태에서 고정 테스트가 통과했다는 것은 실제 체크포인트를 읽어 weight-root와 shape 계약을 단언했다는 뜻이지 건너뛴 것이 아니다.
+- **기준 3, 인덱스 부재 시 기존 동작 유지.** `models/`가 없는 디렉터리에서 테스트 바이너리를 실행해 `models/mlx/muse-glimmer-30b/model.safetensors.index.json is not present`로 skip함을 확인했다.
+- **선택 기준 4.** 같은 실행에 게이트를 켜니 skip 대신 실패했다.
+- **기준 1, 부분 체크포인트가 이유를 담아 skip.** 합성 테스트가 덮는다. `tempfile::tempdir()`에 일회용 체크포인트를 만든다. 작업 전 구간에서 `models/` 아래 무엇도 옮기거나 이름을 바꾸거나 지우거나 자르거나 쓰지 않았고, 이후 두 shard가 원래 타임스탬프 그대로 온전함을 확인했다.
+
+### C. 참고 자료
+- 이슈 #1161(명세), PR #1157(인덱스 부재 가드를 추가했고 그 리뷰가 이 이슈를 발행), #1116
+- `src/vision/encoders/muse_glimmer_fusion_pinned_tests.rs`(신규 모듈), `src/lib/mlxcel-core/src/weights.rs:196`(옮겨온 프로덕션 헤더 상한), `src/models/muse_glimmer_config.rs:26`(스키마 검사가 헛돌지 않는 이유)
+- PR #1173의 리뷰 및 보안 코멘트

--- a/src/vision/encoders/muse_glimmer_fusion.rs
+++ b/src/vision/encoders/muse_glimmer_fusion.rs
@@ -264,3 +264,9 @@ fn check_linear_shape(linear: &UnifiedLinear, expected: &[i32], label: &str) -> 
 #[cfg(test)]
 #[path = "muse_glimmer_fusion_tests.rs"]
 mod tests;
+
+// Contract check against the pinned Muse Glimmer checkpoint, kept in its own
+// module because it reads files off disk rather than exercising fusion math.
+#[cfg(test)]
+#[path = "muse_glimmer_fusion_pinned_tests.rs"]
+mod pinned_tests;

--- a/src/vision/encoders/muse_glimmer_fusion_pinned_tests.rs
+++ b/src/vision/encoders/muse_glimmer_fusion_pinned_tests.rs
@@ -47,7 +47,11 @@ const PINNED_POST_TOWER_WEIGHT_KEYS: [&str; 3] = [
 /// `model.safetensors.index.json` rather than opening it twice.
 #[derive(Debug)]
 struct PinnedCheckpoint {
-    config: MuseGlimmerConfig,
+    /// Raw `config.json` body, deliberately left as `Value` rather than a
+    /// parsed `MuseGlimmerConfig`. A config that is valid JSON but does not
+    /// deserialize into this model's schema is a drifted or wrong checkpoint,
+    /// which the contract assertions must fail on rather than skip.
+    config: Value,
     weight_map: serde_json::Map<String, Value>,
 }
 
@@ -60,7 +64,8 @@ struct PinnedCheckpoint {
 /// skips with a reason instead of panicking on an opaque `unwrap`.
 ///
 /// Contract violations are deliberately NOT detected here. An absent
-/// `weight_map`, an omitted pinned weight root, a config `validate()` rejects,
+/// `weight_map`, an omitted pinned weight root, a config that is valid JSON but
+/// does not deserialize into `MuseGlimmerConfig`, a config `validate()` rejects,
 /// and a wrong recorded shape all flow through to the caller's assertions so
 /// they still fail the test. Availability is the only thing this may veto.
 fn load_pinned_checkpoint(model_dir: &Path) -> Result<PinnedCheckpoint, String> {
@@ -71,12 +76,14 @@ fn load_pinned_checkpoint(model_dir: &Path) -> Result<PinnedCheckpoint, String> 
 
     let config_path = model_dir.join("config.json");
     let config_text = read_checkpoint_file(&config_path)?;
-    let config: MuseGlimmerConfig = serde_json::from_str(&config_text).map_err(|err| {
-        format!(
-            "{} does not parse as a Muse Glimmer config: {err}",
-            config_path.display()
-        )
-    })?;
+    // Only JSON syntax is checked here. Deserializing into `MuseGlimmerConfig`
+    // is deferred to the assertions on purpose: an interrupted download leaves
+    // a truncated config, which is a syntax error and a genuine availability
+    // problem, but a config that parses and still does not fit the schema means
+    // the pinned directory holds the wrong or a drifted model, which is exactly
+    // the divergence this contract test exists to catch.
+    let config: Value = serde_json::from_str(&config_text)
+        .map_err(|err| format!("{} does not parse as JSON: {err}", config_path.display()))?;
 
     // A missing or non-object `weight_map` is a malformed index rather than a
     // missing file: hand the caller an empty map so the weight-root assertion
@@ -152,6 +159,11 @@ fn pinned_post_tower_weight_roots_and_shapes_match_published_contract() {
 fn assert_post_tower_contract(model_dir: &Path, checkpoint: PinnedCheckpoint) {
     let PinnedCheckpoint { config, weight_map } = checkpoint;
 
+    // Schema drift in the pinned config, or a different model dropped into the
+    // pinned directory, surfaces here as a failure rather than as a skip.
+    let config: MuseGlimmerConfig = serde_json::from_value(config).unwrap_or_else(|err| {
+        panic!("config.json does not deserialize into a Muse Glimmer config: {err}")
+    });
     config.validate().unwrap();
     let mut actual_keys = weight_map
         .keys()
@@ -382,6 +394,8 @@ fn pinned_precheck_names_an_unparseable_index() {
 
 #[test]
 fn pinned_precheck_names_an_unparseable_config() {
+    // Truncated mid-object, which is what an interrupted download leaves. A
+    // syntax error is an availability problem, so it skips.
     let dir = tempfile::tempdir().unwrap();
     write_synthetic_index(dir.path(), &PINNED_POST_TOWER_WEIGHT_KEYS, SYNTHETIC_SHARD);
     std::fs::write(dir.path().join("config.json"), "{\"text_config\": {").unwrap();
@@ -389,10 +403,42 @@ fn pinned_precheck_names_an_unparseable_config() {
     let err = load_pinned_checkpoint(dir.path()).unwrap_err();
 
     assert!(err.contains("config.json"), "{err}");
-    assert!(
-        err.contains("does not parse as a Muse Glimmer config"),
-        "{err}"
-    );
+    assert!(err.contains("does not parse as JSON"), "{err}");
+}
+
+#[test]
+fn pinned_precheck_leaves_a_schema_mismatched_config_to_the_contract_assertion() {
+    // Valid JSON that is not a Muse Glimmer config. This is a wrong or drifted
+    // checkpoint rather than a missing one, so the pre-check must pass it
+    // through instead of vetoing it as an availability problem.
+    let dir = tempfile::tempdir().unwrap();
+    write_synthetic_index(dir.path(), &PINNED_POST_TOWER_WEIGHT_KEYS, SYNTHETIC_SHARD);
+    write_synthetic_shard(dir.path(), &PINNED_POST_TOWER_WEIGHT_KEYS, &[6, 4]);
+    std::fs::write(
+        dir.path().join("config.json"),
+        "{\"model_type\": \"something_else\"}",
+    )
+    .unwrap();
+
+    load_pinned_checkpoint(dir.path()).expect("schema mismatch must not be treated as unavailable");
+}
+
+#[test]
+#[should_panic(expected = "does not deserialize into a Muse Glimmer config")]
+fn contract_assertion_still_fails_on_a_schema_mismatched_config() {
+    // The companion to the pre-check test above: once passed through, the
+    // assertion body must fail on it, never skip.
+    let dir = tempfile::tempdir().unwrap();
+    write_synthetic_index(dir.path(), &PINNED_POST_TOWER_WEIGHT_KEYS, SYNTHETIC_SHARD);
+    write_synthetic_shard(dir.path(), &PINNED_POST_TOWER_WEIGHT_KEYS, &[6, 4]);
+    std::fs::write(
+        dir.path().join("config.json"),
+        "{\"model_type\": \"something_else\"}",
+    )
+    .unwrap();
+    let checkpoint = load_pinned_checkpoint(dir.path()).unwrap();
+
+    assert_post_tower_contract(dir.path(), checkpoint);
 }
 
 #[test]
@@ -401,7 +447,7 @@ fn pinned_precheck_accepts_a_complete_synthetic_checkpoint() {
 
     let checkpoint = load_pinned_checkpoint(dir.path()).unwrap();
 
-    assert_eq!(checkpoint.config.text_config.hidden_size, 6);
+    assert_eq!(checkpoint.config["text_config"]["hidden_size"], 6);
     assert_eq!(
         checkpoint.weight_map.len(),
         PINNED_POST_TOWER_WEIGHT_KEYS.len()
@@ -442,6 +488,24 @@ fn pinned_precheck_leaves_an_absent_weight_map_to_the_contract_assertion() {
 }
 
 #[test]
+#[should_panic(expected = "model.vision_adapter.fc1.weight")]
+fn contract_assertion_still_fails_on_an_absent_weight_map() {
+    // Companion to the pre-check test above, matching the missing-weight-root
+    // pair: an index carrying no `weight_map` must fail the weight-root
+    // assertion rather than skip.
+    let dir = tempfile::tempdir().unwrap();
+    write_synthetic_config(dir.path());
+    std::fs::write(
+        dir.path().join("model.safetensors.index.json"),
+        "{\"metadata\": {}}",
+    )
+    .unwrap();
+    let checkpoint = load_pinned_checkpoint(dir.path()).unwrap();
+
+    assert_post_tower_contract(dir.path(), checkpoint);
+}
+
+#[test]
 #[should_panic(expected = "model.vision_projection.weight")]
 fn contract_assertion_still_fails_on_a_missing_weight_root() {
     let dir = complete_synthetic_checkpoint(&PINNED_POST_TOWER_WEIGHT_KEYS[..2], &[4, 8]);
@@ -451,7 +515,11 @@ fn contract_assertion_still_fails_on_a_missing_weight_root() {
 }
 
 #[test]
-#[should_panic(expected = "model.vision_adapter.fc1.weight")]
+// The `failed: ` prefix is the suffix `assert_eq!` emits for its custom
+// message, so this can only pass on the shape assertion. The bare key name
+// also appears in the weight-root assertion and in the "must name a shard"
+// panic, either of which would let this test pass for the wrong reason.
+#[should_panic(expected = "failed: model.vision_adapter.fc1.weight")]
 fn contract_assertion_still_fails_on_a_wrong_recorded_shape() {
     // Every file is present and readable, so the pre-check passes. A recorded
     // shape that disagrees with the config must fail, never skip.

--- a/src/vision/encoders/muse_glimmer_fusion_pinned_tests.rs
+++ b/src/vision/encoders/muse_glimmer_fusion_pinned_tests.rs
@@ -205,13 +205,25 @@ fn assert_post_tower_contract(model_dir: &Path, checkpoint: PinnedCheckpoint) {
     }
 }
 
+/// Absolute ceiling on a declared safetensors header, mirroring the guard
+/// `read_safetensors_header_bytes` in `mlxcel-core` already applies to the same
+/// eight-byte prefix. The file-relative bound in `safetensors_shape` cannot
+/// stand alone here: the pinned shards run to 50 GB, so a corrupt prefix inside
+/// one of them can declare a multi-gigabyte header that is still smaller than
+/// the file, and the allocation that follows would either abort the test
+/// process on allocation failure or pull gigabytes of tensor payload into
+/// memory. Real headers are kilobytes to a few megabytes, and the safetensors
+/// reference implementation caps them at 100 MB.
+const MAX_SAFETENSORS_HEADER_BYTES: u64 = 256 * 1024 * 1024;
+
 /// Read the recorded shape of `key` out of the safetensors header at `path`.
 ///
 /// `Err` covers availability and readability only: a shard that cannot be
-/// opened, a header truncated by an interrupted download, or a header that does
-/// not parse as JSON. A header that parses but does not describe `key` as a
-/// shaped tensor is a wrong checkpoint rather than a missing one, so it panics
-/// and fails the test. Only the file header is read, never the tensor payload.
+/// opened, a header truncated by an interrupted download, a declared header
+/// length no real checkpoint carries, or a header that does not parse as JSON.
+/// A header that parses but does not describe `key` as a shaped tensor is a
+/// wrong checkpoint rather than a missing one, so it panics and fails the test.
+/// Only the file header is read, never the tensor payload.
 fn safetensors_shape(path: &Path, key: &str) -> Result<Vec<usize>, String> {
     let mut file = std::fs::File::open(path)
         .map_err(|err| format!("shard {} could not be opened: {err}", path.display()))?;
@@ -228,8 +240,17 @@ fn safetensors_shape(path: &Path, key: &str) -> Result<Vec<usize>, String> {
         )
     })?;
     let header_len = u64::from_le_bytes(header_len);
-    // Bound the declared header against the file itself before allocating, so a
-    // corrupt length cannot turn into a multi-gigabyte allocation.
+    // Bound the declared header before allocating it, so a corrupt length
+    // cannot turn into a multi-gigabyte allocation: against a fixed ceiling
+    // first, because a 50 GB shard leaves the file-relative bound below far too
+    // loose, then against the file itself.
+    if header_len > MAX_SAFETENSORS_HEADER_BYTES {
+        return Err(format!(
+            "shard {} declares a {header_len}-byte safetensors header, over the \
+             {MAX_SAFETENSORS_HEADER_BYTES}-byte ceiling this reader will allocate",
+            path.display()
+        ));
+    }
     if header_len > file_len.saturating_sub(8) {
         return Err(format!(
             "shard {} declares a {header_len}-byte safetensors header but holds {file_len} bytes",
@@ -553,6 +574,21 @@ fn safetensors_shape_reports_a_truncated_header() {
         err.contains("declares a 4096-byte safetensors header"),
         "{err}"
     );
+}
+
+#[test]
+fn safetensors_shape_refuses_a_header_over_the_allocation_ceiling() {
+    // A corrupt eight-byte prefix inside a genuine multi-gigabyte shard can
+    // declare a header that is enormous and still smaller than the file, which
+    // the file-relative bound alone would wave through. Reproduced with a tiny
+    // file, so the test itself never allocates anything large either.
+    let dir = tempfile::tempdir().unwrap();
+    let shard = write_shard(dir.path(), u64::MAX, b"{}");
+
+    let err = safetensors_shape(&shard, "model.vision_projection.weight").unwrap_err();
+
+    assert!(err.contains(SYNTHETIC_SHARD), "{err}");
+    assert!(err.contains("ceiling this reader will allocate"), "{err}");
 }
 
 #[test]

--- a/src/vision/encoders/muse_glimmer_fusion_pinned_tests.rs
+++ b/src/vision/encoders/muse_glimmer_fusion_pinned_tests.rs
@@ -1,0 +1,499 @@
+// Copyright 2025-2026 Lablup Inc. and Jeongkyu Shin
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Contract check against the pinned Muse Glimmer checkpoint, plus synthetic
+//! coverage for the availability pre-check that guards it.
+//!
+//! The checkpoint is roughly 60 GB and is absent on most machines, so the check
+//! skips when it cannot read what it needs. That skip is deliberately narrow:
+//! only availability and readability problems (an absent file, an unreadable
+//! file, JSON that does not parse, a truncated safetensors header) may skip. A
+//! contract violation always fails, because turning a mismatched weight-root
+//! set, a config `validate()` rejects, or a wrong recorded shape into a silent
+//! skip would permanently disable the contract this module exists to enforce.
+
+use crate::models::muse_glimmer::MuseGlimmerConfig;
+use serde_json::Value;
+use std::collections::BTreeMap;
+use std::io::Read;
+use std::path::{Path, PathBuf};
+
+/// Directory holding the pinned Muse Glimmer checkpoint the published contract
+/// is validated against. Absent on machines that never downloaded it.
+const PINNED_MODEL_DIR: &str = "models/mlx/muse-glimmer-30b";
+
+/// The exact post-tower weight roots the published contract pins. Used both to
+/// enumerate the shards the check will open and as the expected value of the
+/// weight-root assertion itself.
+const PINNED_POST_TOWER_WEIGHT_KEYS: [&str; 3] = [
+    "model.vision_adapter.fc1.weight",
+    "model.vision_adapter.fc2.weight",
+    "model.vision_projection.weight",
+];
+
+/// Checkpoint inputs the post-tower contract assertions read, parsed once so
+/// the availability pre-check and the assertion body share a single read of
+/// `model.safetensors.index.json` rather than opening it twice.
+#[derive(Debug)]
+struct PinnedCheckpoint {
+    config: MuseGlimmerConfig,
+    weight_map: serde_json::Map<String, Value>,
+}
+
+/// Read every file the post-tower contract assertions need.
+///
+/// `Err` is returned for availability and readability problems only: a file
+/// that is absent, a file that cannot be read, or a file whose JSON does not
+/// parse. The message always names the offending path, so a partially
+/// materialized checkpoint (an interrupted `hf download` or `mlxcel download`)
+/// skips with a reason instead of panicking on an opaque `unwrap`.
+///
+/// Contract violations are deliberately NOT detected here. An absent
+/// `weight_map`, an omitted pinned weight root, a config `validate()` rejects,
+/// and a wrong recorded shape all flow through to the caller's assertions so
+/// they still fail the test. Availability is the only thing this may veto.
+fn load_pinned_checkpoint(model_dir: &Path) -> Result<PinnedCheckpoint, String> {
+    let index_path = model_dir.join("model.safetensors.index.json");
+    let index_text = read_checkpoint_file(&index_path)?;
+    let index: Value = serde_json::from_str(&index_text)
+        .map_err(|err| format!("{} does not parse as JSON: {err}", index_path.display()))?;
+
+    let config_path = model_dir.join("config.json");
+    let config_text = read_checkpoint_file(&config_path)?;
+    let config: MuseGlimmerConfig = serde_json::from_str(&config_text).map_err(|err| {
+        format!(
+            "{} does not parse as a Muse Glimmer config: {err}",
+            config_path.display()
+        )
+    })?;
+
+    // A missing or non-object `weight_map` is a malformed index rather than a
+    // missing file: hand the caller an empty map so the weight-root assertion
+    // reports it as the contract violation it is.
+    let weight_map = index["weight_map"].as_object().cloned().unwrap_or_default();
+    for key in PINNED_POST_TOWER_WEIGHT_KEYS {
+        // A pinned key absent from an index that otherwise parsed is a contract
+        // violation, not an availability problem. Leave it for the assertion.
+        let Some(shard) = weight_map.get(key).and_then(Value::as_str) else {
+            continue;
+        };
+        let shard_path = model_dir.join(shard);
+        if !shard_path.exists() {
+            return Err(format!(
+                "shard {} holding {key} is not present",
+                shard_path.display()
+            ));
+        }
+    }
+
+    Ok(PinnedCheckpoint { config, weight_map })
+}
+
+/// Read a checkpoint file, distinguishing "absent" from "present but
+/// unreadable" and naming the path in both cases.
+fn read_checkpoint_file(path: &Path) -> Result<String, String> {
+    std::fs::read_to_string(path).map_err(|err| {
+        if err.kind() == std::io::ErrorKind::NotFound {
+            format!("{} is not present", path.display())
+        } else {
+            format!("{} could not be read: {err}", path.display())
+        }
+    })
+}
+
+/// Report that the pinned checkpoint is not usable. Machines that never
+/// downloaded it skip, so the rest of the suite still runs there. Machines that
+/// own it can set `MLXCEL_REQUIRE_PINNED_CHECKPOINTS=1` to turn the skip into a
+/// failure, so a half-downloaded or corrupted checkpoint cannot quietly disable
+/// this contract check forever on the one machine positioned to enforce it.
+fn skip_or_fail_pinned_checkpoint(reason: &str) {
+    // The crate-wide env lock serializes this read against the tests that
+    // mutate the process environment with `unsafe set_var`; on Rust 2024 an
+    // unsynchronized concurrent read of the env block is undefined behavior.
+    let required = {
+        let _env_guard = crate::test_support::env_lock::env_lock();
+        std::env::var("MLXCEL_REQUIRE_PINNED_CHECKPOINTS").is_ok_and(|value| value == "1")
+    };
+    assert!(
+        !required,
+        "MLXCEL_REQUIRE_PINNED_CHECKPOINTS=1 but the pinned Muse Glimmer checkpoint is not usable: \
+         {reason}"
+    );
+    eprintln!(
+        "Skipping pinned_post_tower_weight_roots_and_shapes_match_published_contract: {reason}"
+    );
+}
+
+#[test]
+fn pinned_post_tower_weight_roots_and_shapes_match_published_contract() {
+    let model_dir = Path::new(PINNED_MODEL_DIR);
+    match load_pinned_checkpoint(model_dir) {
+        Ok(checkpoint) => assert_post_tower_contract(model_dir, checkpoint),
+        Err(reason) => skip_or_fail_pinned_checkpoint(&reason),
+    }
+}
+
+/// The published post-tower contract itself. Every check is an unconditional
+/// assertion: reaching this function means every file it needs was already
+/// confirmed readable, so anything failing here is the checkpoint disagreeing
+/// with the contract. Split out of the test body so the synthetic checkpoints
+/// below can prove a mismatched weight root or shape still fails, never skips.
+fn assert_post_tower_contract(model_dir: &Path, checkpoint: PinnedCheckpoint) {
+    let PinnedCheckpoint { config, weight_map } = checkpoint;
+
+    config.validate().unwrap();
+    let mut actual_keys = weight_map
+        .keys()
+        .filter(|key| {
+            key.starts_with("model.vision_adapter.") || key.starts_with("model.vision_projection.")
+        })
+        .cloned()
+        .collect::<Vec<_>>();
+    actual_keys.sort();
+    assert_eq!(actual_keys, PINNED_POST_TOWER_WEIGHT_KEYS);
+
+    let expected = BTreeMap::from([
+        (
+            "model.vision_adapter.fc1.weight",
+            vec![config.projector_hidden_size, config.out_hidden_size],
+        ),
+        (
+            "model.vision_adapter.fc2.weight",
+            vec![config.projector_hidden_size, config.projector_hidden_size],
+        ),
+        (
+            "model.vision_projection.weight",
+            vec![config.text_config.hidden_size, config.projector_hidden_size],
+        ),
+    ]);
+    for (key, expected_shape) in expected {
+        let shard = weight_map
+            .get(key)
+            .and_then(Value::as_str)
+            .unwrap_or_else(|| panic!("{key} must name a shard in the pinned weight index"));
+        let shape = match safetensors_shape(&model_dir.join(shard), key) {
+            Ok(shape) => shape,
+            Err(reason) => {
+                skip_or_fail_pinned_checkpoint(&reason);
+                return;
+            }
+        };
+        assert_eq!(shape, expected_shape, "{key}");
+    }
+}
+
+/// Read the recorded shape of `key` out of the safetensors header at `path`.
+///
+/// `Err` covers availability and readability only: a shard that cannot be
+/// opened, a header truncated by an interrupted download, or a header that does
+/// not parse as JSON. A header that parses but does not describe `key` as a
+/// shaped tensor is a wrong checkpoint rather than a missing one, so it panics
+/// and fails the test. Only the file header is read, never the tensor payload.
+fn safetensors_shape(path: &Path, key: &str) -> Result<Vec<usize>, String> {
+    let mut file = std::fs::File::open(path)
+        .map_err(|err| format!("shard {} could not be opened: {err}", path.display()))?;
+    let file_len = file
+        .metadata()
+        .map_err(|err| format!("shard {} could not be inspected: {err}", path.display()))?
+        .len();
+
+    let mut header_len = [0u8; 8];
+    file.read_exact(&mut header_len).map_err(|err| {
+        format!(
+            "shard {} is truncated before its header length: {err}",
+            path.display()
+        )
+    })?;
+    let header_len = u64::from_le_bytes(header_len);
+    // Bound the declared header against the file itself before allocating, so a
+    // corrupt length cannot turn into a multi-gigabyte allocation.
+    if header_len > file_len.saturating_sub(8) {
+        return Err(format!(
+            "shard {} declares a {header_len}-byte safetensors header but holds {file_len} bytes",
+            path.display()
+        ));
+    }
+
+    let mut header = vec![0u8; header_len as usize];
+    file.read_exact(&mut header).map_err(|err| {
+        format!(
+            "shard {} is truncated inside its header: {err}",
+            path.display()
+        )
+    })?;
+    let header: Value = serde_json::from_slice(&header).map_err(|err| {
+        format!(
+            "shard {} has a safetensors header that does not parse as JSON: {err}",
+            path.display()
+        )
+    })?;
+
+    Ok(header[key]["shape"]
+        .as_array()
+        .unwrap_or_else(|| panic!("shard {} records no shape for {key}", path.display()))
+        .iter()
+        .map(|dim| {
+            dim.as_u64().unwrap_or_else(|| {
+                panic!(
+                    "shard {} records a non-integer dimension for {key}",
+                    path.display()
+                )
+            }) as usize
+        })
+        .collect())
+}
+
+// Synthetic partial-checkpoint coverage. The real pinned checkpoint is either
+// complete or absent, so the partial cases cannot be exercised against it, and
+// nothing under `models/` may be moved or truncated to fake one. These tests
+// build throwaway checkpoints in a temp dir, which is what makes the skip path
+// observable on machines that do not own the checkpoint.
+
+/// Smallest `config.json` body that both deserializes into a
+/// `MuseGlimmerConfig` and passes `validate()`, so the contract tests below
+/// reach the weight-root and shape assertions rather than tripping on the
+/// config. Every field outside `text_config` carries a serde default.
+const SYNTHETIC_CONFIG_JSON: &str = r#"{
+  "text_config": {
+    "model_type": "muse_glimmer_text", "hidden_size": 6, "intermediate_size": 8,
+    "num_hidden_layers": 1, "num_attention_heads": 1, "num_key_value_heads": 1,
+    "head_dim": 8, "vocab_size": 32, "rms_norm_eps": 1e-6,
+    "layer_types": ["full_attention"]
+  }
+}"#;
+
+/// Shard name every synthetic index below points its pinned keys at.
+const SYNTHETIC_SHARD: &str = "model-00001-of-00002.safetensors";
+
+fn write_synthetic_config(dir: &Path) {
+    std::fs::write(dir.join("config.json"), SYNTHETIC_CONFIG_JSON).unwrap();
+}
+
+/// Write an index whose `weight_map` sends every key in `keys` to `shard`.
+fn write_synthetic_index(dir: &Path, keys: &[&str], shard: &str) {
+    let weight_map = keys
+        .iter()
+        .map(|key| (*key, shard))
+        .collect::<BTreeMap<_, _>>();
+    std::fs::write(
+        dir.join("model.safetensors.index.json"),
+        serde_json::json!({ "weight_map": weight_map }).to_string(),
+    )
+    .unwrap();
+}
+
+/// Write a shard whose 8-byte prefix declares `declared_len` bytes of header
+/// followed by `body`, and return its path. A `declared_len` larger than `body`
+/// reproduces the truncation an interrupted download leaves behind.
+fn write_shard(dir: &Path, declared_len: u64, body: &[u8]) -> PathBuf {
+    let mut bytes = declared_len.to_le_bytes().to_vec();
+    bytes.extend_from_slice(body);
+    let path = dir.join(SYNTHETIC_SHARD);
+    std::fs::write(&path, bytes).unwrap();
+    path
+}
+
+/// Write a well-formed shard whose header records `shape` for every key in
+/// `keys`. The tensor payload is omitted because only the header is ever read.
+fn write_synthetic_shard(dir: &Path, keys: &[&str], shape: &[usize]) -> PathBuf {
+    let header = keys
+        .iter()
+        .map(|key| {
+            (
+                (*key).to_string(),
+                serde_json::json!({ "dtype": "F32", "shape": shape, "data_offsets": [0, 0] }),
+            )
+        })
+        .collect::<serde_json::Map<String, Value>>();
+    let header = Value::Object(header).to_string();
+    write_shard(dir, header.len() as u64, header.as_bytes())
+}
+
+/// Materialize a complete synthetic checkpoint: config, an index over `keys`,
+/// and the shard those keys point at recording `shape` for each of them.
+fn complete_synthetic_checkpoint(keys: &[&str], shape: &[usize]) -> tempfile::TempDir {
+    let dir = tempfile::tempdir().unwrap();
+    write_synthetic_config(dir.path());
+    write_synthetic_index(dir.path(), keys, SYNTHETIC_SHARD);
+    write_synthetic_shard(dir.path(), keys, shape);
+    dir
+}
+
+#[test]
+fn pinned_precheck_names_an_absent_index() {
+    let dir = tempfile::tempdir().unwrap();
+
+    let err = load_pinned_checkpoint(dir.path()).unwrap_err();
+
+    assert!(err.contains("model.safetensors.index.json"), "{err}");
+    assert!(err.contains("is not present"), "{err}");
+}
+
+#[test]
+fn pinned_precheck_names_a_missing_config() {
+    let dir = tempfile::tempdir().unwrap();
+    write_synthetic_index(dir.path(), &PINNED_POST_TOWER_WEIGHT_KEYS, SYNTHETIC_SHARD);
+
+    let err = load_pinned_checkpoint(dir.path()).unwrap_err();
+
+    assert!(err.contains("config.json"), "{err}");
+    assert!(err.contains("is not present"), "{err}");
+}
+
+#[test]
+fn pinned_precheck_names_a_missing_shard() {
+    let dir = tempfile::tempdir().unwrap();
+    write_synthetic_config(dir.path());
+    write_synthetic_index(dir.path(), &PINNED_POST_TOWER_WEIGHT_KEYS, SYNTHETIC_SHARD);
+
+    let err = load_pinned_checkpoint(dir.path()).unwrap_err();
+
+    assert!(err.contains(SYNTHETIC_SHARD), "{err}");
+    assert!(err.contains("is not present"), "{err}");
+}
+
+#[test]
+fn pinned_precheck_names_an_unparseable_index() {
+    let dir = tempfile::tempdir().unwrap();
+    write_synthetic_config(dir.path());
+    // An index whose write was cut short mid-object.
+    std::fs::write(
+        dir.path().join("model.safetensors.index.json"),
+        "{\"weight_map\": {\"model.vision_projection.weight\"",
+    )
+    .unwrap();
+
+    let err = load_pinned_checkpoint(dir.path()).unwrap_err();
+
+    assert!(err.contains("model.safetensors.index.json"), "{err}");
+    assert!(err.contains("does not parse as JSON"), "{err}");
+}
+
+#[test]
+fn pinned_precheck_names_an_unparseable_config() {
+    let dir = tempfile::tempdir().unwrap();
+    write_synthetic_index(dir.path(), &PINNED_POST_TOWER_WEIGHT_KEYS, SYNTHETIC_SHARD);
+    std::fs::write(dir.path().join("config.json"), "{\"text_config\": {").unwrap();
+
+    let err = load_pinned_checkpoint(dir.path()).unwrap_err();
+
+    assert!(err.contains("config.json"), "{err}");
+    assert!(
+        err.contains("does not parse as a Muse Glimmer config"),
+        "{err}"
+    );
+}
+
+#[test]
+fn pinned_precheck_accepts_a_complete_synthetic_checkpoint() {
+    let dir = complete_synthetic_checkpoint(&PINNED_POST_TOWER_WEIGHT_KEYS, &[6, 4]);
+
+    let checkpoint = load_pinned_checkpoint(dir.path()).unwrap();
+
+    assert_eq!(checkpoint.config.text_config.hidden_size, 6);
+    assert_eq!(
+        checkpoint.weight_map.len(),
+        PINNED_POST_TOWER_WEIGHT_KEYS.len()
+    );
+}
+
+#[test]
+fn pinned_precheck_leaves_a_missing_weight_root_to_the_contract_assertion() {
+    // An index that parses but omits a pinned weight root is a contract
+    // violation, not an availability problem, so the pre-check must pass it
+    // through for the weight-root assertion to fail on.
+    let dir = complete_synthetic_checkpoint(&PINNED_POST_TOWER_WEIGHT_KEYS[..2], &[4, 8]);
+
+    let checkpoint = load_pinned_checkpoint(dir.path()).unwrap();
+
+    assert!(
+        !checkpoint
+            .weight_map
+            .contains_key("model.vision_projection.weight")
+    );
+}
+
+#[test]
+fn pinned_precheck_leaves_an_absent_weight_map_to_the_contract_assertion() {
+    // Same boundary for an index object carrying no `weight_map` at all: the
+    // empty map drives the weight-root assertion to fail, not to skip.
+    let dir = tempfile::tempdir().unwrap();
+    write_synthetic_config(dir.path());
+    std::fs::write(
+        dir.path().join("model.safetensors.index.json"),
+        "{\"metadata\": {}}",
+    )
+    .unwrap();
+
+    let checkpoint = load_pinned_checkpoint(dir.path()).unwrap();
+
+    assert!(checkpoint.weight_map.is_empty());
+}
+
+#[test]
+#[should_panic(expected = "model.vision_projection.weight")]
+fn contract_assertion_still_fails_on_a_missing_weight_root() {
+    let dir = complete_synthetic_checkpoint(&PINNED_POST_TOWER_WEIGHT_KEYS[..2], &[4, 8]);
+    let checkpoint = load_pinned_checkpoint(dir.path()).unwrap();
+
+    assert_post_tower_contract(dir.path(), checkpoint);
+}
+
+#[test]
+#[should_panic(expected = "model.vision_adapter.fc1.weight")]
+fn contract_assertion_still_fails_on_a_wrong_recorded_shape() {
+    // Every file is present and readable, so the pre-check passes. A recorded
+    // shape that disagrees with the config must fail, never skip.
+    let dir = complete_synthetic_checkpoint(&PINNED_POST_TOWER_WEIGHT_KEYS, &[1, 1]);
+    let checkpoint = load_pinned_checkpoint(dir.path()).unwrap();
+
+    assert_post_tower_contract(dir.path(), checkpoint);
+}
+
+#[test]
+fn safetensors_shape_reads_a_well_formed_header() {
+    let dir = tempfile::tempdir().unwrap();
+    let shard = write_synthetic_shard(dir.path(), &["model.vision_projection.weight"], &[6, 4]);
+
+    let shape = safetensors_shape(&shard, "model.vision_projection.weight").unwrap();
+
+    assert_eq!(shape, vec![6, 4]);
+}
+
+#[test]
+fn safetensors_shape_reports_a_truncated_header() {
+    // Declare a 4 KiB header, then stop four bytes in, the shape an interrupted
+    // download leaves behind.
+    let dir = tempfile::tempdir().unwrap();
+    let shard = write_shard(dir.path(), 4096, b"{\"mo");
+
+    let err = safetensors_shape(&shard, "model.vision_projection.weight").unwrap_err();
+
+    assert!(err.contains(SYNTHETIC_SHARD), "{err}");
+    assert!(
+        err.contains("declares a 4096-byte safetensors header"),
+        "{err}"
+    );
+}
+
+#[test]
+fn safetensors_shape_reports_an_unparseable_header() {
+    let dir = tempfile::tempdir().unwrap();
+    let shard = write_shard(dir.path(), 16, b"not json at all!");
+
+    let err = safetensors_shape(&shard, "model.vision_projection.weight").unwrap_err();
+
+    assert!(err.contains(SYNTHETIC_SHARD), "{err}");
+    assert!(err.contains("does not parse as JSON"), "{err}");
+}

--- a/src/vision/encoders/muse_glimmer_fusion_tests.rs
+++ b/src/vision/encoders/muse_glimmer_fusion_tests.rs
@@ -18,10 +18,6 @@ use crate::models::muse_glimmer::{
 };
 use mlxcel_core::MlxArray;
 use mlxcel_core::weights::WeightMap;
-use serde_json::Value;
-use std::collections::BTreeMap;
-use std::io::Read;
-use std::path::Path;
 
 fn to_vec_f32(a: &MlxArray) -> Vec<f32> {
     let f = mlxcel_core::astype(a, mlxcel_core::dtype::FLOAT32);
@@ -197,79 +193,4 @@ fn weightless_perception_norm_matches_rms_without_scale() {
     assert_eq!(mlxcel_core::array_shape(&out), vec![1, 2]);
     assert_close(values[0], 3.0 / denom);
     assert_close(values[1], 4.0 / denom);
-}
-
-#[test]
-fn pinned_post_tower_weight_roots_and_shapes_match_published_contract() {
-    let model_dir = Path::new("models/mlx/muse-glimmer-30b");
-    let index_path = model_dir.join("model.safetensors.index.json");
-    if !index_path.exists() {
-        eprintln!(
-            "Skipping pinned_post_tower_weight_roots_and_shapes_match_published_contract: \
-             pinned Muse Glimmer checkpoint index not present at {}",
-            index_path.display()
-        );
-        return;
-    }
-    let config: MuseGlimmerConfig =
-        serde_json::from_str(&std::fs::read_to_string(model_dir.join("config.json")).unwrap())
-            .unwrap();
-    config.validate().unwrap();
-    let index: Value = serde_json::from_str(&std::fs::read_to_string(index_path).unwrap()).unwrap();
-    let weight_map = index["weight_map"].as_object().unwrap();
-    let mut actual_keys = weight_map
-        .keys()
-        .filter(|key| {
-            key.starts_with("model.vision_adapter.") || key.starts_with("model.vision_projection.")
-        })
-        .cloned()
-        .collect::<Vec<_>>();
-    actual_keys.sort();
-    assert_eq!(
-        actual_keys,
-        vec![
-            "model.vision_adapter.fc1.weight",
-            "model.vision_adapter.fc2.weight",
-            "model.vision_projection.weight"
-        ]
-    );
-
-    let expected = BTreeMap::from([
-        (
-            "model.vision_adapter.fc1.weight",
-            vec![config.projector_hidden_size, config.out_hidden_size],
-        ),
-        (
-            "model.vision_adapter.fc2.weight",
-            vec![config.projector_hidden_size, config.projector_hidden_size],
-        ),
-        (
-            "model.vision_projection.weight",
-            vec![config.text_config.hidden_size, config.projector_hidden_size],
-        ),
-    ]);
-    for (key, expected_shape) in expected {
-        let shard = weight_map[key].as_str().unwrap();
-        assert_eq!(
-            safetensors_shape(&model_dir.join(shard), key),
-            expected_shape,
-            "{key}"
-        );
-    }
-}
-
-fn safetensors_shape(path: &Path, key: &str) -> Vec<usize> {
-    let mut file = std::fs::File::open(path).unwrap();
-    let mut header_len = [0u8; 8];
-    file.read_exact(&mut header_len).unwrap();
-    let header_len = u64::from_le_bytes(header_len) as usize;
-    let mut header = vec![0u8; header_len];
-    file.read_exact(&mut header).unwrap();
-    let header: Value = serde_json::from_slice(&header).unwrap();
-    header[key]["shape"]
-        .as_array()
-        .unwrap()
-        .iter()
-        .map(|dim| dim.as_u64().unwrap() as usize)
-        .collect()
 }


### PR DESCRIPTION
> **Post-merge correction (2026-08-16).** This body was corrected after merge. As originally written it justified the file split with a "500-line limit" that is not this repository's convention, and its test counts and run results described only the first of the four commits on this branch. The squash commit on `main` (`0adb53c5`) still carries the original wording, since commit messages cannot be edited after merge; where the two disagree, this body is the accurate one. The threshold question is tracked in #1178, and the incorrect rationale is also recorded in `TECHNICAL_REPORTS/1173-pinned-checkpoint-skip-guard-20260816.en.md`.

## Summary

`pinned_post_tower_weight_roots_and_shapes_match_published_contract` skipped gracefully only when `model.safetensors.index.json` was absent. With the index present but anything else it reads missing or corrupt, the shape an interrupted `hf download` or `mlxcel download` leaves behind, it unwrapped its way to an opaque panic instead of skipping with a reason. This adds an availability pre-check that names the offending file, while leaving every contract assertion able to fail exactly as before.

## Implementation choice

The issue offered two options; this is the hybrid the brief recommended. Option 1 alone (a pure existence pre-check) cannot detect a shard that exists but whose header was truncated mid-download, and option 2 alone (converting each unwrap into a skip) reads the index twice, which the issue explicitly asked to avoid. The hybrid gets both: `load_pinned_checkpoint` parses the index once and hands the parsed `weight_map` to the assertion body, and `safetensors_shape` returns a `Result` so header corruption is covered too.

## How the correctness boundary is kept

The skip is deliberately narrow, and the split is enforced by construction rather than by convention.

- Only **availability and readability** may skip: an absent file, an unreadable file, JSON that does not parse, a truncated or unparseable safetensors header. `load_pinned_checkpoint` returns `Err` for exactly these, and `read_checkpoint_file` distinguishes "not present" from "could not be read" so the message names the path either way.
- **Contract violations still fail.** The `assert_eq!` calls are untouched and are not wrapped in any skip path. `load_pinned_checkpoint` is structured so it cannot swallow one: a `weight_map` that is absent or non-object yields an empty map (which drives the weight-root assertion to fail, not to skip), and a pinned key absent from an otherwise well-formed `weight_map` is skipped over by the shard loop with a comment saying why, so the weight-root assertion is what reports it.
- `config.json` is parsed as plain JSON only in the pre-check, so a truncated config still skips, while deserializing into `MuseGlimmerConfig` happens next to `validate()` in the assertion body, where a schema mismatch panics. A config that parses but does not fit the schema means the pinned directory holds a wrong or drifted model, which is a contract violation rather than an availability problem. This was corrected in review; the first commit deserialized in the pre-check and therefore skipped on schema drift.
- Inside `safetensors_shape`, a header that parses but does not describe the key as a shaped tensor panics rather than returning `Err`, following the issue's "if unsure whether it is missing or wrong, it is wrong" rule.
- The contract assertions moved into `assert_post_tower_contract`, which takes an already-validated `PinnedCheckpoint`. It holds one skip branch only, for a shard header that cannot be read, which is scoped to availability by construction because those are the only conditions under which `safetensors_shape` returns `Err`. That split is what makes the four `should_panic` tests below possible.

## What changed

- `src/vision/encoders/muse_glimmer_fusion_pinned_tests.rs` (new, 603 lines): the pinned-checkpoint contract check, the `load_pinned_checkpoint` availability pre-check, a `Result`-returning `safetensors_shape`, and synthetic partial-checkpoint coverage. `safetensors_shape` bounds the declared header length twice before allocating: against an absolute `MAX_SAFETENSORS_HEADER_BYTES` ceiling of 256 MiB, mirroring the guard the production reader already applies in `src/lib/mlxcel-core/src/weights.rs:196`, and against the file's own size. The absolute ceiling was added in review: the file-relative bound alone permits a declared header as large as the whole file, and the pinned shards are 50 GB and 9.6 GB, so a corrupt eight-byte prefix could have reached an uncatchable allocation abort.
- `src/vision/encoders/muse_glimmer_fusion_tests.rs`: the pinned block and its now-unused imports removed, leaving 196 lines of fusion-math tests.
- `src/vision/encoders/muse_glimmer_fusion.rs`: attaches `pinned_tests` as a second `#[cfg(test)]` module, the same pattern `src/vision/mod.rs` already uses. The split separates disk-reading contract checks from fusion math and follows the established `#[cfg(test)] #[path]` sibling-module convention. Both files sit under the repository's actual 800-line single-file guideline (`.claude/skills/mlxcel-code-structure/SKILL.md`), at 196 and 603 lines.

Test-only change. No production loading path is touched, and `src/loading/vlm_muse_glimmer_tests.rs` is untouched as the issue required.

## Synthetic-checkpoint tests

The real pinned checkpoint is either complete or absent, so the partial cases cannot be exercised against it, and nothing under `models/` may be moved or truncated to fake one. All seventeen new tests build throwaway checkpoints in `tempfile::tempdir()` (already a dev-dependency, no new dependency added). The pinned module now holds 18 tests in total, the eighteenth being the pre-existing contract check that moved here.

Pre-check names the specific missing or unreadable file: `pinned_precheck_names_an_absent_index`, `pinned_precheck_names_a_missing_config`, `pinned_precheck_names_a_missing_shard` (index present naming a shard that does not exist), `pinned_precheck_names_an_unparseable_index`, `pinned_precheck_names_an_unparseable_config`, and `pinned_precheck_accepts_a_complete_synthetic_checkpoint` as the negative control.

Pre-check refuses to swallow contract violations: `pinned_precheck_leaves_a_missing_weight_root_to_the_contract_assertion`, `pinned_precheck_leaves_an_absent_weight_map_to_the_contract_assertion`, and `pinned_precheck_leaves_a_schema_mismatched_config_to_the_contract_assertion` each assert the pre-check returns `Ok`, so the violation reaches the assertion.

Contract violations still fail, proven executably rather than by reading the diff. Four `#[should_panic]` tests run `assert_post_tower_contract` over complete-but-wrong synthetic checkpoints: `contract_assertion_still_fails_on_a_missing_weight_root`, `contract_assertion_still_fails_on_an_absent_weight_map`, `contract_assertion_still_fails_on_a_schema_mismatched_config`, and `contract_assertion_still_fails_on_a_wrong_recorded_shape`. The last one expects the `failed: ` prefix that `assert_eq!` emits before its custom message, so it can only pass on the shape assertion itself; a bare key name would also match the weight-root assertion and the "must name a shard" panic, letting it pass for the wrong reason.

Header handling: `safetensors_shape_reads_a_well_formed_header`, `safetensors_shape_reports_a_truncated_header`, `safetensors_shape_reports_an_unparseable_header`, and `safetensors_shape_refuses_a_header_over_the_allocation_ceiling`, which declares `u64::MAX` in a tiny temp file so the test itself allocates nothing large.

## Optional env var

`MLXCEL_REQUIRE_PINNED_CHECKPOINTS=1` is implemented. It is read inside `skip_or_fail_pinned_checkpoint` under `crate::test_support::env_lock::env_lock()`, held for the duration of the read and dropped before the assertion, because this crate is edition 2024 and `src/server/muse_glimmer_startup_guard_tests.rs` mutates the process environment with `unsafe set_var` under that same lock; an unlocked read is the same class of race being fixed elsewhere in this chain. Only the exact value `1` enables it.

It also turned out to be the cleanest way to prove acceptance criterion 2 on this machine: with skips disabled, the pinned test passing is positive evidence that it read the real checkpoint rather than silently skipping.

Follow-up #1177 tracks extending this gate to the loading-side sibling guard, which does not yet honor it, and documenting the variable in `docs/environment-variables.md`.

## Test plan

Results below are for the merged branch tip, all four commits.

- [x] `cargo test --lib vision::encoders::muse_glimmer_fusion` on a machine holding the real pinned checkpoint: `23 passed; 0 failed` (18 in the pinned module, 5 fusion-math).
- [x] `MLXCEL_REQUIRE_PINNED_CHECKPOINTS=1 cargo test --lib vision::encoders::muse_glimmer_fusion`: `23 passed; 0 failed`. Since any skip is a hard failure under this variable, this confirms the full pinned checkpoint still validates the weight-root and shape contract for real (criterion 2).
- [x] Test binary run from a directory containing no `models/`: skips with `Skipping pinned_post_tower_weight_roots_and_shapes_match_published_contract: models/mlx/muse-glimmer-30b/model.safetensors.index.json is not present` (criterion 3, behavior unchanged).
- [x] Same run with `MLXCEL_REQUIRE_PINNED_CHECKPOINTS=1`: fails with `MLXCEL_REQUIRE_PINNED_CHECKPOINTS=1 but the pinned Muse Glimmer checkpoint is not usable: ... is not present` (criterion 4).
- [x] `cargo clippy --lib --tests -- -D warnings`: clean.
- [x] `cargo check --lib --tests`: clean.
- [x] `cargo fmt --check`: clean.
- [x] Nothing under `models/` or `/home/inureyes/models` was moved, renamed, deleted, truncated, or written to; both 50 GB and 9.6 GB shards verified present afterwards with their original timestamps.

Closes #1161
