### PR TITLE
chore(ci): link an OpenXLA binary in CI so link-only regressions cannot reach main

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -137,7 +137,15 @@ jobs:
   clippy:
     name: cargo-clippy
     needs: changes
-    # Self-hosted, so fork PRs never queue on it. Mirrors `xla-compile` below.
+    # On the repository guard, because it is easy to read more into it than it
+    # does. It keeps this job from queueing forever in a *fork of* this
+    # repository, which has no GB10 runner of its own. It does not stop a pull
+    # request opened *from* a fork against lablup/mlxcel: on that event
+    # `github.repository` is the base repository, so the guard is true and the
+    # job runs here, executing the PR's `build.rs` and `scripts/iree/**` as the
+    # runner's own user. What actually gates that case is the repository's
+    # Actions fork-PR approval policy, currently `first_time_contributors`.
+    # The same reading applies to `xla-compile` and `xla-link` below.
     if: github.repository == 'lablup/mlxcel' && needs.changes.outputs.rust == 'true'
     runs-on: GB10
     permissions:
@@ -472,6 +480,14 @@ jobs:
     runs-on: GB10
     permissions:
       contents: read
+    # The other jobs on this runner are seconds warm; this one is minutes, so
+    # it is the first here that can hold GB10 long enough to matter. Without a
+    # group, three pushes to a `build.rs` PR queue three link jobs of up to
+    # 120 minutes each on the one runner that also serves clippy for every Rust
+    # PR and the release build. Keyed per PR, so PRs never cancel each other.
+    concurrency:
+      group: xla-link-${{ github.event.pull_request.number || github.ref }}
+      cancel-in-progress: true
     timeout-minutes: 120
     env:
       # The value shipped for this runner's architecture. Auto-detection yields

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -95,6 +95,8 @@ jobs:
             # every Rust PR. See the `xla-link` job comment for the rationale.
             xla_link:
               - 'build.rs'
+              - 'src/lib/mlxcel-xla/build.rs'
+              - 'src/lib/mlxcel-xla/csrc/**'
               - 'scripts/iree/**'
               - 'rust-toolchain.toml'
               - '.github/workflows/ci.yml'
@@ -406,12 +408,16 @@ jobs:
   # What it links, and why: `cargo test --release --features cuda,xla-iree
   # --test xla_prepared_prefill --no-run`. `build.rs` emits the IREE recipe
   # through `cargo:rustc-link-arg`, which applies to every linked artifact of
-  # the crate, so the smallest linked target exercises the same recipe as
-  # `mlxcel-server` does. `--no-run` links without executing, so this job never
-  # touches the GPU and never contends with development work on the shared
-  # GB10 host. `cargo build --release --features cuda,xla-iree --bin
-  # mlxcel-server` was considered and rejected: it costs 17m06s cold on this
-  # runner and adds no additional recipe coverage over the test binary.
+  # the crate, so any linked target exercises the same recipe `mlxcel-server`
+  # does, and an integration test is the direct reproducer because #1274 was an
+  # integration-test link failure. Cargo also builds the package's `[[bin]]`
+  # targets whenever an integration test is selected, so `mlxcel-server` and
+  # the other three binaries are linked here as well; the costs measured below
+  # already include them, which makes `cargo build --release --features
+  # cuda,xla-iree --bin mlxcel-server` a strict subset of this command rather
+  # than a cheaper alternative to it. `--no-run` links without executing, so
+  # this job never touches the GPU and never contends with development work on
+  # the shared GB10 host.
   #
   # Profile: `--release` is mandatory, not a choice. On this host the debug
   # profile cannot link these targets at all: it fails with hundreds of
@@ -420,12 +426,14 @@ jobs:
   # exceeds the AArch64 direct-branch range.
   #
   # Trigger: path-filtered via the `changes` job's `xla_link` output, not every
-  # Rust PR and not scheduled. `build.rs` holds the recipe and
-  # `scripts/iree/**` pins the IREE distribution whose archive set the recipe
-  # names, so those two are the causal surface. `rust-toolchain.toml` is on the
-  # same causal path because the #1274 failure was entirely about where rustc
-  # places its own `-lc` relative to appended `rustc-link-arg` entries, which a
-  # toolchain bump can move. `.github/workflows/ci.yml` is included so edits to
+  # Rust PR and not scheduled. `build.rs` holds the recipe, `scripts/iree/**`
+  # pins the IREE distribution whose archive set the recipe names, and
+  # `src/lib/mlxcel-xla/build.rs` with its `csrc/**` sources builds the shim
+  # object whose undefined symbols those archives resolve, so those are the
+  # causal surface. `rust-toolchain.toml` is on the same causal path because
+  # the #1274 failure was entirely about where rustc places its own `-lc`
+  # relative to appended `rustc-link-arg` entries, which a toolchain bump can
+  # move. `.github/workflows/ci.yml` is included so edits to
   # this job itself are testable. A schedule was rejected because it decouples
   # the failure from the PR that caused it, which is the exact failure mode of
   # #1274 (found by hand later, not by CI). Running on every Rust PR was
@@ -446,19 +454,22 @@ jobs:
   # unset means a red run here is unambiguously a link failure, not a lint
   # failure wearing a link job's name.
   #
-  # What the gate was demonstrated on, since #1274's own defect no longer
-  # reproduces here: the IREE runtime currently pinned by
-  # `scripts/iree/setup-cuda.sh` is built without the stack protector, so
-  # `libiree_runtime_unified.a` holds no `__stack_chk_guard` reference at all
-  # (`nm` reports zero) and removing the `-lc` entry from `build.rs` links
-  # cleanly today. The `-lc` entry is therefore inert against this particular
-  # distribution, though still correct to keep for one built with the stack
-  # protector. The gate was instead demonstrated by dropping
-  # `-l:libflatcc_parsing.a` from the same recipe: on that tree `cargo check
+  # What the gate was demonstrated on: dropping `-l:libflatcc_parsing.a` from
+  # the `IREE_CUDA_HOME` recipe in `build.rs`. On that tree `cargo check
   # --features cuda,xla-iree --all-targets` still passed in 59 seconds while
   # this job's link command failed with undefined references to
   # `flatcc_verify_*`, which is the same shape as #1274 and the exact gap this
   # job exists to close.
+  #
+  # #1274's own defect, removing the second `-lc`, was tried as the control
+  # first and did not fail the link on the tree this job was validated against.
+  # Why it did not is unresolved, so do not read that run as evidence the entry
+  # is dead: against the pinned runtime, `nm` still reports `__stack_chk_guard`
+  # undefined in 176 objects of `libiree_runtime_unified.a`, including the
+  # `call.c.o` named in #1274; the symbol is still undefined in `libc.so.6`;
+  # and it is still defined only in `ld-linux-aarch64.so.1`. Every precondition
+  # the `build.rs` comment records holds today, so leave that entry alone until
+  # a control that actually reproduces says otherwise.
   #
   # Deliberately NOT covered, so the gap is recorded rather than assumed shut:
   #   - The `IREE_DIST` recipe (`build.rs:180-220`) and the macOS

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,6 +66,7 @@ jobs:
     outputs:
       rust: ${{ steps.filter.outputs.rust }}
       mlx_pin: ${{ steps.filter.outputs.mlx_pin }}
