### PR TITLE
docs(python): quote pip extras argument so install commands work under zsh

### DIFF
--- a/docs/python-client.md
+++ b/docs/python-client.md
@@ -8,7 +8,7 @@ This is Phase 1 of Python integration. It builds entirely on the existing HTTP s
 
 ```bash
 pip install ./python          # from a repo checkout
-pip install ./python[dev]     # adds pytest, ruff, mypy
+pip install "./python[dev]"   # adds pytest, ruff, mypy
 ```
 
 Requires Python 3.9 or newer. Runtime dependencies are `openai>=1.40` and `httpx>=0.27`. Managed mode additionally needs the `mlxcel` binary; the client finds it via the `binary=` argument, the `MLXCEL_BIN` environment variable, or `mlxcel` on `PATH`, in that order. See [Installation](installation.md) for building the binary.

--- a/python/README.md
+++ b/python/README.md
@@ -8,7 +8,7 @@ This is Phase 1 of Python integration: it builds entirely on the existing HTTP s
 
 ```bash
 pip install ./python          # from a repo checkout
-pip install ./python[dev]     # with pytest, ruff, mypy for development
+pip install "./python[dev]"   # with pytest, ruff, mypy for development
 ```
 
 Requires Python 3.9+. The client itself is pure Python (`openai>=1.40`, `httpx>=0.27`). Managed mode additionally needs the `mlxcel` binary on `PATH`, or pass `binary=` / set `MLXCEL_BIN`.
@@ -66,7 +66,7 @@ HTTP and API errors surface as native `openai` SDK exceptions (for example `open
 ## Tests
 
 ```bash
-pip install -e ./python[dev]
+pip install -e "./python[dev]"
 ruff check python
 ruff format --check python
 mypy python/src


### PR DESCRIPTION
Fixes #1222.

`pip install ./python[dev]` fails under zsh (default shell on macOS, this project's primary platform) because `[dev]` is a glob pattern — the shell errors with "no matches found" before pip ever runs. CI already quotes it (`.github/workflows/python.yml` uses `pip install -e "python[dev]"`).

Quoted the argument in all three doc sites:

- `python/README.md` (both the bare install and the editable install)
- `docs/python-client.md`

Docs-only change.