### PR TITLE
chore(lint): use expect_err in the image-capacity rejection test

### DIFF
--- a/src/multimodal/host_preprocessor_tests.rs
+++ b/src/multimodal/host_preprocessor_tests.rs
@@ -413,8 +413,7 @@ fn a_missing_preprocessor_config_reports_no_floor_instead_of_guessing() {
 fn the_default_capacity_is_rejected_with_the_derived_requirement() {
     let dir = molmo2_checkpoint_dir();
     let error = ensure_xla_image_context_capacity(dir.path(), 256, false)
-        .err()
-        .expect("a graph that cannot admit any image must fail at startup");
+        .expect_err("a graph that cannot admit any image must fail at startup");
     let HostPreprocessorError::InvalidConfig(message) = &error else {
         panic!("expected a configuration error, got {error:?}");
     };


### PR DESCRIPTION
## Summary

clippy 1.97 flags `.err().expect()` as `err_expect`, and the workspace clippy gate runs with `-D warnings`, so a clean checkout of `main` fails local clippy since #1280 landed. One-line fix to `expect_err`.

The two `load_xla_image_preprocessor` sites in the same file keep the `.err().expect()` shape: their Ok type does not implement `Debug`, so `expect_err` does not apply and the lint does not fire there.

## Type of change

- [x] `chore`

## Test plan

- [x] `cargo clippy -p mlxcel --all-targets --features metal,accelerate -- -D warnings` clean
- [x] `cargo test --release -p mlxcel --lib the_default_capacity_is_rejected` passes