+      xla_link: ${{ steps.filter.outputs.xla_link }}
     steps:
       - uses: actions/checkout@v7
         with:
@@ -88,6 +89,14 @@ jobs:
               - 'src/lib/mlxcel-mlx-pin/**'
               - 'scripts/ci/mlx_pinned_commit.sh'
               - 'scripts/ci/mlx_pinned_commit_test.sh'
+              - '.github/workflows/ci.yml'
+            # Narrower than `rust` above: only the paths that can move the IREE
+            # link recipe itself, so the release link job below does not run on
+            # every Rust PR. See the `xla-link` job comment for the rationale.
+            xla_link:
+              - 'build.rs'
+              - 'scripts/iree/**'
+              - 'rust-toolchain.toml'
               - '.github/workflows/ci.yml'
 
   deny:
@@ -312,6 +321,10 @@ jobs:
   # runner.
   #
   # Deliberately NOT covered, so the gap is recorded rather than assumed shut:
+  #   - Linking. `cargo check` never invokes the linker, so a regression in the
+  #     IREE link recipe in `build.rs` (see #1274/#1275) is invisible here. The
+  #     `xla-link` job immediately below closes that gap for the CUDA/IREE
+  #     recipe; see its comment for what it covers and what it still does not.
   #   - `cargo test`. This is a compile gate; running the XLA suites needs a
   #     GPU that is not contended with development work on the same host.
   #   - Full `-D warnings`. The XLA feature combination carries a pre-existing
@@ -368,3 +381,108 @@ jobs:
 
       - name: Compile the diagnostics XLA feature set
         run: cargo check --no-default-features --features xla-diagnostics --all-targets
+
+  # ============================================================================
+  # OpenXLA feature link (self-hosted GB10)
+  # ============================================================================
+  # `xla-compile` above never invokes the linker, so it cannot catch a
+  # regression in the IREE link recipe in `build.rs`. That is not hypothetical:
+  # #1274 was exactly a link failure, and `cargo check --features
+  # cuda,xla-iree --all-targets` passed cleanly on the same tree that could not
+  # link a single integration test. It reached `main` and was found by hand
+  # while validating an unrelated PR. The fix, #1275, appends a second `-lc`
+  # after the IREE archives in `build.rs`, because rustc emits its own `-lc`
+  # before anything `cargo:rustc-link-arg` can append. This job is a direct
+  # reproducer of that failure class.
+  #
+  # What it links, and why: `cargo test --release --features cuda,xla-iree
+  # --test xla_prepared_prefill --no-run`. `build.rs` emits the IREE recipe
+  # through `cargo:rustc-link-arg`, which applies to every linked artifact of
+  # the crate, so the smallest linked target exercises the same recipe as
+  # `mlxcel-server` does. `--no-run` links without executing, so this job never
+  # touches the GPU and never contends with development work on the shared
+  # GB10 host. `cargo build --release --features cuda,xla-iree --bin
+  # mlxcel-server` was considered and rejected: it costs 17m06s cold on this
+  # runner and adds no additional recipe coverage over the test binary.
+  #
+  # Profile: `--release` is mandatory, not a choice. On this host the debug
+  # profile cannot link these targets at all: it fails with hundreds of
+  # `relocation truncated to fit: R_AARCH64_CALL26` errors against ordinary
+  # `libstd`/`compiler_builtins` symbols, because the unoptimized binary
+  # exceeds the AArch64 direct-branch range.
+  #
+  # Trigger: path-filtered via the `changes` job's `xla_link` output, not every
+  # Rust PR and not scheduled. `build.rs` holds the recipe and
+  # `scripts/iree/**` pins the IREE distribution whose archive set the recipe
+  # names, so those two are the causal surface. `rust-toolchain.toml` is on the
+  # same causal path because the #1274 failure was entirely about where rustc
+  # places its own `-lc` relative to appended `rustc-link-arg` entries, which a
+  # toolchain bump can move. `.github/workflows/ci.yml` is included so edits to
+  # this job itself are testable. A schedule was rejected because it decouples
+  # the failure from the PR that caused it, which is the exact failure mode of
+  # #1274 (found by hand later, not by CI). Running on every Rust PR was
+  # rejected because the release link is minutes of shared-runner time and the
+  # overwhelming majority of Rust PRs cannot affect the link line.
+  #
+  # Measured cost: a cold release link of the `xla_prepared_prefill` test
+  # binary under `cuda,xla-iree` on this runner takes COLD_COST_PLACEHOLDER.
+  #
+  # `RUSTFLAGS` is deliberately unset here, unlike `xla-compile`. This job
+  # gates the link, not lints; `xla-compile` owns the lint policy. Leaving it
+  # unset means a red run here is unambiguously a link failure, not a lint
+  # failure wearing a link job's name.
+  #
+  # Deliberately NOT covered, so the gap is recorded rather than assumed shut:
+  #   - The `IREE_DIST` recipe (`build.rs:180-220`) and the macOS
+  #     `IREE_MACOS_HOME` recipe (`build.rs:38-90`). Both remain unverified by
+  #     any link, on any machine, because no runner in this repository holds
+  #     either distribution. Only the `IREE_CUDA_HOME` recipe this job exercises
+  #     is covered.
+  #   - Anything outside the path filter above. Because the trigger is
+  #     path-filtered rather than universal, a link regression arriving through
+  #     a path the filter does not name (a new dependency pulling in a
+  #     conflicting native library, for instance) is still not caught at PR
+  #     time.
+  #   - GPU execution. `--no-run` links only; the XLA test suites still have no
+  #     CI coverage, per the `xla-compile` comment above.
+  xla-link:
+    name: OpenXLA feature link
+    needs: changes
+    if: github.repository == 'lablup/mlxcel' && needs.changes.outputs.xla_link == 'true'
+    runs-on: GB10
+    permissions:
+      contents: read
+    timeout-minutes: 120
+    env:
+      # The value shipped for this runner's architecture. Auto-detection yields
+      # `121a`, which is numerically identical here but is not what releases
+      # build, so the gate links what ships.
+      MLX_CUDA_ARCHITECTURES: "121"
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          persist-credentials: false
+
+      - name: Use a persistent target directory
+        run: |
+          # Its own directory, not shared with `xla-compile` or the release
+          # job: a link job emits release artifacts and build-script output
+          # that a check-only cache does not, and sharing would have the two
+          # jobs repeatedly invalidate each other.
+          CARGO_TARGET="$HOME/.cargo-target/mlxcel-xla-link-ci"
+          mkdir -p "$CARGO_TARGET"
+          echo "CARGO_TARGET_DIR=$CARGO_TARGET" >> $GITHUB_ENV
+
+      - name: Provision the IREE runtime
+        run: |
+          # Idempotent: reuses `~/.cache/mlxcel/iree-cuda-<version>` when the
+          # runtime is already built, and builds it once when it is not.
+          bash scripts/iree/setup-cuda.sh
+          # The script emits shell `export VAR=value` lines; GITHUB_ENV wants
+          # bare `VAR=value`, and without stripping the prefix the variables
+          # would be named "export IREE_CUDA_HOME" and build.rs would abort
+          # claiming no IREE distribution is configured.
+          bash scripts/iree/setup-cuda.sh --env | sed 's/^export //' >> "$GITHUB_ENV"
+
+      - name: Link the OpenXLA integration test
+        run: cargo test --release --features cuda,xla-iree --test xla_prepared_prefill --no-run

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -424,13 +424,33 @@ jobs:
   # rejected because the release link is minutes of shared-runner time and the
   # overwhelming majority of Rust PRs cannot affect the link line.
   #
