### PR TITLE
docs(make): record the TF32 pin at the verify-test-cuda gate definition

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -578,6 +578,26 @@ pre-commit: fmt clippy test ## Pre-commit checks
 #     `the_cuda_test_suite_must_run_single_threaded` guard so a hand-run
 #     `cargo test --workspace --features cuda` names the problem instead of
 #     aborting anonymously.
+#   * Neither gate sets `MLX_ENABLE_TF32`, and that is deliberate rather than an
+#     oversight: the pin lives in the test binaries instead. MLX defaults the
+#     variable to 1 in `mlx/utils.h`, which routes f32 GEMMs through a
+#     reduced-precision kernel (TF32 on CUDA, NAX on Apple GPU generation 17)
+#     and breaks the suite's algorithm-equivalence tests, the ones that compute
+#     the same quantity two ways and expect full-f32 agreement. #1088 hit this
+#     on the CUDA gate and #1259 hit the same mechanism on Metal. The fix
+#     (#1260) is a `ctor` in `src/lib.rs` and in `src/lib/mlxcel-core/src/lib.rs`
+#     that sets `MLX_ENABLE_TF32=0` before MLX latches the value into its
+#     process-wide static, so it covers every gate running those two binaries
+#     without the two gates' command lines diverging from each other. An
+#     explicit operator setting still wins over the pin.
+#
+#     The policy this encodes: unit tests verify algorithm equivalence at full
+#     f32, while shipped numerics stay on MLX defaults and are covered by the
+#     runtime exactness probes (#1188, #1189). So do not answer a future red
+#     here by widening a parity tolerance before checking whether the run had
+#     TF32 on. Measured on GB10 (sm_121) at `670512c2`: this gate is 8167 passed
+#     and 0 failed, while re-running with `MLX_ENABLE_TF32=1` still reds three
+#     of the four tests #1088 listed. The pin is load-bearing, not decorative.
 #
 # There is deliberately no `verify-clippy-cuda` here yet: the CUDA lint half is
 # a separate hole from the CUDA test half, and #1048 is about the test gate.


### PR DESCRIPTION
## Summary

#1088's second acceptance criterion asked that whichever fix was chosen be documented at the gate's own definition, so the next person does not rediscover the mechanism from a confusing failure set. #1260 fixed the mechanism but documented it only in the ctor doc comments inside `src/lib.rs` and `src/lib/mlxcel-core/src/lib.rs`. Somebody starting from the `Makefile` and asking "why is this gate green now, and what am I allowed to change" finds nothing. This adds the missing note as a third bullet in the `verify-test-cuda` comment block. Comment-only, no recipe change.

## Related issues

Refs #1088. Refs #1259, #1260 (the pin this documents).

## Type of change

- [x] `docs`

## What the note records

Four things a future reader needs, in the place they will actually look:

- Neither gate setting `MLX_ENABLE_TF32` is deliberate, not an oversight. The pin lives in the test binaries so it covers every gate running them without the macOS and CUDA command lines diverging from each other.
- MLX defaults the variable to 1 in `mlx/utils.h`, which routes f32 GEMMs through a reduced-precision kernel on both backends: TF32 on CUDA, NAX on Apple GPU generation 17. That is why #1088 and #1259 are the same bug on different hardware.
- The encoded policy: algorithm-equivalence unit tests run at full f32, while shipped numerics stay on MLX defaults and are covered by the runtime exactness probes (#1188, #1189).
- The trap to avoid: do not answer a future red here by widening a parity tolerance before checking whether the run had TF32 on.

## Validation

The evidence cited in the note is from the CUDA-runner validation of #1088, run on GB10 (sm_121, Linux aarch64, driver 580.173.02) at `670512c2` with MLX pin `9a795735`:

- `make verify-test-cuda`, unmodified: **8167 passed, 0 failed, 310 ignored** across 101 test binaries. No `FAILED`, no `panicked`, no `SIGABRT`/`SIGSEGV`, no compile errors.
- `MLX_ENABLE_TF32=1` at the same commit still reds three of the four tests #1088 listed (bailing GLA, deepseek_v2 MLA, florence2), confirming the pin is load-bearing rather than decorative. florence2 reproduces at `max abs diff 0.00014263391`, identical to the value recorded in #1088 at `0f727572`.
- klear is the one that no longer reproduces under TF32; its margin was the thinnest of the four (1.1e-3 measured against a 1e-3 tolerance). It was checked instead by deliberately perturbing `src/models/klear.rs:617` to skip the causal kernel, which fails the test by 0.28, roughly 280x its tolerance. The perturbation was reverted.

## Test plan

- [x] `make -n verify-test-cuda` emits the same recipe as before the change
- [x] Comment-only diff, no Rust sources touched, so no `fmt`/`clippy` surface
