### PR TITLE
docs: fix garbled comments left by issue-reference scrubbing

### DIFF
--- a/src/cli/speculative_args.rs
+++ b/src/cli/speculative_args.rs
@@ -184,7 +184,7 @@ pub fn default_block_size_for_kind(kind: DrafterKind) -> u32 {
         DrafterKind::Mtp => DEFAULT_MTP_BLOCK_SIZE,
         // DFlash and the future InternalMtp variant both share the
         // upstream-published 16-token default. InternalMtp's user-facing
-        // override surface lands in for now its CLI knob
+        // override surface lands later; for now its CLI knob
         // shares the DFlash default.
         DrafterKind::Dflash | DrafterKind::InternalMtp => DEFAULT_DFLASH_BLOCK_SIZE,
         // `DrafterKind` is `#[non_exhaustive]` so future variants force a

--- a/src/cli/speculative_args_tests.rs
+++ b/src/cli/speculative_args_tests.rs
@@ -107,7 +107,7 @@ fn default_block_size_for_dflash_is_16() {
 
 #[test]
 fn default_block_size_for_internal_mtp_shares_dflash_default() {
-    // InternalMtp's CLI surface lands in for now we share the
+    // InternalMtp's CLI surface lands later; for now we share the
     // DFlash 16-token default to keep the helper exhaustive.
     assert_eq!(
         default_block_size_for_kind(DrafterKind::InternalMtp),

--- a/src/server/config.rs
+++ b/src/server/config.rs
@@ -444,7 +444,7 @@ pub struct ServerConfig {
     /// Defaults to the baseline policy (enabled with 2 GiB / 1024 entries /
     /// 1-hour TTL). When `enabled = false` the store is skipped entirely at
     /// startup so no memory is reserved. CLI/env parsing for the individual
-    /// fields is tracked separately in for now operators set
+    /// fields is tracked separately; for now, operators set
     /// the policy via the Rust API or keep the default.
     pub prompt_cache: crate::server::prompt_cache::PromptCacheConfig,
 

--- a/src/server/prompt_cache/key.rs
+++ b/src/server/prompt_cache/key.rs
@@ -242,9 +242,9 @@ pub struct PromptCacheKey<'a> {
     pub model_id: &'a str,
     /// LoRA adapter identifier; `None` for the base model.
     pub lora_id: Option<&'a str>,
-    /// Chat-template signature. Full wiring is; for now any stable
-    /// digest of the template + tool-schema inputs is acceptable and will
-    /// simply slot into this field.
+    /// Chat-template signature. Full wiring is not plumbed yet; for now
+    /// any stable digest of the template + tool-schema inputs is
+    /// acceptable and will simply slot into this field.
     pub template_sig: &'a str,
     /// Caller-supplied tenancy / conversation scope. `None` means global.
     pub session_key: Option<&'a str>,


### PR DESCRIPTION
Fixes #1218.

Four comments (two doc comments in `src/server`, two in `src/cli`) were left ungrammatical when private issue references were scrubbed from the text — e.g. "fields is tracked separately in for now operators set the policy...". Rewrote each into a complete sentence:

- `src/server/config.rs`: "fields is tracked separately; for now, operators set the policy via the Rust API or keep the default."
- `src/server/prompt_cache/key.rs`: clarified that full wiring is not plumbed yet, so any stable digest is acceptable for now
- `src/cli/speculative_args.rs` + `speculative_args_tests.rs`: "lands later; for now ..." wording

Comment-only change, zero behavior impact.