-  # Measured cost: a cold release link of the `xla_prepared_prefill` test
-  # binary under `cuda,xla-iree` on this runner takes COLD_COST_PLACEHOLDER.
+  # Measured cost of this job's link command on the GB10 runner: 15m40s from a
+  # purged `CARGO_TARGET_DIR`, most of which is MLX's CUDA sources compiling
+  # from scratch rather than the link itself, and 6m to 7m30s warm. Warm is the
+  # figure that matters, because the trigger below fires on `build.rs`, which
+  # invalidates the `mlxcel` crate but not `mlxcel-core`'s MLX build. For
+  # comparison, `xla-compile`'s `cargo check` over the same feature set is
+  # about a minute warm, which is why the two are separate jobs on separate
+  # triggers.
   #
   # `RUSTFLAGS` is deliberately unset here, unlike `xla-compile`. This job
   # gates the link, not lints; `xla-compile` owns the lint policy. Leaving it
   # unset means a red run here is unambiguously a link failure, not a lint
   # failure wearing a link job's name.
+  #
+  # What the gate was demonstrated on, since #1274's own defect no longer
+  # reproduces here: the IREE runtime currently pinned by
+  # `scripts/iree/setup-cuda.sh` is built without the stack protector, so
+  # `libiree_runtime_unified.a` holds no `__stack_chk_guard` reference at all
+  # (`nm` reports zero) and removing the `-lc` entry from `build.rs` links
+  # cleanly today. The `-lc` entry is therefore inert against this particular
+  # distribution, though still correct to keep for one built with the stack
+  # protector. The gate was instead demonstrated by dropping
+  # `-l:libflatcc_parsing.a` from the same recipe: on that tree `cargo check
+  # --features cuda,xla-iree --all-targets` still passed in 59 seconds while
+  # this job's link command failed with undefined references to
+  # `flatcc_verify_*`, which is the same shape as #1274 and the exact gap this
+  # job exists to close.
   #
   # Deliberately NOT covered, so the gap is recorded rather than assumed shut:
   #   - The `IREE_DIST` recipe (`build.rs:180-220`) and the macOS

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -484,6 +484,15 @@ jobs:
   #     time.
   #   - GPU execution. `--no-run` links only; the XLA test suites still have no
   #     CI coverage, per the `xla-compile` comment above.
+  #   - A run where cargo finds nothing to redo. The target directory persists
+  #     across PRs, so a green run does not by itself prove a link happened:
+  #     this job's own first run on the PR that added it finished in 12 seconds
+  #     with `Finished release profile in 0.14s`. That is correct, because
+  #     cargo relinks exactly when the fingerprint moves, and `build.rs`
+  #     declares `rerun-if-env-changed` for all three IREE variables so a
+  #     version bump does move it. The narrow hole is a `scripts/iree/**` edit
+  #     that changes how the runtime is built without moving `IREE_VERSION`:
+  #     the script is idempotent, so nothing rebuilds and nothing relinks.
   xla-link:
     name: OpenXLA feature link
     needs: changes

