### PR TITLE
refactor(server): give the four LRU eviction min_by_key calls a total order

### DIFF
--- a/TECHNICAL_REPORTS/1299-lru-eviction-total-order-20260822.en.md
+++ b/TECHNICAL_REPORTS/1299-lru-eviction-total-order-20260822.en.md
@@ -1,0 +1,69 @@
+# Technical Report: PR #1299 - A total order for the four LRU eviction victim selections
+
+## Executive Summary
+
+Four LRU eviction sites picked their victim with `min_by_key` directly over a `HashMap`. `Iterator::min_by_key` returns the first minimum, so entries sharing a timestamp were separated by `HashMap` iteration order, which `RandomState` randomizes per map instance. Each now selects through a total order by appending the map key.
+
+**This was not a live defect and the change does not fix an observed bug.** All four keys are `std::time::Instant`, stamped once per call, so the tie was not reachable. What the change removes is a latent fragility that would become real the moment the key got coarser than a per-call `Instant`.
+
+## 1. Problem Statement
+
+The sites, all over an unordered map:
+
+| Site | Function | Map |
+| --- | --- | --- |
+| `src/server/prompt_cache/store.rs:315` | `evict_oldest` | `entries: HashMap<PromptCacheKeyDigest, EntrySlot>` |
+| `src/server/prompt_cache/store.rs:336` | `evict_oldest_snapshot` | `snapshots` |
+| `src/server/responses_store.rs:243` | LRU eviction loop | `HashMap<String, Entry>` |
+| `src/server/conversation_store.rs:151` | `evict_to_capacity` | `HashMap<String, Entry>` |
+
+Why the tie is unreachable today, stated so the severity is not misread later: each writer computes `Instant::now()` once per call and stamps a single entry with it, and `Instant` resolves to nanoseconds on the platforms this project targets, so two entries never take the same value. The reachable-tie counterpart of this pattern is #1293, where the key is `generated_tokens.len()`, a small integer that ties routinely.
+
+These four are also the reason the `min_by_key` static-check candidate was declined in #1287: it flags exactly these, catches none of the seven live instances, and gating on it would have meant suppressing four of four findings on day one. Fixing them by hand removes that tension rather than carrying it.
+
+## 2. Technical Decisions
+
+### 2.1 Two forms, chosen per key type
+
+`PromptCacheKeyDigest` derives only `Clone, Copy, PartialEq, Eq, Hash` (`src/server/prompt_cache/key.rs:54`), so the obvious tuple key does not compile. Rather than widen the type's derive, both prompt-cache sites key on the raw bytes: `min_by_key(|(digest, slot)| (slot.entry.last_used(), *digest.as_bytes()))`. `[u8; 32]` is `Ord`, and the digest type keeps its original surface.
+
+The two `String`-keyed stores use the comparator form, `min_by(|(key_a, a), (key_b, b)| a.last_accessed.cmp(&b.last_accessed).then_with(|| key_a.cmp(key_b)))`, because `min_by_key` would have to clone the `String` into a tuple on every element.
+
+Both forms are recorded as correct in `docs/code-guidelines.md` under "HashMap Iteration Order", and the choice between them there is explicitly stylistic. Each site carries a comment naming the tie-break component as the thing that makes the order total, per the same guideline, since otherwise it reads as redundant and gets simplified away.
+
+### 2.2 No regression test, deliberately
+
+The issue framed this as a judgment call rather than a requirement, and the judgment here is not to add one. Constructing the tie means writing an identical `Instant` directly into private state, bypassing every real write path (`touch`, `insert`, `get`, `append`). A test built that way pins the behavior of a comparator rather than any reachable production state, and it would need private-field access or a test-only setter to exist at all. The reasoning is recorded in the PR body so the absence is a decision rather than an oversight.
+
+This is the opposite call from #1288, where the tie was reachable and eight tests were both possible and necessary. The distinction is reachability, not effort.
+
+## 3. Change Summary
+
+| File | Change |
+| --- | --- |
+| `src/server/prompt_cache/store.rs` | Both sites key on `(last_used(), *digest.as_bytes())`, with comments |
+| `src/server/responses_store.rs` | Comparator form tie-breaking on the map key, with a comment |
+| `src/server/conversation_store.rs` | Same |
+
+33 lines added, 5 removed, across three files. No public API changed, no type derive widened.
+
+## 4. Review Findings
+
+One implementation detail worth recording, checked rather than assumed: `min_by_key` invokes its closure once per element, so `slot.entry.last_used()` still takes its mutex exactly as many times as before. Folding the digest into the key adds no additional locking.
+
+The issue's coordination note about #1248 was re-checked at implementation time: still `status:ready`, no PR, not in flight, so all four sites stayed in this PR rather than two of them moving there.
+
+## 5. Validation
+
+Measured on GB10 (DGX Spark, CUDA sm_121, Linux aarch64). The branch was current with `main` at gate time.
+
+- `make verify-test-cuda`: recorded in the PR thread.
+- `cargo test --profile test-fast --features cuda --lib server::prompt_cache`: 168 passed, exit 0. `server::responses_store`: 8 passed. `server::conversation_store`: 5 passed. Both of the latter through the prebuilt binary, since `cargo test` takes one filter.
+- `cargo fmt --all -- --check`, `cargo check --lib --tests --features cuda`, `cargo clippy --lib --tests --features cuda -- -D warnings`: all exit 0.
+
+## 6. Related Work
+
+- #1291: the issue this closes.
+- #1287 and PR #1290: the guideline that records the class and the accepted remedy forms, and whose declined static check flagged exactly these four sites.
+- #1293: the reachable-tie sibling in `BatchScheduler::select_eviction_victim`, handled separately because its tie occurs in ordinary batch state and therefore does warrant tests.
+- #1265 and PR #1266, #1267 and PR #1269, #1276 and PR #1281, #1277 and PR #1284, #1286 and PR #1288: the seven live instances of the same class.

