### PR TITLE
refactor(cli): deduplicate eleven identical image-loading closures into open_image

### DIFF
--- a/src/commands/generate_diffusion.rs
+++ b/src/commands/generate_diffusion.rs
@@ -33,6 +33,7 @@ use mlxcel::server::model_provider::model_worker::StreamingDecodeState;
 use mlxcel::tokenizer::MlxcelTokenizer;
 
 use super::generate::print_generation_preamble;
+use super::open_image;
 use crate::GenerateArgs;
 
 /// Preprocess `--image` paths, expand the prompt, and build the vision
@@ -50,9 +51,7 @@ fn prepare_diffusion_vision(
 ) -> Result<PreparedDiffusionImagePrompt> {
     let images: Vec<image::DynamicImage> = image_paths
         .iter()
-        .map(|path| {
-            image::open(path).map_err(|e| anyhow!("Failed to load image {:?}: {}", path, e))
-        })
+        .map(|path| open_image(path))
         .collect::<Result<Vec<_>>>()?;
     println!("Loaded {} image(s).", images.len());
 

--- a/src/commands/generate_vlm.rs
+++ b/src/commands/generate_vlm.rs
@@ -24,6 +24,7 @@ use mlxcel::vlm_prompt::ImageTokenBlockAction;
 use mlxcel::vlm_runtime::{VlmPreparationSummary, prepare_and_compute_vlm_embeddings_with_budget};
 
 use crate::MlxcelTokenizer;
+use crate::commands::open_image;
 
 fn print_audio_preprocess_summary(batch: &mlxcel::audio::AudioWaveformBatch, started: Instant) {
     println!(
@@ -583,9 +584,7 @@ pub(crate) fn compute_vlm_embeddings(
 
     let images: Vec<image::DynamicImage> = image_paths
         .iter()
-        .map(|path| {
-            image::open(path).map_err(|e| anyhow::anyhow!("Failed to load image {:?}: {}", path, e))
-        })
+        .map(|path| open_image(path))
         .collect::<Result<Vec<_>>>()?;
     println!("Loaded {} image(s).", images.len());
 
@@ -629,10 +628,7 @@ fn compute_phi4mm_audio_embeddings(
 ) -> Result<Option<InputEmbeddings>> {
     let images: Vec<image::DynamicImage> = image_paths
         .iter()
-        .map(|path| {
-            image::open(path)
-                .map_err(|error| anyhow::anyhow!("Failed to load image {:?}: {}", path, error))
-        })
+        .map(|path| open_image(path))
         .collect::<Result<Vec<_>>>()?;
     let processed_images = phi4mm.processor.preprocess(&images);
 
@@ -772,10 +768,7 @@ fn compute_gemma3n_audio_embeddings(
     let invalid = mlxcel_core::logical_not(&valid);
     let images = image_paths
         .iter()
-        .map(|path| {
-            image::open(path)
-                .map_err(|error| anyhow::anyhow!("Failed to load image {:?}: {error}", path))
-        })
+        .map(|path| open_image(path))
         .collect::<Result<Vec<_>>>()?;
     let pixel_values = if images.is_empty() {
         None
@@ -909,9 +902,7 @@ fn compute_gemma4_multimodal_embeddings(
     // Process images
     let images: Vec<image::DynamicImage> = image_paths
         .iter()
-        .map(|path| {
-            image::open(path).map_err(|e| anyhow::anyhow!("Failed to load image {:?}: {}", path, e))
-        })
+        .map(|path| open_image(path))
         .collect::<Result<Vec<_>>>()?;
     println!("Loaded {} image(s).", images.len());
 
@@ -1009,10 +1000,7 @@ fn compute_gemma4_unified_multimodal_embeddings(
     } else {
         let images: Vec<image::DynamicImage> = image_paths
             .iter()
-            .map(|path| {
-                image::open(path)
-                    .map_err(|e| anyhow::anyhow!("Failed to load image {:?}: {}", path, e))
-            })
+            .map(|path| open_image(path))
             .collect::<Result<Vec<_>>>()?;
         println!("Loaded {} image(s).", images.len());
         let processed = unified
@@ -1104,9 +1092,7 @@ fn compute_gemma4_video_embeddings(
     // Optional companion images (e.g. user passes both --image and --video).
     let images: Vec<image::DynamicImage> = image_paths
         .iter()
-        .map(|path| {
-            image::open(path).map_err(|e| anyhow::anyhow!("Failed to load image {:?}: {}", path, e))
-        })
+        .map(|path| open_image(path))
         .collect::<Result<Vec<_>>>()?;
     if !images.is_empty() {
         println!("Loaded {} image(s).", images.len());
@@ -1230,9 +1216,7 @@ fn compute_kimi_vl_video_embeddings(
     // Optional companion images (e.g. user passes both --image and --video).
     let images: Vec<image::DynamicImage> = image_paths
         .iter()
-        .map(|path| {
-            image::open(path).map_err(|e| anyhow::anyhow!("Failed to load image {:?}: {}", path, e))
-        })
+        .map(|path| open_image(path))
         .collect::<Result<Vec<_>>>()?;
     if !images.is_empty() {
         println!("Loaded {} image(s).", images.len());
@@ -1298,10 +1282,7 @@ fn compute_gemma4_unified_video_embeddings(
     } else {
         let images: Vec<image::DynamicImage> = image_paths
             .iter()
-            .map(|path| {
-                image::open(path)
-                    .map_err(|e| anyhow::anyhow!("Failed to load image {:?}: {}", path, e))
-            })
+            .map(|path| open_image(path))
             .collect::<Result<Vec<_>>>()?;
         println!("Loaded {} image(s).", images.len());
         let processed = unified
@@ -1453,10 +1434,7 @@ fn compute_qwen3_omni_audio_embeddings(
     let images_data = if !image_paths.is_empty() {
         let images: Vec<image::DynamicImage> = image_paths
             .iter()
-            .map(|path| {
-                image::open(path)
-                    .map_err(|e| anyhow::anyhow!("Failed to load image {:?}: {}", path, e))
-            })
+            .map(|path| open_image(path))
             .collect::<Result<Vec<_>>>()?;
         println!("Loaded {} image(s).", images.len());
         let (pixel_values, grid_thw) = model.processor.preprocess_with_grid(&images);
@@ -1680,10 +1658,7 @@ fn compute_nemotron_h_nano_omni_audio_embeddings(
     let processed_images = if !image_paths.is_empty() {
         let images: Vec<image::DynamicImage> = image_paths
             .iter()
-            .map(|path| {
-                image::open(path)
-                    .map_err(|e| anyhow::anyhow!("Failed to load image {:?}: {}", path, e))
-            })
+            .map(|path| open_image(path))
             .collect::<Result<Vec<_>>>()?;
         println!("Loaded {} image(s).", images.len());
         let processed = model.processor.preprocess_batch(&images);

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -18,6 +18,13 @@
 //! argument/schema wiring while command-specific execution logic evolves in
 //! isolated modules.
 
+use std::path::Path;
+
+/// Load an image file, mapping decode failures to a consistent message.
+pub(crate) fn open_image(path: &Path) -> anyhow::Result<image::DynamicImage> {
+    image::open(path).map_err(|e| anyhow::anyhow!("Failed to load image {:?}: {}", path, e))
+}
+
 pub(crate) mod chat;
 pub(crate) mod detect;
 pub(crate) mod download;


### PR DESCRIPTION
Fixes #1245.

The same `image::open` error closure was copy-pasted eleven times across `generate_vlm.rs` (10x) and `generate_diffusion.rs` (1x), and the copies had started drifting in formatting (one inline-capture variant at `generate_vlm.rs:777`, a bare `anyhow!` import in `generate_diffusion.rs`).

Changes:
- Added one shared `pub(crate) fn open_image(path: &Path) -> anyhow::Result<image::DynamicImage>` in `src/commands/mod.rs` with the canonical message.
- All eleven call sites now use `open_image(path)`; the closure bodies are gone.
- The user-facing error text is byte-identical to the pre-existing majority variant, so nothing observable changes.

No Rust toolchain on this machine, so I couldn't run `cargo fmt`/`cargo test` locally — I formatted the call sites to what rustfmt would produce (single-line `.map(|path| open_image(path))`) and the helper mirrors the exact code it replaces.
