### PR TITLE
fix(make): scope the TF32 note's nondeterminism claim to klear

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -597,11 +597,15 @@ pre-commit: fmt clippy test ## Pre-commit checks
 #     here by widening a parity tolerance before checking whether the run had
 #     TF32 on. Measured on GB10 (sm_121) at `670512c2`: this gate is 8167 passed
 #     and 0 failed, while re-running with `MLX_ENABLE_TF32=1` reds every one of
-#     the four tests #1088 listed. Three of them fail on every run. klear
-#     straddles its own 1e-3 bound instead: over 10 runs it failed 8 and its max
-#     logit delta ranged 5.9e-4 to 2.0e-3 (median 1.2e-3), against 3.6e-7 to
-#     7.2e-7 over 10 pinned-precision runs. So MLX's reduced-precision kernel is
-#     also nondeterministic run to run, and a single green run under
+#     the four tests #1088 listed. Three of them fail on every run, at a
+#     bit-identical magnitude across 6 runs each. klear straddles its own 1e-3
+#     bound instead: over 10 runs it failed 8 and its max logit delta ranged
+#     5.9e-4 to 2.0e-3 (median 1.2e-3), against 3.6e-7 to 7.2e-7 over 10
+#     pinned-precision runs. That spread is klear's own, not TF32's: it is the
+#     only one of the four that runs a whole quantized MoE model rather than an
+#     isolated module over small dense tensors, and it varies at both precision
+#     settings, so the pin bounds the magnitude rather than the variance. Filed
+#     separately. What it means here is that a single green run under
 #     `MLX_ENABLE_TF32=1` is not evidence that a test has stopped depending on
 #     the pin. The pin is load-bearing, not decorative.
 #


### PR DESCRIPTION
## Summary

#1263 fixed the count in the `verify-test-cuda` TF32 note but overreached on the mechanism. It asserts that "MLX's reduced-precision kernel is also nondeterministic run to run". The evidence behind that sentence was klear alone, and the other three tests do not behave that way. This narrows the claim to what was actually measured.

## Related issues

Refs #1088. Corrects the note as amended by #1262 and #1263.

## Type of change

- [x] `docs` (comment-only, no recipe change)

## What the control run showed

The other three tests #1088 listed, run 6 times each under `MLX_ENABLE_TF32=1` on the same host (GB10, sm_121) and commit, fail every run at a **bit-identical** magnitude. One distinct value each across all 6 runs:

| test | magnitude, all 6 runs |
| --- | --- |
| bailing GLA | `state[11]: chunked -0.23453808 vs recurrence -0.23468243` |
| deepseek_v2 MLA | `step 1 drifted by 0.00027007936` |
| florence2 | `max abs diff 0.00014263391` |

The florence2 figure is also identical to the one #1088 recorded at MLX pin `2c46b953`, so that path is stable across the pin bump as well. Nothing here supports a backend-wide nondeterminism claim.

## Why klear is the outlier

It is the only one of the four that builds and runs a **whole model**. `small_args()` in `src/models/klear_tests.rs` configures 4-bit quantization (`group_size: 64, bits: 4`) with `num_experts = 8` and `num_experts_per_tok = 2`. The other three are isolated module-level parity checks over small dense f32 tensors: the bailing test drives the GLA kernel on noise arrays with no model, MoE or quantization at all, and the deepseek_v2 test drives the MLA attention module alone.

klear also varies at **both** precision settings, 3.6e-7 to 7.2e-7 with the pin active against 5.9e-4 to 2.0e-3 without. So the pin bounds the magnitude, not the variance, and TF32 is amplifying a spread that is already present.

## What the note says now

The operational advice is unchanged and is the part that survives: a single green run under `MLX_ENABLE_TF32=1` is not evidence that a test has stopped depending on the pin. The klear variance is described as klear's own, attributed structurally, and pointed at a separate issue rather than expanded on here, since it is not a property of the gate.

## Test plan

- [x] 6 runs of the other three tests under `MLX_ENABLE_TF32=1`, magnitudes compared for bit-identity
- [x] `make -n verify-test-cuda` emits the same recipe as before
- [x] Comment-only diff, no Rust sources touched
