### PR TITLE
perf(speculative): single-slice the MTP accept hook and drop the drafter's materialized causal mask

### DIFF
--- a/src/lib/mlxcel-core/src/drafter/qwen3_5_mtp/layer.rs
+++ b/src/lib/mlxcel-core/src/drafter/qwen3_5_mtp/layer.rs
@@ -72,16 +72,16 @@ impl Qwen35MtpAttention {
     /// Attention forward over the drafter's own KV cache.
     ///
     /// - `x`: `[B, L, hidden_size]` input (post `input_layernorm`).
-    /// - `mask`: `Some(causal mask)` for multi-token forwards (drafter
-    ///   prompt prefill and accepted-token extension), `None` for the
-    ///   single-token draft steps.
+    /// - `causal`: `true` for multi-token forwards (drafter prompt prefill
+    ///   and accepted-token extension), `false` for the single-token draft
+    ///   steps, which see no future positions.
     /// - `cache`: this layer's own KV cache; keys/values are appended.
     /// - `rope_offset`: absolute position of `x`'s first token in the
     ///   target sequence (the drafter's `next_position`).
     pub fn forward(
         &self,
         x: &MlxArray,
-        mask: Option<&MlxArray>,
+        causal: bool,
         cache: &mut KVCache,
         rope_offset: i32,
     ) -> UniquePtr<MlxArray> {
@@ -142,8 +142,18 @@ impl Qwen35MtpAttention {
 
         let (cache_k, cache_v) = cache.update_and_fetch(keys, values);
 
-        let attn_out =
-            crate::layers::attention(&queries, &cache_k, &cache_v, self.scale, mask, 0.0, 0);
+        // The causal wrapper derives the query offset from the cache K
+        // length (bottom-right alignment), which equals the explicit
+        // `create_causal_mask(s, cache.offset)` this call site used to
+        // build, in the degraded empty-cache mode included. It selects
+        // MLX's native "causal" mask mode instead of materializing an
+        // `[L, k_len]` additive mask per multi-token call; the kernel
+        // difference only touches drafter numerics (see module docs).
+        let attn_out = if causal {
+            crate::causal_attention(&queries, &cache_k, &cache_v, self.scale, 0.0, 0)
+        } else {
+            crate::layers::attention(&queries, &cache_k, &cache_v, self.scale, None, 0.0, 0)
+        };
 
         let output = ffi::transpose_axes(&attn_out, &[0, 2, 1, 3]);
         let output = ffi::reshape(&output, &[b, l, -1]);
@@ -216,12 +226,12 @@ impl Qwen35MtpDecoderLayer {
     pub fn forward(
         &self,
         x: &MlxArray,
-        mask: Option<&MlxArray>,
+        causal: bool,
         cache: &mut KVCache,
         rope_offset: i32,
     ) -> UniquePtr<MlxArray> {
         let normed = self.input_layernorm.forward(x);
-        let r = self.attention.forward(&normed, mask, cache, rope_offset);
+        let r = self.attention.forward(&normed, causal, cache, rope_offset);
         let h = ffi::add(x, &r);
         let mlp_out = self.mlp.forward(&self.post_attention_layernorm.forward(&h));
         ffi::add(&h, &mlp_out)

--- a/src/lib/mlxcel-core/src/drafter/qwen3_5_mtp/model.rs
+++ b/src/lib/mlxcel-core/src/drafter/qwen3_5_mtp/model.rs
@@ -519,21 +519,17 @@ impl Qwen35MtpDraftModel {
         let fused = crate::ops::concatenate(&a, &b, -1);
         let mut h = self.fc.forward(&fused);
 
-        // Multi-token forwards use a causal mask offset by the drafter
+        // Multi-token forwards need causal masking offset by the drafter
         // cache's key length (mirrors upstream
         // `create_attention_mask(h, layer_cache)`); single-token draft steps
-        // need none. The RoPE offset is the drafter's logical position, which
-        // equals the cache offset while state is intact and runs ahead of it
-        // in the empty-cache degraded mode.
-        let mask = if s > 1 {
-            let cache_offset = self.cache.first().map(|c| c.offset).unwrap_or(0);
-            Some(crate::utils::create_causal_mask(s, cache_offset))
-        } else {
-            None
-        };
+        // need none. The layer derives that offset from its own cache K
+        // length, which stays correct in the empty-cache degraded mode where
+        // the RoPE offset (the drafter's logical position) runs ahead of the
+        // cache.
+        let causal = s > 1;
         let rope_offset = self.next_position;
         for (layer, cache) in self.layers.iter().zip(self.cache.iter_mut()) {
-            h = layer.forward(&h, mask.as_deref(), cache, rope_offset);
+            h = layer.forward(&h, causal, cache, rope_offset);
         }
         let h = self.norm.forward(&h);
         maybe_sync(&h);
@@ -839,28 +835,18 @@ impl Drafter for Qwen35MtpDraftModel {
         }
 
         // Extend with the accepted tokens not yet in the cache, paired with
-        // the target's true verify hidden, plus the newly emitted bonus.
-        let h_dim = hshape[2];
-        let mut tokens: Vec<i32> = Vec::new();
-        let mut hidden_cat: Option<UniquePtr<MlxArray>> = None;
-        let push_slice = |pos: usize, hidden_cat: &mut Option<UniquePtr<MlxArray>>| {
-            let pos = pos as i32;
-            let s = ffi::slice(verify_hidden, &[0, pos, 0], &[hshape[0], pos + 1, h_dim]);
-            *hidden_cat = Some(match hidden_cat.take() {
-                None => s,
-                Some(prev) => crate::ops::concatenate(&prev, &s, 1),
-            });
-        };
-        for (draft_idx, &draft_tok) in draft_tokens.iter().enumerate().take(accepted).skip(keep) {
-            tokens.push(draft_tok);
-            push_slice(draft_idx, &mut hidden_cat);
-        }
+        // the target's true verify hidden, plus the newly emitted bonus. The
+        // hidden positions are the contiguous range starting at `keep`
+        // (drafts `keep..accepted`, then position `accepted` for the bonus),
+        // so one slice covers them all.
+        let mut tokens: Vec<i32> = draft_tokens[keep..accepted].to_vec();
         if let Some(&last) = new_tokens.last() {
             tokens.push(last);
-            push_slice(accepted, &mut hidden_cat);
         }
-
-        if let (false, Some(hiddens)) = (tokens.is_empty(), hidden_cat) {
+        if !tokens.is_empty() {
+            let start = keep as i32;
+            let end = start + tokens.len() as i32;
+            let hiddens = ffi::slice(verify_hidden, &[0, start, 0], &[hshape[0], end, hshape[2]]);
             let h = self.forward_hidden_stack(&tokens, &hiddens)?;
             self.set_seed_from_hidden(&h, sampler)?;
         }


### PR DESCRIPTION
## Summary

The two Phase 4 structural cleanups from #1185, plus the measurement that closes out the drafter side of that issue.

- `accept_verified_tokens` built its paired-hidden block with a chain of per-position `concatenate` calls. The positions are the contiguous range starting at `keep` (drafts `keep..accepted`, then position `accepted` for the bonus), so one `slice` of `verify_hidden` replaces n slices plus n-1 intermediate buffers.
- `forward_hidden_stack` materialized an `[s, s+offset]` additive causal mask on every multi-token call. Multi-token forwards now route through the shared `causal_attention` wrapper, which derives the same bottom-right alignment from the cache K length and selects MLX's native `"causal"` mask mode (and the M5 NAX causal kernel where present) without building a mask array. Single-token draft steps keep the maskless dispatch byte-for-byte unchanged.

The caching the issue suggested for the mask does not apply: the offset advances every round, so an `(s, offset)` key never repeats. Removing the materialization is the version of that cleanup that actually exists.

## Related issues

Refs #1185 (Phase 4).

## Type of change

- [x] `perf` — structural cleanup on the drafter's per-round path

## Why this cannot move the output

Drafter numerics only influence acceptance (`layer.rs` module docs): the target verifies every proposal, so emitted tokens are the target's own greedy choices regardless of what the drafter proposes. Verified directly below anyway, and on this run even the drafted blocks came out identical.

## Measurements

Apple M5 Max 128 GB, macOS 26.6.1, `qwen3.8-27b-4bit` + `qwen3.8-27b-mtp-4bit`, block 3, temperature 0, offline CLI. Arms: `main` at `9e2c6675` (before) and this branch (after). ABBA blocks, two warm-ups discarded, 6 samples per arm, 8 s cooldowns.

**Byte identity, 400 tokens**: classic == MTP(before) == MTP(after). The two MTP arms also produced identical round statistics (113 rounds, acceptance 0.8274), so the causal-mode switch did not perturb the drafter's proposals on this run.

**Throughput, 300 tokens** (tok/s): before median 54.81 (52.93-55.90), after median 55.27 (53.52-56.29). +0.8%, inside the spread. This is a wash, as expected at a ~370-token context where the mask is small; the change is structural, not a headline number.

**Round-loop diagnostics** (one logged run per arm, same 113 rounds):

| per round | before | after |
|---|---:|---:|
| draft_ms | 2.740 | 2.727 |
| accept_hook_ms | 2.769 | 2.744 |
| verify_forward_ms | 41.85 | 42.74 |

The drafter-side terms move at the sub-1% level; the verify difference is run noise on an untouched path.

**Gemma 4 regression check** (`gemma-4-12b-it-4bit` + 4-bit assistant, block 5, 300 tokens, branch binary): 71.05 tok/s, acceptance 0.7841, emitted_per_verify 3.6463 — the same chain figure PR #1214 recorded for this pairing. The gemma4_assistant drafter and the shared round loop are untouched by this PR.

## Phase 2a, considered and declined

Phase 2a (fused LM-head + argmax) targeted 21.4% of a drafter step that #1203 has since cut from 10.5 ms to 2.7 ms per round. The remaining prize is ~0.6 ms per forward, ~1.2 ms per round, under 2% of a 62 ms round, and it costs a custom quantized-matmul-with-argmax Metal kernel that has to survive every future MLX pin bump. Declined on that ratio; recorded here so the issue can close over it.

## Test plan

- [x] `cargo fmt --check`
- [x] `cargo clippy --workspace --all-targets --features metal,accelerate -- -D warnings`
- [x] `cargo test --release -p mlxcel-core --features metal,accelerate qwen3_5_mtp` (22 tests) and `speculative` (129 tests)
- [x] Real checkpoint validation as above: byte identity, ABBA A/B, round diagnostics, Gemma 4 smoke
