### PR TITLE
chore(deps): bump h2 to 0.4.16 for RUSTSEC-2026-0258

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1236,9 +1236,9 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.4.15"
+version = "0.4.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6cb093c84e8bd9b188d4c4a8cb6579fc016968d14c99882163cd3ff402a4f155"
+checksum = "a9f37a958b41b3b19ee2707c06439c0e9e547e847223eb791ecb0cb821c65e27"
 dependencies = [
  "atomic-waker",
  "bytes",


### PR DESCRIPTION
## Summary

`h2` 0.4.15 accepts and queues empty DATA frames without bounding them, so a stream that is not actively drained can grow memory without limit, or panic if the length overflows. Low severity, patched in 0.4.16 ([RUSTSEC-2026-0258](https://rustsec.org/advisories/RUSTSEC-2026-0258), [GHSA-q83h-524g-xf6h](https://github.com/hyperium/hyper/security/advisories/GHSA-q83h-524g-xf6h)).

It reaches this tree twice: through axum for `mlxcel-server`, and through reqwest for the model downloader.

The advisory published today, so `cargo deny check` now fails on every PR, including ones that touch no dependency at all. This unblocks them.

## Related issues

No issue; advisory-driven.

## Type of change

- [x] `chore` — build, CI, dependencies, release infrastructure

## Why the lockfile was hand-edited

`cargo update -p h2` produces a 22-line diff, not a 4-line one: it re-resolves `windows-sys` for nine unrelated crates (`anstyle-query`, `anstyle-wincon`, `errno`, `nu-ansi-term`, `rustix`, `socket2` among them), moving them off the 0.61.2 this tree currently unifies them on and back down to 0.52.0 / 0.59.0 / 0.60.2. That is a separate change and it should not ride along in a security bump.

Editing the `h2` stanza alone leaves exactly the version and checksum lines changed. `cargo metadata --locked` accepting the result is what confirms 0.4.16's dependency list still matches what the lock records; a patch release that had added or changed a dependency would fail there rather than build something the lock does not describe.

## Test plan

- [x] `cargo deny check advisories` clean locally (was failing on this advisory before the bump)
- [x] `cargo metadata --locked` accepts the lockfile unchanged
- [x] `cargo build --profile test-fast --locked --bin mlxcel-server --features metal,accelerate`
- [ ] Real-checkpoint validation: not applicable, no runtime code changes

## Noticed, not fixed

`deny.toml` still ignores RUSTSEC-2026-0202 and cargo-deny warns that no crate matches it any more. Stale ignore, worth its own cleanup.