### PR TITLE
docs: replace opaque (A4:)/(B11:) task codes in rustdoc comments

### DIFF
--- a/src/models/sanitize_tests.rs
+++ b/src/models/sanitize_tests.rs
@@ -1233,7 +1233,7 @@ operations:
         }
     }
 
-    /// (A4): when the CLI installs an active pipeline via
+    /// When the CLI installs an active pipeline via
     /// `crate::surgery::set_active_pipeline`, the consolidated loader
     /// must pick it up for `load_text_weights(_, None)` callers. This
     /// is the integration glue that lets `mlxcel generate --surgery
@@ -1287,7 +1287,7 @@ operations:
         std::fs::remove_dir_all(&dir_with_slot).unwrap();
     }
 
-    /// (A4): explicit `transform` argument takes precedence
+    /// Explicit `transform` argument takes precedence
     /// over the active-pipeline slot. This is the contract callers
     /// (e.g. future programmatic users and the existing integration tests) rely on to bypass the global slot.
     #[test]

--- a/src/server/cli_input.rs
+++ b/src/server/cli_input.rs
@@ -427,7 +427,7 @@ pub struct ServerStartupInput {
     /// `--conversation-store-ttl-secs` value (`0` disables TTL).
     pub conversation_store_ttl_secs: u64,
 
-    /// (A4): path to a YAML weight-load surgery configuration.
+    /// Path to a YAML weight-load surgery configuration.
     ///
     /// `None` (the default) keeps the server on the bit-exact baseline
     /// weight-load path — no surgery crate work, no observable

--- a/src/server/config.rs
+++ b/src/server/config.rs
@@ -448,7 +448,7 @@ pub struct ServerConfig {
     /// the policy via the Rust API or keep the default.
     pub prompt_cache: crate::server::prompt_cache::PromptCacheConfig,
 
-    /// (B11): server-wide KV cache mode.
+    /// Server-wide KV cache mode.
     ///
     /// Resolved from `--cache-type-k`/`--cache-type-v` (llama-server split
     /// flags) or the legacy `--kv-cache-mode` shorthand.  Defaults to

--- a/src/server/startup.rs
+++ b/src/server/startup.rs
@@ -301,7 +301,7 @@ pub struct ServerStartupConfig {
     /// (enabled, 2 GiB cap, 1024 entries, 3600 s TTL, 32 token min).
     pub prompt_cache: super::prompt_cache::PromptCacheConfig,
 
-    /// (B11): resolved KV cache mode for per-sequence cache
+    /// Resolved KV cache mode for per-sequence cache
     /// construction.
     ///
     /// Resolved from `--cache-type-k`/`--cache-type-v` (split flags,
@@ -359,7 +359,7 @@ pub struct ServerStartupConfig {
     /// disables TTL.
     pub conversation_store_ttl_secs: u64,
 
-    /// (A4): resolved path to a YAML weight-load surgery
+    /// Resolved path to a YAML weight-load surgery
     /// configuration. `None` keeps the bit-exact baseline load path.
     ///
     /// The path is parsed into a [`mlxcel_surgery::SurgeryPipeline`]


### PR DESCRIPTION
Fixes #1234.

Six doc comments carried internal task codes (`(A4)`/`(B11)`) that mean nothing in rendered rustdoc, while the rest of the codebase uses `(issue #NNN)`. No matching public issue numbers exist for these codes, so I dropped the prefixes and let the sentences read normally:

- `src/server/cli_input.rs`, `src/server/config.rs` (B11), `src/server/startup.rs` (x2), `src/models/sanitize_tests.rs` (x2)

Comment-only change.