--- a/TECHNICAL_REPORTS/1305-openxla-link-gate-20260822.en.md
+++ b/TECHNICAL_REPORTS/1305-openxla-link-gate-20260822.en.md
@@ -1,0 +1,159 @@
+# Technical Report: PR #1305 - link an OpenXLA binary in CI so link-only regressions cannot reach main
+
+**Date**: 2026-08-22
+**Author**: Jeongkyu Shin
+**Status**: Completed
+**Languages**: YAML (GitHub Actions)
+**Risk Level**: Low (CI configuration only; no runtime code changed)
+
+---
+
+## Executive Summary
+
+CI compiled the OpenXLA feature combinations but never linked them. `cargo check` does not invoke the linker, so a regression in the IREE link recipe in `build.rs` could reach `main` with every check green. That is not a hypothetical: issue #1274 was exactly such a failure, and `cargo check --features cuda,xla-iree --all-targets` passed on the same tree that could not link a single integration test.
+
+This PR adds an `xla-link` job to `.github/workflows/ci.yml` that links a real target under `--features cuda,xla-iree` on the self-hosted GB10 runner, triggered by a narrow path filter over the paths that can actually move the link line. The gate was validated by breaking the recipe and confirming the split: `cargo check` still passed in 59 seconds while the link failed.
+
+The review cycle corrected three factual errors in the change's own comments, including one this report treats as its main learning point: a claim about the IREE archive that came from running `nm` in a shell where `nm` is an alias for an unrelated command.
+
+## 1. Problem Statement
+
+### 1.1 Background
+
+PR #1282 added the `xla-compile` job, which runs two commands on the GB10 runner:
+
+```
+cargo check --features cuda,xla-iree --all-targets
+cargo check --no-default-features --features xla-diagnostics --all-targets
+```
+
+Nothing else in CI compiles any XLA feature: `pipeline-parallel-ci.yml` runs clippy on default features, `nightly-verify.yml` runs `make verify` with `metal,accelerate`, and `release.yml` does not build `xla-iree`. That job's own comment recorded the linking gap as deliberately open, pending this work.
+
+### 1.2 Existing Issues
+
+`cargo check` stops after type checking and never runs the linker, so the entire `cargo:rustc-link-arg` recipe that `build.rs` emits for the IREE runtime is untested by CI. The #1274 failure is the canonical example:
+
+```
+/usr/bin/ld: libiree_runtime_unified.a(call.c.o): undefined reference to symbol '__stack_chk_guard@@GLIBC_2.17'
+/usr/bin/ld: /lib/ld-linux-aarch64.so.1: error adding symbols: DSO missing from command line
+```
+
+It reached `main` and was found by hand while validating an unrelated PR. The fix, PR #1275, appends a second `-lc` after the IREE archives, because rustc emits its own `-lc` before anything `cargo:rustc-link-arg` can append.
+
+### 1.3 Risk Assessment
+
+The exposure is bounded but real: the OpenXLA path is not on the default feature set, so a broken link does not break the shipped default build. It does break every developer working on that path, and it is discovered at the worst time, by hand, after the fact.
+
+## 2. Change Summary
+
+One file, `.github/workflows/ci.yml`.
+
+| Change | Detail |
+|---|---|
+| New `changes` output | `xla_link`, from a sibling `dorny/paths-filter` filter |
+| Filter paths | `build.rs`, `src/lib/mlxcel-xla/build.rs`, `src/lib/mlxcel-xla/csrc/**`, `scripts/iree/**`, `rust-toolchain.toml`, `.github/workflows/ci.yml` |
+| New job | `xla-link`, after `xla-compile`, `runs-on: GB10`, `timeout-minutes: 120`, `permissions: contents: read` |
+| Link command | `cargo test --release --features cuda,xla-iree --test xla_prepared_prefill --no-run` |
+| Target dir | `$HOME/.cargo-target/mlxcel-xla-link-ci`, separate from `xla-compile`'s and the release job's |
+| Concurrency | Job-scoped group keyed per PR, `cancel-in-progress: true` |
+| Comment corrections | `clippy`'s fork-guard note; `xla-compile`'s "not covered" list now points at the new job |
+
+## 3. Technical Decisions
+
+### 3.1 The release profile is forced, not chosen
+
+The debug profile cannot link these targets on this host at all. It fails with hundreds of `relocation truncated to fit: R_AARCH64_CALL26` errors against ordinary `libstd` and `compiler_builtins` symbols, because the unoptimized binary exceeds the AArch64 direct-branch range. The cheaper debug link was never an option, which is why the job costs minutes rather than seconds and why it is a separate job rather than a step appended to `xla-compile`.
+
+### 3.2 Link the smallest target, not the shipped binary
+
+`build.rs` emits the recipe through `cargo:rustc-link-arg`, which applies to every linked artifact of the crate. The recipe under test is therefore identical no matter which target is linked, and the integration test is the direct reproducer because #1274 was an integration-test link failure.
+
+The review corrected the rationale here. Cargo builds the package's `[[bin]]` targets whenever an integration test is selected, so this command links `mlxcel`, `mlxcel-server`, `speculative_bench`, and `mlxcel-bench-decode` in addition to the test binary. The rejected `cargo build --release --bin mlxcel-server` alternative is a strict subset of the chosen command, not a costlier one, and the measured figures below already include the binaries. The target choice was right; the reason first written down for it was not.
+
+### 3.3 Path-filtered trigger, not every Rust PR and not a schedule
+
+A schedule decouples the failure from the PR that caused it, which is precisely how #1274 escaped. Running on every Rust PR spends minutes of a shared runner on the large majority of PRs that cannot affect the link line.
+
+The filter covers the causal surface: the root `build.rs` holds the recipe, `scripts/iree/**` pins the distribution whose archive set the recipe names, `mlxcel-xla`'s build script and its `csrc/**` sources produce the shim object whose undefined symbols those archives resolve, and `rust-toolchain.toml` is on the path because #1274 was entirely about where rustc places its own `-lc` relative to appended arguments, which a toolchain bump can move.
+
+The last two `mlxcel-xla` paths were added during review. The original filter named only `build.rs` and `scripts/iree/**`; as a picomatch pattern `build.rs` matches only the root build script, so a change to the C shim would have passed `cargo check` and not started this job either.
+
+### 3.4 `RUSTFLAGS` is deliberately unset
+
+`xla-compile` sets `RUSTFLAGS: "-D unused_imports"` and owns the lint policy. Leaving it unset here means a red run is unambiguously a link failure rather than a lint failure wearing a link job's name. Issue #1304 separately clears the dead-code backlog and widens `xla-compile` to `-D warnings`.
+
+### 3.5 A concurrency group, because this is the first slow job on GB10
+
+Every other GB10 job is seconds warm. This one is minutes, with `timeout-minutes: 120`. `ci.yml` carries no concurrency control at all, so three pushes to a `build.rs` PR would queue three link jobs on the single runner that also serves clippy for every Rust PR and the release build, with superseded runs occupying it to completion. The group is keyed per PR so PRs never cancel each other, matching the pattern `pipeline-parallel-ci.yml` already uses.
+
+## 4. Review Findings
+
+### 4.1 HIGH: a comment recorded a fact that a shell alias had invented
+
+An earlier revision explained the failed `-lc` control by asserting that the pinned IREE runtime was built without the stack protector and that `libiree_runtime_unified.a` held no `__stack_chk_guard` reference, "`nm` reports zero".
+
+It holds 176 such references, including in the `call.c.o` named in #1274. The zero came from this shell:
+
+```
+nm is an alias for mosh --ssh="ssh -i ~/.ssh/nubimaru.pem" ubuntu@<host>
+```
+
+`nm <archive> | grep -c __stack_chk_guard` therefore counted the output of a program that never examined the archive, and `2>/dev/null` hid the `command not found` that would have exposed it. With `/usr/bin/nm`, every precondition the `build.rs` comment records still holds: the symbol is undefined in 176 objects of the archive, undefined in `libc.so.6`, and defined only in `ld-linux-aarch64.so.1`.
+
+### 4.2 HIGH: the path filter missed part of the causal surface
+
+See 3.3. Fixed by adding `src/lib/mlxcel-xla/build.rs` and `src/lib/mlxcel-xla/csrc/**`.
+
+### 4.3 MEDIUM: the "what it links" rationale was wrong about the binaries
+
+See 3.2. The comment now records that the binaries are linked here too.
+
+### 4.4 Security: the fork-guard comment was false and propagating
+
+The note above the `clippy` job asserted that `if: github.repository == 'lablup/mlxcel'` means fork PRs never queue on the self-hosted runner. On a `pull_request` event opened from a fork against this repository, `github.repository` is the base repository, so the guard is true and the job runs, executing the PR's `build.rs` and `scripts/iree/**` as the runner's own user. The guard's real effect is to stop the job queueing forever in a *fork of* the repository, which has no GB10 runner. What gates the fork case is the repository's Actions fork-PR approval policy, currently `first_time_contributors`.
+
+Issue #1303 repeated the incorrect reading when specifying this job, so the misconception was spreading. The comment now records what the guard actually does. This PR adds no new exposure: `clippy` and `xla-compile` gate on a strictly wider filter and already run fork PR code on that runner.
+
+## 5. Validation
+
+All runs on the GB10 host with the IREE runtime provisioned.
+
+| Run | Result |
+|---|---|
+| Cold link, purged `CARGO_TARGET_DIR` | exit 0, 15m40s, ends at `Executable tests/xla_prepared_prefill.rs` |
+| Warm link (two runs) | exit 0, 6m01s and 7m24s |
+| `cargo check` on a link-broken tree | **exit 0, 59s** |
+| Link on the same broken tree | **exit 101**, `error: linking with cc failed`, undefined references to `flatcc_verify_*` |
+| Link after restoring the archive | exit 0 |
+| The job on this PR itself | success, all four commits |
+
+The break was dropping `-l:libflatcc_parsing.a` from the `IREE_CUDA_HOME` branch of `build.rs`. The middle two rows are the whole point of the change: the same tree, one command green and the other red, which is the shape of #1274. `build.rs` is unchanged by this PR; every control was run outside the branch and reverted.
+
+Most of the cold figure is MLX's CUDA sources compiling from scratch rather than the link. Warm is the figure that matters, because the trigger fires on `build.rs`, which invalidates the `mlxcel` crate but not `mlxcel-core`'s MLX build.
+
+## 6. What Remains Unverified
+
+- **Why the `-lc` control does not reproduce.** It was tried first, per the issue's acceptance criteria, and the link succeeded with `rustc-link-arg=-lc` confirmed absent from the emitted build-script output and the IREE archives confirmed present on the link line. The stack-protector explanation was wrong (4.1). Two further hypotheses were tested and ruled out: `-lpthread` and `-ldl` resolve to stub archives on this glibc rather than to linker scripts that would pull libc in late, and `libm.so` groups only `libm.so.6`. The entry stays, and the comment says not to remove it on the strength of one control that failed to reproduce.
+- **The `IREE_DIST` and macOS `IREE_MACOS_HOME` recipes** in `build.rs` remain unverified by any link, on any machine, because no runner holds either distribution.
+- **A green run does not prove a link happened.** The target directory persists across PRs, so cargo can find nothing to redo; this job's first run finished in 12 seconds with `Finished release profile in 0.14s`. That is correct behavior, since cargo relinks exactly when the fingerprint moves and `build.rs` declares `rerun-if-env-changed` for all three IREE variables. The narrow hole is a `scripts/iree/**` edit that changes how the runtime is built without moving `IREE_VERSION`: the script is idempotent, so nothing rebuilds and nothing relinks.
+- **`Cargo.toml` and `Cargo.lock` are outside the filter**, so a dependency-driven link change does not trigger the job. Widening would fire on every dependency bump.
+
+## 7. Learning Points
+
+1. **Verify that a diagnostic tool is the tool you think it is.** A shell alias turned `nm` into an SSH client, and suppressing stderr turned the resulting `command not found` into a confident empty result. A search that returns zero matches deserves one confirming positive control before a conclusion is built on it.
+2. **`cargo check` is not a link gate, and `--all-targets` does not change that.** The flag widens what is type checked, not what is linked.
+3. **`cargo:rustc-link-arg` applies to every linked artifact**, so any linked target exercises the same recipe. Choosing the smallest one is a cost decision, not a coverage decision.
+4. **Selecting an integration test also builds the package's binaries.** `cargo test --test X --no-run` is not the minimal link it appears to be, which makes it a better gate than expected and makes `--bin` alternatives a subset rather than a saving.
+5. **A path filter is a claim about causality.** Writing one forces the question of what can actually move the artifact under test, and the first draft here missed the C shim that produces the very symbols the archives resolve.
+
+## 8. Follow-up Actions
+
+- **Fork PRs do reach the GB10 runner** (4.4). Inherited from the existing jobs, not introduced here. Worth a hardening issue covering a head-repository check on all three GB10 jobs, a tighter approval policy, or a dedicated runner account.
+- **Disk pressure.** This adds a fourth permanent target directory on a volume at 93 percent; `~/.cargo-target` is already 39 GB with nothing pruning it, on the same host that cuts releases.
+- **The `-lc` root cause** is open (section 6). Whoever resolves it should also revisit the "Measured, not assumed" claim in the `build.rs` comment.
+- **Issue #1304** clears the dead-code backlog and widens `xla-compile` to `-D warnings`.
+
+## References
+
+- Issue #1303 (this work), #1274 (the link failure), #1275 (the `-lc` fix), #1282 (the compile gate this extends), #1304 (the lint half of the same exclusion list)
+- `.github/workflows/ci.yml`, `build.rs:143-176`, `src/lib/mlxcel-xla/build.rs`

