### PR TITLE
refactor(server): remove unused build_failed_response helper

### DIFF
--- a/src/server/responses_translator.rs
+++ b/src/server/responses_translator.rs
@@ -644,42 +644,6 @@ pub(crate) fn short_uuid() -> String {
     raw.chars().take(16).collect()
 }
 
-/// Convenience entry point for the route layer: build a response object
-/// representing an error that occurred mid-generation.
-#[allow(dead_code)]
-pub fn build_failed_response(
-    id: String,
-    model: String,
-    created_at: f64,
-    error_code: &str,
-    error_message: &str,
-    request: &CreateResponseRequest,
-) -> ResponseObject {
-    let ctx = OutboundContext {
-        response_id: id,
-        model_id: model,
-        created_at,
-        completed_at: created_at,
-        status: ResponseStatus::Failed,
-        prompt_tokens: 0,
-        completion_tokens: 0,
-        cached_tokens: 0,
-        reasoning_tokens: 0,
-        text: String::new(),
-        reasoning_text: None,
-        parsed_tool_calls: None,
-        max_tool_calls: None,
-        request,
-        error: Some(ResponseErrorBody {
-            code: error_code.to_string(),
-            message: error_message.to_string(),
-        }),
-        incomplete_reason: None,
-        finish_reason: "error".to_string(),
-    };
-    build_response_object(ctx)
-}
-
 #[cfg(test)]
 mod tests {
     use std::collections::HashMap;


### PR DESCRIPTION
Fixes #1226.

`build_failed_response` in `src/server/responses_translator.rs` has zero callers, zero tests, and survives only behind an `#[allow(dead_code)]`. I checked the route layer before deleting: `routes/responses.rs` surfaces mid-generation failures as HTTP `ErrorResponse`s (`generation_error_to_response`), never as a failed `ResponseObject`, so wiring the helper in would mean changing the endpoint's error semantics — a behavioral decision I didn't want to make unilaterally. Deleted the function (option 1 in the issue). `OutboundContext`, `ResponseErrorBody`, `ResponseStatus` and `build_response_object` all remain in use elsewhere in the file.

Note: no Rust toolchain on this machine, so I couldn't run `cargo build`/tests locally; the change is a pure dead-code removal with no call sites.