### PR TITLE
fix(speculative): report the block width the MTP round loop actually used

### DIFF
--- a/src/lib/mlxcel-core/src/speculative/mtp/generator.rs
+++ b/src/lib/mlxcel-core/src/speculative/mtp/generator.rs
@@ -53,6 +53,17 @@ use super::walk::speculative_walk;
 #[derive(Debug, Default)]
 struct MtpRoundDiagnostics {
     rounds: usize,
+    /// Narrowest and widest block the round loop actually drafted at.
+    ///
+    /// Not the same as the requested width, and reported separately because
+    /// they can differ silently: the adaptive controller pins a drafter at
+    /// its configured depth until acceptance justifies expanding, and the
+    /// remaining-token budget clamps the last rounds of a generation. Before
+    /// issue #1206 only the request was logged, so a run at width 4 and a run
+    /// at width 6 were indistinguishable in the record even though the second
+    /// had been overridden into the first.
+    effective_block_min: usize,
+    effective_block_max: usize,
     proposed_tokens: usize,
     accepted_draft_tokens: usize,
     emitted_from_verify_tokens: usize,
@@ -98,6 +109,16 @@ impl MtpRoundDiagnostics {
         self.probe_ms += verify_ms;
     }
 
+    /// Note the width one round actually drafted at.
+    fn record_effective_block(&mut self, block: usize) {
+        if self.effective_block_min == 0 || block < self.effective_block_min {
+            self.effective_block_min = block;
+        }
+        if block > self.effective_block_max {
+            self.effective_block_max = block;
+        }
+    }
+
     fn record_round(&mut self, proposed_tokens: usize, accepted: usize, emitted_tokens: usize) {
         self.rounds += 1;
         self.proposed_tokens += proposed_tokens;
@@ -135,6 +156,8 @@ impl MtpRoundDiagnostics {
     fn summary(&self) -> MtpAcceptanceSummary {
         MtpAcceptanceSummary {
             rounds: self.rounds,
+            effective_block_min: self.effective_block_min,
+            effective_block_max: self.effective_block_max,
             proposed_tokens: self.proposed_tokens,
             accepted_draft_tokens: self.accepted_draft_tokens,
             draft_ms: self.draft_ms,
@@ -155,6 +178,8 @@ impl MtpRoundDiagnostics {
     ) {
         tracing::info!(
             block_size,
+            effective_block_min = self.effective_block_min,
+            effective_block_max = self.effective_block_max,
             prompt_tokens,
             generated_tokens,
             rounds = self.rounds,
@@ -240,6 +265,17 @@ pub struct MtpAcceptanceSummary {
     /// `max_tokens == 1`, in which case the speculative path produced no
     /// timing signal.
     pub rounds: usize,
+    /// Narrowest and widest block the round loop actually drafted at, which
+    /// is not necessarily the width that was requested.
+    ///
+    /// The adaptive controller holds a drafter at its configured depth until
+    /// acceptance justifies expanding, and the remaining-token budget narrows
+    /// the closing rounds of a generation. Reporting only the request made a
+    /// run at width 4 indistinguishable from a run at width 6 that had been
+    /// overridden into it, which is what made `--draft-block-size` look
+    /// tunable when it was not (issue #1206). Zero when no round ran.
+    pub effective_block_min: usize,
+    pub effective_block_max: usize,
     /// Total draft tokens proposed across all rounds.
     pub proposed_tokens: usize,
     /// Total draft tokens accepted by the target's argmax walk across all
@@ -320,6 +356,10 @@ pub struct MtpSessionState {
     /// Per-round accepted counts feeding the adaptive block-size controller
     /// ([`effective_mtp_block_size`]). Probe rounds are excluded.
     accept_lens: Vec<f64>,
+    /// Whether the narrower-than-requested block warning has already fired.
+    /// Once per session: the condition holds every round it holds at all, and
+    /// a per-round warning would bury the run's own diagnostics.
+    warned_block_override: bool,
     /// Classic-step probe rounds still to run (issue #736).
     probes_remaining: usize,
     /// Round diagnostics, accumulated across steps exactly as the
@@ -717,6 +757,7 @@ impl<T: MtpTarget> MtpGenerator<T> {
             drafter_prefill_tokens,
             emitted_count: 1,
             accept_lens: Vec::new(),
+            warned_block_override: false,
             probes_remaining: self.profile_probe_rounds,
             diagnostics,
             prefill_time,
@@ -914,6 +955,25 @@ impl<T: MtpTarget> MtpGenerator<T> {
             if bs <= 1 {
                 state.finished = true;
                 return MtpStepOutput::finished_empty();
+            }
+            state.diagnostics.record_effective_block(bs);
+            // Warn once, at the level an operator sees by default, when the
+            // controller overrides a request that the budget did not force.
+            // A request silently reduced to the configured depth is the case
+            // that makes `--draft-block-size` look tunable when it is not
+            // (issue #1206); a reduction the remaining budget forced is
+            // ordinary end-of-generation behavior and stays quiet.
+            if bs < self.block_size && self.block_size <= remaining && !state.warned_block_override
+            {
+                state.warned_block_override = true;
+                tracing::warn!(
+                    requested = self.block_size,
+                    effective = bs,
+                    configured = self.configured_block_size,
+                    "MTP drafted at a narrower block than requested: the adaptive controller \
+                     holds this drafter at its configured depth until recent acceptance shows \
+                     that prefix is usually fully accepted"
+                );
             }
 
             // Arm the drafter's shared K/V from the stored verify output

--- a/src/lib/mlxcel-core/src/speculative/mtp/tests.rs
+++ b/src/lib/mlxcel-core/src/speculative/mtp/tests.rs
@@ -229,6 +229,10 @@ struct MockMtpDrafter {
     /// Records each `draft_block` call's `last_bonus` so we can assert
     /// the bonus token propagates correctly.
     draft_block_log: RefCell<Vec<i32>>,
+    /// Configured depth, when this mock stands in for a drafter that has one.
+    /// `None` (the default) leaves the adaptive controller with nothing to
+    /// pin against, which is what every other test here wants.
+    configured_block: Option<usize>,
 }
 
 impl MockMtpDrafter {
@@ -237,11 +241,23 @@ impl MockMtpDrafter {
             scripted_draft_tokens: RefCell::new(scripted),
             set_shared_kv_log: RefCell::new(Vec::new()),
             draft_block_log: RefCell::new(Vec::new()),
+            configured_block: None,
         }
+    }
+
+    /// Stand in for a drafter that declares a configured depth, so the
+    /// adaptive controller has something to hold the request down to.
+    fn with_configured_block(mut self, block: usize) -> Self {
+        self.configured_block = Some(block);
+        self
     }
 }
 
 impl Drafter for MockMtpDrafter {
+    fn configured_block_size(&self) -> Option<usize> {
+        self.configured_block
+    }
+
     fn bind(&mut self, _target: &dyn crate::generate::LanguageModel) -> Result<(), DrafterError> {
         Ok(())
     }
@@ -938,5 +954,52 @@ fn round_loop_probe_rounds_emit_one_greedy_token_and_stay_out_of_acceptance() {
         log,
         vec![(0, 1), (0, 1), (3, 4)],
         "probe rounds must finalize as zero-trim single-position verifies",
+    );
+}
+
+/// A request the adaptive controller overrides must not be reported as the
+/// width that ran.
+///
+/// Before issue #1206 the round-loop diagnostics carried only the requested
+/// width, so a run pinned to a drafter's configured depth was indistinguishable
+/// in the record from a run that genuinely used the requested one. On the
+/// Gemma 4 pairing that made `--draft-block-size 6` produce a run byte-identical
+/// to `--draft-block-size 4` while still reporting 6, which is what makes the
+/// flag look tunable when it is not.
+#[test]
+fn an_overridden_block_request_is_not_reported_as_the_width_used() {
+    let target = MockMtpTarget::new(
+        vec![vec![10, 11, 12, 13, 14], vec![20, 21, 22, 23, 24]],
+        vec![],
+    );
+    let drafter = MockMtpDrafter::new(vec![vec![10, 11, 12, 13], vec![20, 21, 22, 23]])
+        .with_configured_block(2);
+    let mut gen_ = MtpGenerator::new(target, Box::new(drafter), 5);
+    let _ = gen_.generate(
+        &[1, 2, 3],
+        10,
+        &SamplingConfig::greedy(),
+        &[],
+        &AtomicBool::new(false),
+        &LogprobsConfig::default(),
+    );
+
+    let summary = gen_
+        .last_acceptance()
+        .expect("a run with rounds must produce a summary");
+    assert!(summary.rounds > 0, "the fixture must actually run rounds");
+    assert!(
+        summary.effective_block_max < 5,
+        "the controller pinned this drafter at depth 2, so 5 must not be \
+         reported as the width used; got {}",
+        summary.effective_block_max
+    );
+    assert!(
+        summary.effective_block_min > 0,
+        "an executed round must record the width it drafted at"
+    );
+    assert!(
+        summary.effective_block_min <= summary.effective_block_max,
+        "the recorded range must be ordered"
     );
 }

--- a/src/server/batch/mtp_policy_tests.rs
+++ b/src/server/batch/mtp_policy_tests.rs
@@ -50,6 +50,8 @@ fn sample(
 ) -> MtpBurstProfile {
     MtpBurstProfile::from_summary(
         MtpAcceptanceSummary {
+            effective_block_min: 0,
+            effective_block_max: 0,
             rounds,
             proposed_tokens: proposed_per_round * rounds,
             accepted_draft_tokens: accepted_per_round * rounds,
@@ -247,6 +249,8 @@ fn accumulator_records_batch_and_prompt_shape() {
     let mut acc = ProfileAccumulator::default();
     acc.add(&MtpBurstProfile::from_summary(
         MtpAcceptanceSummary {
+            effective_block_min: 0,
+            effective_block_max: 0,
             rounds: 4,
             proposed_tokens: 12,
             accepted_draft_tokens: 8,
@@ -259,6 +263,8 @@ fn accumulator_records_batch_and_prompt_shape() {
     ));
     acc.add(&MtpBurstProfile::from_summary(
         MtpAcceptanceSummary {
+            effective_block_min: 0,
+            effective_block_max: 0,
             rounds: 4,
             proposed_tokens: 12,
             accepted_draft_tokens: 8,
@@ -676,6 +682,8 @@ fn profile_sample_carries_no_token_level_data() {
     // realized byte-identity is validated on real models by the orchestrator
     // and by the greedy-parity gate in mlxcel_core::speculative::mtp::tests.
     let summary = MtpAcceptanceSummary {
+        effective_block_min: 0,
+        effective_block_max: 0,
         rounds: 8,
         proposed_tokens: 24,
         accepted_draft_tokens: 18,
@@ -711,6 +719,8 @@ fn measured_sample(
 ) -> MtpBurstProfile {
     MtpBurstProfile::from_summary(
         MtpAcceptanceSummary {
+            effective_block_min: 0,
+            effective_block_max: 0,
             rounds,
             proposed_tokens: proposed_per_round * rounds,
             accepted_draft_tokens: accepted_total,


### PR DESCRIPTION
## Summary

The MTP round-loop diagnostics carried the **requested** block width only. A request the adaptive controller overrode was indistinguishable in the record from one it honored.

On the Gemma 4 pairing, `--draft-block-size 6` produced a run byte-identical to `--draft-block-size 4`, same round count and same acceptance to four decimals, while still reporting:

```
MTP round-loop diagnostics block_size=6 ... rounds=44 proposed_tokens=130
                           acceptance_rate=0.5846153846153846
```

`proposed_tokens / rounds` is 2.95, the three proposals a width of 4 makes, not the five a width of 6 would.

## Why it is worth fixing rather than documenting

It makes `--draft-block-size` look tunable when it is not, and it puts two rows in a benchmark table that differ only by a label, which reads as evidence that the width does not matter.

It cost real time on #1204: two identical runs at different requested widths looked like a bug in the sweep harness until the proposal count gave it away.

## What changed

The round loop records the width it drafted at each round and reports the range, on the tracing line and on `MtpAcceptanceSummary` so callers read it rather than parse logs.

A request the controller narrowed warns **once**, at `WARN`, naming all three numbers:

```
MTP drafted at a narrower block than requested: ... requested=6 effective=4 configured=4
```

A request the remaining token budget narrowed stays quiet. That is ordinary end-of-generation behavior, not an override worth interrupting for, and warning on it would fire on every run.

## Verified on the pairing that exposed it

| request | warning | reported effective range |
|---|---|---|
| `--draft-block-size 4` | none | 3 to 4 |
| `--draft-block-size 6` | `requested=6 effective=4 configured=4` | 3 to 4 |

The 3 in both ranges is the closing round, narrowed by the remaining budget.

## Test plan

- [x] New unit test: a drafter with a configured depth of 2, asked for 5, must not report 5 as the width used. Fails without the change.
- [x] `-p mlxcel-core --lib` and `-p mlxcel --lib`: failure sets identical to baseline by set comparison (13 in `mlxcel`, 4 in `mlxcel-core`), all the pre-existing TF32 class of #1065. The `mlxcel` count reads 13 or 14 across runs, which is the known whole-binary parallelism flake tracked on #1092, not this change.
- [x] `cargo fmt --check` and `cargo clippy --all-targets --features metal,accelerate -- -D warnings` clean.
- [x] Confirmed live on `gemma-4-12b-it-4bit` with the `gemma-4-12b-it-assistant-4bit` drafter.

## Not covered

Whether the controller *should* be overriding this pairing is a separate question, measured and filed as #1207: block 5 is 98.16 tok/s against the configured 4's 93.54, so the policy is holding it about 5% below its own optimum. This PR only makes the override visible; it changes no decision.

Fixes #1206