--- a/TECHNICAL_REPORTS/1305-openxla-link-gate-20260822.ko.md
+++ b/TECHNICAL_REPORTS/1305-openxla-link-gate-20260822.ko.md
@@ -1,0 +1,159 @@
+# 기술 보고서: PR #1305 - 링크 전용 회귀가 main에 들어오지 못하도록 CI에서 OpenXLA 바이너리를 링크
+
+**날짜**: 2026-08-22
+**작성자**: Jeongkyu Shin
+**상태**: 완료
+**언어/기술**: YAML (GitHub Actions)
+**위험도**: 낮음 (CI 설정만 변경, 런타임 코드 변경 없음)
+
+---
+
+## 요약
+
+CI는 OpenXLA 기능 조합을 컴파일하기만 했고 링크한 적이 없다. `cargo check`는 링커를 부르지 않으므로, `build.rs`의 IREE 링크 레시피가 깨져도 모든 체크가 초록인 채로 `main`에 들어갈 수 있었다. 가정이 아니라 실제로 일어난 일이다. 이슈 #1274가 정확히 그 실패였고, 통합 테스트 하나조차 링크하지 못하는 트리에서 `cargo check --features cuda,xla-iree --all-targets`는 통과했다.
+
+이 PR은 `.github/workflows/ci.yml`에 `xla-link` job을 추가한다. 셀프호스티드 GB10 러너에서 `--features cuda,xla-iree`로 실제 타깃을 링크하며, 링크 라인을 실제로 움직일 수 있는 경로만 좁게 필터링해 트리거된다. 게이트가 동작한다는 것은 레시피를 일부러 깨서 확인했다. 같은 트리에서 `cargo check`는 59초 만에 통과하는데 링크는 실패한다.
+
+리뷰 과정에서 이 변경 자체의 주석에 있던 사실 오류 세 건이 정정되었다. 그중 하나는 이 보고서가 핵심 학습 포인트로 다루는 것으로, `nm`이 전혀 다른 명령의 alias로 잡혀 있는 쉘에서 `nm`을 실행해 만들어낸 주장이었다.
+
+## 1. 문제 정의
+
+### 1.1 배경
+
+PR #1282가 추가한 `xla-compile` job은 GB10 러너에서 두 명령을 실행한다.
+
+```
+cargo check --features cuda,xla-iree --all-targets
+cargo check --no-default-features --features xla-diagnostics --all-targets
+```
+
+CI의 다른 어떤 것도 XLA 기능을 컴파일하지 않는다. `pipeline-parallel-ci.yml`은 기본 기능으로 clippy를 돌리고, `nightly-verify.yml`은 `metal,accelerate`로 `make verify`를 돌리며, `release.yml`은 `xla-iree`를 빌드하지 않는다. 그 job의 주석 자체가 링크 공백을 "의도적으로 열어둔 것"으로 기록하며 이 작업을 예고하고 있었다.
+
+### 1.2 기존 문제
+
+`cargo check`는 타입 검사에서 멈추고 링커를 실행하지 않는다. 따라서 `build.rs`가 IREE 런타임을 위해 내보내는 `cargo:rustc-link-arg` 레시피 전체가 CI에서 한 번도 검증되지 않는다. #1274가 대표 사례다.
+
+```
+/usr/bin/ld: libiree_runtime_unified.a(call.c.o): undefined reference to symbol '__stack_chk_guard@@GLIBC_2.17'
+/usr/bin/ld: /lib/ld-linux-aarch64.so.1: error adding symbols: DSO missing from command line
+```
+
+이것이 `main`에 들어갔고, 무관한 PR을 검증하다가 사람 손으로 발견되었다. 수정 PR #1275는 IREE 아카이브 뒤에 `-lc`를 한 번 더 붙인다. rustc가 자기 `-lc`를 `cargo:rustc-link-arg`가 덧붙일 수 있는 어떤 것보다 먼저 내보내기 때문이다.
+
+### 1.3 위험 평가
+
+노출 범위는 제한적이지만 실재한다. OpenXLA 경로는 기본 기능이 아니므로 링크가 깨져도 배포되는 기본 빌드는 멀쩡하다. 대신 그 경로를 작업하는 모든 개발자가 막히고, 발견 시점이 최악이다. 사후에, 사람 손으로.
+
+## 2. 변경 요약
+
+파일 하나, `.github/workflows/ci.yml`이다.
+
+| 변경 | 내용 |
+|---|---|
+| `changes` 출력 추가 | `xla_link`, `dorny/paths-filter`의 형제 필터 |
+| 필터 경로 | `build.rs`, `src/lib/mlxcel-xla/build.rs`, `src/lib/mlxcel-xla/csrc/**`, `scripts/iree/**`, `rust-toolchain.toml`, `.github/workflows/ci.yml` |
+| 새 job | `xla-link`, `xla-compile` 뒤, `runs-on: GB10`, `timeout-minutes: 120`, `permissions: contents: read` |
+| 링크 명령 | `cargo test --release --features cuda,xla-iree --test xla_prepared_prefill --no-run` |
+| 타깃 디렉터리 | `$HOME/.cargo-target/mlxcel-xla-link-ci`, `xla-compile`/릴리스 job과 분리 |
+| 동시성 | PR 단위 job 스코프 그룹, `cancel-in-progress: true` |
+| 주석 정정 | `clippy`의 fork 가드 설명, `xla-compile`의 미커버 목록이 새 job을 가리키도록 |
+
+## 3. 기술적 선택과 그 이유
+
+### 3.1 릴리스 프로파일은 선택이 아니라 강제
+
+이 호스트에서 디버그 프로파일은 이 타깃들을 아예 링크하지 못한다. 최적화되지 않은 바이너리가 AArch64 직접 분기 범위를 넘어서, 평범한 `libstd`와 `compiler_builtins` 심볼에 대해 `relocation truncated to fit: R_AARCH64_CALL26` 오류가 수백 개 난다. 값싼 디버그 링크는 애초에 선택지가 아니었고, 그래서 이 job은 초 단위가 아니라 분 단위이며 `xla-compile`에 스텝 하나를 덧붙이는 대신 별도 job이 되었다.
+
+### 3.2 배포 바이너리가 아니라 가장 작은 타깃을 링크
+
+`build.rs`는 레시피를 `cargo:rustc-link-arg`로 내보내고, 이는 해당 크레이트가 링크하는 모든 산출물에 적용된다. 따라서 어느 타깃을 링크하든 검증되는 레시피는 동일하며, #1274가 통합 테스트 링크 실패였으므로 통합 테스트가 직접적인 재현자다.
+
+리뷰가 여기 근거를 정정했다. cargo는 통합 테스트가 선택되면 해당 패키지의 `[[bin]]` 타깃도 함께 빌드한다. 그래서 이 명령은 테스트 바이너리 외에 `mlxcel`, `mlxcel-server`, `speculative_bench`, `mlxcel-bench-decode`까지 링크한다. 기각한 `cargo build --release --bin mlxcel-server` 대안은 더 비싼 선택지가 아니라 선택된 명령의 진부분집합이고, 아래 측정치에는 이미 바이너리들이 포함되어 있다. 타깃 선택 자체는 옳았지만, 처음 적어둔 이유는 틀렸다.
+
+### 3.3 매 Rust PR도 스케줄도 아닌 경로 필터
+
+스케줄은 실패를 그 실패를 만든 PR과 분리시킨다. #1274가 빠져나간 방식이 정확히 그것이다. 매 Rust PR 실행은 링크 라인에 영향을 줄 수 없는 대다수 PR에 공유 러너의 몇 분을 쓰는 일이다.
+
+필터는 인과 표면을 덮는다. 루트 `build.rs`가 레시피를 갖고 있고, `scripts/iree/**`가 레시피에 이름이 적힌 아카이브 집합을 가진 배포판을 고정하며, `mlxcel-xla`의 빌드 스크립트와 `csrc/**` 소스가 그 아카이브들이 해결해주는 미정의 심볼을 가진 shim 오브젝트를 만든다. `rust-toolchain.toml`이 같은 경로에 있는 이유는, #1274가 전적으로 rustc가 자기 `-lc`를 덧붙인 인자들 대비 어디에 두느냐의 문제였고 툴체인 상향이 그것을 옮길 수 있기 때문이다.
+
+뒤의 `mlxcel-xla` 경로 둘은 리뷰 중 추가되었다. 최초 필터는 `build.rs`와 `scripts/iree/**`만 지정했는데, picomatch 패턴으로서 `build.rs`는 루트 빌드 스크립트만 매치한다. C shim 변경은 `cargo check`를 통과하면서 이 job도 시작시키지 못했을 것이다.
+
+### 3.4 `RUSTFLAGS`를 의도적으로 설정하지 않음
+
+`xla-compile`이 `RUSTFLAGS: "-D unused_imports"`를 설정하며 린트 정책을 소유한다. 여기서 설정하지 않으면 빨간 실행은 명백히 링크 실패이지, 링크 job 이름을 쓴 린트 실패가 아니다. 이슈 #1304가 별도로 dead-code 백로그를 정리하고 `xla-compile`을 `-D warnings`로 확대한다.
+
+### 3.5 GB10 위 첫 느린 job이므로 동시성 그룹
+
+GB10의 다른 job은 웜 상태에서 전부 초 단위다. 이것만 분 단위이고 `timeout-minutes: 120`이다. `ci.yml`에는 동시성 제어가 전혀 없어서, `build.rs`를 건드리는 PR에 세 번 푸시하면 러너 하나에 최대 120분짜리 링크 job 세 개가 쌓이고, 그 러너는 모든 Rust PR의 clippy와 릴리스 빌드도 처리한다. 그룹은 PR 단위로 키를 잡아 PR끼리는 서로를 취소하지 않으며, `pipeline-parallel-ci.yml`이 이미 쓰는 패턴을 따른다.
+
+## 4. 리뷰에서 나온 지적
+
+### 4.1 HIGH: 쉘 alias가 만들어낸 사실이 주석에 기록됨
+
+초기 리비전은 실패한 `-lc` 대조 실험을, 고정된 IREE 런타임이 스택 프로텍터 없이 빌드되어 `libiree_runtime_unified.a`에 `__stack_chk_guard` 참조가 전혀 없다("`nm`이 0을 보고한다")고 설명했다.
+
+실제로는 176개가 있고, #1274에 이름이 나오는 `call.c.o`도 포함된다. 0이 나온 이유는 이 쉘이다.
+
+```
+nm is an alias for mosh --ssh="ssh -i ~/.ssh/nubimaru.pem" ubuntu@<host>
+```
+
+`nm <archive> | grep -c __stack_chk_guard`는 아카이브를 들여다본 적 없는 프로그램의 출력을 센 것이고, `2>/dev/null`이 그 사실을 드러냈을 `command not found`를 가렸다. `/usr/bin/nm`으로 보면 `build.rs` 주석이 기록한 전제가 오늘도 전부 성립한다. 아카이브의 176개 오브젝트에서 미정의, `libc.so.6`에서도 미정의, 정의는 `ld-linux-aarch64.so.1`에만 있다.
+
+### 4.2 HIGH: 경로 필터가 인과 표면의 일부를 빠뜨림
+
+3.3 참조. `src/lib/mlxcel-xla/build.rs`와 `src/lib/mlxcel-xla/csrc/**` 추가로 수정.
+
+### 4.3 MEDIUM: "무엇을 링크하는가" 근거가 바이너리에 대해 틀림
+
+3.2 참조. 주석이 바이너리들도 여기서 링크된다는 사실을 기록하도록 수정.
+
+### 4.4 보안: fork 가드 주석이 사실과 다르고 전파되고 있었음
+
+`clippy` job 위 주석은 `if: github.repository == 'lablup/mlxcel'`이 fork PR을 셀프호스티드 러너에 올리지 않는다는 뜻이라고 단언했다. fork에서 이 저장소로 연 `pull_request` 이벤트에서는 `github.repository`가 base 저장소이므로 가드가 참이고 job이 실행되며, PR의 `build.rs`와 `scripts/iree/**`가 러너 사용자 권한으로 실행된다. 가드의 실제 효과는 GB10 러너가 없는 *이 저장소의 fork*에서 job이 영원히 대기하는 것을 막는 것이다. fork 케이스를 실제로 통제하는 것은 저장소의 Actions fork-PR 승인 정책이며 현재 `first_time_contributors`다.
+
+이슈 #1303이 이 job을 명세하면서 그 잘못된 해석을 그대로 옮겨 적었으므로 오해가 번지고 있었다. 주석은 이제 가드가 실제로 하는 일을 기록한다. 이 PR이 새로 만드는 노출은 없다. `clippy`와 `xla-compile`이 더 넓은 필터로 게이트되며 이미 fork PR 코드를 그 러너에서 실행한다.
+
+## 5. 검증
+
+모두 IREE 런타임이 준비된 GB10 호스트에서 실행했다.
+
+| 실행 | 결과 |
+|---|---|
+| 콜드 링크, `CARGO_TARGET_DIR` 비움 | exit 0, 15분 40초, `Executable tests/xla_prepared_prefill.rs`로 종료 |
+| 웜 링크 (2회) | exit 0, 6분 01초 / 7분 24초 |
+| 링크가 깨진 트리에서 `cargo check` | **exit 0, 59초** |
+| 같은 트리에서 링크 | **exit 101**, `error: linking with cc failed`, `flatcc_verify_*` 미정의 참조 |
+| 아카이브 복원 후 링크 | exit 0 |
+| 이 PR 자체에서의 job | 커밋 4개 모두 성공 |
+
+깨뜨린 방법은 `build.rs`의 `IREE_CUDA_HOME` 분기에서 `-l:libflatcc_parsing.a`를 제거한 것이다. 가운데 두 줄이 이 변경의 전부다. 같은 트리에서 한 명령은 초록, 다른 하나는 빨강이고, 그것이 #1274의 모양이다. 이 PR은 `build.rs`를 건드리지 않으며 모든 대조 실험은 브랜치 밖에서 실행하고 되돌렸다.
+
+콜드 수치의 대부분은 링크가 아니라 MLX의 CUDA 소스를 처음부터 컴파일하는 시간이다. 의미 있는 값은 웜 쪽이다. 트리거가 `build.rs`에서 걸리는데, 그것은 `mlxcel` 크레이트를 무효화하지만 `mlxcel-core`의 MLX 빌드는 건드리지 않기 때문이다.
+
+## 6. 검증되지 않은 채로 남은 것
+
+- **`-lc` 대조 실험이 재현되지 않는 이유.** 이슈의 인수 조건대로 먼저 시도했고, 링크는 성공했다. 내보낸 빌드 스크립트 출력에 `rustc-link-arg=-lc`가 없음을, 그리고 IREE 아카이브들이 링크 라인에 있음을 각각 확인했다. 스택 프로텍터 설명은 틀렸다(4.1). 추가 가설 둘도 검증 후 배제했다. 이 glibc에서 `-lpthread`와 `-ldl`은 libc를 뒤늦게 끌어오는 링커 스크립트가 아니라 스텁 아카이브로 해석되고, `libm.so`는 `libm.so.6`만 그룹한다. 해당 항목은 남기며, 재현에 실패한 대조 실험 하나를 근거로 제거하지 말라고 주석에 적었다.
+- **`IREE_DIST` 레시피와 macOS `IREE_MACOS_HOME` 레시피**는 어느 기계에서도 링크로 검증된 적이 없다. 두 배포판을 가진 러너가 없다.
+- **초록 실행이 링크가 일어났다는 증거는 아니다.** 타깃 디렉터리가 PR 간에 유지되므로 cargo가 할 일을 못 찾을 수 있다. 이 job의 첫 실행은 `Finished release profile in 0.14s`와 함께 12초에 끝났다. 이는 정상 동작이다. cargo는 fingerprint가 움직일 때 정확히 재링크하고, `build.rs`는 IREE 환경변수 세 개 모두에 `rerun-if-env-changed`를 선언한다. 좁은 구멍은 `IREE_VERSION`을 바꾸지 않으면서 런타임 빌드 방식만 바꾸는 `scripts/iree/**` 수정이다. 스크립트가 멱등이라 아무것도 다시 빌드되지 않는다.
+- **`Cargo.toml`과 `Cargo.lock`은 필터 밖**이라 의존성 변경으로 인한 링크 변화는 job을 트리거하지 않는다. 넓히면 모든 의존성 상향에서 실행된다.
+
+## 7. 학습 포인트
+
+1. **진단 도구가 정말 그 도구인지 확인할 것.** 쉘 alias가 `nm`을 SSH 클라이언트로 바꿔놓았고, stderr를 버린 탓에 `command not found`가 자신 있는 빈 결과로 둔갑했다. 0건을 반환한 검색은 결론을 세우기 전에 양성 대조 하나를 거칠 자격이 있다.
+2. **`cargo check`는 링크 게이트가 아니며 `--all-targets`도 그걸 바꾸지 않는다.** 이 플래그는 타입 검사 범위를 넓힐 뿐 링크 범위를 넓히지 않는다.
+3. **`cargo:rustc-link-arg`는 링크되는 모든 산출물에 적용된다.** 따라서 어떤 타깃이든 같은 레시피를 검증한다. 가장 작은 것을 고르는 일은 커버리지 결정이 아니라 비용 결정이다.
+4. **통합 테스트를 선택하면 패키지의 바이너리들도 함께 빌드된다.** `cargo test --test X --no-run`은 보이는 것만큼 최소한의 링크가 아니며, 그래서 예상보다 나은 게이트이고 `--bin` 대안은 절약이 아니라 부분집합이다.
+5. **경로 필터는 인과에 대한 주장이다.** 필터를 쓰는 일은 검증 대상 산출물을 실제로 무엇이 움직이는지 묻게 만들며, 여기서 초안은 아카이브가 해결해주는 바로 그 심볼을 만들어내는 C shim을 놓쳤다.
+
+## 8. 후속 작업
+
+- **fork PR은 실제로 GB10 러너에 도달한다**(4.4). 이 PR이 만든 것이 아니라 기존 job들에서 물려받은 상태다. GB10 job 세 개 전부에 head 저장소 검사를 넣거나, 승인 정책을 조이거나, 전용 러너 계정을 두는 하드닝 이슈가 필요하다.
+- **디스크 압박.** 93퍼센트 찬 볼륨에 네 번째 영구 타깃 디렉터리가 추가된다. `~/.cargo-target`은 이미 39GB이고 정리하는 주체가 없으며, 같은 호스트에서 릴리스를 만든다.
+- **`-lc` 근본 원인**은 미해결이다(6절). 이를 해결하는 사람은 `build.rs` 주석의 "Measured, not assumed" 문구도 함께 다시 볼 것.
+- **이슈 #1304**가 dead-code 백로그를 정리하고 `xla-compile`을 `-D warnings`로 확대한다.
+
+## 참고
+
+- 이슈 #1303(이 작업), #1274(링크 실패), #1275(`-lc` 수정), #1282(이 게이트가 확장하는 컴파일 게이트), #1304(같은 제외 목록의 린트 절반)
+- `.github/workflows/ci.yml`, `build.rs:143-176`, `src/lib/mlxcel-xla/build.rs`


