### PR TITLE
feat(speculative): branch the draft tree, and verify it at its own positions

### DIFF
--- a/src/distributed/tensor_parallel/llama_runtime.rs
+++ b/src/distributed/tensor_parallel/llama_runtime.rs
@@ -1004,7 +1004,7 @@ impl TensorParallelGemma4Model {
                 }
                 let pre_offset = cache.offset();
                 let (attn_out, stored_kv) =
-                    full_attn.forward(&attn_norm, layer_mask, cache, shared_kv, None);
+                    full_attn.forward(&attn_norm, layer_mask, cache, shared_kv, None, None);
                 if let Some((keys, values)) = stored_kv {
                     shared_kv_store[0].insert(layer_idx, (keys, values, pre_offset));
                 }
@@ -1032,7 +1032,7 @@ impl TensorParallelGemma4Model {
                         let pre_offset = cache.offset();
                         let (attn_out, stored_kv) = rank.text_model.layers[layer_idx]
                             .self_attn
-                            .forward(&attn_norm, layer_mask, cache, shared_kv, None);
+                            .forward(&attn_norm, layer_mask, cache, shared_kv, None, None);
                         if let Some((keys, values)) = stored_kv {
                             shared_store.insert(layer_idx, (keys, values, pre_offset));
                         }

--- a/src/lib/mlxcel-core/src/drafter/gemma4_assistant/model.rs
+++ b/src/lib/mlxcel-core/src/drafter/gemma4_assistant/model.rs
@@ -816,46 +816,50 @@ impl Gemma4AssistantDraftModel {
     }
 
     /// How many runner-up candidates a tree round may spend verify positions
-    /// on, from `MLXCEL_MTP_TREE_BRANCHES`.
+    /// on, from `MLXCEL_MTP_TREE_BRANCHES`. **Default 0.**
     ///
-    /// **Defaults to 0, because branching is not correct yet.** A flattened
-    /// tree is fed to the target as a contiguous span of positions, and the
-    /// tree mask fixes what each node can see but not where each node sits.
-    /// A node's RoPE position is its index in that span, which equals its
-    /// depth only while the tree is a chain. The moment a sibling exists,
-    /// every node after it is one position too far along, and the target
-    /// verifies them at the wrong place.
+    /// Zero proposes the linear tree the trait default builds, so the switch
+    /// degrades to exactly the chain behaviour rather than to something new,
+    /// and that is the default for two reasons that are worth stating rather
+    /// than discovering.
     ///
-    /// That is why linear trees are byte-identical to the chain path and a
-    /// branching one is not: measured on gemma-4-12b at block 5, 400 tokens,
-    /// temperature 0, the branching arm's text diverges from the chain's.
-    /// Speculative decoding is supposed to preserve the target's greedy
-    /// output exactly, so that divergence is a defect and not a tradeoff.
+    /// First, a branching round does not reproduce the chain's exact tokens,
+    /// and cannot. When a leaf is accepted its bonus is the target's argmax
+    /// evaluated at a tree position, while the chain evaluates the same
+    /// context at the head of the next block. Both are the target's own
+    /// greedy choice for the same context and they differ only where the top
+    /// two sit within f16 reduction noise, which is the jitter class MTP
+    /// already carries against non-speculative decoding: measured on
+    /// gemma-4-12b, chain, linear tree and branching all first diverge from
+    /// the non-speculative path at the same character. But the linear tree is
+    /// byte-identical to the chain and a branching one is not, so it is a
+    /// weaker guarantee and an opt-in.
     ///
-    /// Closing it needs per-node position ids threaded into the Gemma 4
-    /// forward, which has no parameter for them today: positions are derived
-    /// from the cache offset and the index within the span. Until then a
-    /// non-zero budget is a research setting that produces wrong output, and
-    /// it warns when set (issue #1204).
+    /// Second, the throughput case is not made. Branching lifts acceptance
+    /// (emitted-per-verify 2.4630 to 2.6600, zero-accept rounds 51 to 26 of
+    /// 162) and widens every verify block to do it. Whether that trades
+    /// positive has not been measured on a quiet machine under the protocol
+    /// that measurement needs.
     ///
-    /// What the measurements said before the defect was found, kept because
-    /// they are what makes the position work worth doing: with the budget
-    /// spent on the earliest uncertain steps, emitted-per-verify went 2.4630
-    /// to 2.6600 and zero-accept rounds halved from 51 to 26 out of 162.
+    /// A branching tree is only correct because the verify block now carries
+    /// per-node RoPE positions. A flattened tree hands the target a contiguous
+    /// span, and the tree mask fixes what each node can see but not where each
+    /// node sits; a node's position is its index in the span, which equals its
+    /// depth only while the tree is a chain. Before `DraftTree::depths` was
+    /// threaded through the Gemma 4 forward, one sibling put every later node
+    /// a place too far along and the branching arm's output diverged from the
+    /// chain's, which for temperature-0 speculative decoding is a defect
+    /// rather than a tradeoff (issue #1204).
+    ///
+    /// The extra nodes widen the verify block, so they eat into the rotating
+    /// cache's speculative slack. That slack is `max(32, min(128, K * 8))`
+    /// tokens against blocks of 4 to 8, so a budget in the low single digits
+    /// is comfortably inside it.
     fn branch_budget() -> usize {
-        let budget = std::env::var("MLXCEL_MTP_TREE_BRANCHES")
+        std::env::var("MLXCEL_MTP_TREE_BRANCHES")
             .ok()
             .and_then(|v| v.trim().parse::<usize>().ok())
-            .unwrap_or(0);
-        if budget > 0 {
-            tracing::warn!(
-                budget,
-                "MLXCEL_MTP_TREE_BRANCHES is set: a branching draft tree is verified at the \
-                 wrong RoPE positions and does NOT preserve the target's greedy output \
-                 (issue #1204). Research setting only."
-            );
-        }
-        budget
+            .unwrap_or(0)
     }
 
     /// Top-two logit gap under which a step counts as uncertain, from
@@ -898,7 +902,7 @@ impl Gemma4AssistantDraftModel {
     /// chosen token is not one of the top two, which at temperature 0 means a
     /// tie the sampler broke some other way; branching on a step whose own
     /// ordering is not understood is not worth a position.
-    pub(crate) fn runner_up(last_logits: &MlxArray, chosen: i32) -> Option<(i32, f32)> {
+    pub(crate) fn runner_up_token(last_logits: &MlxArray, chosen: i32) -> Option<i32> {
         let shape = ffi::array_shape(last_logits);
         let vocab = *shape.last()?;
         if vocab < 2 {
@@ -909,13 +913,23 @@ impl Gemma4AssistantDraftModel {
         ffi::eval(&pair);
         let first = ffi::item_i32(&ffi::slice(&pair, &[0, 0], &[1, 1]));
         let second = ffi::item_i32(&ffi::slice(&pair, &[0, 1], &[1, 2]));
-        let other = if first == chosen {
-            second
+        if first == chosen {
+            Some(second)
         } else if second == chosen {
-            first
+            Some(first)
         } else {
-            return None;
-        };
+            None
+        }
+    }
+
+    /// [`Self::runner_up_token`] plus the top-two logit gap.
+    ///
+    /// Only the optional margin gate wants the gap, and it costs a second
+    /// device round trip to read. The default policy selects by step rather
+    /// than by margin, so this is off the hot path and the token-only lookup
+    /// above is what a normal round pays (issue #1204).
+    pub(crate) fn runner_up(last_logits: &MlxArray, chosen: i32) -> Option<(i32, f32)> {
+        let other = Self::runner_up_token(last_logits, chosen)?;
         let ids = ffi::from_slice_i32(&[chosen, other], &[2]);
         let values = ffi::take(last_logits, &ids, -1);
         ffi::eval(&values);
@@ -1349,6 +1363,7 @@ impl Drafter for Gemma4AssistantDraftModel {
         // `(step, runner-up token, margin)` for every step that produced one.
         let mut candidates: Vec<(usize, i32, f32)> = Vec::new();
 
+        let margin_gate = Self::branch_margin();
         let mut h_prev = ffi::copy(hidden);
         let mut last_token = last_bonus;
 
@@ -1371,8 +1386,18 @@ impl Drafter for Gemma4AssistantDraftModel {
             ffi::eval(&token);
             let token_i32 = ffi::item_i32(&token);
 
-            if let Some((other, margin)) = Self::runner_up(&last_logits, token_i32) {
-                candidates.push((step, other, margin));
+            // Only look up what the policy can use. The default selects the
+            // earliest steps, so past the budget there is nothing to gain and
+            // the lookup is skipped entirely; the margin, which costs a second
+            // device round trip, is read only when the gate is actually on.
+            if margin_gate.is_finite() {
+                if let Some((other, gap)) = Self::runner_up(&last_logits, token_i32) {
+                    candidates.push((step, other, gap));
+                }
+            } else if candidates.len() < budget
+                && let Some(other) = Self::runner_up_token(&last_logits, token_i32)
+            {
+                candidates.push((step, other, 0.0));
             }
 
             tokens.push(token_i32);
@@ -1381,11 +1406,7 @@ impl Drafter for Gemma4AssistantDraftModel {
         }
 
         let mut tree = DraftTree::linear(last_bonus, &tokens);
-        // Only steps the drafter was actually unsure about are worth a verify
-        // position; on a confident step the extra node widens the block and
-        // buys nothing.
-        let margin = Self::branch_margin();
-        candidates.retain(|&(_, _, gap)| gap < margin);
+        candidates.retain(|&(_, _, gap)| gap < margin_gate);
         // Earliest step first, not smallest margin. A runner-up at step `i`
         // can only be reached if every step before it was accepted, so its
         // value decays with `i` in a way the logit gap does not describe. The

--- a/src/lib/mlxcel-core/src/drafter/gemma4_assistant/model.rs
+++ b/src/lib/mlxcel-core/src/drafter/gemma4_assistant/model.rs
@@ -815,6 +815,115 @@ impl Gemma4AssistantDraftModel {
         Ok((last_hidden, logits))
     }
 
+    /// How many runner-up candidates a tree round may spend verify positions
+    /// on, from `MLXCEL_MTP_TREE_BRANCHES`.
+    ///
+    /// **Defaults to 0, because branching is not correct yet.** A flattened
+    /// tree is fed to the target as a contiguous span of positions, and the
+    /// tree mask fixes what each node can see but not where each node sits.
+    /// A node's RoPE position is its index in that span, which equals its
+    /// depth only while the tree is a chain. The moment a sibling exists,
+    /// every node after it is one position too far along, and the target
+    /// verifies them at the wrong place.
+    ///
+    /// That is why linear trees are byte-identical to the chain path and a
+    /// branching one is not: measured on gemma-4-12b at block 5, 400 tokens,
+    /// temperature 0, the branching arm's text diverges from the chain's.
+    /// Speculative decoding is supposed to preserve the target's greedy
+    /// output exactly, so that divergence is a defect and not a tradeoff.
+    ///
+    /// Closing it needs per-node position ids threaded into the Gemma 4
+    /// forward, which has no parameter for them today: positions are derived
+    /// from the cache offset and the index within the span. Until then a
+    /// non-zero budget is a research setting that produces wrong output, and
+    /// it warns when set (issue #1204).
+    ///
+    /// What the measurements said before the defect was found, kept because
+    /// they are what makes the position work worth doing: with the budget
+    /// spent on the earliest uncertain steps, emitted-per-verify went 2.4630
+    /// to 2.6600 and zero-accept rounds halved from 51 to 26 out of 162.
+    fn branch_budget() -> usize {
+        let budget = std::env::var("MLXCEL_MTP_TREE_BRANCHES")
+            .ok()
+            .and_then(|v| v.trim().parse::<usize>().ok())
+            .unwrap_or(0);
+        if budget > 0 {
+            tracing::warn!(
+                budget,
+                "MLXCEL_MTP_TREE_BRANCHES is set: a branching draft tree is verified at the \
+                 wrong RoPE positions and does NOT preserve the target's greedy output \
+                 (issue #1204). Research setting only."
+            );
+        }
+        budget
+    }
+
+    /// Top-two logit gap under which a step counts as uncertain, from
+    /// `MLXCEL_MTP_TREE_MARGIN`.
+    ///
+    /// This is what stops the budget from being spent every round. A verify
+    /// position is not free: it widens the block for that round, and the
+    /// verify forward is where the round's time goes, so paying for a
+    /// candidate on a step the drafter was sure about is a straight loss.
+    /// Measured on gemma-4-12b at block 5, spending the budget
+    /// unconditionally lifted emitted-per-verify from 2.46 to 2.71 and took
+    /// throughput from 84 to 65 tok/s, because a block widening by half
+    /// bought an acceptance gain of a tenth (issue #1204).
+    ///
+    /// Defaults to no gate, because gating on it was measured to do nothing.
+    /// At 0.3, 1.0 and 3.0 the gate admitted 2, 2 and 5 extra nodes across 162
+    /// rounds and left emitted-per-verify at the chain's 2.46296 exactly. The
+    /// drafter is sharply peaked and still only about half right, so the steps
+    /// it is unsure about are not the steps it is wrong about, and its top-two
+    /// gap does not predict whether the target will agree. Kept as an escape
+    /// hatch, and kept documented, so the next person does not re-run the same
+    /// sweep.
+    fn branch_margin() -> f32 {
+        std::env::var("MLXCEL_MTP_TREE_MARGIN")
+            .ok()
+            .and_then(|v| v.trim().parse::<f32>().ok())
+            .unwrap_or(f32::INFINITY)
+    }
+
+    /// The second-best token at this step and how far behind it is.
+    ///
+    /// The drafter projects the whole vocabulary to pick one argmax and then
+    /// discards the rest. The runner-up is the piece of that worth keeping:
+    /// where the top two are close the drafter is guessing, the target is the
+    /// thing that settles it, and a verify position is exactly what buys that
+    /// answer (issue #1204).
+    ///
+    /// One partition over the vocabulary rather than a sort, next to a
+    /// projection that already dominates the step. Returns `None` when the
+    /// chosen token is not one of the top two, which at temperature 0 means a
+    /// tie the sampler broke some other way; branching on a step whose own
+    /// ordering is not understood is not worth a position.
+    pub(crate) fn runner_up(last_logits: &MlxArray, chosen: i32) -> Option<(i32, f32)> {
+        let shape = ffi::array_shape(last_logits);
+        let vocab = *shape.last()?;
+        if vocab < 2 {
+            return None;
+        }
+        let part = ffi::argpartition(last_logits, vocab - 2, -1);
+        let pair = ffi::slice(&part, &[0, vocab - 2], &[1, vocab]);
+        ffi::eval(&pair);
+        let first = ffi::item_i32(&ffi::slice(&pair, &[0, 0], &[1, 1]));
+        let second = ffi::item_i32(&ffi::slice(&pair, &[0, 1], &[1, 2]));
+        let other = if first == chosen {
+            second
+        } else if second == chosen {
+            first
+        } else {
+            return None;
+        };
+        let ids = ffi::from_slice_i32(&[chosen, other], &[2]);
+        let values = ffi::take(last_logits, &ids, -1);
+        ffi::eval(&values);
+        let chosen_logit = ffi::item_f32(&ffi::slice(&values, &[0, 0], &[1, 1]));
+        let other_logit = ffi::item_f32(&ffi::slice(&values, &[0, 1], &[1, 2]));
+        Some((other, chosen_logit - other_logit))
+    }
+
     /// Single-row argmax sample from a `[1, 1, vocab]` logits tensor.
     ///
     /// The full `SamplingConfig`-aware sampler currently operates on
@@ -1179,6 +1288,116 @@ impl Drafter for Gemma4AssistantDraftModel {
         }
 
         Ok(tokens)
+    }
+
+    /// Propose a tree: the same chain as [`Self::draft_block`], plus a
+    /// runner-up leaf at the steps where the drafter was least sure.
+    ///
+    /// The chain is unchanged, node for node, which is what keeps the linear
+    /// equivalence available as a control: setting `MLXCEL_MTP_TREE_BRANCHES=0`
+    /// yields exactly the tree the trait default builds, and that one is
+    /// asserted byte-identical to the chain path (issue #1204).
+    ///
+    /// A runner-up is attached as a **leaf**, not as the head of a second
+    /// chain. Extending it would need its own drafter forward for every
+    /// remaining step, which is the expensive kind of tree; this one buys a
+    /// candidate for one verify position and no extra drafting. What it can
+    /// win is the round where the target diverges immediately: the walk
+    /// accepts nothing today, and with the runner-up present it accepts one
+    /// token instead, if the target's choice was the drafter's second guess.
+    ///
+    /// Which steps get one is decided by the top-two logit margin, smallest
+    /// first, rather than by an absolute threshold, so it needs no
+    /// calibration and the budget is spent where the drafter was least
+    /// certain.
+    ///
+    /// The extra nodes widen the verify block, so they eat into the rotating
+    /// cache's speculative slack. That slack is
+    /// `max(32, min(128, K * 8))` tokens against blocks of 4 to 8, so a
+    /// budget in the low single digits is comfortably inside it.
+    fn draft_tree(
+        &mut self,
+        last_bonus: i32,
+        hidden: Option<&MlxArray>,
+        block_size: usize,
+        sampler: &SamplingConfig,
+    ) -> Result<crate::speculative::mtp::tree::DraftTree, DrafterError> {
+        use crate::speculative::mtp::tree::DraftTree;
+
+        let budget = Self::branch_budget();
+        // Branching is a greedy-path idea: the walk accepts a child only when
+        // it equals the target's argmax, so a sampled draft has no claim on
+        // the second-best token. Falling back to the linear tree means
+        // switching this on cannot change a sampled run at all.
+        if budget == 0 || sampler.temperature != 0.0 {
+            let drafts = self.draft_block(last_bonus, hidden, block_size, sampler)?;
+            return Ok(DraftTree::linear(last_bonus, &drafts));
+        }
+
+        if self.shared_kv.is_none() {
+            return Err(DrafterError::SetSharedKvNotCalled);
+        }
+        if self.lm_head.is_none() {
+            return Err(DrafterError::BindNotCalled);
+        }
+        if block_size == 0 {
+            return Ok(DraftTree::root(last_bonus));
+        }
+        let hidden = hidden.ok_or(DrafterError::DraftBlockMissingHidden)?;
+
+        let mut tokens: Vec<i32> = Vec::with_capacity(block_size.saturating_sub(1));
+        // `(step, runner-up token, margin)` for every step that produced one.
+        let mut candidates: Vec<(usize, i32, f32)> = Vec::new();
+
+        let mut h_prev = ffi::copy(hidden);
+        let mut last_token = last_bonus;
+
+        for step in 0..block_size.saturating_sub(1) {
+            let tok_ids = ffi::from_slice_i32(&[last_token], &[1, 1]);
+            let tok_embed = self.draft_input_embed(&tok_ids);
+            let inputs_embeds = crate::concatenate(&tok_embed, &h_prev, -1);
+
+            let (next_hidden, logits) = self.forward(&inputs_embeds)?;
+            // Sliced once and reused: the sampler and the runner-up lookup
+            // both want the same `[1, vocab]` row.
+            let last_logits = ffi::slice_last_logits(&logits);
+            let token = ffi::fused_sample(
+                &last_logits,
+                sampler.temperature,
+                sampler.top_k,
+                sampler.top_p,
+                sampler.min_p,
+            );
+            ffi::eval(&token);
+            let token_i32 = ffi::item_i32(&token);
+
+            if let Some((other, margin)) = Self::runner_up(&last_logits, token_i32) {
+                candidates.push((step, other, margin));
+            }
+
+            tokens.push(token_i32);
+            last_token = token_i32;
+            h_prev = next_hidden;
+        }
+
+        let mut tree = DraftTree::linear(last_bonus, &tokens);
+        // Only steps the drafter was actually unsure about are worth a verify
+        // position; on a confident step the extra node widens the block and
+        // buys nothing.
+        let margin = Self::branch_margin();
+        candidates.retain(|&(_, _, gap)| gap < margin);
+        // Earliest step first, not smallest margin. A runner-up at step `i`
+        // can only be reached if every step before it was accepted, so its
+        // value decays with `i` in a way the logit gap does not describe. The
+        // round this is trying to rescue is the one that accepts nothing,
+        // and that is decided at step 0.
+        candidates.sort_by_key(|&(step, _, _)| step);
+        for &(step, token, _) in candidates.iter().take(budget) {
+            // Step `i` was drafted from node `i`, so its alternative is a
+            // sibling of node `i + 1` and a second child of node `i`.
+            tree.push_child(step, token);
+        }
+        Ok(tree)
     }
 
     fn sanitize(&mut self, weights: &mut WeightMap) -> Result<(), DrafterError> {

--- a/src/lib/mlxcel-core/src/drafter/gemma4_assistant/tests.rs
+++ b/src/lib/mlxcel-core/src/drafter/gemma4_assistant/tests.rs
@@ -805,3 +805,39 @@ fn set_shared_kv_with_left_padding_routes_through_normalizer() {
         .set_shared_kv(shared, 0, 0, /* left_padding */ 3)
         .expect("set_shared_kv with left_padding must succeed");
 }
+
+/// The runner-up lookup has to name the second-best token and its margin.
+///
+/// This is the confidence signal branching spends verify positions on, and it
+/// is read off a `[1, vocab]` logits row rather than a sort, so the shape and
+/// the partition orientation both have to be right. Getting either wrong
+/// returns `None` on every step, which is silent: the tree simply never grows
+/// a branch and the round statistics come out identical to the chain's, which
+/// looks like "branching did not help" rather than "branching did not run"
+/// (issue #1204).
+#[test]
+fn runner_up_names_the_second_best_token_and_its_margin() {
+    use crate::drafter::gemma4_assistant::model::Gemma4AssistantDraftModel;
+
+    // Best is index 5 at 9.0, second is index 2 at 7.5, margin 1.5.
+    let row = crate::ffi::from_slice_f32(&[0.0, 1.0, 7.5, 2.0, 3.0, 9.0, 4.0, 5.0], &[1, 8]);
+
+    let (token, margin) = Gemma4AssistantDraftModel::runner_up(&row, 5)
+        .expect("a row with a distinct top two must produce a runner-up");
+    assert_eq!(
+        token, 2,
+        "the runner-up is the second-largest logit's index"
+    );
+    assert!(
+        (margin - 1.5).abs() < 1e-4,
+        "the margin is the top-two logit gap, got {margin}"
+    );
+
+    // A `chosen` that is not in the top two is a tie the sampler broke some
+    // other way; branching on a step whose ordering is not understood is
+    // declined rather than guessed at.
+    assert!(
+        Gemma4AssistantDraftModel::runner_up(&row, 0).is_none(),
+        "a chosen token outside the top two must decline"
+    );
+}

--- a/src/lib/mlxcel-core/src/speculative/mtp/tree.rs
+++ b/src/lib/mlxcel-core/src/speculative/mtp/tree.rs
@@ -206,6 +206,28 @@ impl DraftTree {
         mask
     }
 
+    /// Each node's depth, which is its RoPE position relative to the cache
+    /// offset the verify block is appended at.
+    ///
+    /// The flattened block gives every node the position of its index, and
+    /// index equals depth only while the tree is a chain. One sibling puts
+    /// every later node a place too far along, and the target then verifies
+    /// them somewhere they do not belong, so the block has to carry this
+    /// alongside the mask: the mask says what a node can see, this says where
+    /// it sits (issue #1204).
+    ///
+    /// A linear tree returns `0..len`, which is what the uniform rotation
+    /// already does, so the tree path reduces to it exactly.
+    pub fn depths(&self) -> Vec<i32> {
+        let mut depths = vec![0i32; self.tokens.len()];
+        // `parents[i] < i` holds by construction, so one forward pass suffices
+        // and no node is read before it is written.
+        for node in 1..self.tokens.len() {
+            depths[node] = depths[self.parents[node]] + 1;
+        }
+        depths
+    }
+
     /// Descend the branch the target agreed with.
     ///
     /// `target_tokens[i]` is the target's greedy choice conditional on the

--- a/src/lib/mlxcel-core/src/speculative/mtp/tree_tests.rs
+++ b/src/lib/mlxcel-core/src/speculative/mtp/tree_tests.rs
@@ -280,3 +280,34 @@ fn a_linear_history_mask_matches_a_causal_mask_with_the_same_offset() {
     }
     assert_eq!(tree.additive_mask_with_history(offset, MASKED), expected);
 }
+
+/// A node's depth is its RoPE position, and index equals depth only in a chain.
+///
+/// The flattened verify block gives every node the position of its index. For a
+/// linear tree that is already right, which is why the tree path could look
+/// correct while carrying this defect; one sibling makes them disagree and the
+/// target then verifies later nodes somewhere they do not belong (issue #1204).
+#[test]
+fn depths_are_the_positions_a_flattened_block_gets_wrong() {
+    let linear = DraftTree::linear(7, &[10, 11, 12]);
+    assert_eq!(
+        linear.depths(),
+        vec![0, 1, 2, 3],
+        "a chain's depths are its indices, so it reduces to the uniform rotation"
+    );
+
+    // Root, a chain of two, then a sibling of the first chain node.
+    let mut tree = DraftTree::linear(7, &[10, 11]);
+    let leaf = tree.push_child(0, 99);
+    assert_eq!(leaf, 3, "the leaf is appended after the chain");
+    assert_eq!(
+        tree.depths(),
+        vec![0, 1, 2, 1],
+        "the leaf sits beside node 1, not after node 2, whatever its index says"
+    );
+
+    // A leaf hung off the deeper node, to check the walk down the parents.
+    let mut deeper = DraftTree::linear(7, &[10, 11, 12]);
+    deeper.push_child(2, 98);
+    assert_eq!(deeper.depths(), vec![0, 1, 2, 3, 3]);
+}

--- a/src/models/gemma4.rs
+++ b/src/models/gemma4.rs
@@ -1954,6 +1954,112 @@ impl Attention {
         out.expect("compiled_q_path_proportional_per_row requires at least one batch row")
     }
 
+    /// Rotate a `[B, H, L, D]` verify block whose positions are not
+    /// consecutive.
+    ///
+    /// A draft tree node sits at its depth, and depth equals index only while
+    /// the tree is a chain, so a flattened tree needs a position per node
+    /// rather than one offset for the whole span. Without this a sibling
+    /// pushes every later node one place too far along and the target
+    /// verifies them somewhere they do not belong (issue #1204).
+    ///
+    /// Consecutive positions are rotated in one call, so a linear tree is a
+    /// single `apply_rope` and stays bit-identical to the uniform path; a tree
+    /// with `n` leaves costs `n + 1` calls, and `n` is in the low single
+    /// digits.
+    ///
+    /// `positions` are **relative** to `offset`, i.e. node depths. Keeping them
+    /// relative means the caller does not have to know which cache offset each
+    /// layer family is at, and a linear tree's `0..L` reduces to exactly the
+    /// uniform `offset` the non-tree path passes.
+    fn apply_rope_per_position(
+        &self,
+        x: &MlxArray,
+        offset: i32,
+        positions: &[i32],
+    ) -> UniquePtr<MlxArray> {
+        let shape = mlxcel_core::array_shape(x);
+        debug_assert_eq!(shape.len(), 4, "rope input must be [B, H, L, D]");
+        debug_assert_eq!(
+            shape[2] as usize,
+            positions.len(),
+            "apply_rope_per_position needs exactly one position per node"
+        );
+        let mut out: Option<UniquePtr<MlxArray>> = None;
+        let mut start = 0usize;
+        while start < positions.len() {
+            let mut end = start + 1;
+            while end < positions.len() && positions[end] == positions[end - 1] + 1 {
+                end += 1;
+            }
+            let run = mlxcel_core::slice(
+                x,
+                &[0, 0, start as i32, 0],
+                &[shape[0], shape[1], end as i32, shape[3]],
+            );
+            let rotated = self.apply_rope(&run, offset + positions[start]);
+            out = Some(match out {
+                None => rotated,
+                Some(acc) => {
+                    mlxcel_core::concatenate(acc.as_ref().unwrap(), rotated.as_ref().unwrap(), 2)
+                }
+            });
+            start = end;
+        }
+        out.expect("apply_rope_per_position requires at least one position")
+    }
+
+    /// Per-position variant of the compiled proportional Q/K path.
+    ///
+    /// Same run grouping as [`Self::apply_rope_per_position`] and for the same
+    /// reason: a linear tree resolves to one call through the identical kernel
+    /// the uniform path uses, so switching tree drafting on cannot move the
+    /// numerics on the configuration it subsumes.
+    #[allow(clippy::too_many_arguments)]
+    fn compiled_q_path_proportional_per_position(
+        &self,
+        proj_out: &MlxArray,
+        norm_weight: &MlxArray,
+        norm_eps: f32,
+        freqs: &MlxArray,
+        n_heads: i32,
+        rotated_dims: i32,
+        offset: i32,
+        positions: &[i32],
+    ) -> UniquePtr<MlxArray> {
+        let shape = mlxcel_core::array_shape(proj_out);
+        let b = shape[0];
+        let width = n_heads * self.head_dim;
+        let mut out: Option<UniquePtr<MlxArray>> = None;
+        let mut start = 0usize;
+        while start < positions.len() {
+            let mut end = start + 1;
+            while end < positions.len() && positions[end] == positions[end - 1] + 1 {
+                end += 1;
+            }
+            let run = mlxcel_core::slice(proj_out, &[0, start as i32, 0], &[b, end as i32, width]);
+            let rotated = mlxcel_core::compiled_q_path_proportional(
+                &run,
+                norm_weight,
+                freqs,
+                norm_eps,
+                n_heads,
+                self.head_dim,
+                rotated_dims,
+                offset + positions[start],
+            );
+            out = Some(match out {
+                None => rotated,
+                Some(acc) => {
+                    mlxcel_core::concatenate(acc.as_ref().unwrap(), rotated.as_ref().unwrap(), 2)
+                }
+            });
+            start = end;
+        }
+        out.expect("compiled_q_path_proportional_per_position requires at least one position")
+    }
+
+    #[allow(clippy::too_many_arguments)]
     pub(crate) fn forward(
         &self,
         x: &MlxArray,
@@ -1961,6 +2067,7 @@ impl Attention {
         cache: &mut dyn CacheInterface,
         shared_kv: Option<(&MlxArray, &MlxArray)>,
         divergent_rows: Option<&DivergentVerifyRows<'_>>,
+        tree_positions: Option<&[i32]>,
     ) -> (
         UniquePtr<MlxArray>,
         Option<(UniquePtr<MlxArray>, UniquePtr<MlxArray>)>,
@@ -1992,7 +2099,35 @@ impl Attention {
         // op-at-a-time chain otherwise), just sliced per row, so lockstep
         // rows stay bitwise-identical to the uniform rounds and near-tie
         // argmaxes cannot flip from a kernel-path change.
-        let queries = if let Some(offsets) = rope_offsets {
+        let queries = if let Some(positions) = tree_positions {
+            // Draft-tree verify: each node rotates at its own depth. Runs of
+            // consecutive positions go through the same kernels the uniform
+            // path uses, so a linear tree is one call and is bit-identical
+            // to it (issue #1204).
+            if let Some(ref freqs) = self.proportional_rope_freqs {
+                let rotated_dims = 2 * ((self.proportional_partial_rotary_factor as f64
+                    * self.head_dim as f64
+                    / 2.0)
+                    .floor() as i32)
+                    .max(0);
+                self.compiled_q_path_proportional_per_position(
+                    &q_proj_out,
+                    &self.q_norm.weight,
+                    self.q_norm.eps,
+                    freqs,
+                    self.n_heads,
+                    rotated_dims,
+                    offset,
+                    positions,
+                )
+            } else {
+                let queries =
+                    mlxcel_core::reshape(&q_proj_out, &[b, l, self.n_heads, self.head_dim]);
+                let queries = self.q_norm.forward(&queries);
+                let queries = mlxcel_core::transpose_axes(&queries, &[0, 2, 1, 3]);
+                self.apply_rope_per_position(&queries, offset, positions)
+            }
+        } else if let Some(offsets) = rope_offsets {
             if let Some(ref freqs) = self.proportional_rope_freqs {
                 let rotated_dims = 2 * ((self.proportional_partial_rotary_factor as f64
                     * self.head_dim as f64
@@ -2045,7 +2180,7 @@ impl Attention {
             return (self.project_output(&attn_out, b, l), None);
         }
 
-        let (keys, values) = self.project_kv(x, b, l, offset, cache, rope_offsets);
+        let (keys, values) = self.project_kv(x, b, l, offset, cache, rope_offsets, tree_positions);
         let attn_out = self.attend(&queries, &keys, &values, mask);
         let stored = if self.store_full_length_kv {
             Some((keys, values))
@@ -2111,6 +2246,7 @@ impl Attention {
         offset: i32,
         cache: &mut dyn CacheInterface,
         rope_offsets: Option<&[i32]>,
+        tree_positions: Option<&[i32]>,
     ) -> (UniquePtr<MlxArray>, UniquePtr<MlxArray>) {
         let (raw_keys, raw_values) = match &self.projection {
             AttentionProjection::Fused(proj) => {
@@ -2147,7 +2283,30 @@ impl Attention {
             .k_norm
             .as_ref()
             .expect("k_norm must be Some for non-KV-shared layers");
-        let keys = if let Some(offsets) = rope_offsets {
+        let keys = if let Some(positions) = tree_positions {
+            if let Some(ref freqs) = self.proportional_rope_freqs {
+                let rotated_dims = 2 * ((self.proportional_partial_rotary_factor as f64
+                    * self.head_dim as f64
+                    / 2.0)
+                    .floor() as i32)
+                    .max(0);
+                self.compiled_q_path_proportional_per_position(
+                    &raw_keys,
+                    &k_norm.weight,
+                    k_norm.eps,
+                    freqs,
+                    self.n_kv_heads,
+                    rotated_dims,
+                    offset,
+                    positions,
+                )
+            } else {
+                let keys = mlxcel_core::reshape(&raw_keys, &[b, l, self.n_kv_heads, self.head_dim]);
+                let keys = k_norm.forward(&keys);
+                let keys = mlxcel_core::transpose_axes(&keys, &[0, 2, 1, 3]);
+                self.apply_rope_per_position(&keys, offset, positions)
+            }
+        } else if let Some(offsets) = rope_offsets {
             // Divergent batched MTP verify (issue #203): rotate each row's
             // new keys at the row's own logical positions, mirroring the
             // per-row query rotation in `forward`, through the same kernels
@@ -2710,6 +2869,7 @@ impl DecoderLayer {
             usize::MAX,
             false,
             None,
+            None,
         )
     }
 
@@ -2724,6 +2884,7 @@ impl DecoderLayer {
         layer_idx: usize,
         profile_subops: bool,
         divergent_rows: Option<&DivergentVerifyRows<'_>>,
+        tree_positions: Option<&[i32]>,
     ) -> (
         UniquePtr<MlxArray>,
         Option<(UniquePtr<MlxArray>, UniquePtr<MlxArray>)>,
@@ -2736,9 +2897,14 @@ impl DecoderLayer {
         // residual is only *read* by the final `add`.
         let h_attn = self.input_layernorm.forward(x);
         timer.tick("input_layernorm", &h_attn);
-        let (h_attn, stored_kv) =
-            self.self_attn
-                .forward(&h_attn, mask, cache, shared_kv, divergent_rows);
+        let (h_attn, stored_kv) = self.self_attn.forward(
+            &h_attn,
+            mask,
+            cache,
+            shared_kv,
+            divergent_rows,
+            tree_positions,
+        );
         timer.tick("self_attn", &h_attn);
         let h_attn = self.post_attention_layernorm.forward(&h_attn);
         timer.tick("post_attention_layernorm", &h_attn);
@@ -2883,7 +3049,9 @@ impl DecoderLayer {
     ) -> UniquePtr<MlxArray> {
         let mut timer = SubopTimer::new(false, usize::MAX);
         let h_attn = self.input_layernorm.forward(x);
-        let (h_attn, _stored_kv) = self.self_attn.forward(&h_attn, mask, cache, None, None);
+        let (h_attn, _stored_kv) = self
+            .self_attn
+            .forward(&h_attn, mask, cache, None, None, None);
         let h_attn = self.post_attention_layernorm.forward(&h_attn);
         let after_attn = mlxcel_core::add(x, &h_attn);
 
@@ -3092,6 +3260,15 @@ pub struct Gemma4TextModel {
 pub struct Gemma4SpeculativeSinks {
     pub hidden_sink: Option<Vec<UniquePtr<MlxArray>>>,
     pub shared_kv_sink: Option<HashMap<String, (UniquePtr<MlxArray>, UniquePtr<MlxArray>)>>,
+    /// Per-node RoPE positions for a draft-tree verify block, relative to the
+    /// cache offset: entry `i` is node `i`'s depth.
+    ///
+    /// An **input**, unlike the two sinks above, and carried here because this
+    /// struct is the one thing already threaded from the MTP adapter into the
+    /// forward that needs it. `None` means the block's positions are the span
+    /// itself, which is what every non-tree caller wants and what a linear
+    /// tree resolves to anyway (issue #1204).
+    pub tree_positions: Option<Vec<i32>>,
 }
 
 impl Gemma4SpeculativeSinks {
@@ -3102,6 +3279,7 @@ impl Gemma4SpeculativeSinks {
         Self {
             hidden_sink: Some(Vec::new()),
             shared_kv_sink: None,
+            tree_positions: None,
         }
     }
 
@@ -3112,6 +3290,7 @@ impl Gemma4SpeculativeSinks {
         Self {
             hidden_sink: None,
             shared_kv_sink: Some(HashMap::new()),
+            tree_positions: None,
         }
     }
 
@@ -3122,6 +3301,7 @@ impl Gemma4SpeculativeSinks {
         Self {
             hidden_sink: Some(Vec::new()),
             shared_kv_sink: Some(HashMap::new()),
+            tree_positions: None,
         }
     }
 }
@@ -3262,6 +3442,15 @@ impl Gemma4TextModel {
             && per_row_valid_end
                 .map(|ve| ve.iter().any(|&v| v != global_offset_pre))
                 .unwrap_or(false);
+        // Per-node RoPE positions for a draft-tree verify block. Cloned out
+        // of the sinks up front because the sinks are borrowed mutably below,
+        // and it is a handful of `i32` per round. `None` for every non-tree
+        // caller, and for a linear tree the positions are the span itself, so
+        // the attention path resolves it back to a single uniform rotation
+        // (issue #1204).
+        let tree_positions: Option<Vec<i32>> =
+            sinks.as_ref().and_then(|s| s.tree_positions.clone());
+
         // Per-row context for the divergent verify path (issue #203): the
         // attention layers rotate queries/keys at per-row logical positions
         // and run attention per row over each row's exact contiguous K/V, so
@@ -3597,6 +3786,7 @@ impl Gemma4TextModel {
                 i,
                 profile_subops,
                 divergent_rows.as_ref(),
+                tree_positions.as_deref(),
             );
             h = next_h;
             if let Some(start) = layer_build_start {

--- a/src/models/gemma4_mtp_target.rs
+++ b/src/models/gemma4_mtp_target.rs
@@ -203,9 +203,32 @@ impl<'a> Gemma4MtpTargetAdapter<'a> {
         sampler: &SamplingConfig,
         logprobs_config: &mlxcel_core::sampling::LogprobsConfig,
     ) -> VerifyForwardOutput {
+        self.verify_forward_with_mask_and_positions(
+            verify_input,
+            mask,
+            None,
+            sampler,
+            logprobs_config,
+        )
+    }
+
+    /// [`Self::verify_forward_with_mask`] with per-node RoPE positions.
+    ///
+    /// `tree_positions` are node depths relative to the cache offset. `None`
+    /// means the block's positions are the span itself, which is what the
+    /// chain path wants and what a linear tree resolves to (issue #1204).
+    fn verify_forward_with_mask_and_positions(
+        &self,
+        verify_input: &[i32],
+        mask: Option<&mlxcel_core::MlxArray>,
+        tree_positions: Option<Vec<i32>>,
+        sampler: &SamplingConfig,
+        logprobs_config: &mlxcel_core::sampling::LogprobsConfig,
+    ) -> VerifyForwardOutput {
         // Sink-aware forward over `[bonus, draft_0, …, draft_{K-2}]`.
         let verify_arr = mlxcel_core::from_slice_i32(verify_input, &[1, verify_input.len() as i32]);
         let mut sinks = Gemma4SpeculativeSinks::with_hidden_and_shared_kv();
+        sinks.tree_positions = tree_positions;
         // Greedy/no-logprobs can use the latest upstream deferred path: run
         // the transformer once with `skip_final_norm=True`, capture pre-norm
         // hidden/shared K/V, then project hidden positions to logits only as
@@ -816,7 +839,16 @@ impl<'a> MtpTarget for Gemma4MtpTargetAdapter<'a> {
         // into NaN through the softmax.
         let flat = tree.additive_mask_with_history(offset, -1.0e9);
         let mask = mlxcel_core::from_slice_f32(&flat, &[nodes as i32, (offset + nodes) as i32]);
-        Ok(self.verify_forward_with_mask(tree.tokens(), Some(&mask), sampler, logprobs_config))
+        // The mask says what each node can see; the depths say where it sits.
+        // A tree needs both, and the second one is what a flattened block
+        // silently gets wrong as soon as it stops being a chain.
+        Ok(self.verify_forward_with_mask_and_positions(
+            tree.tokens(),
+            Some(&mask),
+            Some(tree.depths()),
+            sampler,
+            logprobs_config,
+        ))
     }
 
     /// Gemma 4 can round-trip a tree whenever every cache of this sequence can


### PR DESCRIPTION
## Summary

Tree drafting can now branch: the drafter keeps the runner-up it was already computing and attaches it as a leaf, and the target verifies every node at its own position instead of at the span's. Branching is opt-in and defaults to off; the tree path it sits on is itself behind `MLXCEL_MTP_TREE`.

## Related issues

Refs #1204

## Type of change

- [x] `feat` — new user-visible feature
- [x] `fix` — bug fix

## The defect this found

The tree mask says what each node can see. Nothing said where each node sits.

A flattened tree is handed to the target as a contiguous span, so a node's RoPE position is its index in that span. Index equals depth only while the tree is a chain, so one sibling puts every later node a place too far along and the target verifies them somewhere they do not belong. That is exactly why the linear tree merged in #1212 was byte-identical to the chain path and a branching one was not, and it is not a tradeoff: temperature-0 speculative decoding is supposed to reproduce the target's own greedy choice.

`DraftTree::depths` is the missing half of the block description. It rides beside the mask on `Gemma4SpeculativeSinks`, which is already threaded from the MTP adapter into the forward that needs it, and is consumed by two new per-position rotations in the attention layer. Both group consecutive positions into one call, so a linear tree resolves to exactly one `apply_rope` through the identical kernel the uniform path uses and cannot move the numerics on the configuration it subsumes; a tree with `n` leaves costs `n + 1`. Positions are relative to the cache offset, so the caller does not have to know which offset each layer family is at.

## How it was isolated

Rather than reasoning about which of mask, positions, widening or rollback was wrong, a probe replaced the candidate with a token the target would never pick. The block still widened, the mask still ran, the positions still applied and the rollback still gathered a path, but no leaf was ever accepted.

That run is byte-identical to the chain over 400 tokens. So all four are correct and what remained was confined to accepting a leaf.

## What accepting a leaf does, precisely

It does not reproduce the chain's exact tokens, and it cannot.

A leaf's bonus is the target's argmax evaluated at a tree position; the chain evaluates that same context at the head of the next block. Both are the target's greedy choice for the same context, and they differ only where the top two sit inside f16 reduction noise. That is the jitter class MTP already carries against non-speculative decoding, and the measurement says so directly: chain MTP, linear tree and branching all first diverge from the non-speculative path at the same character (161), and the branching arm is deterministic run to run.

It is still a weaker guarantee than the linear tree's byte-identity with the chain, so `MLXCEL_MTP_TREE_BRANCHES` defaults to 0 and the code says why.

## Two findings about the selection policy

**The drafter's confidence does not predict its errors.** The issue proposed spending verify positions where the drafter was least sure. Gating on the top-two logit gap at 0.3, 1.0 and 3.0 admitted 2, 2 and 5 extra nodes across 162 rounds and left emitted-per-verify at the chain's value exactly. The drafter is sharply peaked and still only about half right, so the steps it is unsure about are not the steps it is wrong about.

**Selecting the earliest step beats it on every measure at once**: more acceptance, fewer proposed tokens, half the zero-accept rounds. A runner-up at step `i` is only reachable if everything before it was accepted, which the logit gap does not describe and the step index does. The margin survives as a documented escape hatch, off by default.

## Drafter overhead

The first branching measurement looked worse than the mechanism deserved because the runner-up lookup cost two device round trips per step, one of them purely to read a margin the default policy does not use. Per round that was draft time 2.87 ms to 4.77 ms, +66%, against a verify that grew only 11% for a block widening 25%. The margin is now read only when its gate is on, and the token-only lookup stops once the budget is filled.

## Test plan

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets --features metal,accelerate -- -D warnings`
- [x] `cargo test --workspace --profile test-fast --features metal,accelerate -- --test-threads=1`, failure sets unchanged from `main` on this machine (13 pre-existing local reds in the root lib, 4 numeric-tolerance ones in mlxcel-core)
- [x] Validated with a real checkpoint: `gemma-4-12b-it-4bit` + `gemma-4-12b-it-assistant-4bit`, block 5, 400 tokens, temperature 0
  - linear tree byte-identical to chain
  - widened block with an unacceptable leaf byte-identical to chain
  - branching deterministic run to run, and first diverging from the non-speculative path at the same character as chain and linear
- [x] Unit: `depths` on a chain, on a tree with a shallow sibling, and on one with a deep sibling; `runner_up` naming the second-best token and its margin, and declining a chosen token outside the top two

## The throughput verdict: negative, and worse at the block the bar came from

Measured on a quiet machine, three warm-up runs discarded, then `chain b0 b1 b1 b0 chain` blocks so residual drift cancels inside each block. Six samples per arm per regime, spreads under 0.7 tok/s, no overlap between arms.

**Block 4** (400 tokens, chain at 2.4630 emitted per round):

| arm | median | vs chain |
|---|---|---|
| chain | 84.34 | |
| linear tree | 80.87 | -4.1% |
| branching | 77.48 | -8.1% |

**Block 5** (300 tokens, chain at 3.6463 emitted per round, above the 3.49 bar this issue set):

| arm | median | vs chain |
|---|---|---|
| chain | 121.81 | |
| linear tree | 119.52 | -1.9% |
| branching | 109.50 | -10.1% |

The linear tree's overhead amortizes with the block, 4.1% down to 1.9%, which is what it should do. Branching goes the other way, and the reason is structural rather than incidental: what branching fixes is the round whose chain breaks early, and at block 5 the acceptance rate is 0.78, so only 11 of 82 rounds are that round. The leaf is attached to the other 71 anyway. The gain is concentrated and the cost is unconditional, so the regime where tree drafting works best is the regime where branching hurts most.

| regime | break-even needs | branching delivers | shortfall |
|---|---|---|---|
| block 4 | 2.9028 emit/round | 2.6600 | 9.1% |
| block 5 | 4.3911 emit/round | 3.9342 | 11.6% |

**The ceiling, for whoever considers reviving this.** Give branching a perfect oracle: it knows in advance which rounds its leaf will rescue and widens only those. Block 4 goes 4743 ms to 4453 ms, **+6.5%**; block 5 goes 2463 ms to 2319 ms, **+6.2%**. That is the physical limit, a real signal collects a fraction of it and pays for its false positives, and the linear tree's own 1.9% comes off the top. Best case is around +4%, and it needs a round-failure predictor. The most natural candidate, the drafter's own top-two confidence, is measured here and does not work: the drafter is sharply peaked and about half right, so the steps it is unsure about are not the steps it is wrong about.

So branching stays off, and the acceptance result is recorded rather than shipped: emitted-per-verify 2.4630 to 2.6600 at block 4 and 3.6463 to 3.9342 at block 5, with zero-accept rounds 51 to 26 and 11 to 3.

## What this PR is for, given that

The position-id work is a correctness fix and stands on its own. A flattened tree was being verified at the span's positions rather than its own, which is wrong for any branching tree and was invisible while only linear trees ran. Merging it means the tree path is correct if anyone revives branching, and means the finding is in the tree rather than in a closed branch.

Branching defaults to 0, so nothing changes for anyone who does not set it.
