### PR TITLE
test(harness): pin f32 GEMMs to full precision, and accept minijinja's Python-style bools

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -670,6 +670,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "ctor"
+version = "1.0.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "914a755b7c2d4af2bdcff7ce1739e2db9a1b81a9b07123d8015786ae03c0980d"
+dependencies = [
+ "link-section",
+ "linktime-proc-macro",
+]
+
+[[package]]
 name = "cxx"
 version = "1.0.199"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1730,6 +1740,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "link-section"
+version = "0.19.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "39c29a617ce3df32c08497bdc1ab6e2376e0b17948ac166a2fbe5977c5954cd9"
+
+[[package]]
+name = "linktime-proc-macro"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7e57c38c1e860fd37c604281cdfb1dd2216977fd76a50f85ba2f388ef3219616"
+
+[[package]]
 name = "linux-raw-sys"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1902,6 +1924,7 @@ dependencies = [
  "bytes",
  "chrono",
  "clap",
+ "ctor",
  "dirs",
  "fancy-regex 0.17.0",
  "futures",
@@ -1949,6 +1972,7 @@ name = "mlxcel-core"
 version = "0.5.2"
 dependencies = [
  "cmake",
+ "ctor",
  "cxx",
  "cxx-build",
  "dirs",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -305,6 +305,7 @@ large_enum_variant = "allow"
 should_implement_trait = "allow"
 
 [dev-dependencies]
+ctor = "1.0.13"
 tempfile = "3"
 
 [[test]]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -126,3 +126,25 @@ pub use loading::{
     load_model_with_tensor_parallel, load_qwen3_omni_speech, read_eos_token_ids,
     read_generation_config_defaults, read_model_context_window,
 };
+
+/// Pin f32 GEMMs to full precision for this test process (issue #1259).
+///
+/// MLX selects its reduced-precision NAX matmul kernel as
+/// `is_nax_available() && (enable_tf32() || dtype != float32)`, and
+/// `MLX_ENABLE_TF32` defaults to 1 in `mlx/utils.h`, so on Apple GPU
+/// generation 17 an f32 GEMM runs at TF32-class precision. The suite's
+/// algorithm-equivalence tests (chunked vs sequential, prefill vs the
+/// single-token chain, absorbed vs decompressed) assert full-f32 agreement
+/// and break under that default, on this hardware only. Shipped numerics
+/// stay on MLX defaults and are covered by the runtime exactness probes
+/// instead. This runs before `main`, before MLX latches the value into its
+/// process-wide static; an explicit operator setting wins.
+#[cfg(test)]
+#[ctor::ctor(unsafe)]
+fn pin_full_precision_f32_matmuls_for_tests() {
+    if std::env::var_os("MLX_ENABLE_TF32").is_none() {
+        // SAFETY: ctor runs before main, on one thread, before anything
+        // else can read the environment.
+        unsafe { std::env::set_var("MLX_ENABLE_TF32", "0") };
+    }
+}

--- a/src/lib/mlxcel-core/Cargo.toml
+++ b/src/lib/mlxcel-core/Cargo.toml
@@ -29,6 +29,7 @@ libm = "0.2"
 tracing = "0.1"
 
 [dev-dependencies]
+ctor = "1.0.13"
 tempfile = "3"
 
 [build-dependencies]

--- a/src/lib/mlxcel-core/src/lib.rs
+++ b/src/lib/mlxcel-core/src/lib.rs
@@ -3426,3 +3426,25 @@ mod rms_norm_small_axis_tests;
 #[cfg(test)]
 #[path = "fused_rope_parity_tests.rs"]
 mod fused_rope_parity_tests;
+
+/// Pin f32 GEMMs to full precision for this test process (issue #1259).
+///
+/// MLX selects its reduced-precision NAX matmul kernel as
+/// `is_nax_available() && (enable_tf32() || dtype != float32)`, and
+/// `MLX_ENABLE_TF32` defaults to 1 in `mlx/utils.h`, so on Apple GPU
+/// generation 17 an f32 GEMM runs at TF32-class precision. The suite's
+/// algorithm-equivalence tests (chunked vs sequential, prefill vs the
+/// single-token chain, absorbed vs decompressed) assert full-f32 agreement
+/// and break under that default, on this hardware only. Shipped numerics
+/// stay on MLX defaults and are covered by the runtime exactness probes
+/// instead. This runs before `main`, before MLX latches the value into its
+/// process-wide static; an explicit operator setting wins.
+#[cfg(test)]
+#[ctor::ctor(unsafe)]
+fn pin_full_precision_f32_matmuls_for_tests() {
+    if std::env::var_os("MLX_ENABLE_TF32").is_none() {
+        // SAFETY: ctor runs before main, on one thread, before anything
+        // else can read the environment.
+        unsafe { std::env::set_var("MLX_ENABLE_TF32", "0") };
+    }
+}

--- a/src/server/chat_request_tests.rs
+++ b/src/server/chat_request_tests.rs
@@ -851,8 +851,11 @@ TEMPLATE_OK:{{ tool_call.function.name }}
         "object string arguments must be iterable as a mapping: {:?}",
         prepared.prompt
     );
+    // Python-style `True` is what HF `transformers` renders for a Jinja2
+    // bool, and minijinja follows it since 2.24 (#1259); the value surviving
+    // as a bool rather than a string is what this pins.
     assert!(
-        prepared.prompt.contains("ARG:recursive=true;"),
+        prepared.prompt.contains("ARG:recursive=True;"),
         "boolean argument value must survive mapping normalization: {:?}",
         prepared.prompt
     );


### PR DESCRIPTION
## Summary

Eighteen tests were red on Apple GPU generation 17 hosts and nowhere else, and every recent PR test plan on this machine has been diffing its failure set against `main` to prove it added nothing. Both causes are identified in #1259; this PR fixes them, and both suites run green on an M5 Max with no env vars set (mlxcel-core 1513 passed, root lib 5711 passed).

## Related issues

Closes #1259. Refs #1088 (same mechanism on the CUDA gate; see below).

## Type of change

- [x] `test`

## Cause 1: MLX runs f32 GEMMs at TF32-class precision on NAX hardware (17 tests)

MLX's matmul dispatch is `is_nax_available() && (enable_tf32() || dtype != float32)`, and `MLX_ENABLE_TF32` defaults to **1** in `mlx/utils.h`. On generation 17 that routes f32 GEMMs through the reduced-precision NAX kernel, so the suite's algorithm-equivalence tests (chunked vs sequential GLA, prefill vs the single-token chain, absorbed vs decompressed MLA, incremental vs full decode) stop agreeing to their pinned tolerances: measured 2.2e-4 against a 1e-4 bound on the MLA up projection, 1.4e-3 against 1e-3 on a klear position-0 logit. `MLXCEL_METAL4_ATTENTION=0` changes nothing, because the mechanism is the matmul dispatch, not the attention route.

The fix is a `ctor` in each lib test binary that sets `MLX_ENABLE_TF32=0` before MLX latches the value into its process-wide static, with an explicit operator setting winning over the pin. The policy this encodes: unit tests verify algorithm equivalence at full f32; shipped numerics stay on MLX defaults and are covered by the runtime exactness probes (#1189, #1188).

Verified three ways: all 17 pass individually under `MLX_ENABLE_TF32=0` before the change; both full suites pass after it; and `MLX_ENABLE_TF32=1` still reproduces the red, so the override is real.

## Cause 2: minijinja 2.24 renders Jinja2 bools Python-style (1 test)

`prepare_chat_request_renders_tool_call_arguments_as_mapping` pinned `ARG:recursive=true;` and the #1162 bump to minijinja 2.24 renders `ARG:recursive=True;`, which is what HF `transformers` (Python Jinja2) produces for the same template. The expectation moves to the Python-style form with the rationale recorded; the test's actual subject, the bool surviving argument-mapping normalization as a bool rather than a string, is unchanged.

## The CUDA gate (#1088)

The pin lives in the test binaries, so a CUDA build's test run gets it too, and #1088's "the gate leaves MLX TF32 enabled" is the same default this pin overrides. Validation needs the CUDA runner; this PR does not claim it.

## Test plan

- [x] `cargo fmt --check`
- [x] `cargo clippy --workspace --all-targets --features metal,accelerate -- -D warnings`
- [x] `cargo test --release -p mlxcel-core --features metal,accelerate`: 1513 passed, 0 failed
- [x] `cargo test --release -p mlxcel --lib --features metal,accelerate`: 5711 passed, 0 failed
- [x] `MLX_ENABLE_TF32=1` reproduces the pre-fix failure (operator override wins)