### PR DESCRIPTION
## Summary

`xla-compile` runs `cargo check`, which never invokes the linker, so a regression in the IREE link recipe in `build.rs` can reach `main` unobserved; #1274 was exactly that failure, found by hand after the fact rather than by CI. This PR adds a new `xla-link` job that actually links an OpenXLA target on the self-hosted GB10 runner, closing the gap `xla-compile`'s own comment already recorded as open.

## What changed

- `changes` job: a new `xla_link` output from a sibling `dorny/paths-filter` filter keyed on `build.rs`, `src/lib/mlxcel-xla/build.rs`, `src/lib/mlxcel-xla/csrc/**`, `scripts/iree/**`, `rust-toolchain.toml`, and `.github/workflows/ci.yml`. That is narrower than the existing `rust` filter, so the link job does not run on every Rust PR, but it covers the whole causal surface of a link failure: the root `build.rs` holds the IREE recipe, `scripts/iree/**` pins the distribution whose archive set the recipe names, `mlxcel-xla`'s build script and its `csrc/**` sources produce the shim object whose undefined symbols those archives resolve, and `rust-toolchain.toml` is on the path because #1274 was entirely about where rustc places its own `-lc` relative to appended `rustc-link-arg` entries.
- New `xla-link` job, placed immediately after `xla-compile`, `needs: changes`, gated on `github.repository == 'lablup/mlxcel' && needs.changes.outputs.xla_link == 'true'`, `runs-on: GB10`, `permissions: contents: read`, `timeout-minutes: 120`, a job-scoped `concurrency` group keyed per PR with `cancel-in-progress`, and its own `CARGO_TARGET_DIR` (`$HOME/.cargo-target/mlxcel-xla-link-ci`) separate from `xla-compile`'s and from the release job's.
- The link step runs `cargo test --release --features cuda,xla-iree --test xla_prepared_prefill --no-run`. `--release` is mandatory because the debug profile cannot link these targets on this host at all (hundreds of `relocation truncated to fit: R_AARCH64_CALL26` errors against ordinary libstd symbols, the unoptimized binary exceeding the AArch64 direct-branch range). `--no-run` links without executing, so the job never touches the GPU. Because cargo also builds the package's `[[bin]]` targets whenever an integration test is selected, this command links `mlxcel`, `mlxcel-server`, `speculative_bench`, and `mlxcel-bench-decode` in addition to the test binary, so it is a superset of the `--bin mlxcel-server` alternative rather than a cheaper substitute for it. `RUSTFLAGS` is deliberately left unset, unlike `xla-compile`, so a red run here is unambiguously a link failure rather than a lint failure.
- The `concurrency` group exists because `xla-link` is the first job on the shared GB10 runner whose warm cost is minutes rather than seconds. Without it, three pushes to a `build.rs` PR queue three link jobs of up to 120 minutes each on the one runner that also serves `cargo-clippy` for every Rust PR and the release build.
- Comment blocks recording the trigger rationale, the measured cost, what the gate was demonstrated on, and the residual coverage gaps: the `IREE_DIST` and macOS `IREE_MACOS_HOME` recipes in `build.rs` remain unverified because no runner in this repository holds either distribution, and a link regression arriving through a path outside the filter is still not caught at PR time.
- Corrected the note above the `clippy` job, which asserted that the repository guard means fork PRs never queue on the self-hosted runner. It does not. On a `pull_request` event opened from a fork against this repository, `github.repository` is the base repository, so the guard is true and the job runs here. The guard's real effect is to stop the job queueing forever in a fork of the repository. What gates the fork-PR case is the repository's Actions fork-PR approval policy. That reading applies equally to `xla-compile` and to the new job, and the issue specifying this work repeated the incorrect version, so it was propagating.