--- a/TECHNICAL_REPORTS/1299-lru-eviction-total-order-20260822.ko.md
+++ b/TECHNICAL_REPORTS/1299-lru-eviction-total-order-20260822.ko.md
@@ -1,0 +1,69 @@
+# 기술 보고서: PR #1299 - LRU 축출 victim 선택 네 곳에 전순서 부여
+
+## 요약
+
+LRU 축출 네 곳이 `HashMap` 위에서 `min_by_key`로 victim을 골랐다. `Iterator::min_by_key`는 첫 번째 최솟값을 반환하므로, 타임스탬프가 같은 엔트리는 `HashMap` 순회 순서로 갈렸고 그 순서는 `RandomState`가 맵 인스턴스마다 무작위화한다. 이제 네 곳 모두 맵 키를 덧붙여 전순서로 선택한다.
+
+**이것은 live 결함이 아니었고 이 변경은 관측된 버그를 고치지 않는다.** 네 키가 모두 호출당 한 번 찍히는 `std::time::Instant`라 동점이 도달 불가였다. 이 변경이 없애는 것은 키가 호출당 `Instant`보다 거칠어지는 순간 실재하게 될 잠재적 취약성이다.
+
+## 1. 문제
+
+전부 정렬되지 않은 맵 위의 지점들이다.
+
+| 지점 | 함수 | 맵 |
+| --- | --- | --- |
+| `src/server/prompt_cache/store.rs:315` | `evict_oldest` | `entries: HashMap<PromptCacheKeyDigest, EntrySlot>` |
+| `src/server/prompt_cache/store.rs:336` | `evict_oldest_snapshot` | `snapshots` |
+| `src/server/responses_store.rs:243` | LRU 축출 루프 | `HashMap<String, Entry>` |
+| `src/server/conversation_store.rs:151` | `evict_to_capacity` | `HashMap<String, Entry>` |
+
+지금 동점이 왜 도달 불가인지 적어 둔다. 나중에 심각도를 잘못 읽지 않도록. 각 writer가 호출당 `Instant::now()`를 한 번 계산해 엔트리 하나에만 찍고, `Instant`는 이 프로젝트가 대상으로 하는 플랫폼에서 나노초로 해석되므로 두 엔트리가 같은 값을 갖지 않는다. 이 패턴의 **도달 가능한** 짝은 #1293이며, 거기서는 키가 `generated_tokens.len()`이라는 작은 정수라 동점이 일상이다.
+
+이 네 곳은 #1287에서 `min_by_key` 정적 검사 후보가 기각된 이유이기도 하다. 정확히 이것들만 플래그하고, live 인스턴스 일곱 중 하나도 못 잡으며, 게이트를 걸면 도입 당일 4건 중 4건을 억제해야 했다. 손으로 고치면 그 긴장이 남지 않는다.
+
+## 2. 기술적 판단
+
+### 2.1 키 타입에 따라 두 형태
+
+`PromptCacheKeyDigest`는 `Clone, Copy, PartialEq, Eq, Hash`만 파생하므로(`src/server/prompt_cache/key.rs:54`) 명백해 보이는 튜플 키가 컴파일되지 않는다. 타입의 derive를 넓히는 대신 두 프롬프트 캐시 지점은 원시 바이트로 키잉한다: `min_by_key(|(digest, slot)| (slot.entry.last_used(), *digest.as_bytes()))`. `[u8; 32]`는 `Ord`이고 digest 타입은 원래 표면을 유지한다.
+
+`String` 키를 쓰는 두 저장소는 비교자 형태를 쓴다. `min_by_key`라면 원소마다 `String`을 튜플에 클론해야 하기 때문이다.
+
+두 형태 모두 `docs/code-guidelines.md`의 "HashMap Iteration Order"에 옳은 것으로 기록돼 있고, 그 선택은 명시적으로 취향 문제다. 각 지점에 타이브레이크 성분이 전순서를 만드는 것임을 지목하는 주석을 달았다. 같은 가이드라인의 요구이며, 없으면 잉여로 읽혀 다음 사람이 지운다.
+
+### 2.2 회귀 테스트 없음, 의도적
+
+이슈가 이것을 요구가 아니라 판단 사항으로 규정했고, 여기서의 판단은 넣지 않는 것이다. 동점을 만들려면 같은 `Instant`를 비공개 상태에 직접 써 넣어야 하고, 이는 실제 쓰기 경로(`touch`, `insert`, `get`, `append`)를 전부 우회한다. 그렇게 만든 테스트는 도달 가능한 프로덕션 상태가 아니라 비교자의 동작을 고정할 뿐이고, 애초에 존재하려면 비공개 필드 접근이나 테스트 전용 setter가 필요하다. 부재가 실수가 아니라 결정이 되도록 근거를 PR 본문에 적었다.
+
+#1288과는 반대 판단이다. 거기서는 동점이 도달 가능했고 테스트 여덟 개가 가능하면서 필요했다. 구분 기준은 노력이 아니라 **도달 가능성**이다.
+
+## 3. 변경 요약
+
+| 파일 | 변경 |
+| --- | --- |
+| `src/server/prompt_cache/store.rs` | 두 지점을 `(last_used(), *digest.as_bytes())`로 키잉, 주석 포함 |
+| `src/server/responses_store.rs` | 맵 키로 타이브레이크하는 비교자 형태, 주석 포함 |
+| `src/server/conversation_store.rs` | 동일 |
+
+세 파일에 33줄 추가, 5줄 제거. 공개 API 변경 없음, 타입 derive 확장 없음.
+
+## 4. 리뷰 지적사항
+
+가정하지 않고 확인한 구현 세부 하나를 기록해 둔다. `min_by_key`는 클로저를 원소당 한 번 호출하므로 `slot.entry.last_used()`가 잡는 뮤텍스 횟수는 이전과 같다. digest를 키에 접는다고 락이 늘지 않는다.
+
+이슈의 #1248 조정 메모는 구현 시점에 재확인했다. 여전히 `status:ready`, PR 없음, 진행 중 아님. 그래서 네 지점이 전부 이 PR에 남았고 둘이 그쪽으로 옮겨가지 않았다.
+
+## 5. 검증
+
+GB10(DGX Spark, CUDA sm_121, Linux aarch64)에서 실측. 게이트 시점에 브랜치가 `main`과 동기였다.
+
+- `make verify-test-cuda`: PR 스레드에 기록.
+- `cargo test --profile test-fast --features cuda --lib server::prompt_cache`: 168 통과, exit 0. `server::responses_store`: 8 통과. `server::conversation_store`: 5 통과. 뒤의 둘은 `cargo test`가 필터를 하나만 받으므로 미리 빌드한 바이너리로 실행.
+- `cargo fmt --all -- --check`, `cargo check --lib --tests --features cuda`, `cargo clippy --lib --tests --features cuda -- -D warnings`: 전부 exit 0.
+
+## 6. 관련 작업
+
+- #1291: 이 PR이 닫는 이슈.
+- #1287과 PR #1290: 계열과 허용 해법 형태를 기록한 가이드라인. 거기서 기각된 정적 검사가 정확히 이 네 지점을 플래그했다.
+- #1293: `BatchScheduler::select_eviction_victim`의 도달 가능한 동점 형제. 평범한 배치 상태에서 동점이 나므로 테스트가 필요해 별도로 처리한다.
+- #1265와 PR #1266, #1267과 PR #1269, #1276과 PR #1281, #1277과 PR #1284, #1286과 PR #1288: 같은 계열의 live 인스턴스 일곱.

