### PR TITLE
fix(bench): fail with a context error instead of panicking on --target paths with no file name

### DIFF
--- a/src/bin/speculative_bench.rs
+++ b/src/bin/speculative_bench.rs
@@ -805,6 +805,9 @@ fn main() -> Result<()> {
             .as_deref()
             .context("--target is required when --sweep is not set")?
             .to_path_buf();
+        let target_name = target
+            .file_name()
+            .context("--target must name a model directory (paths ending in '..' or a trailing slash have no file name)")?;
         let pairing_name = format!("{} ({})", target.display(), args.kind);
         let synthetic = Pairing {
             name: Box::leak(pairing_name.into_boxed_str()),
@@ -826,7 +829,7 @@ fn main() -> Result<()> {
         // The synthetic pairing references the canonical layout via
         // `resolve_model_dir`; pass the explicit `--target` directly so an
         // operator who points at a non-canonical path is honored.
-        let row = if synthetic.target_subdir == target.file_name().unwrap().to_string_lossy() {
+        let row = if synthetic.target_subdir == target_name.to_string_lossy() {
             // Default canonical path; fall back to `bench_one_pairing` which
             // re-resolves via `resolve_model_dir`.
             bench_one_pairing(&synthetic, &args.prompt, args.batch, args.max_tokens)


### PR DESCRIPTION
Fixes #1242.

`speculative_bench` called `.file_name().unwrap()` on the `--target` path. `Path::file_name()` returns `None` for paths ending in `..` or a trailing slash, so those inputs aborted the run with a bare unwrap panic. Now the file name is resolved once, right after the `--target` argument is read, and a missing file name fails with:

```
--target must name a model directory (paths ending in '..' or a trailing slash have no file name)
```

The canonical `models/<name>` comparison behaves exactly as before for normal paths. No Rust toolchain on this machine, so I couldn't compile locally — the change only replaces an unwrap with the same `?`-propagated `Context` pattern used two lines above it.
