### PR TITLE
docs: correct the MLXCEL_DEVICE row in installation.md

### DIFF
--- a/docs/installation.md
+++ b/docs/installation.md
@@ -253,7 +253,7 @@ MLXCEL_CXX_MARCH=none cargo build --release --features cuda
 | `MLXCEL_CUTLASS_DIR` | Override for the bundled CUTLASS/CuTe header dir used by the CUDA NVRTC JIT for quantized matmul kernels | bundled `<exe-dir>/../include`, then build-time fallback |
 | `MLX_PTX_CACHE_DIR` | On-disk cache for JIT-compiled CUDA kernels | system temp dir |
 | `MLXCEL_QUIET_JIT` | Suppress the one-time "compiling CUDA kernels" notice on a cold first run | unset (notice shown) |
-| `MLXCEL_DEVICE` | Runtime device hint (`gpu` or `cpu`) | auto |
+| `MLXCEL_DEVICE` | Runtime device hint (`gpu` default; `metal`, `cpu`) | `gpu` |
 | `MLXCEL_WIRED_LIMIT` | Apple Silicon wired-memory ceiling, e.g. `64GB`; `0`/`none` disables it | `max` |
 | `LLAMA_ARG_*` | Environment-backed server options accepted by clap | unset |
 


### PR DESCRIPTION
Fixes #1223.

`docs/installation.md` documented `MLXCEL_DEVICE` with a default of `auto` and only `gpu`/`cpu` as values, but the code disagrees:

- `src/execution/runtime.rs::resolve_runtime_device` returns `RuntimeDevice::Gpu` when the variable is unset (default is `gpu`, not `auto`)
- `parse_runtime_device` accepts `"cpu" | "gpu" | "metal"`

Both other surfaces already state this (`src/main.rs` clap after_help and `docs/environment-variables.md`). Updated the row to: values `gpu` (default), `metal`, `cpu`; default `gpu`.