### PR TITLE
fix(server): gate tile-aligned prefill on the model, not on the hardware alone

### DIFF
--- a/src/server/batch/scheduler.rs
+++ b/src/server/batch/scheduler.rs
@@ -5851,27 +5851,29 @@ impl BatchScheduler {
         // text backbone then builds a causal mask sized to the embeddings,
         // matching the CLI generate path. Token-id (text-only) prefill — for
         // VLMs and plain text models alike — is unaffected.
-        let (effective_tokens, pad_mask_opt) =
-            if should_align_prefill() && seq.vlm_embeddings.is_none() {
-                let padded_len = align_to_na_tile(actual_len);
-                if padded_len > actual_len {
-                    let mut padded = suffix_tokens.clone();
-                    padded.resize(padded_len, 0);
-                    // The padding mask anchors to the adopted cache offset so
-                    // the newly-prefilled positions see the correct KV-history
-                    // positions on M5+ hardware.
-                    let mask = create_padded_prefill_mask(
-                        actual_len as i32,
-                        padded_len as i32,
-                        seq.prefill_start_offset as i32,
-                    );
-                    (padded, Some(mask))
-                } else {
-                    (suffix_tokens.clone(), None)
-                }
+        let (effective_tokens, pad_mask_opt) = if self.model.supports_padded_prefill()
+            && should_align_prefill()
+            && seq.vlm_embeddings.is_none()
+        {
+            let padded_len = align_to_na_tile(actual_len);
+            if padded_len > actual_len {
+                let mut padded = suffix_tokens.clone();
+                padded.resize(padded_len, 0);
+                // The padding mask anchors to the adopted cache offset so
+                // the newly-prefilled positions see the correct KV-history
+                // positions on M5+ hardware.
+                let mask = create_padded_prefill_mask(
+                    actual_len as i32,
+                    padded_len as i32,
+                    seq.prefill_start_offset as i32,
+                );
+                (padded, Some(mask))
             } else {
                 (suffix_tokens.clone(), None)
-            };
+            }
+        } else {
+            (suffix_tokens.clone(), None)
+        };
 
         let eff_len = effective_tokens.len() as i32;
         let input = mlxcel_core::from_slice_i32(&effective_tokens, &[1, eff_len]);
@@ -6024,25 +6026,26 @@ impl BatchScheduler {
 
         // Align the first chunk to a 32-token tile boundary on M5+ hardware.
         let actual_chunk_len = chunk.len();
-        let (eff_chunk, pad_mask_opt) = if should_align_prefill() {
-            let padded_len = align_to_na_tile(actual_chunk_len);
-            if padded_len > actual_chunk_len {
-                let mut padded = chunk.to_vec();
-                padded.resize(padded_len, 0);
-                // Mask anchored to the KV offset the adopted prefix already
-                // installed (starts at zero for cold prefills).
-                let mask = create_padded_prefill_mask(
-                    actual_chunk_len as i32,
-                    padded_len as i32,
-                    start as i32,
-                );
-                (padded, Some(mask))
+        let (eff_chunk, pad_mask_opt) =
+            if self.model.supports_padded_prefill() && should_align_prefill() {
+                let padded_len = align_to_na_tile(actual_chunk_len);
+                if padded_len > actual_chunk_len {
+                    let mut padded = chunk.to_vec();
+                    padded.resize(padded_len, 0);
+                    // Mask anchored to the KV offset the adopted prefix already
+                    // installed (starts at zero for cold prefills).
+                    let mask = create_padded_prefill_mask(
+                        actual_chunk_len as i32,
+                        padded_len as i32,
+                        start as i32,
+                    );
+                    (padded, Some(mask))
+                } else {
+                    (chunk.to_vec(), None)
+                }
             } else {
                 (chunk.to_vec(), None)
-            }
-        } else {
-            (chunk.to_vec(), None)
-        };
+            };
 
         let eff_len = eff_chunk.len() as i32;
         let input = mlxcel_core::from_slice_i32(&eff_chunk, &[1, eff_len]);
@@ -6241,23 +6244,24 @@ impl BatchScheduler {
                 offset as i32
             }
         };
-        let (eff_chunk, pad_mask_opt) = if should_align_prefill() {
-            let padded_len = align_to_na_tile(actual_chunk_len);
-            if padded_len > actual_chunk_len {
-                let mut padded = chunk.to_vec();
-                padded.resize(padded_len, 0);
-                let mask = create_padded_prefill_mask(
-                    actual_chunk_len as i32,
-                    padded_len as i32,
-                    kv_offset,
-                );
-                (padded, Some(mask))
+        let (eff_chunk, pad_mask_opt) =
+            if self.model.supports_padded_prefill() && should_align_prefill() {
+                let padded_len = align_to_na_tile(actual_chunk_len);
+                if padded_len > actual_chunk_len {
+                    let mut padded = chunk.to_vec();
+                    padded.resize(padded_len, 0);
+                    let mask = create_padded_prefill_mask(
+                        actual_chunk_len as i32,
+                        padded_len as i32,
+                        kv_offset,
+                    );
+                    (padded, Some(mask))
+                } else {
+                    (chunk.to_vec(), None)
+                }
             } else {
                 (chunk.to_vec(), None)
-            }
-        } else {
-            (chunk.to_vec(), None)
-        };
+            };
 
         let eff_len = eff_chunk.len() as i32;
         let input = mlxcel_core::from_slice_i32(&eff_chunk, &[1, eff_len]);

--- a/tests/vlm_wrapper_capability_delegation.rs
+++ b/tests/vlm_wrapper_capability_delegation.rs
@@ -193,3 +193,89 @@ fn a_vision_wrapper_delegates_padded_prefill_when_its_backbone_refuses_it() {
         violations.join("\n  ")
     );
 }
