### PR TITLE
fix(multimodal): stop labeling non-LLaVA config errors as LLaVA

### DIFF
--- a/src/multimodal/host_preprocessor.rs
+++ b/src/multimodal/host_preprocessor.rs
@@ -1106,7 +1106,7 @@ pub enum HostPreprocessorError {
     Placeholder(#[from] ImageTokenBlockError),
     #[error("incompatible multimodal family: expected LLaVA, got {actual}")]
     FamilyMismatch { actual: String },
-    #[error("invalid LLaVA host-preprocessor config: {0}")]
+    #[error("invalid OpenXLA host-preprocessor config: {0}")]
     InvalidConfig(String),
     #[error("failed to load LLaVA host-preprocessor weights: {0}")]
     WeightLoad(String),


### PR DESCRIPTION
Fixes #986.

`HostPreprocessorError::InvalidConfig` is used by family-independent and Qwen2-VL paths — `MLXCEL_XLA_VISION_BACKEND` policy parsing, model-family detection, the Qwen2-VL `xla-iree` gate, Muse Glimmer, and IREE shape validation — so the `invalid LLaVA host-preprocessor config` prefix pointed operators at the wrong checkpoint family:

```
OpenXLA image preprocessor load failed: invalid LLaVA host-preprocessor config: Qwen2-VL XLA image execution requires the xla-iree feature
```

Change: the variant's display text is now family-neutral — `invalid OpenXLA host-preprocessor config: {0}`. This satisfies the acceptance criteria:

- The LLaVA claim is gone from family-independent and Qwen2-VL messages.
- All inner messages are preserved verbatim (env var name, accepted values, `--features xla-iree` rebuild instruction).
- LLaVA diagnostics still name LLaVA: the config-validation messages on the LLaVA path (e.g. "LLaVA mm_tokens_per_image must be greater than zero") carry the family name themselves, and `WeightLoad` is untouched.
- Variant discriminant is unchanged, so the `matches!`-based tests in `host_preprocessor_tests.rs` (lines 300/314) are unaffected; nothing in the tree asserts on the old display string.

No Rust toolchain on this machine, so I couldn't run the suite locally — the change is a one-line error-text edit with no logic or discriminant changes.