### PR TITLE
refactor(loading): remove dead is_special_weight_model_type wrapper

### DIFF
--- a/src/loading/special.rs
+++ b/src/loading/special.rs
@@ -97,11 +97,6 @@ fn special_weight_loader_kind(model_type: ModelType) -> Option<SpecialWeightLoad
     }
 }
 
-#[allow(dead_code)]
-pub(crate) fn is_special_weight_model_type(model_type: ModelType) -> bool {
-    model_metadata::is_special_weight_model_type(model_type)
-}
-
 pub(crate) fn try_load_special_model_from_weights(
     model_type: ModelType,
     config_str: &str,


### PR DESCRIPTION
Fixes #1225.

`src/loading/special.rs` carries a pass-through wrapper for `is_special_weight_model_type` that has zero callers and sits behind an `#[allow(dead_code)]`. A repo-wide grep confirms the only references are the `model_metadata` original, the wrapper itself, and `model_metadata_tests.rs`, which imports the original directly. Deleted the wrapper; `use crate::model_metadata` stays because `special.rs` still calls `model_metadata::adapter_loading_unsupported_message`.