### PR TITLE
fix(bench): use binary units in KV-transfer benchmark byte formatter

### DIFF
--- a/src/distributed/kv_cache_transfer/benchmark.rs
+++ b/src/distributed/kv_cache_transfer/benchmark.rs
@@ -340,11 +340,11 @@ fn mean_duration(durations: &[Duration]) -> Duration {
 
 fn format_bytes(bytes: usize) -> String {
     if bytes >= 1024 * 1024 * 1024 {
-        format!("{:.1}GB", bytes as f64 / (1024.0 * 1024.0 * 1024.0))
+        format!("{:.1}GiB", bytes as f64 / (1024.0 * 1024.0 * 1024.0))
     } else if bytes >= 1024 * 1024 {
-        format!("{:.1}MB", bytes as f64 / (1024.0 * 1024.0))
+        format!("{:.1}MiB", bytes as f64 / (1024.0 * 1024.0))
     } else if bytes >= 1024 {
-        format!("{:.1}KB", bytes as f64 / 1024.0)
+        format!("{:.1}KiB", bytes as f64 / 1024.0)
     } else {
         format!("{bytes}B")
     }

--- a/src/distributed/kv_cache_transfer/benchmark_tests.rs
+++ b/src/distributed/kv_cache_transfer/benchmark_tests.rs
@@ -153,7 +153,7 @@ fn benchmark_result_summary_format() {
 #[test]
 fn format_bytes_ranges() {
     assert!(format_bytes(500).contains("B"));
-    assert!(format_bytes(2048).contains("KB"));
-    assert!(format_bytes(5 * 1024 * 1024).contains("MB"));
-    assert!(format_bytes(2 * 1024 * 1024 * 1024).contains("GB"));
+    assert!(format_bytes(2048).contains("KiB"));
+    assert!(format_bytes(5 * 1024 * 1024).contains("MiB"));
+    assert!(format_bytes(2 * 1024 * 1024 * 1024).contains("GiB"));
 }


### PR DESCRIPTION
Fixes #1221.

`format_bytes` in the KV-transfer benchmark divides by 1024 at each tier but labels the result with decimal unit names (`GB`/`MB`/`KB`), so printed units didn't match the arithmetic. Every sibling formatter already uses binary units correctly (`src/downloader/mod.rs`, `src/execution/quant_advisor.rs`, `src/distributed/bench_activation.rs`).

Changes:
- `src/distributed/kv_cache_transfer/benchmark.rs`: labels `GB`→`GiB`, `MB`→`MiB`, `KB`→`KiB`
- `src/distributed/kv_cache_transfer/benchmark_tests.rs`: `format_bytes_ranges` assertions updated to match

Report-string only; the measurement path is untouched. I couldn't run `cargo test` locally (no Rust toolchain on this machine), but the change is a pure label substitution — I verified the exact formatted strings for all four test values against the updated assertions.