### PR TITLE
fix(server): report the exactness veto at /v1/internal/mtp-policy instead of profiling forever

### DIFF
--- a/docs/mtp-policy-api.md
+++ b/docs/mtp-policy-api.md
@@ -29,6 +29,7 @@ On a model-serving node, the endpoint is always mounted, unlike `/props`, `/slot
   "schema_version": 1,
   "state": "settled",
   "reason": null,
+  "decline_detail": null,
   "verdict": "enable",
   "mtp_enabled": true,
   "target": "Gemma4-12B",
@@ -45,8 +46,9 @@ On a model-serving node, the endpoint is always mounted, unlike `/props`, `/slot
 | Field | Type | Meaning |
 |-------|------|---------|
 | `schema_version` | integer | Wire schema version of this body. See [Versioning and compatibility](#versioning-and-compatibility). |
-| `state` | string | `"settled"`, `"profiling"`, `"forced"`, or `"unavailable"`. |
+| `state` | string | `"settled"`, `"profiling"`, `"forced"`, `"unavailable"`, or `"exactness_declined"`. |
 | `reason` | string or null | Why the policy is unavailable. Non-null only when `state` is `"unavailable"`. |
+| `decline_detail` | string or null | The exactness probe's one-line reason. Non-null only when `state` is `"exactness_declined"`; the same sentence the boot-time WARN logs. |
 | `verdict` | string or null | `"enable"` or `"decline"` once settled, `null` otherwise. Same values as the `verdict` field of the persisted hint. |
 | `mtp_enabled` | boolean or null | Whether the *policy* is not blocking the B=1 MTP burst right now. This is the live gate, not the verdict: it is `true` while profiling, because profiling forces MTP on at the policy level. It does not mean a burst is actually running: later runtime gates (target support, exactness, capability checks) can still reject every burst attempt, in which case profiling never accumulates a sample despite `mtp_enabled: true`. |
 | `target` | string or null | Served model directory basename. |
@@ -65,7 +67,8 @@ The four fields `target`, `drafter`, `hardware`, and `block_size` are the pairin
 | `state` | Meaning |
 |---------|---------|
 | `settled` | A verdict is in effect, either measured in this process or restored from a persisted hint. `verdict` says which way. |
-| `profiling` | Still accumulating samples. There is no verdict yet; `samples_remaining` says how many qualifying single-request generations are still needed. MTP is forced on at the policy level meanwhile, so `mtp_enabled` is `true`. Limitation: if the runtime gates below the policy (target support, exactness, capability checks) reject every burst attempt, no sample is ever recorded, and the endpoint reports `state: "profiling"`, `samples: 0`, `samples_remaining: 4` for the life of the process, with `mtp_enabled: true` misleadingly suggesting MTP is running. |
+| `profiling` | Still accumulating samples. There is no verdict yet; `samples_remaining` says how many qualifying single-request generations are still needed. MTP is forced on at the policy level meanwhile, so `mtp_enabled` is `true`. Limitation: if per-request runtime gates below the policy (target support, per-sequence capability checks) reject every burst attempt, no sample is ever recorded and this state persists with `samples: 0`. The one structural case of that starvation, the exactness-probe veto, reports as `exactness_declined` instead since issue #1298. |
+| `exactness_declined` | The runtime exactness probe declined the pairing: the multi-token verify block is not byte-identical to the single-token chain on this hardware under any available kernel selection, so the B=1 burst never dispatches and requests serve classic decode. `decline_detail` carries the probe's reason, `mtp_enabled` is `false`, and no verdict will ever arrive, which is exactly why this is not `profiling`. `MLXCEL_MTP_ALLOW_INEXACT=1` opts into running anyway, forfeiting the temperature-0 byte-identity contract. |
 | `forced` | `MLXCEL_ENABLE_MTP_B1` pinned the decision. Nothing was profiled and nothing was measured, so `verdict`, `acceptance_rate`, and `samples` carry no measurement. `mtp_enabled` still reports what the pin resolved to. |
 | `unavailable` | No adaptive policy is running. `reason` says why. |
 
@@ -116,6 +119,7 @@ While profiling:
   "schema_version": 1,
   "state": "profiling",
   "reason": null,
+  "decline_detail": null,
   "verdict": null,
   "mtp_enabled": true,
   "target": "Gemma4-12B",
@@ -138,6 +142,7 @@ On a server with no drafter:
   "schema_version": 1,
   "state": "unavailable",
   "reason": "no_mtp_dispatch",
+  "decline_detail": null,
   "verdict": null,
   "mtp_enabled": false,
   "target": null,
@@ -150,5 +155,28 @@ On a server with no drafter:
   "samples_remaining": null
 }
 ```
+
+On a generation 15+ host whose pairing fails the exactness probe under both kernel selections (measured on the Gemma 4 31B + bf16 assistant pairing on M3 Ultra and M5 Max, issue #1279):
+
+```json
+{
+  "schema_version": 1,
+  "state": "exactness_declined",
+  "reason": null,
+  "decline_detail": "verify block position 0 differs from the single-token chain in 245722 of 524288 logit bytes. Disabling qmv_wide did not make it exact either.",
+  "verdict": null,
+  "mtp_enabled": false,
+  "target": "gemma-4-31b-it-4bit",
+  "drafter": "gemma-4-31b-it-assistant-bf16",
+  "hardware": "M5-40c",
+  "block_size": 4,
+  "acceptance_rate": null,
+  "samples": 0,
+  "samples_required": 4,
+  "samples_remaining": null
+}
+```
+
+which renders as "MTP configured but vetoed; running classic decode", with the reason available verbatim.
 
 The same state is also included in the `/health` observability snapshot under `observability.mtp_policy`, in a similar but unversioned shape (it spells the state field `status` and omits `schema_version` and `samples_remaining`), for operators already polling that endpoint. `/health` is an operator surface with no stability promise; `/v1/internal/mtp-policy` is the one with the contract above.

--- a/src/models/speculative_exactness.rs
+++ b/src/models/speculative_exactness.rs
@@ -163,9 +163,34 @@ pub fn allow_inexact() -> bool {
     })
 }
 
-fn verdict_cache() -> &'static Mutex<HashMap<ProbeKey, bool>> {
-    static CACHE: OnceLock<Mutex<HashMap<ProbeKey, bool>>> = OnceLock::new();
+/// Memoized outcome of one gate run: the decision, plus the decline reason
+/// when there was one, so observability surfaces can say why MTP is not
+/// running without re-probing (issue #1298).
+#[derive(Debug, Clone)]
+struct CachedDecision {
+    decision: bool,
+    decline_reason: Option<String>,
+}
+
+fn verdict_cache() -> &'static Mutex<HashMap<ProbeKey, CachedDecision>> {
+    static CACHE: OnceLock<Mutex<HashMap<ProbeKey, CachedDecision>>> = OnceLock::new();
     CACHE.get_or_init(|| Mutex::new(HashMap::new()))
+}
+
+/// The one-line reason the gate declined MTP at `block_size`, when it did.
+///
+/// Keyed by block width alone: a process serves one target model (see
+/// [`ProbeKey`]), so the width is the only discriminator a server-side
+/// consumer has, or needs. `None` when no gate run at that width has
+/// declined, including when the probe has not run at all.
+///
+/// Used by: the scheduler's `/v1/internal/mtp-policy` publish (issue #1298).
+pub fn decline_reason(block_size: u32) -> Option<String> {
+    let cache = verdict_cache().lock().ok()?;
+    cache
+        .iter()
+        .find(|(key, cached)| key.block_size == block_size && cached.decline_reason.is_some())
+        .and_then(|(_, cached)| cached.decline_reason.clone())
 }
 
 /// Whether MTP may engage for `key`, running `probe` at most once per key.
@@ -275,9 +300,9 @@ where
     F: FnMut() -> BlockChainExactness,
 {
     if let Ok(cache) = verdict_cache().lock()
-        && let Some(decision) = cache.get(&key)
+        && let Some(cached) = cache.get(&key)
     {
-        return *decision;
+        return cached.decision;
     }
 
     let verdict = probe();
@@ -288,6 +313,21 @@ where
     };
     let exact = verdict.is_equal() || retried == Some(true);
     let decision = exact || allow_inexact();
+    let also_tried = match retried {
+        Some(false) => " Disabling qmv_wide did not make it exact either.",
+        None if qmv_wide_pinned_by_operator() => {
+            " The qmv_wide retry was skipped because MLXCEL_QMV_WIDE is pinned."
+        }
+        _ => "",
+    };
+    // The sentence observability surfaces show for a declined pairing
+    // (issue #1298): the same content the WARN below logs, minus the
+    // env-var instructions, which are operator-console text.
+    let decline_reason = (!decision).then(|| {
+        format!("{}.{}", verdict.reason(), also_tried)
+            .trim()
+            .to_string()
+    });
 
     if verdict.is_equal() {
         tracing::info!(
@@ -306,13 +346,6 @@ where
             verdict.reason()
         );
     } else {
-        let also_tried = match retried {
-            Some(false) => " Disabling qmv_wide did not make it exact either.",
-            None if qmv_wide_pinned_by_operator() => {
-                " The qmv_wide retry was skipped because MLXCEL_QMV_WIDE is pinned."
-            }
-            _ => "",
-        };
         tracing::warn!(
             block_size = key.block_size,
             "MTP declined: {}.{} Falling back to classic decode. Set \
@@ -324,7 +357,13 @@ where
     }
 
     if let Ok(mut cache) = verdict_cache().lock() {
-        cache.insert(key, decision);
+        cache.insert(
+            key,
+            CachedDecision {
+                decision,
+                decline_reason,
+            },
+        );
     }
     decision
 }

--- a/src/models/speculative_exactness_tests.rs
+++ b/src/models/speculative_exactness_tests.rs
@@ -209,3 +209,29 @@ fn reason_strings_name_the_position_and_the_byte_counts() {
     assert!(reason.contains("17"), "{reason}");
     assert!(reason.contains("496640"), "{reason}");
 }
+
+/// A decline records its reason beside the memoized decision, so the
+/// server's policy endpoint can say why MTP is not running without
+/// re-probing (issue #1298). A pass records nothing.
+#[test]
+fn a_decline_records_its_reason_and_a_pass_does_not() {
+    let declined = key(9105);
+    let decision = mtp_exactness_gate(declined, || BlockChainExactness::Diverges {
+        position: 0,
+        differing_bytes: 7,
+        total_bytes: 100,
+    });
+    assert!(!decision);
+    let reason = super::decline_reason(9105).expect("a decline records its reason");
+    assert!(
+        reason.contains("differs from the single-token chain"),
+        "{reason}"
+    );
+    assert!(
+        reason.contains("Disabling qmv_wide did not make it exact either"),
+        "the retry outcome is part of the story: {reason}"
+    );
+
+    assert!(mtp_exactness_gate(key(9106), || BlockChainExactness::Equal));
+    assert_eq!(super::decline_reason(9106), None);
+}

--- a/src/server/batch/mtp_policy.rs
+++ b/src/server/batch/mtp_policy.rs
@@ -782,6 +782,15 @@ pub enum MtpPolicyStatus {
     /// A verdict is in effect, either settled in this process or loaded from a
     /// persisted hint.
     Settled,
+    /// The runtime exactness probe declined the pairing
+    /// (`models::speculative_exactness`), so the B=1 burst never dispatches
+    /// and requests serve classic decode. Distinct from
+    /// [`Profiling`](Self::Profiling) precisely so a vetoed pairing does not
+    /// report a verdict as pending forever, which is the ambiguity #1257
+    /// exists to remove, and distinct from [`Settled`](Self::Settled)
+    /// because this policy measured nothing: the veto happened upstream of
+    /// it (issue #1298).
+    ExactnessDeclined,
 }
 
 impl MtpPolicyStatus {
@@ -795,6 +804,7 @@ impl MtpPolicyStatus {
             Self::Forced => "forced",
             Self::Profiling => "profiling",
             Self::Settled => "settled",
+            Self::ExactnessDeclined => "exactness_declined",
         }
     }
 }
@@ -851,6 +861,12 @@ pub struct MtpPolicySnapshot {
     pub status: MtpPolicyStatus,
     /// Set only when `status` is [`MtpPolicyStatus::Unavailable`].
     pub reason: Option<MtpPolicyUnavailableReason>,
+    /// The exactness probe's one-line reason, set only when `status` is
+    /// [`MtpPolicyStatus::ExactnessDeclined`]. The same sentence the
+    /// boot-time WARN logs, so the endpoint and the log tell one story
+    /// (issue #1298).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub decline_detail: Option<String>,
     /// Target identity (the served model directory's basename).
     pub target: Option<String>,
     /// Drafter identity (the draft model directory's basename).
@@ -891,11 +907,43 @@ impl MtpPolicySnapshot {
         Self {
             status: MtpPolicyStatus::Unavailable,
             reason: Some(reason),
+            decline_detail: None,
             target: None,
             drafter: None,
             hardware: None,
             block_size: None,
             mtp_enabled,
+            verdict: None,
+            acceptance_rate: None,
+            samples: 0,
+            samples_required: PROFILE_SAMPLE_TARGET,
+        }
+    }
+
+    /// The "exactness probe vetoed this pairing" view (issue #1298).
+    ///
+    /// Published instead of the attached policy's own snapshot when
+    /// `mtp_capable_target` is false for the resolved MTP dispatch: the
+    /// policy would otherwise report `profiling` forever, because the burst
+    /// it waits to sample never dispatches. `mtp_enabled` is `false`, no
+    /// verdict exists, and nothing was measured; `decline_detail` carries
+    /// the probe's reason when the gate recorded one.
+    #[must_use]
+    pub fn exactness_declined(
+        target: String,
+        drafter: String,
+        block_size: u32,
+        decline_detail: Option<String>,
+    ) -> Self {
+        Self {
+            status: MtpPolicyStatus::ExactnessDeclined,
+            reason: None,
+            decline_detail,
+            target: Some(target),
+            drafter: Some(drafter),
+            hardware: Some(hardware_label()),
+            block_size: Some(block_size),
+            mtp_enabled: Some(false),
             verdict: None,
             acceptance_rate: None,
             samples: 0,
@@ -1161,6 +1209,7 @@ impl MtpPolicy {
         MtpPolicySnapshot {
             status,
             reason: None,
+            decline_detail: None,
             target: Some(self.key.target.clone()),
             drafter: Some(self.key.drafter.clone()),
             hardware: Some(self.key.hardware.clone()),

--- a/src/server/batch/observability.rs
+++ b/src/server/batch/observability.rs
@@ -1002,6 +1002,7 @@ mod tests {
         let settled = MtpPolicySnapshot {
             status: MtpPolicyStatus::Settled,
             reason: None,
+            decline_detail: None,
             target: Some("t".to_string()),
             drafter: Some("d".to_string()),
             hardware: Some("M5-16c".to_string()),

--- a/src/server/batch/scheduler.rs
+++ b/src/server/batch/scheduler.rs
@@ -1672,6 +1672,13 @@ impl BatchScheduler {
     pub fn with_mtp_policy(mut self, target_model_id: Option<String>) -> Self {
         use super::mtp_policy::{MtpPolicySnapshot, MtpPolicyUnavailableReason};
 
+        // Snapshot to publish when the exactness gate has vetoed the
+        // pairing (issue #1298). Checked here, at attach time, because the
+        // gate is memoized per block width and cannot change later in the
+        // process: publishing the attached policy instead would report
+        // `profiling` forever, since the burst the policy waits to sample
+        // never dispatches past `mtp_capable_target`.
+        let mut exactness_veto: Option<MtpPolicySnapshot> = None;
         let mtp_dispatch = if let crate::server::SpeculativeDispatch::Mtp {
             draft_model_path,
             block_size,
@@ -1683,6 +1690,15 @@ impl BatchScheduler {
                 .map(|name| name.to_string_lossy().into_owned())
                 .unwrap_or_else(|| "unknown-drafter".to_string());
             let target_id = target_model_id.unwrap_or_else(|| "unknown-target".to_string());
+            let block = *block_size as usize;
+            if block >= 2 && !super::speculative_burst::mtp_capable_target(&self.model, block) {
+                exactness_veto = Some(MtpPolicySnapshot::exactness_declined(
+                    target_id.clone(),
+                    drafter_id.clone(),
+                    *block_size,
+                    crate::models::speculative_exactness::decline_reason(*block_size),
+                ));
+            }
             self.mtp_policy = super::mtp_policy::MtpPolicy::initialize(
                 target_id,
                 drafter_id,
@@ -1697,23 +1713,30 @@ impl BatchScheduler {
         // (issue #1257). Doing it here, rather than letting the endpoint reach
         // into `self.mtp_policy`, is what keeps `MtpPolicy` single-threaded and
         // lock-free on the decode path.
-        let published = match (&self.mtp_policy, mtp_dispatch) {
-            (Some(policy), _) => policy.snapshot(),
-            // MTP dispatch with the adaptive path switched off
-            // (`MLXCEL_MTP_ADAPTIVE=0`): the pre-#333 static per-hardware gate
-            // decides, so report what it decided rather than leaving a
-            // consumer to guess whether MTP runs.
-            (None, true) => MtpPolicySnapshot::unavailable(
-                MtpPolicyUnavailableReason::AdaptiveDisabled,
-                Some(super::speculative_burst::mtp_b1_burst_enabled(
-                    self.model.supports_batching(),
-                )),
-            ),
-            // No MTP dispatch at all: there is no pairing and no burst.
-            (None, false) => MtpPolicySnapshot::unavailable(
-                MtpPolicyUnavailableReason::NoMtpDispatch,
-                Some(false),
-            ),
+        // The exactness veto outranks the attached policy's own view: a
+        // vetoed pairing's policy is structurally starved and its
+        // `profiling` state would be a lie (issue #1298).
+        let published = if let Some(veto) = exactness_veto {
+            veto
+        } else {
+            match (&self.mtp_policy, mtp_dispatch) {
+                (Some(policy), _) => policy.snapshot(),
+                // MTP dispatch with the adaptive path switched off
+                // (`MLXCEL_MTP_ADAPTIVE=0`): the pre-#333 static per-hardware gate
+                // decides, so report what it decided rather than leaving a
+                // consumer to guess whether MTP runs.
+                (None, true) => MtpPolicySnapshot::unavailable(
+                    MtpPolicyUnavailableReason::AdaptiveDisabled,
+                    Some(super::speculative_burst::mtp_b1_burst_enabled(
+                        self.model.supports_batching(),
+                    )),
+                ),
+                // No MTP dispatch at all: there is no pairing and no burst.
+                (None, false) => MtpPolicySnapshot::unavailable(
+                    MtpPolicyUnavailableReason::NoMtpDispatch,
+                    Some(false),
+                ),
+            }
         };
         self.batch_observability.set_mtp_policy(published);
         self

--- a/src/server/routes/mtp_policy.rs
+++ b/src/server/routes/mtp_policy.rs
@@ -68,16 +68,23 @@ pub const MTP_POLICY_SCHEMA_VERSION: u32 = 1;
 pub struct MtpPolicyResponse {
     /// See [`MTP_POLICY_SCHEMA_VERSION`].
     pub schema_version: u32,
-    /// `"settled"`, `"profiling"`, `"forced"`, or `"unavailable"`.
+    /// `"settled"`, `"profiling"`, `"forced"`, `"unavailable"`, or
+    /// `"exactness_declined"`.
     ///
     /// `"forced"` is not `"settled"`: it means `MLXCEL_ENABLE_MTP_B1` pinned
     /// the decision, so nothing was measured on this machine and rendering it
-    /// as a measured verdict would be a lie.
+    /// as a measured verdict would be a lie. `"exactness_declined"` means the
+    /// runtime exactness probe vetoed the pairing, the B=1 burst never
+    /// dispatches, and requests serve classic decode; nothing is profiling
+    /// and no verdict will arrive (issue #1298).
     pub state: String,
     /// Why the policy is unavailable: `"no_mtp_dispatch"`,
     /// `"adaptive_disabled"`, or `"worker_not_ready"`. `null` in every other
     /// state.
     pub reason: Option<String>,
+    /// The exactness probe's one-line reason, present only when `state` is
+    /// `"exactness_declined"`. The same sentence the boot-time WARN logs.
+    pub decline_detail: Option<String>,
     /// `"enable"` or `"decline"` once settled, `null` otherwise. Matches the
     /// `verdict` values in the persisted hint file.
     pub verdict: Option<String>,
@@ -136,6 +143,7 @@ pub(crate) fn build_mtp_policy_response(snapshot: Option<MtpPolicySnapshot>) -> 
         schema_version: MTP_POLICY_SCHEMA_VERSION,
         state: snapshot.status.as_str().to_string(),
         reason: snapshot.reason.map(|r| r.as_str().to_string()),
+        decline_detail: snapshot.decline_detail,
         verdict: snapshot
             .verdict
             .map(|v| if v.runs() { "enable" } else { "decline" }.to_string()),

--- a/src/server/routes/mtp_policy_tests.rs
+++ b/src/server/routes/mtp_policy_tests.rs
@@ -27,6 +27,7 @@ fn settled(run: bool, acceptance_rate: f64, samples: usize) -> MtpPolicySnapshot
     MtpPolicySnapshot {
         status: MtpPolicyStatus::Settled,
         reason: None,
+        decline_detail: None,
         target: Some("Gemma4-12B".to_string()),
         drafter: Some("Gemma4-12B-MTP".to_string()),
         hardware: Some("M5-16c".to_string()),
@@ -75,6 +76,7 @@ fn profiling_reports_no_verdict_and_the_remaining_sample_count() {
     let snapshot = MtpPolicySnapshot {
         status: MtpPolicyStatus::Profiling,
         reason: None,
+        decline_detail: None,
         target: Some("Gemma4-12B".to_string()),
         drafter: Some("Gemma4-12B-MTP".to_string()),
         hardware: Some("M5-16c".to_string()),
@@ -103,6 +105,7 @@ fn forced_is_reported_separately_from_settled() {
     let snapshot = MtpPolicySnapshot {
         status: MtpPolicyStatus::Forced,
         reason: None,
+        decline_detail: None,
         target: Some("Gemma4-12B".to_string()),
         drafter: Some("Gemma4-12B-MTP".to_string()),
         hardware: Some("M5-16c".to_string()),
@@ -173,6 +176,7 @@ fn profiling_is_distinguishable_from_unavailable() {
     let profiling = build_mtp_policy_response(Some(MtpPolicySnapshot {
         status: MtpPolicyStatus::Profiling,
         reason: None,
+        decline_detail: None,
         target: Some("t".to_string()),
         drafter: Some("d".to_string()),
         hardware: Some("hw".to_string()),
@@ -217,4 +221,38 @@ fn response_round_trips_through_json_with_the_documented_field_names() {
 
     let parsed: MtpPolicyResponse = serde_json::from_value(json).expect("round-trips");
     assert_eq!(parsed, body);
+}
+
+/// The exactness veto is a first-class state (issue #1298): not `profiling`
+/// (no verdict is pending, none can arrive) and not `unavailable` (the
+/// dispatch exists; the measured gate refused it). The probe's reason rides
+/// along so the endpoint and the boot-time WARN tell one story.
+#[test]
+fn exactness_declined_reports_the_veto_and_its_reason() {
+    let detail = "verify block position 0 differs from the single-token chain \
+                  in 245722 of 524288 logit bytes. Disabling qmv_wide did not \
+                  make it exact either.";
+    let snapshot = MtpPolicySnapshot::exactness_declined(
+        "Gemma4-31B".to_string(),
+        "Gemma4-31B-assistant".to_string(),
+        4,
+        Some(detail.to_string()),
+    );
+    let body = build_mtp_policy_response(Some(snapshot));
+
+    assert_eq!(body.state, "exactness_declined");
+    assert_eq!(body.mtp_enabled, Some(false));
+    assert_eq!(body.verdict, None, "nothing was measured by the policy");
+    assert_eq!(body.reason, None, "reason is the unavailable-state field");
+    assert_eq!(body.decline_detail.as_deref(), Some(detail));
+    assert_eq!(body.samples, 0);
+    assert_eq!(
+        body.samples_remaining, None,
+        "a vetoed pairing must not render a countdown"
+    );
+
+    let json = serde_json::to_value(&body).expect("serializes");
+    assert_eq!(json["state"], "exactness_declined");
+    assert_eq!(json["decline_detail"], detail);
+    assert_eq!(json["block_size"], 4);
 }


### PR DESCRIPTION
## Summary

A server whose MTP pairing is vetoed by the runtime exactness probe used to report `"state": "profiling"` at `GET /v1/internal/mtp-policy` forever: the attached adaptive policy waits for burst samples, the vetoed burst never dispatches past `mtp_capable_target`, and the endpoint invites the operator to wait for a verdict that structurally cannot arrive. The `profiling` state's own doc row admitted this as a known limitation. This is the ambiguity #1257 was filed to remove, reintroduced through a gate that did not exist when #1257 landed, and it currently bites the Gemma 4 31B + bf16 assistant pairing on every generation 15+ host measured (#1279: M3 Ultra and M5 Max, both-kernel probe failure, a measured 2.25x served as classic decode).

The veto is now a first-class endpoint state:

- `MtpPolicyStatus::ExactnessDeclined` (wire label `exactness_declined`), with a new `decline_detail` field carrying the probe's one-line reason, the same sentence the boot-time WARN logs, so the endpoint and the log tell one story. `mtp_enabled` is `false`, `verdict` stays absent, no countdown renders.
- `models::speculative_exactness` memoizes the decline reason beside the decision (`decline_reason(block_size)`), so the publisher reads it without re-probing.
- The scheduler's attach-time publish checks the memoized gate first: MTP dispatch present but `mtp_capable_target` false publishes the vetoed snapshot instead of the starving policy's `profiling`. Attach-time is sufficient because the gate is memoized per block width and cannot change later in the process.
- `docs/mtp-policy-api.md` documents the state, the field, and an example body, and narrows the `profiling` limitation note to the per-request gates that can still starve it. The label addition stays inside `schema_version` 1 per the documented growth rule ("a new state ... can appear without a version bump"); `decline_detail` is a new field, which the same rule allows.

The `/health` mirror follows automatically (it renders the same snapshot). `MLXCEL_MTP_ALLOW_INEXACT=1` behavior is unchanged: the gate returns true there and the policy publishes as before.

## Related issues

Closes #1298.

## Type of change

- [x] `fix`

## Test plan

- [x] `cargo fmt --check`, `cargo clippy --workspace --all-targets --features metal,accelerate -- -D warnings`
- [x] `cargo test --release -p mlxcel --lib` (5771, +2 new) and `-p mlxcel-core --lib` green
- [x] New unit tests: the route body for the vetoed state (label, `mtp_enabled: false`, no verdict, no countdown, `decline_detail` verbatim, JSON field names) and the gate recording its reason on decline and nothing on a pass
- [x] Real-checkpoint E2E on the M5 Max host where #1279 reproduces:

  - `mlxcel-server -m gemma-4-31b-it-4bit --model-draft gemma-4-31b-it-assistant-bf16 --draft-block-size 4` publishes `"state": "exactness_declined"`, `"mtp_enabled": false`, and `decline_detail` = "verify block position 0 differs from the single-token chain in 245722 of 524288 logit bytes. Disabling qmv_wide did not make it exact either." verbatim, with the pairing identity filled in
  - the same server with `gemma-4-12b-it-4bit` + its 4-bit assistant (passes via the narrow retry) publishes `"state": "profiling"`, `"mtp_enabled": true`, `decline_detail: null`, byte-for-byte what it published before this change