+
+/// Every tile-aligned padded prefill must be guarded on the model predicate.
+///
+/// The wrapper test above covers one way to lose the guard: a type that
+/// answers the trait default instead of forwarding. This covers the other:
+/// a call site that never asks. `src/server/batch/scheduler.rs` had three,
+/// `execute_full_prefill` and both chunked-prefill paths, each gated on
+/// hardware alone, so every hybrid model served on Neural Accelerator
+/// hardware had its recurrent state corrupted by pad positions. The same
+/// file's boundary-snapshot path documents the hazard in a comment and
+/// declines to pad, which is what makes the omission a slip rather than a
+/// disagreement.
+///
+/// The rule is deliberately shallow: the guard must appear within the dozen
+/// lines before the call, either as the predicate itself or as a local bound
+/// to it (`let can_pad_prefill = self.model.supports_padded_prefill()`, which
+/// the batched path does read fourteen lines up). A guard further away than
+/// that is one a reader cannot see either.
+#[test]
+fn every_tile_aligned_prefill_is_guarded_on_the_model_predicate() {
+    const WINDOW: usize = 12;
+    let mut files = Vec::new();
+    rust_sources(&repo_root().join("src"), &mut files);
+    files.sort();
+
+    let mut unguarded = Vec::new();
+    for file in &files {
+        let Ok(src) = fs::read_to_string(file) else {
+            continue;
+        };
+        let lines: Vec<&str> = src.lines().collect();
+        // Locals bound to the predicate count as the guard, so a site that
+        // hoists it out of a loop is not reported as unguarded.
+        let mut aliases: Vec<String> = Vec::new();
+        for line in &lines {
+            let Some(rest) = line.trim().strip_prefix("let ") else {
+                continue;
+            };
+            if !line.contains("supports_padded_prefill") {
+                continue;
+            }
+            let name: String = rest
+                .chars()
+                .take_while(|c| c.is_alphanumeric() || *c == '_')
+                .collect();
+            if !name.is_empty() {
+                aliases.push(name);
+            }
+        }
+        for (i, line) in lines.iter().enumerate() {
+            let trimmed = line.trim_start();
+            // The definition, its doc examples and its own unit tests are not
+            // prefill sites and have nothing to guard.
+            if !line.contains("align_to_na_tile(")
+                || trimmed.starts_with("//")
+                || trimmed.starts_with("fn ")
+                || trimmed.starts_with("pub fn ")
+                || trimmed.starts_with("assert")
+            {
+                continue;
+            }
+            let start = i.saturating_sub(WINDOW);
+            if lines[start..=i].iter().any(|l| {
+                l.contains("supports_padded_prefill")
+                    || aliases.iter().any(|a| l.contains(a.as_str()))
+            }) {
+                continue;
+            }
+            unguarded.push(format!(
+                "{}:{}: {}",
+                file.strip_prefix(repo_root()).unwrap_or(file).display(),
+                i + 1,
+                line.trim()
+            ));
+        }
+    }
+
+    assert!(
+        unguarded.is_empty(),
+        "a tile-aligned prefill must be gated on the model's own \
+         `supports_padded_prefill()`, not on hardware alone: padding a hybrid \
+         model corrupts its conv / SSM / GatedDeltaNet recurrent state, which \
+         trimming the KV caches afterwards does not undo. Unguarded sites:\n  {}",
+        unguarded.join("\n  ")
+    );
+}


