### PR TITLE
chore(cli): unify error-message capitalization across CLI commands

### DIFF
--- a/src/commands/chat.rs
+++ b/src/commands/chat.rs
@@ -297,7 +297,7 @@ pub fn run_chat(opts: ChatOptions) -> Result<()> {
     )?;
 
     let mut editor = DefaultEditor::new()
-        .map_err(|e| anyhow!("failed to initialize the interactive line editor: {e}"))?;
+        .map_err(|e| anyhow!("Failed to initialize the interactive line editor: {e}"))?;
     let interactive = io::stdin().is_terminal();
 
     print_banner(interactive);

--- a/src/commands/detect.rs
+++ b/src/commands/detect.rs
@@ -51,11 +51,11 @@ pub(crate) fn run_detect(args: DetectArgs) -> Result<()> {
     let _runtime = initialize_runtime();
 
     let predictor = RtDetrV2Predictor::from_pretrained(&args.model, args.threshold)
-        .map_err(|e| anyhow!("failed to load RT-DETRv2 model: {e}"))?;
+        .map_err(|e| anyhow!("Failed to load RT-DETRv2 model: {e}"))?;
 
     let result = predictor
         .predict_path(&args.image)
-        .map_err(|e| anyhow!("detection failed: {e}"))?;
+        .map_err(|e| anyhow!("Detection failed: {e}"))?;
 
     let mut detections = result.detections;
     sort_reading_order(&mut detections);

--- a/src/commands/generate.rs
+++ b/src/commands/generate.rs
@@ -477,7 +477,7 @@ fn generate_pipeline_text(
         )])?
         .into_iter()
         .next()
-        .ok_or_else(|| anyhow!("pipeline worker loop did not return a prefill output"))?
+        .ok_or_else(|| anyhow!("Pipeline worker loop did not return a prefill output"))?
         .logits;
     let prefill_elapsed = prefill_start.elapsed();
 
@@ -515,7 +515,7 @@ fn generate_pipeline_text(
             )])?
             .into_iter()
             .next()
-            .ok_or_else(|| anyhow!("pipeline worker loop did not return a decode output"))?
+            .ok_or_else(|| anyhow!("Pipeline worker loop did not return a decode output"))?
             .logits;
     }
 
@@ -1207,7 +1207,7 @@ fn decode_xla_cli_images(paths: &[std::path::PathBuf]) -> Result<Vec<image::Dyna
     let read_limit = limits
         .max_payload_bytes
         .checked_add(1)
-        .ok_or_else(|| anyhow!("configured image payload limit overflowed"))?;
+        .ok_or_else(|| anyhow!("Configured image payload limit overflowed"))?;
     let mut payloads = Vec::with_capacity(paths.len());
     for path in paths {
         let mut bytes = Vec::new();

--- a/src/commands/generate_falcon_ocr.rs
+++ b/src/commands/generate_falcon_ocr.rs
@@ -123,7 +123,7 @@ pub(crate) fn load_layout_detections(path: &Path) -> Result<Vec<Detection>> {
 /// dump is long enough that "invalid input" alone is not actionable.
 fn parse_layout_detections(text: &str) -> Result<Vec<Detection>> {
     let root: Value =
-        serde_json::from_str(text).map_err(|error| anyhow!("not valid JSON: {error}"))?;
+        serde_json::from_str(text).map_err(|error| anyhow!("Not valid JSON: {error}"))?;
 
     let items: &[Value] = match &root {
         Value::Array(items) => items,
@@ -412,7 +412,7 @@ pub(crate) fn run_falcon_ocr_layout_generation(
             .with_context(|| format!("Failed to decode image {image_path:?}"))?;
     let page = images
         .pop()
-        .ok_or_else(|| anyhow!("image decoding returned no image for {image_path:?}"))?;
+        .ok_or_else(|| anyhow!("Image decoding returned no image for {image_path:?}"))?;
 
     // Planned without cropping, then cropped one region at a time below. A crop
     // copies, so materializing the whole plan up front would hold one full-size

--- a/src/commands/generate_falcon_ocr_tests.rs
+++ b/src/commands/generate_falcon_ocr_tests.rs
@@ -104,7 +104,7 @@ fn alternative_box_key_spellings_parse() {
 #[test]
 fn malformed_json_is_rejected_with_a_parse_error() {
     let error = parse_layout_detections("{ this is not json").expect_err("must fail");
-    assert!(error.to_string().contains("not valid JSON"), "got: {error}");
+    assert!(error.to_string().contains("Not valid JSON"), "got: {error}");
 }
 
 #[test]
@@ -266,7 +266,7 @@ fn a_coordinate_that_overflows_to_infinity_is_rejected() {
         .expect_err("must fail");
     let message = error.to_string();
     assert!(
-        message.contains("not valid JSON") || message.contains("non-finite"),
+        message.contains("Not valid JSON") || message.contains("non-finite"),
         "got: {message}"
     );
 }

--- a/src/commands/generate_florence2.rs
+++ b/src/commands/generate_florence2.rs
@@ -77,7 +77,7 @@ pub(crate) fn run_florence2_generation(
             .with_context(|| format!("Failed to decode image {image_path:?}"))?;
     let image = images
         .pop()
-        .ok_or_else(|| anyhow!("image decoding returned no image for {image_path:?}"))?;
+        .ok_or_else(|| anyhow!("Image decoding returned no image for {image_path:?}"))?;
 
     print_generation_preamble(user_prompt)?;
     println!();

--- a/src/commands/models.rs
+++ b/src/commands/models.rs
@@ -566,7 +566,7 @@ fn confirm_removal(repo_id: &str, path: &str, size: &str) -> Result<bool> {
     let mut answer = String::new();
     std::io::stdin()
         .read_line(&mut answer)
-        .map_err(|e| anyhow!("failed to read confirmation: {e}"))?;
+        .map_err(|e| anyhow!("Failed to read confirmation: {e}"))?;
     let answer = answer.trim().to_ascii_lowercase();
     Ok(answer == "y" || answer == "yes")
 }


### PR DESCRIPTION
Fixes #1236.

10 `anyhow!` error strings across `src/commands/*.rs` started with a lowercase letter while the majority style (36 of 46) capitalizes the first word. Capitalized the first word at all 10 sites (`detect.rs` x2, `models.rs`, `chat.rs`, `generate_falcon_ocr.rs` x2, `generate_florence2.rs`, `generate.rs` x3) and updated the two assertions in `generate_falcon_ocr_tests.rs` that matched the old lowercase `"not valid JSON"` string. Message content otherwise unchanged.