### PR TITLE
fix(make): correct the TF32 note, klear reproduces too and is flaky

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -596,8 +596,14 @@ pre-commit: fmt clippy test ## Pre-commit checks
 #     runtime exactness probes (#1188, #1189). So do not answer a future red
 #     here by widening a parity tolerance before checking whether the run had
 #     TF32 on. Measured on GB10 (sm_121) at `670512c2`: this gate is 8167 passed
-#     and 0 failed, while re-running with `MLX_ENABLE_TF32=1` still reds three
-#     of the four tests #1088 listed. The pin is load-bearing, not decorative.
+#     and 0 failed, while re-running with `MLX_ENABLE_TF32=1` reds every one of
+#     the four tests #1088 listed. Three of them fail on every run. klear
+#     straddles its own 1e-3 bound instead: over 10 runs it failed 8 and its max
+#     logit delta ranged 5.9e-4 to 2.0e-3 (median 1.2e-3), against 3.6e-7 to
+#     7.2e-7 over 10 pinned-precision runs. So MLX's reduced-precision kernel is
+#     also nondeterministic run to run, and a single green run under
+#     `MLX_ENABLE_TF32=1` is not evidence that a test has stopped depending on
+#     the pin. The pin is load-bearing, not decorative.
 #
 # There is deliberately no `verify-clippy-cuda` here yet: the CUDA lint half is
 # a separate hole from the CUDA test half, and #1048 is about the test gate.


### PR DESCRIPTION
## Summary

#1262 added a TF32 note to the `verify-test-cuda` comment block and cited that `MLX_ENABLE_TF32=1` reds "three of the four" tests #1088 listed. That count came from observing each test once, and it is wrong. klear reproduces too. All four tests depend on the pin.

## Related issues

Refs #1088. Corrects the note added in #1262.

## Type of change

- [x] `fix` (documentation accuracy; comment-only, no recipe change)

## What was wrong and how it was found

klear was checked once under `MLX_ENABLE_TF32=1`, passed, and got recorded as an exception. It is not an exception, it is flaky: its max logit delta straddles its own 1e-3 tolerance. Repeating it 10 times at `07474633` on GB10 (sm_121, Linux aarch64):

| | `MLX_ENABLE_TF32=0` (pin active) | `MLX_ENABLE_TF32=1` |
| --- | --- | --- |
| max logit delta | 3.6e-7 to 7.2e-7 | 5.9e-4 to 2.0e-3 |
| median | about 4.7e-7 | about 1.2e-3 |
| result | 10 ok, 0 failed | 2 ok, **8 failed** |

The two green runs behind the wrong count were the 20 percent tail. #1088's originally recorded 1.1e-3 sits at the median of this distribution, so klear behaves exactly as that issue described and nothing about it has changed.

This also refutes a hypothesis recorded in #1088's closing comment, that the MLX pin bump from `2c46b953` to `9a795735` had nudged klear under its bound. It did not. klear was never under the bound; it straddles it.

## What the corrected note now says

- All four tests reproduce under `MLX_ENABLE_TF32=1`, three deterministically and klear 8 runs in 10.
- The measured spread on both sides, so the pinned path's determinism is on the record next to the policy it justifies: about 2500x smaller and effectively deterministic with the pin active.
- An explicit warning that a single green run under `MLX_ENABLE_TF32=1` is not evidence that a test has stopped depending on the pin. That is the exact mistake this PR corrects, and it is cheap to repeat.

## Test plan

- [x] 10 runs per mode of `models::klear::tests::the_prefill_is_causal_without_being_handed_a_mask`, instrumented to print the max delta, instrumentation reverted afterwards
- [x] `make -n verify-test-cuda` emits the same recipe as before
- [x] Comment-only diff, no Rust sources touched