### PR DESCRIPTION
## Summary

`execute_full_prefill`, `start_chunked_prefill` and `continue_chunked_prefill` padded the prompt to a 32-token Neural Accelerator tile whenever the host had one:

```rust
if should_align_prefill() && seq.vlm_embeddings.is_none() {   // hardware only
```

`should_align_prefill()` in the scheduler is `hw.has_neural_accelerator && hw.macos_supports_na`. It never asks the model. Every hybrid and recurrent family answers `supports_padded_prefill() == false`, because pad positions are absorbed by a conv / SSM / GatedDeltaNet state and trimming the KV caches afterwards does not rewind it.

So on an M5-class host, every such model served through these paths had its recurrent state corrupted whenever a prompt or chunk was not already tile-aligned. That is Mamba, Mamba2, Jamba, RWKV, Nemotron-H, Falcon-H1, Kimi Linear, LFM2, Plamo2, GraniteMoeHybrid, Qwen 3.5 and the rest of the `false` list, VLM-wrapped or not.

## The file already knew

Two other places in the same scheduler get it right, which is what makes this a slip rather than a disagreement:

```rust
// No NA-tile padding here: several snapshot-only families report
// `supports_padded_prefill() == false` because padding tokens corrupt
// their conv / SSM recurrent state, and a padded segment would make the
// captured state describe more tokens than the key claims.
```

and the batched path reads it into a local:

```rust
let can_pad_prefill = self.model.supports_padded_prefill();
```

## Measured, not inferred

M5 Max, `qwen3.8-27b-4bit` (its backbone answers `false`), the same `/v1/completions` request at `temperature: 0`, before and after this change:

```
before: ...broken down into its key components.\n\n### 1. The Core: ...
after:  ...illustrated with a series of images.\n\n### 1. The Core: ...
                                   ^ diverges at char 74 of the completion
```

The `after` side is the correct one: no padding on a model that says it cannot take it.

A CLI-to-server comparison is not the discriminator here, because the server parses the reasoning channel differently, so the before/after A/B on the same endpoint is what isolates the variable.

## Relationship to #1201

This is the server-side twin, and wider. #1201 needed a VLM wrapper to lose the predicate by inheriting the trait default instead of delegating; the offline path itself asked correctly. Here the call sites never ask, so it reaches every hybrid model directly.

Same corruption, same hardware gate, different way of losing the guard.

## The guard test grows a second case

`tests/vlm_wrapper_capability_delegation.rs` already fails when a wrapper does not forward the predicate. It now also fails when an `align_to_na_tile` call site is not guarded by it.

| failure mode | check |
|---|---|
| a type answers the trait default instead of forwarding | wrapper scan (#1202) |
| a call site never asks | call-site scan (this PR) |

The call-site rule is deliberately shallow: the guard must appear within a dozen lines before the call, either as the predicate itself or as a local bound to it, since the batched path hoists it fourteen lines up. A guard further away is one a reader cannot see either. The definition, its doc examples and its own unit tests are skipped.

**Verified to fail** by removing one of the three guards: it names the file, the line and the call.

## Test plan

- [x] `-p mlxcel --lib` fails the same 13 tests as baseline, by set comparison rather than by count. The count reads 12 to 14 across runs, which is the pre-existing parallel-execution flakiness in the "prefill is causal" family, not this change.
- [x] Both guard tests pass, and the new one fails when a guard is removed.
- [x] `cargo fmt --check` and `cargo clippy --all-targets --features metal,accelerate -- -D warnings` clean.
- [x] Behavior confirmed on a running server, before and after, same request.

## Not covered

Whether padding actually buys anything is a separate question this PR does not settle. Measured on the CLI earlier today at 68, 75, 237 and 1324 tokens, tile alignment made no difference to prefill throughput outside noise, because where the padding is a large fraction the prefill is fixed-cost dominated, and where the prefill is compute-bound the padding is at most 31 tokens. If that holds on the server too, the optimization is costing correctness risk for nothing and should be reconsidered rather than guarded.

Refs #1201