## Verification

All of the following ran on the GB10 host with the IREE runtime provisioned (`bash scripts/iree/setup-cuda.sh`, `eval "$(bash scripts/iree/setup-cuda.sh --env)"`, `MLX_CUDA_ARCHITECTURES=121`).

- The job's link command passes from a purged `CARGO_TARGET_DIR`: exit 0 in 15m40s, ending at `Executable tests/xla_prepared_prefill.rs`. Most of that is MLX's CUDA sources compiling from scratch, not the link.
- Warm cost, which is what a `build.rs` edit actually pays because it invalidates the `mlxcel` crate but not `mlxcel-core`'s MLX build: 6m01s and 7m24s across two runs, both exit 0.
- **The gate catches a link-only regression that `xla-compile` cannot.** With `-l:libflatcc_parsing.a` dropped from the `IREE_CUDA_HOME` branch of `build.rs`, `xla-compile`'s command `cargo check --features cuda,xla-iree --all-targets` still exits 0 in 59 seconds, while this job's command exits 101 with `error: linking with cc failed` and undefined references to `flatcc_verify_string_field`, `flatcc_verify_table_vector_field`, and `flatcc_verify_vector_field`. Restoring the archive returns the link to exit 0. That is the same shape as #1274, on the same tree, and is the demonstration the issue asked for.
- The job runs green on this PR itself, since the PR changes `.github/workflows/ci.yml` and so matches the filter.