--- a/src/server/conversation_store.rs
+++ b/src/server/conversation_store.rs
@@ -146,9 +146,19 @@ impl ConversationStore {
 
     fn evict_to_capacity(map: &mut HashMap<String, Entry>, target_size: usize) {
         while map.len() > target_size {
+            // The key component makes the comparator a TOTAL order: `map`
+            // iterates in `HashMap` order, which `RandomState` randomizes
+            // per instance, and without this tie-break two entries sharing
+            // `last_accessed` would resolve to whichever one hash order
+            // placed first. Comparator form avoids cloning the key that
+            // `min_by_key` would need to fold it into a tuple.
             let Some(victim) = map
                 .iter()
-                .min_by_key(|(_, e)| e.last_accessed)
+                .min_by(|(key_a, a), (key_b, b)| {
+                    a.last_accessed
+                        .cmp(&b.last_accessed)
+                        .then_with(|| key_a.cmp(key_b))
+                })
                 .map(|(k, _)| k.clone())
             else {
                 break;

--- a/src/server/prompt_cache/store.rs
+++ b/src/server/prompt_cache/store.rs
@@ -309,10 +309,14 @@ impl Inner {
     /// Evict the single oldest entry. Returns the number of bytes freed, or
     /// `0` if the store is empty.
     fn evict_oldest(&mut self) -> usize {
+        // The digest bytes make the key a TOTAL order: `entries` iterates in
+        // `HashMap` order, which `RandomState` randomizes per instance, and
+        // without this tie-break component two entries sharing `last_used`
+        // would resolve to whichever one hash order placed first.
         let oldest = self
             .entries
             .iter()
-            .min_by_key(|(_, slot)| slot.entry.last_used())
+            .min_by_key(|(digest, slot)| (slot.entry.last_used(), *digest.as_bytes()))
             .map(|(d, _)| *d);
         match oldest {
             Some(digest) => {
@@ -330,10 +334,14 @@ impl Inner {
     }
 
     fn evict_oldest_snapshot(&mut self) -> usize {
+        // The digest bytes make the key a TOTAL order: `snapshots` iterates
+        // in `HashMap` order, which `RandomState` randomizes per instance,
+        // and without this tie-break component two entries sharing
+        // `last_used` would resolve to whichever one hash order placed first.
         let oldest = self
             .snapshots
             .iter()
-            .min_by_key(|(_, slot)| slot.entry.last_used())
+            .min_by_key(|(digest, slot)| (slot.entry.last_used(), *digest.as_bytes()))
             .map(|(d, _)| *d);
         match oldest {
             Some(digest) => match self.remove_snapshot(&digest) {

--- a/src/server/responses_store.rs
+++ b/src/server/responses_store.rs
@@ -237,10 +237,20 @@ impl ResponsesStore {
     fn evict_to_capacity(map: &mut HashMap<String, Entry>, target_size: usize) {
         while map.len() > target_size {
             // Pick the least-recently-accessed entry. O(n) per eviction;
-            // acceptable for Phase 1's expected store sizes (≤1024).
+            // acceptable for Phase 1's expected store sizes (≤1024). The
+            // key component makes the comparator a TOTAL order: `map`
+            // iterates in `HashMap` order, which `RandomState` randomizes
+            // per instance, and without this tie-break two entries sharing
+            // `last_accessed` would resolve to whichever one hash order
+            // placed first. Comparator form avoids cloning the key that
+            // `min_by_key` would need to fold it into a tuple.
             let Some(victim) = map
                 .iter()
-                .min_by_key(|(_, e)| e.last_accessed)
+                .min_by(|(key_a, a), (key_b, b)| {
+                    a.last_accessed
+                        .cmp(&b.last_accessed)
+                        .then_with(|| key_a.cmp(key_b))
+                })
                 .map(|(k, _)| k.clone())
             else {
                 break;


### PR DESCRIPTION
## Summary

Four LRU eviction sites picked their victim with `min_by_key` applied directly to a `HashMap` iterator: `Inner::evict_oldest` and `Inner::evict_oldest_snapshot` in `src/server/prompt_cache/store.rs:315` and `:336`, and `evict_to_capacity` in both `src/server/responses_store.rs:243` and `src/server/conversation_store.rs:151`. `Iterator::min_by_key` returns the FIRST minimum, so two entries tied on the timestamp key would be separated only by `HashMap` iteration order, which `RandomState` randomizes per map instance.

**This is not a live bug, and it is not described as four bugs here.** All four keys are `std::time::Instant`, and every writer (`touch()`, `insert()`, `get()`, `append()`) stamps a single entry with one `Instant::now()` call. At nanosecond resolution the tie is not reachable through the public API today. What this PR removes is a latent fragility: the pattern would become a real defect the moment one of these keys becomes coarser than a per-call `Instant` (a seconds-granularity timestamp, a logical clock, a value hoisted out of a loop), and nothing in the current code flags that risk.

## What changed

- `src/server/prompt_cache/store.rs`, `evict_oldest` (line ~315) and `evict_oldest_snapshot` (line ~336): both now key on `(slot.entry.last_used(), *digest.as_bytes())`. `PromptCacheKeyDigest` derives only `Clone, Copy, PartialEq, Eq, Hash` and is not `Ord`, so a bare tuple key would not compile. Per the issue's recommendation, I keyed on `*digest.as_bytes()` (`&[u8; 32]`, which is `Ord`) rather than adding `PartialOrd, Ord` to the digest's derive, to avoid widening that type's public trait surface for one call site. `last_used()` is still called exactly once per element (the key-function closure runs once per item), so this does not turn the per-entry mutex lock into a double lock.
- `src/server/responses_store.rs`, `evict_to_capacity` (line ~243): switched to `min_by` with `a.last_accessed.cmp(&b.last_accessed).then_with(|| key_a.cmp(key_b))`. The key is a `String`, so the comparator form avoids the clone a tuple key would force.
- `src/server/conversation_store.rs`, `evict_to_capacity` (line ~151): same comparator form.
- Each site carries a comment naming the tie-break component (digest bytes or map key) as what makes the order total, per `docs/code-guidelines.md`'s "HashMap Iteration Order" section, so a later simplification pass does not read the component as redundant and strip it.

Scope matches the issue exactly: the four call sites plus a comment at each. No change to eviction policy, cap-enforcement loops, or what the stores are bounded by. `#1248` (byte-bounding of the two stores) is open but still `status:ready` with no PR, i.e. not in flight, so this PR keeps all four sites rather than folding two into that work.

## Regression test: decision and reasoning

No regression test was added. Reasoning:

- The tie is not reachable through any production write path on any of the four sites (confirmed per site above), so a test would have to write an identical `Instant` directly into private state, bypassing `touch()`/`insert()`/`get()`/`append()` entirely.
- Such a test would pin the comparator/tuple-key's generic sort behavior, not any reachable production state. It would not catch a real regression that a code reviewer plus the comment at each site wouldn't also catch.
- The general defect class, its testing methodology (fresh map per iteration, 32+ iterations, an actual constructed tie), and precedent test suites are already recorded in `docs/code-guidelines.md`'s "HashMap Iteration Order" section, including its explicit accounting that these exact four sites are "true positives for the lint and zero live bugs."
- A test becomes worth adding the moment a future change makes one of these keys coarser than a per-call `Instant` (the actual risk this PR is guarding against) — and that change would introduce its own new code path, which is the natural place for its own review and its own test, not a synthetic test bolted onto code that cannot exercise the coarser key today.

This is a judgment call per the issue's acceptance criteria, which explicitly allow either outcome with reasoning stated. No existing test's expected outcome changed.

## Test plan

- [x] `cargo fmt --all -- --check` — exit 0
- [x] `cargo check --lib --tests --features cuda` — exit 0
- [x] `cargo clippy --lib --tests --features cuda -- -D warnings` — exit 0
- [x] `cargo test --profile test-fast --features cuda --lib server::prompt_cache` — exit 0, 168 passed, 0 failed
- [x] `cargo test --profile test-fast --features cuda --lib server::responses_store --no-run` then run the built binary filtered to `server::responses_store` — exit 0, 8 passed, 0 failed
- [x] Same binary filtered to `server::conversation_store` — exit 0, 5 passed, 0 failed

`make verify-test-cuda` will be run separately against this branch.

Closes #1291