`build.rs` is unchanged by this PR; every control above was run outside the branch and reverted.

## On the negative control the issue specified

The issue's acceptance criteria asked for the demonstration to be done by reverting the `-lc` entry added in #1275. That control was tried first and did not fail the link: the command exits 0 with `rustc-link-arg=-lc` confirmed absent from the emitted build-script output and the IREE archives confirmed present on the link line.

Why it does not fail is unresolved, and nothing here should be read as evidence that the entry is dead. An earlier revision of this PR claimed the pinned runtime was built without the stack protector; that claim was wrong and has been removed. It came from running `nm` in a shell where `nm` is an alias for an unrelated command, so the search silently matched nothing. Against the pinned distribution, using `/usr/bin/nm`: `__stack_chk_guard` is undefined in 176 objects of `libiree_runtime_unified.a`, including the `call.c.o` named in #1274; it is undefined in `libc.so.6`; and it is defined only in `ld-linux-aarch64.so.1`. Every precondition the `build.rs` comment records still holds today. Two further explanations were tested and ruled out: `-lpthread` and `-ldl` resolve to stub archives on this glibc rather than to scripts that would pull libc in late, and `libm.so` groups only `libm.so.6`.

So `build.rs` is left alone, the flatcc control above is what demonstrated the gate, and the workflow comment records all of this so the next reader does not delete the `-lc` entry on the strength of one control that failed to reproduce.

Closes #1303