### PR TITLE
chore: clear the OpenXLA warning backlog and deny all warnings in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -345,6 +345,15 @@ jobs:
   #     `clippy` job above covers default features only. That half of the
   #     backlog cleared by #1304 can therefore regrow silently; closing it means
   #     running clippy here, which was left out of #1304 deliberately.
+  #   - The path dependencies' own test targets. There is no `default-members`
+  #     (see the note at the top of `Cargo.toml`), so `cargo check` run here
+  #     resolves to `-p mlxcel` and `--all-targets` expands within that package
+  #     only. `mlxcel-core`, `mlxcel-surgery` and `mlxcel-xla` are compiled as
+  #     plain library dependencies, so their `#[cfg(test)]` modules are never
+  #     built. That leaves `mlxcel-xla`'s unit tests ungated by every job,
+  #     because the `clippy` job above builds default features and the crate is
+  #     default-off there. `cargo clippy -p mlxcel-xla --all-targets` covers
+  #     them, but only by hand.
   #   - macOS and `IREE_DIST` builds of the same features. Neither has a runner
   #     with the required distribution.
   xla-compile:
@@ -365,6 +374,15 @@ jobs:
       # dead-code backlog that would have made the job red on arrival; #1304
       # cleared it. See the note above for what `-D warnings` on `cargo check`
       # still does not cover.
+      #
+      # Blast radius, deliberately: `RUSTFLAGS` reaches every unit cargo builds
+      # from a path, so the `mlxcel-core`, `mlxcel-surgery` and `mlxcel-xla`
+      # library units and the build scripts are gated here too, and a warning in
+      # any of them reds a job named for OpenXLA. Registry and git dependencies
+      # cannot, because cargo compiles those with `--cap-lints allow`. The
+      # toolchain is pinned exactly in `rust-toolchain.toml`, so a new rustc
+      # release cannot turn this red on its own; bumping that pin is what has to
+      # re-clear these two feature sets.
       RUSTFLAGS: "-D warnings"
     steps:
       - uses: actions/checkout@v7

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -337,13 +337,14 @@ jobs:
   #     recipe; see its comment for what it covers and what it still does not.
   #   - `cargo test`. This is a compile gate; running the XLA suites needs a
   #     GPU that is not contended with development work on the same host.
-  #   - Full `-D warnings`. The XLA feature combination carries a pre-existing
-  #     dead-code backlog in `mlxcel-xla` and `mlxcel`, and clippy fails on it
-  #     today, so denying every lint would make this job red on arrival and
-  #     therefore ignored. It denies `unused_imports` instead, which is the
-  #     exact lint class of the dead re-export above, and compile errors cover
-  #     the other. Broadening to `-D warnings` needs that backlog cleared
-  #     first.
+  #   - Clippy-only lints. This job runs `cargo check`, and `RUSTFLAGS: "-D
+  #     warnings"` denies rustc lints only, so `dead_code` and `unused_imports`
+  #     are now gated but `collapsible_if`, `needless_match`,
+  #     `too_many_arguments`, `while_let_loop` and the rest of clippy's own
+  #     lints are not gated by anything in CI under these feature sets. The
+  #     `clippy` job above covers default features only. That half of the
+  #     backlog cleared by #1304 can therefore regrow silently; closing it means
+  #     running clippy here, which was left out of #1304 deliberately.
   #   - macOS and `IREE_DIST` builds of the same features. Neither has a runner
   #     with the required distribution.
   xla-compile:
@@ -359,9 +360,12 @@ jobs:
       # `121a`, which is numerically identical here but is not what releases
       # build, so the gate compiles what ships.
       MLX_CUDA_ARCHITECTURES: "121"
-      # See the note above: this denies the lint that let a defect through, not
-      # every lint.
-      RUSTFLAGS: "-D unused_imports"
+      # Every rustc lint, not just the `unused_imports` this job started with.
+      # The narrower value existed because the XLA feature combination carried a
+      # dead-code backlog that would have made the job red on arrival; #1304
+      # cleared it. See the note above for what `-D warnings` on `cargo check`
+      # still does not cover.
+      RUSTFLAGS: "-D warnings"
     steps:
       - uses: actions/checkout@v7
         with:

--- a/TECHNICAL_REPORTS/1381-openxla-warning-backlog-20260822.en.md
+++ b/TECHNICAL_REPORTS/1381-openxla-warning-backlog-20260822.en.md
@@ -1,0 +1,146 @@
+# Technical Report: PR #1381 - clear the OpenXLA warning backlog and deny all warnings in CI
+
+**Date**: 2026-08-22
+**Author**: Jeongkyu Shin
+**Status**: Completed
+**Languages**: Rust, YAML (GitHub Actions)
+**Risk Level**: Low (lint and visibility change; no runtime behavior altered)
+
+---
+
+## Executive Summary
+
+The `xla-compile` CI job denied a single lint, `unused_imports`, rather than all warnings. That was deliberate: the OpenXLA feature combinations carried a dead-code and clippy backlog, and a job that is red the day it lands gets routed around and then ignored.
+
+This PR clears the backlog and widens the gate to `RUSTFLAGS: "-D warnings"`. Fourteen findings across two crates were resolved, one by deletion and the rest by cfg gates, scoped `#[allow]`s with comments naming what keeps each item alive, and three mechanical fixes. Four of the fourteen were not in the issue's list at all; they were found by re-measuring the backlog before starting, because the issue's list had drifted since it was filed.
+
+The change is verified by the widened gate running green on the PR that widens it: `OpenXLA feature compile` did a real 7m44s rebuild under the new flag and passed.
+
+## 1. Problem Statement
+
+### 1.1 Background
+
+PR #1282 added `xla-compile` with `RUSTFLAGS: "-D unused_imports"`. That lint was chosen because it is the exact class of one of the two defects that reached `main` through the OpenXLA coverage gap, a dead `load_weights_from_dir_with_filter` re-export; compile errors covered the other, a non-exhaustive `match` after a new `ModelRequest` variant landed. Both historical breaks were caught. New dead code under these features was not.
+
+### 1.2 Existing Issues
+
+Clearing the backlog is the precondition for widening the gate, and the backlog spanned both `mlxcel-xla` and `mlxcel`. Deletion was usually the wrong fix, because several items are live under feature sets other than the one that reports them dead.
+
+### 1.3 Risk Assessment
+
+Low in isolation, compounding over time. Every ungated warning is a place where the next real defect of the same class arrives unremarked, and the two defects that motivated #1282 are the existing proof.
+
+## 2. Change Summary
+
+Ten files: eight Rust, one workflow, and the report.
+
+| File | Resolution |
+|---|---|
+| `mlxcel-xla/src/aux.rs` | `Float16`, `Uint32`: `cfg_attr(not(micro-oracle), allow(dead_code))` |
+| `mlxcel-xla/src/aux_manifest.rs` | collapsible `if` rewritten as an edition-2024 let chain |
+| `mlxcel-xla/src/iree.rs` | `decode_ragged_logits` cfg-gated to `diagnostics`; `decode_ragged_mrope_logits` deleted; stranded doc comment reattached |
+| `mlxcel-xla/src/phi4_audio.rs` | scoped `allow(clippy::too_many_arguments)` |
+| `src/loading/vlm.rs`, `src/models/sanitize.rs` | `cfg_attr(not(surgery), allow(clippy::needless_match))` |
+| `src/server/batch/xla_audio_preprocess.rs` | seven `cfg_attr(not(test), allow(dead_code))`, each with its caller named |
+| `src/server/batch/xla_worker_admission.rs` | `allow(clippy::while_let_loop)` with reason |
+| `src/server/media.rs` | cfg_attr condition widened to `any(not(xla-iree), not(test))` |
+| `.github/workflows/ci.yml` | `RUSTFLAGS` to `-D warnings`; policy comment replaced; two coverage gaps recorded |
+
+## 3. Technical Decisions
+
+### 3.1 Re-measure the backlog before working from it
+
+The issue's list was measured when it was filed. Re-running both clippy commands on the current tree produced fourteen findings against the issue's ten, and the four extras were not incidental: two were plain mechanical fixes, and two were the `needless_match` pair that is the most dangerous item in the whole change (3.3). Working from the stale list would have shipped a PR that fails its own acceptance criteria.
+
+### 3.2 One deletion, and only after proving the item is dead everywhere
+
+`decode_ragged_mrope_logits` is a thin wrapper over `decode_ragged_mrope_logits_with_modes` and is dead under both measured feature sets. It was deleted rather than allowed, because the acceptance criterion requires every `#[allow]` to name a caller keeping the item alive, and there is none. The justification is a repo-wide search across all file types, extended during review to the paths a plain grep misses: macros (`mlxcel-xla` has one `macro_rules!`, for MLIR fixtures, and no `paste!` or `concat_idents!`), doc tests, `pub use` re-exports, trait impls, and feature-gated callers under `micro-oracle` and `xla-diagnostics-cpu`. What remains is the identically-named C function `xla_llama_decode_ragged_mrope_logits`, its extern declaration, and the `_with_modes` sibling, which keeps its live caller.
+
+Its twin `decode_ragged_logits` was **not** deleted. It is dead under `cuda,xla-iree` and live under `xla-diagnostics`, so it was cfg-gated to `feature = "diagnostics"` instead, matching all four of its callers in `batch.rs`, which already carry that cfg. Since `diagnostics = ["iree"]`, the new gate is strictly narrower than the `#[cfg(feature = "iree")] mod iree` containing it and cannot break any combination. Deleting it would have turned a warning into a build break on the other feature set, which is the failure this issue explicitly warned against.
+
+### 3.3 Two clippy suggestions that had to be refused
+
+`src/loading/vlm.rs` and `src/models/sanitize.rs` both contain:
+
+```rust
+let resolved_transform = match transform {
+    Some(t) => Some(t),
+    None => {
+        #[cfg(feature = "surgery")]
+        { active_pipeline.as_deref().map(...) }
+        #[cfg(not(feature = "surgery"))]
+        ...
+    }
+};
+```
+
+Under `--no-default-features` the `surgery` arm compiles out, the `None` arm collapses to `None`, and clippy correctly reports the match as needless with the suggestion "replace it with `transform`". Taking that suggestion would delete active-pipeline resolution from the default build, where `default = ["surgery"]`.
+
+The fix is `#[cfg_attr(not(feature = "surgery"), allow(clippy::needless_match))]` on the `let` statement: silenced exactly for the builds that see the collapsed shape, and still linted in the default build. This is the concrete instance of the issue's rule that a fix which alters behavior is the wrong fix.
+
+### 3.4 `not(test)` rather than a bare allow
+
+Every suppression in `xla_audio_preprocess.rs` and `media.rs` is conditioned on `not(test)`. `cargo check --all-targets` compiles the `mlxcel` lib twice, once under `cfg(test)`, so the suppression is self-enforcing: if the sole test caller is deleted, the lint returns rather than staying silent forever. Each attribute carries a comment naming the caller, which the review checked one by one.
+
+A detail worth recording: `#[allow]` suppresses a lint without marking the symbol live, so the `healthy` field still warned on its own after `is_healthy` was allowed. Each item needed its own attribute.
+
+### 3.5 Widen `RUSTFLAGS`, and record what it still does not cover
+
+`RUSTFLAGS: "-D warnings"` on a `cargo check` job denies rustc lints only. Clippy's own lints, which are most of what this PR fixed, remain gated by nothing under these feature sets, because the `clippy` job builds default features where `mlxcel-xla` is default-off. Swapping the job's `cargo check` for `cargo clippy` would close that, and was deliberately left out of scope. The gap is recorded in the workflow's exclusion list rather than left implied, so the cleared half of the backlog cannot regrow behind a comment that claims full coverage.
+
+## 4. Review Findings
+
+No CRITICAL or HIGH findings survived either review. The follow-up commit fixed four accuracy defects:
+
+- **Error messages naming functions the build does not contain.** Two arity-check messages in `iree.rs` named the thin wrappers rather than their `_with_modes` emitters. Since one wrapper is now deleted and the other is diagnostics-only, a production `cuda,xla-iree` build could return `"decode_ragged_mrope_logits expects ..."` naming a function it does not have.
+- **An incomplete caller list.** `AudioPreprocessStage::spawn`'s comment named one test file; `xla_worker_tests.rs` calls it too. Since the acceptance criterion is that every allow names what keeps the item alive, an incomplete list is precisely what it exists to prevent.
+- **A comment describing half of what it covered.** `drain_preprocessed` has two drain loops, image and audio, and the function-level allow covers both.
+- **Two unrecorded properties of the widened gate**, added to the exclusion list (see 5.2).
+
+## 5. Validation
+
+### 5.1 What passed
+
+All on the GB10 host with the IREE runtime provisioned, and re-run on the final commit.
+
+| Command | Result |
+|---|---|
+| `cargo clippy --features cuda,xla-iree --all-targets -- -D warnings` | exit 0, clean |
+| `cargo clippy --no-default-features --features xla-diagnostics --all-targets -- -D warnings` | exit 0, clean |
+| `cargo clippy -p mlxcel --lib --tests -- -D warnings` (default regression) | exit 0, clean |
+| `RUSTFLAGS="-D warnings" cargo check --features cuda,xla-iree --all-targets` | exit 0 |
+| `RUSTFLAGS="-D warnings" cargo check --no-default-features --features xla-diagnostics --all-targets` | exit 0 |
+| `cargo clippy -p mlxcel-xla --lib --features iree,micro-oracle --all-targets -- -D warnings` | exit 0 |
+| `OpenXLA feature compile` on this PR | success, 7m44s real rebuild under the new flag |
+
+The two `cargo check` rows are not redundant with the clippy rows. `cargo clippy -- -D warnings` applies the flag to the primary package only, while `RUSTFLAGS` reaches every path-built unit, so a warning in `mlxcel-core` or `mlxcel-surgery` would red the job without appearing in any clippy run. Verifying the acceptance criteria alone would not have shown whether the job goes green.
+
+### 5.2 What the gate covers, precisely
+
+`RUSTFLAGS` reaches `mlxcel-core`, `mlxcel-surgery`, `mlxcel-xla` and the build scripts, so a CUDA-only warning in `mlxcel-core` now reds a job named for OpenXLA. Registry and git dependencies cannot, because cargo compiles them with `--cap-lints allow`. `rust-toolchain.toml` pins `1.97.1` exactly rather than tracking `stable`, so a new rustc release cannot turn the job red on its own; the cost moves to the pin bump, deliberately.
+
+There is no `default-members`, so `cargo check` here resolves to `-p mlxcel` and `--all-targets` expands within that package only. `mlxcel-xla`'s 23 `#[cfg(test)]` modules are therefore gated by no job at all. This PR's test plan ran `-p mlxcel-xla --all-targets` by hand; CI will not.
+
+### 5.3 What was not verified
+
+`metal,accelerate` cannot be built on this Linux host, so it is unverified by execution. The static argument that it is unaffected: `make verify-clippy` runs `--features metal,accelerate` without `--no-default-features`, so `surgery` stays on and both `needless_match` attributes expand to nothing; `mlxcel-xla` builds with no features there, so every file changed in it sits behind `#[cfg(feature = "iree")]` and never compiles; and on the `mlxcel` side only `media.rs` and `xla_audio_preprocess.rs` compile, where every change is an `allow` attribute that cannot break a build.
+
+## 6. Learning Points
+
+1. **A backlog measured at filing time is a snapshot, not a specification.** Re-measure before working from it. Here the drift was 40 percent, and one of the drifted items was the trap that would have caused a behavior regression.
+2. **Verifying the acceptance criteria is not the same as verifying the deliverable.** The criteria named clippy; the job runs `cargo check` with `RUSTFLAGS`, which has a wider blast radius. Run what the artifact will actually run.
+3. **`#[allow]` suppresses a lint; it does not mark a symbol live.** Allowing an accessor does not stop the field it reads from warning on its own.
+4. **Condition suppressions so they expire.** `not(test)` keeps the lint alive in the test build, so a suppression whose justification disappears turns red again instead of outliving its reason.
+5. **A clippy suggestion is a suggestion about the configuration clippy was run in.** Under `cfg`-split code, applying it can delete behavior that exists only in a configuration clippy never saw.
+
+## 7. Follow-up Actions
+
+- **`mlxcel-xla`'s test modules are ungated by any CI job.** Recorded in the workflow's exclusion list; closing it means selecting the package explicitly or adding `default-members`.
+- **Clippy-only lints under these feature sets remain ungated**, so that half of the backlog can regrow. Closing it means running clippy in this job.
+- **`media_tests.rs` reaches `validate_xla_raw_counts_with_audio` only through the `supports_audio = false` wrapper**, so the `true` branch has no direct unit coverage, and the sign of that flag is the security-relevant bit.
+- **A pre-existing stranded doc comment** at `iree.rs:2296-2305`, the same defect this PR fixed at `:1819`, leaves two broken intra-doc links. It predates this branch and emits no warning because no blank line separates it.
+
+## References
+
+- Issue #1304 (this work), #1282 (the job and its recorded exclusions), #1303 and PR #1305 (the link half of the same exclusion list)
+- `.github/workflows/ci.yml`, `src/lib/mlxcel-xla/src/iree.rs`, `src/server/batch/xla_audio_preprocess.rs`

--- a/TECHNICAL_REPORTS/1381-openxla-warning-backlog-20260822.ko.md
+++ b/TECHNICAL_REPORTS/1381-openxla-warning-backlog-20260822.ko.md
@@ -1,0 +1,146 @@
+# 기술 보고서: PR #1381 - OpenXLA 경고 백로그 정리 후 CI에서 모든 경고 거부
+
+**날짜**: 2026-08-22
+**작성자**: Jeongkyu Shin
+**상태**: 완료
+**언어/기술**: Rust, YAML (GitHub Actions)
+**위험도**: 낮음 (린트와 가시성 변경, 런타임 동작 변화 없음)
+
+---
+
+## 요약
+
+`xla-compile` CI job은 모든 경고가 아니라 `unused_imports` 하나만 거부하고 있었다. 의도적인 선택이었다. OpenXLA 기능 조합에 dead-code와 clippy 백로그가 쌓여 있었고, 착륙하는 날부터 빨간 job은 우회당한 뒤 무시되기 때문이다.
+
+이 PR은 백로그를 정리하고 게이트를 `RUSTFLAGS: "-D warnings"`로 확대한다. 두 크레이트에 걸친 14건을 처리했다. 하나는 삭제, 나머지는 cfg 게이트와 무엇이 그 항목을 살려두는지 이름을 적은 범위 한정 `#[allow]`, 그리고 기계적 수정 세 건이다. 14건 중 4건은 이슈 목록에 아예 없었다. 시작 전에 백로그를 다시 측정했기 때문에 찾았고, 이슈 목록은 작성 시점 이후 실제와 어긋나 있었다.
+
+검증은 확대된 게이트가 확대를 수행하는 바로 그 PR에서 초록으로 도는 것으로 이루어졌다. `OpenXLA feature compile`이 새 플래그 아래 7분 44초짜리 실제 재빌드를 수행하고 통과했다.
+
+## 1. 문제 정의
+
+### 1.1 배경
+
+PR #1282가 `RUSTFLAGS: "-D unused_imports"`로 `xla-compile`을 추가했다. 그 린트를 고른 이유는, OpenXLA 커버리지 공백으로 `main`에 들어간 두 결함 중 하나가 정확히 그 린트 부류였기 때문이다(죽은 `load_weights_from_dir_with_filter` 재수출). 나머지 하나는 컴파일 오류가 잡았다(새 `ModelRequest` 변형이 추가된 뒤의 비망라 `match`). 과거의 두 사고는 모두 잡힌다. 잡히지 않는 것은 이 기능들 아래 새로 생기는 dead code다.
+
+### 1.2 기존 문제
+
+백로그 정리는 게이트 확대의 선행 조건이고, 백로그는 `mlxcel-xla`와 `mlxcel` 양쪽에 걸쳐 있었다. 삭제는 대개 틀린 해법이다. 여러 항목이 죽었다고 보고되는 기능 조합이 아닌 다른 조합에서는 살아 있기 때문이다.
+
+### 1.3 위험 평가
+
+단독으로는 낮지만 누적된다. 게이트되지 않은 경고 하나하나가 같은 부류의 다음 진짜 결함이 조용히 도착하는 지점이고, #1282를 촉발한 두 결함이 이미 그 증거다.
+
+## 2. 변경 요약
+
+파일 열 개. Rust 여덟, 워크플로 하나, 그리고 보고서.
+
+| 파일 | 처리 |
+|---|---|
+| `mlxcel-xla/src/aux.rs` | `Float16`, `Uint32`: `cfg_attr(not(micro-oracle), allow(dead_code))` |
+| `mlxcel-xla/src/aux_manifest.rs` | collapsible `if`를 edition 2024 let chain으로 재작성 |
+| `mlxcel-xla/src/iree.rs` | `decode_ragged_logits`를 `diagnostics`로 cfg 게이트, `decode_ragged_mrope_logits` 삭제, 떨어져 나간 doc 주석 원위치 |
+| `mlxcel-xla/src/phi4_audio.rs` | 범위 한정 `allow(clippy::too_many_arguments)` |
+| `src/loading/vlm.rs`, `src/models/sanitize.rs` | `cfg_attr(not(surgery), allow(clippy::needless_match))` |
+| `src/server/batch/xla_audio_preprocess.rs` | `cfg_attr(not(test), allow(dead_code))` 일곱 건, 각각 호출자 명시 |
+| `src/server/batch/xla_worker_admission.rs` | 사유를 적은 `allow(clippy::while_let_loop)` |
+| `src/server/media.rs` | cfg_attr 조건을 `any(not(xla-iree), not(test))`로 확장 |
+| `.github/workflows/ci.yml` | `RUSTFLAGS`를 `-D warnings`로, 정책 주석 교체, 커버리지 공백 두 건 기록 |
+
+## 3. 기술적 선택과 그 이유
+
+### 3.1 이슈 목록을 그대로 쓰지 않고 백로그를 다시 측정
+
+이슈 목록은 작성 시점의 측정값이다. 현재 트리에서 두 clippy 명령을 다시 돌리니 이슈의 10건이 아니라 14건이 나왔고, 늘어난 4건은 부수적인 것이 아니었다. 둘은 단순 기계적 수정이었지만, 나머지 둘이 이 변경 전체에서 가장 위험한 `needless_match` 쌍이었다(3.3). 낡은 목록으로 작업했다면 자기 인수 조건을 통과하지 못하는 PR이 나왔을 것이다.
+
+### 3.2 삭제는 한 건, 그것도 어디서도 죽었음을 증명한 뒤에
+
+`decode_ragged_mrope_logits`는 `decode_ragged_mrope_logits_with_modes`를 감싼 얇은 래퍼이고 측정한 두 기능 조합 모두에서 죽어 있다. allow가 아니라 삭제한 이유는, 인수 조건이 모든 `#[allow]`에 그 항목을 살려두는 호출자를 명시하라고 요구하는데 그런 호출자가 없기 때문이다. 근거는 모든 파일 유형에 대한 저장소 전역 검색이며, 리뷰 과정에서 단순 grep이 놓치는 경로까지 확장했다. 매크로(`mlxcel-xla`에는 MLIR 픽스처용 `macro_rules!` 하나뿐이고 `paste!`나 `concat_idents!`는 없다), doc test, `pub use` 재수출, trait impl, 그리고 `micro-oracle`과 `xla-diagnostics-cpu` 아래의 기능 게이트된 호출자. 남은 것은 이름이 같은 C 함수 `xla_llama_decode_ragged_mrope_logits`와 그 extern 선언, 그리고 살아 있는 호출자를 유지하는 `_with_modes` 형제뿐이다.
+
+쌍둥이인 `decode_ragged_logits`는 **삭제하지 않았다.** `cuda,xla-iree`에서는 죽어 있고 `xla-diagnostics`에서는 살아 있으므로, `batch.rs`의 네 호출자가 이미 달고 있는 cfg와 맞춰 `feature = "diagnostics"`로 게이트했다. `diagnostics = ["iree"]`이므로 새 게이트는 이를 감싸는 `#[cfg(feature = "iree")] mod iree`보다 엄격히 좁고 어떤 조합도 깨뜨릴 수 없다. 이것을 지웠다면 경고가 다른 기능 조합의 빌드 실패로 바뀌었을 것이고, 그것이 이 이슈가 명시적으로 경고한 실패다.
+
+### 3.3 거부해야 했던 clippy 제안 두 건
+
+`src/loading/vlm.rs`와 `src/models/sanitize.rs`에는 다음 형태가 있다.
+
+```rust
+let resolved_transform = match transform {
+    Some(t) => Some(t),
+    None => {
+        #[cfg(feature = "surgery")]
+        { active_pipeline.as_deref().map(...) }
+        #[cfg(not(feature = "surgery"))]
+        ...
+    }
+};
+```
+
+`--no-default-features`에서는 `surgery` 팔이 컴파일에서 빠지고 `None` 팔이 `None`으로 무너지며, clippy는 정확하게 이 match를 무의미하다고 보고하면서 "`transform`으로 바꿔라"라고 제안한다. 그 제안을 받아들이면 `default = ["surgery"]`인 기본 빌드에서 active pipeline 해석이 사라진다.
+
+해법은 `let` 문에 붙인 `#[cfg_attr(not(feature = "surgery"), allow(clippy::needless_match))]`다. 무너진 형태를 보는 빌드에서만 정확히 침묵시키고, 기본 빌드에서는 계속 린트한다. 동작을 바꾸는 수정은 틀린 수정이라는 이슈의 규칙이 구체화된 사례다.
+
+### 3.4 맨 allow가 아니라 `not(test)`
+
+`xla_audio_preprocess.rs`와 `media.rs`의 모든 억제는 `not(test)` 조건부다. `cargo check --all-targets`는 `mlxcel` lib을 `cfg(test)` 포함해 두 번 컴파일하므로 억제가 스스로 만료된다. 유일한 테스트 호출자를 지우면 린트가 영원히 침묵하는 대신 다시 살아난다. 각 속성에는 호출자를 명시한 주석이 붙어 있고, 리뷰가 하나씩 확인했다.
+
+기록해둘 세부 사항 하나. `#[allow]`는 린트를 억제할 뿐 심볼을 살아 있는 것으로 표시하지 않는다. 그래서 `is_healthy`를 allow한 뒤에도 `healthy` 필드가 따로 경고했다. 항목마다 속성이 필요했다.
+
+### 3.5 `RUSTFLAGS`를 넓히되, 여전히 못 덮는 것을 기록
+
+`cargo check` job에서 `RUSTFLAGS: "-D warnings"`는 rustc 린트만 거부한다. 이 PR이 고친 것의 대부분인 clippy 자체 린트는 이 기능 조합들 아래에서 여전히 아무것도 게이트하지 않는다. `clippy` job은 `mlxcel-xla`가 기본 꺼짐인 기본 기능으로 빌드하기 때문이다. job의 `cargo check`를 `cargo clippy`로 바꾸면 닫히지만, 의도적으로 범위 밖으로 두었다. 이 공백은 암시로 남기지 않고 워크플로의 제외 목록에 기록했다. 정리한 절반이 완전 커버리지를 주장하는 주석 뒤에서 다시 자라나지 않도록.
+
+## 4. 리뷰에서 나온 지적
+
+두 리뷰 모두 CRITICAL과 HIGH는 없었다. 후속 커밋이 정확성 결함 네 건을 고쳤다.
+
+- **빌드에 없는 함수 이름을 담은 오류 메시지.** `iree.rs`의 arity 검사 메시지 둘이 실제로 메시지를 내보내는 `_with_modes`가 아니라 얇은 래퍼 이름을 담고 있었다. 래퍼 하나는 삭제됐고 다른 하나는 diagnostics 전용이 되었으므로, 프로덕션 `cuda,xla-iree` 빌드가 자신이 갖고 있지 않은 함수를 지칭하는 `"decode_ragged_mrope_logits expects ..."`를 반환할 수 있었다.
+- **불완전한 호출자 목록.** `AudioPreprocessStage::spawn`의 주석이 테스트 파일 하나만 언급했는데 `xla_worker_tests.rs`도 호출한다. 인수 조건이 모든 allow에 살려두는 대상을 명시하라는 것이므로, 불완전한 목록은 그 조건이 막으려는 바로 그것이다.
+- **덮는 범위의 절반만 설명한 주석.** `drain_preprocessed`에는 이미지와 오디오 두 개의 drain 루프가 있고 함수 수준 allow는 둘 다 덮는다.
+- **기록되지 않았던 확대 게이트의 성질 두 가지**를 제외 목록에 추가(5.2 참조).
+
+## 5. 검증
+
+### 5.1 통과한 것
+
+모두 IREE 런타임이 준비된 GB10 호스트에서, 최종 커밋 기준으로 재실행했다.
+
+| 명령 | 결과 |
+|---|---|
+| `cargo clippy --features cuda,xla-iree --all-targets -- -D warnings` | exit 0, 무경고 |
+| `cargo clippy --no-default-features --features xla-diagnostics --all-targets -- -D warnings` | exit 0, 무경고 |
+| `cargo clippy -p mlxcel --lib --tests -- -D warnings` (기본 기능 회귀) | exit 0, 무경고 |
+| `RUSTFLAGS="-D warnings" cargo check --features cuda,xla-iree --all-targets` | exit 0 |
+| `RUSTFLAGS="-D warnings" cargo check --no-default-features --features xla-diagnostics --all-targets` | exit 0 |
+| `cargo clippy -p mlxcel-xla --lib --features iree,micro-oracle --all-targets -- -D warnings` | exit 0 |
+| 이 PR의 `OpenXLA feature compile` | 성공, 새 플래그 아래 7분 44초 실제 재빌드 |
+
+`cargo check` 두 줄은 clippy 줄과 중복이 아니다. `cargo clippy -- -D warnings`는 플래그를 primary 패키지에만 적용하지만 `RUSTFLAGS`는 path로 빌드되는 모든 유닛에 도달한다. 따라서 `mlxcel-core`나 `mlxcel-surgery`의 경고는 어떤 clippy 실행에도 나타나지 않은 채 job을 빨갛게 만들 수 있다. 인수 조건만 검증했다면 job이 초록이 되는지는 알 수 없었다.
+
+### 5.2 게이트가 정확히 무엇을 덮는가
+
+`RUSTFLAGS`는 `mlxcel-core`, `mlxcel-surgery`, `mlxcel-xla`와 빌드 스크립트에 도달한다. 그래서 `mlxcel-core`의 CUDA 전용 경고가 OpenXLA 이름을 단 job을 빨갛게 만든다. 레지스트리와 git 의존성은 그럴 수 없다. cargo가 `--cap-lints allow`로 컴파일하기 때문이다. `rust-toolchain.toml`은 `stable`을 따라가지 않고 `1.97.1`을 정확히 고정하므로, 새 rustc 릴리스가 혼자서 job을 빨갛게 만들 수 없다. 비용은 의도적으로 핀 상향 시점으로 옮겨진다.
+
+`default-members`가 없으므로 여기서 `cargo check`는 `-p mlxcel`로 해석되고 `--all-targets`는 그 패키지 안에서만 전개된다. 따라서 `mlxcel-xla`의 `#[cfg(test)]` 모듈 23개는 어떤 job도 게이트하지 않는다. 이 PR의 테스트 계획은 `-p mlxcel-xla --all-targets`를 수동으로 돌렸지만 CI는 돌리지 않는다.
+
+### 5.3 검증하지 못한 것
+
+`metal,accelerate`는 이 Linux 호스트에서 빌드할 수 없어 실행으로 검증하지 못했다. 영향이 없다는 정적 논거는 이렇다. `make verify-clippy`는 `--no-default-features` 없이 `--features metal,accelerate`로 돌리므로 `surgery`가 켜진 채이고 `needless_match` 속성 둘은 아무것도 확장하지 않는다. 거기서 `mlxcel-xla`는 기능 없이 빌드되므로 이 크레이트에서 바뀐 모든 파일이 `#[cfg(feature = "iree")]` 뒤에 있어 컴파일되지 않는다. `mlxcel` 쪽에서는 `media.rs`와 `xla_audio_preprocess.rs`만 컴파일되는데, 두 변경 모두 빌드를 깨뜨릴 수 없는 `allow` 속성이다.
+
+## 6. 학습 포인트
+
+1. **작성 시점에 측정된 백로그는 명세가 아니라 스냅숏이다.** 그것으로 작업하기 전에 다시 측정할 것. 여기서는 40퍼센트가 어긋나 있었고, 어긋난 항목 중 하나가 동작 회귀를 일으켰을 함정이었다.
+2. **인수 조건을 검증하는 것과 산출물을 검증하는 것은 다르다.** 조건은 clippy를 지목했지만 job은 `RUSTFLAGS`와 함께 `cargo check`를 돌리고, 영향 범위가 더 넓다. 산출물이 실제로 실행할 것을 실행할 것.
+3. **`#[allow]`는 린트를 억제할 뿐 심볼을 살아 있게 표시하지 않는다.** 접근자를 allow해도 그것이 읽는 필드는 따로 경고한다.
+4. **억제에는 만료 조건을 걸 것.** `not(test)`는 테스트 빌드에서 린트를 살려두므로, 근거가 사라진 억제는 근거보다 오래 살아남는 대신 다시 빨개진다.
+5. **clippy 제안은 clippy가 실행된 그 구성에 대한 제안이다.** `cfg`로 갈라진 코드에서는, 제안을 적용하면 clippy가 본 적 없는 구성에만 존재하는 동작을 지울 수 있다.
+
+## 7. 후속 작업
+
+- **`mlxcel-xla`의 테스트 모듈은 어떤 CI job도 게이트하지 않는다.** 워크플로 제외 목록에 기록했다. 닫으려면 패키지를 명시적으로 선택하거나 `default-members`를 추가해야 한다.
+- **이 기능 조합들 아래 clippy 전용 린트는 여전히 게이트되지 않으므로** 백로그의 그 절반은 다시 자랄 수 있다. 닫으려면 이 job에서 clippy를 돌려야 한다.
+- **`media_tests.rs`는 `validate_xla_raw_counts_with_audio`에 `supports_audio = false` 래퍼로만 도달하므로** `true` 분기에 직접적인 단위 테스트가 없고, 그 플래그의 부호가 보안상 의미 있는 비트다.
+- **`iree.rs:2296-2305`의 기존 doc 주석 이탈.** 이 PR이 `:1819`에서 고친 것과 같은 결함으로, intra-doc 링크 두 개가 깨져 있다. 이 브랜치 이전부터 있었고 빈 줄이 없어 경고를 내지 않는다.
+
+## 참고
+
+- 이슈 #1304(이 작업), #1282(해당 job과 기록된 제외 목록), #1303 및 PR #1305(같은 제외 목록의 링크 절반)
+- `.github/workflows/ci.yml`, `src/lib/mlxcel-xla/src/iree.rs`, `src/server/batch/xla_audio_preprocess.rs`

--- a/src/lib/mlxcel-xla/src/aux.rs
+++ b/src/lib/mlxcel-xla/src/aux.rs
@@ -97,7 +97,15 @@ impl AuxiliaryTensorDType {
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) enum AuxiliaryWeightDType {
     Float32,
+    // Constructed only by `numeric_probe.rs`, which is behind the
+    // `micro-oracle` feature, while `ffi_code` / `size_bytes` below must keep
+    // mapping them for the FFI contract on every build. Allowed rather than
+    // cfg-gated: gating the variants would force a `cfg` on each arm of those
+    // two matches, including the `Float32 | Uint32` arm, and leave two shapes
+    // of the same enum to keep in step.
+    #[cfg_attr(not(feature = "micro-oracle"), allow(dead_code))]
     Float16,
+    #[cfg_attr(not(feature = "micro-oracle"), allow(dead_code))]
     Uint32,
 }
 

--- a/src/lib/mlxcel-xla/src/aux_manifest.rs
+++ b/src/lib/mlxcel-xla/src/aux_manifest.rs
@@ -589,13 +589,13 @@ fn acquire_auxiliary_cache_lock_with_policy(
 fn cache_lock_is_stale(path: &Path, stale_after: Duration) -> bool {
     #[cfg(target_os = "linux")]
     {
-        if let Ok(token) = std::fs::read_to_string(path) {
-            if let Some(pid) = cache_lock_owner_pid(&token) {
-                match Path::new("/proc").join(pid.to_string()).try_exists() {
-                    Ok(false) => return true,
-                    Ok(true) => {}
-                    Err(_) => {}
-                }
+        if let Ok(token) = std::fs::read_to_string(path)
+            && let Some(pid) = cache_lock_owner_pid(&token)
+        {
+            match Path::new("/proc").join(pid.to_string()).try_exists() {
+                Ok(false) => return true,
+                Ok(true) => {}
+                Err(_) => {}
             }
         }
     }

--- a/src/lib/mlxcel-xla/src/iree.rs
+++ b/src/lib/mlxcel-xla/src/iree.rs
@@ -1819,10 +1819,6 @@ fn deepstack_descriptors(
     ))
 }
 
-/// Load the weights and create the C execution context for a (prefill, decode)
-/// vmfb pair on `device`. Shared by the single-sequence ([`IreeLlama`]) and ragged
-/// ([`IreeRaggedLlama`]) engines, which differ only in which decode vmfb they pass.
-
 /// Create a context that shares `base`'s uploaded weights, differing only in the
 /// compiled bundle and the capacity baked into it.
 ///
@@ -1876,6 +1872,9 @@ fn create_bucket_ctx(
     Ok(ctx)
 }
 
+/// Load the weights and create the C execution context for a (prefill, decode)
+/// vmfb pair on `device`. Shared by the single-sequence ([`IreeLlama`]) and ragged
+/// ([`IreeRaggedLlama`]) engines, which differ only in which decode vmfb they pass.
 fn create_ctx(
     model_dir: &Path,
     cfg: &RuntimeConfig,
@@ -3008,6 +3007,14 @@ impl IreeRaggedLlama {
     /// LOGITS (#449 M3 Stage 2d). `tokens` / `pos` / `cache_len` are per-row (length
     /// `b_max`); an inactive slot carries zeros (a masked no-op whose logits the
     /// caller discards). The caller samples a token per row from `logits[s*vocab..]`.
+    ///
+    /// Every caller is diagnostics-only (`LlavaReferenceDiagnosticEngine::capture`
+    /// and the Gemma3n diagnostic runners in `batch.rs`); serving goes through
+    /// [`decode_ragged_logits_with_modes`] directly. Gated to match those callers
+    /// so the production feature set neither compiles nor warns about it.
+    ///
+    /// [`decode_ragged_logits_with_modes`]: Self::decode_ragged_logits_with_modes
+    #[cfg(feature = "diagnostics")]
     pub fn decode_ragged_logits(
         &mut self,
         tokens: &[i32],
@@ -3074,22 +3081,6 @@ impl IreeRaggedLlama {
             ));
         }
         Ok(logits)
-    }
-
-    /// Advance an M-RoPE batch with explicit temporal/height/width coordinates
-    /// per row while retaining physical KV writes at `cache_len`.
-    pub fn decode_ragged_mrope_logits(
-        &mut self,
-        tokens: &[i32],
-        positions: &[[i32; 3]],
-        cache_len: &[i32],
-    ) -> Result<Vec<f32>, String> {
-        self.decode_ragged_mrope_logits_with_modes(
-            &vec![0; self.b_max],
-            tokens,
-            positions,
-            cache_len,
-        )
     }
 
     /// Mode-aware M-RoPE ragged decode.

--- a/src/lib/mlxcel-xla/src/iree.rs
+++ b/src/lib/mlxcel-xla/src/iree.rs
@@ -3042,7 +3042,7 @@ impl IreeRaggedLlama {
             || cache_len.len() != self.b_max
         {
             return Err(format!(
-                "decode_ragged_logits expects adapter/token/position/cache arrays of length b_max = {}",
+                "decode_ragged_logits_with_modes expects adapter/token/position/cache arrays of length b_max = {}",
                 self.b_max
             ));
         }
@@ -3100,7 +3100,7 @@ impl IreeRaggedLlama {
             || cache_len.len() != self.b_max
         {
             return Err(format!(
-                "decode_ragged_mrope_logits expects adapter/token/position/cache arrays of length b_max = {}",
+                "decode_ragged_mrope_logits_with_modes expects adapter/token/position/cache arrays of length b_max = {}",
                 self.b_max
             ));
         }

--- a/src/lib/mlxcel-xla/src/phi4_audio.rs
+++ b/src/lib/mlxcel-xla/src/phi4_audio.rs
@@ -322,6 +322,12 @@ fn load_audio_weights(
         .collect()
 }
 
+// Eight arguments against clippy's threshold of seven. Both call sites are in
+// this file and pass a different `graph` / `artifact_name` / `entry_name` triple
+// for the encoder and the projector, so a parameter struct would only move the
+// same eight values into a type that exists for one private helper and ripple
+// through both callers.
+#[allow(clippy::too_many_arguments)]
 fn load_audio_module(
     model_dir: &Path,
     device: &str,

--- a/src/loading/vlm.rs
+++ b/src/loading/vlm.rs
@@ -326,6 +326,11 @@ fn finish_vlm_weights_common(
         .flatten();
     #[cfg(not(feature = "surgery"))]
     let _ = allow_active_pipeline;
+    // Without `surgery` the `None` arm collapses to `None` and clippy calls the
+    // match needless. Taking that suggestion would delete the active-pipeline
+    // resolution from the default build, where `surgery` is on, so the lint is
+    // silenced for the builds that see the collapsed shape instead.
+    #[cfg_attr(not(feature = "surgery"), allow(clippy::needless_match))]
     let resolved_transform: Option<&dyn mlxcel_core::weights::WeightTransform> = match transform {
         Some(t) => Some(t),
         None => {

--- a/src/models/sanitize.rs
+++ b/src/models/sanitize.rs
@@ -1661,6 +1661,11 @@ pub fn load_text_weights<P: AsRef<std::path::Path>>(
         .is_none()
         .then(crate::surgery::snapshot_active_pipeline)
         .flatten();
+    // Without `surgery` the `None` arm collapses to `None` and clippy calls the
+    // match needless. Taking that suggestion would delete the active-pipeline
+    // resolution from the default build, where `surgery` is on, so the lint is
+    // silenced for the builds that see the collapsed shape instead.
+    #[cfg_attr(not(feature = "surgery"), allow(clippy::needless_match))]
     let resolved_transform: Option<&dyn mlxcel_core::weights::WeightTransform> = match transform {
         Some(t) => Some(t),
         None => {

--- a/src/server/batch/xla_audio_preprocess.rs
+++ b/src/server/batch/xla_audio_preprocess.rs
@@ -433,8 +433,9 @@ pub(crate) struct AudioPreprocessStage {
 }
 
 impl AudioPreprocessStage {
-    /// Used by `xla_audio_preprocess_tests.rs`. The serve worker constructs the
-    /// stage through `spawn_with_loader` so MLX handles stay thread-confined.
+    /// Used by `xla_audio_preprocess_tests.rs` and `xla_worker_tests.rs`. The
+    /// serve worker constructs the stage through `spawn_with_loader` so MLX
+    /// handles stay thread-confined.
     #[cfg_attr(not(test), allow(dead_code))]
     pub fn spawn<P: AudioFeatureProducer + Send>(
         producer: P,

--- a/src/server/batch/xla_audio_preprocess.rs
+++ b/src/server/batch/xla_audio_preprocess.rs
@@ -48,7 +48,13 @@ pub(crate) struct AudioPreprocessJob {
 
 pub(crate) enum AudioPreprocessOutcome {
     Prepared(PreparedPrefill),
-    Cancelled(AudioPreprocessCheckpoint),
+    // The checkpoint payload records where cancellation was observed. Serving
+    // matches it as `Cancelled(_)` (`xla_worker_admission.rs`), so only the
+    // unit tests in `xla_audio_preprocess_tests.rs` read the value. Keeping the
+    // payload is deliberate: `Cancelled` is constructed at several checkpoints
+    // in this file, and dropping the field would erase that distinction from
+    // the type rather than from one caller.
+    Cancelled(#[cfg_attr(not(test), allow(dead_code))] AudioPreprocessCheckpoint),
     Failed(AudioStageError),
 }
 
@@ -220,6 +226,9 @@ impl AudioPreprocessMetrics {
         }
     }
 
+    /// Read by the unit tests in `xla_audio_preprocess_tests.rs`; serving reads
+    /// these counters through `BatchObservability` instead of this struct.
+    #[cfg_attr(not(test), allow(dead_code))]
     pub fn snapshot(&self) -> AudioPreprocessMetricsSnapshot {
         AudioPreprocessMetricsSnapshot {
             accepted: self.accepted.load(Ordering::Relaxed),
@@ -338,6 +347,9 @@ enum AudioRejectionReason {
     ContextLimit,
 }
 
+/// Constructed only by `AudioPreprocessMetrics::snapshot`, which the unit tests
+/// in `xla_audio_preprocess_tests.rs` are the only callers of.
+#[cfg_attr(not(test), allow(dead_code))]
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) struct AudioPreprocessMetricsSnapshot {
     pub accepted: u64,
@@ -409,6 +421,11 @@ pub(crate) struct AudioPreprocessStage {
     sender: Option<mpsc::SyncSender<QueuedJob>>,
     result_rx: Option<mpsc::Receiver<AudioPreprocessResult>>,
     metrics: Arc<AudioPreprocessMetrics>,
+    // Written by the worker thread and read back through `is_healthy`, which
+    // only `xla_audio_preprocess_tests.rs` calls. The worker still needs the
+    // flag to publish its liveness, so it stays a field rather than becoming a
+    // test-only construct.
+    #[cfg_attr(not(test), allow(dead_code))]
     healthy: Arc<AtomicBool>,
     max_queued_encoded_bytes: usize,
     max_in_flight_host_bytes: usize,
@@ -416,6 +433,9 @@ pub(crate) struct AudioPreprocessStage {
 }
 
 impl AudioPreprocessStage {
+    /// Used by `xla_audio_preprocess_tests.rs`. The serve worker constructs the
+    /// stage through `spawn_with_loader` so MLX handles stay thread-confined.
+    #[cfg_attr(not(test), allow(dead_code))]
     pub fn spawn<P: AudioFeatureProducer + Send>(
         producer: P,
         limits: AudioPreprocessLimits,
@@ -634,14 +654,24 @@ impl AudioPreprocessStage {
             .try_recv()
     }
 
+    /// Blocking counterpart to `try_recv`, used by
+    /// `xla_audio_preprocess_tests.rs`. The scheduling loop must not block, so
+    /// serving drains the stage with `try_recv` only.
+    #[cfg_attr(not(test), allow(dead_code))]
     pub fn recv(&self) -> Result<AudioPreprocessResult, mpsc::RecvError> {
         self.result_rx.as_ref().ok_or(mpsc::RecvError)?.recv()
     }
 
+    /// Read by `xla_audio_preprocess_tests.rs`; serving observes the same
+    /// counters through the `BatchObservability` the metrics forward to.
+    #[cfg_attr(not(test), allow(dead_code))]
     pub fn metrics(&self) -> &Arc<AudioPreprocessMetrics> {
         &self.metrics
     }
 
+    /// Read by `xla_audio_preprocess_tests.rs` to assert that a per-request
+    /// panic does not take the worker thread down with it.
+    #[cfg_attr(not(test), allow(dead_code))]
     pub fn is_healthy(&self) -> bool {
         self.healthy.load(Ordering::Acquire)
     }

--- a/src/server/batch/xla_worker_admission.rs
+++ b/src/server/batch/xla_worker_admission.rs
@@ -436,6 +436,7 @@ impl<E: XlaServingEngine> XlaServeWorker<E> {
         }
     }
 
+    // Both loops below, the image drain and the audio drain, take this allow.
     // clippy::while_let_loop wants `while let Some(stage) =
     // self.image_preprocessor.as_ref()`, but that head holds a shared borrow of
     // `self` for the whole body, which then calls `&mut self` methods and clears

--- a/src/server/batch/xla_worker_admission.rs
+++ b/src/server/batch/xla_worker_admission.rs
@@ -436,6 +436,12 @@ impl<E: XlaServingEngine> XlaServeWorker<E> {
         }
     }
 
+    // clippy::while_let_loop wants `while let Some(stage) =
+    // self.image_preprocessor.as_ref()`, but that head holds a shared borrow of
+    // `self` for the whole body, which then calls `&mut self` methods and clears
+    // the field. Taking the receiver result inside the loop ends the borrow at
+    // the `let`, so the `match` shape is load-bearing rather than stylistic.
+    #[allow(clippy::while_let_loop)]
     pub(super) fn drain_preprocessed(&mut self) {
         loop {
             let received = match self.image_preprocessor.as_ref() {

--- a/src/server/media.rs
+++ b/src/server/media.rs
@@ -196,7 +196,12 @@ impl MediaRequestMetadata {
     /// failed resolver cannot erase an unsupported modality. Images require a
     /// one-to-one declaration → raw payload handoff; decoded cardinality is
     /// checked later by the bounded preprocessing worker.
-    #[cfg_attr(not(feature = "xla-iree"), allow(dead_code))]
+    ///
+    /// Called by `media_tests.rs` only. The XLA admission path calls
+    /// [`Self::validate_xla_raw_counts_with_audio`] directly because it knows
+    /// whether the loaded family supports audio, so this no-audio wrapper is
+    /// the test-facing spelling of the same check.
+    #[cfg_attr(any(not(feature = "xla-iree"), not(test)), allow(dead_code))]
     pub(crate) fn validate_xla_raw_counts(
         self,
         images: usize,


### PR DESCRIPTION
## Summary

The `xla-compile` job denied `unused_imports` rather than `warnings` because the `cuda,xla-iree` and `xla-diagnostics` feature sets carried a dead-code and clippy backlog that would have made the job red the day it landed. This clears that backlog and widens the gate to `-D warnings`.

Resolution followed the criterion in the issue: cfg-gate to the feature set that has a real consumer where the gate needs no duplicate definition, otherwise allow with a comment naming the caller, and delete only when a search finds no consumer under any feature combination.

## What changed

### `mlxcel-xla`

- `src/lib/mlxcel-xla/src/iree.rs`: `IreeRaggedLlama::decode_ragged_logits` is now `#[cfg(feature = "diagnostics")]`. Its only callers are `LlavaReferenceDiagnosticEngine::capture` and the Gemma3n diagnostic runners in `batch.rs`, all of which are already `#[cfg(feature = "diagnostics")]`; serving calls `decode_ragged_logits_with_modes` directly.
- `src/lib/mlxcel-xla/src/iree.rs`: `decode_ragged_mrope_logits` is deleted. This is the one deletion in the PR. `grep -rn "decode_ragged_mrope_logits" . --exclude-dir=.git --exclude-dir=target` filtered of the `_with_modes` sibling and the `xla_llama_` extern returns exactly two hits: the definition itself, and an error-message string inside `decode_ragged_mrope_logits_with_modes` that stays. There is no caller in any crate, test, bench, or example, under any feature combination.
- `src/lib/mlxcel-xla/src/iree.rs`: a doc comment describing `create_ctx` had been stranded above a blank line when #1302 inserted `create_bucket_ctx` and its own doc block between them, which is what `clippy::empty_line_after_doc_comments` was reporting. It is moved back onto `create_ctx`.
- `src/lib/mlxcel-xla/src/aux.rs`: `AuxiliaryWeightDType::Float16` and `Uint32` are allowed under `not(feature = "micro-oracle")`. `numeric_probe.rs`, behind that feature, is their only construction site, while `ffi_code` and `size_bytes` have to keep mapping them for the FFI contract on every build. Gating the variants themselves would force a `cfg` onto each arm of those two matches, including the `Float32 | Uint32` arm.
- `src/lib/mlxcel-xla/src/phi4_audio.rs`: `load_audio_module` takes a scoped `#[allow(clippy::too_many_arguments)]`. A parameter struct would ripple into both call sites for a private single-file helper, so the allow was preferred per the issue's guidance.
- `src/lib/mlxcel-xla/src/aux_manifest.rs`: the nested `if let` in `cache_lock_is_stale` collapses to an edition-2024 let chain.

### `mlxcel`

- `src/server/batch/xla_audio_preprocess.rs`: the test-only surface is allowed under `not(test)`, following the `#[cfg_attr(not(test), allow(dead_code))]` pattern already used in `src/model_metadata.rs` and `src/server/startup.rs`. Each site names `xla_audio_preprocess_tests.rs` as the caller: `AudioPreprocessStage::spawn` (serving uses `spawn_with_loader` to keep MLX handles thread-confined), `recv` (serving must not block, so it drains with `try_recv`), `metrics`, `is_healthy`, the `healthy` field it reads, `AudioPreprocessMetrics::snapshot`, and `AudioPreprocessMetricsSnapshot`. The `Cancelled(AudioPreprocessCheckpoint)` payload keeps its field with the same allow: serving matches it as `Cancelled(_)`, and the checkpoint distinction belongs in the type because `Cancelled` is constructed at several checkpoints in that file.
- `src/server/media.rs`: `validate_xla_raw_counts` gains a `not(test)` arm alongside its existing `not(feature = "xla-iree")` one. `media_tests.rs` is its only caller; the XLA admission path calls `validate_xla_raw_counts_with_audio` directly because it knows whether the loaded family supports audio.
- `src/server/batch/xla_worker_admission.rs`: `drain_preprocessed` takes `#[allow(clippy::while_let_loop)]`. The suggested `while let Some(stage) = self.image_preprocessor.as_ref()` head holds a shared borrow of `self` across a body that calls `&mut self` methods and clears the field, so the `match` shape is load-bearing rather than stylistic.
- `src/loading/vlm.rs` and `src/models/sanitize.rs`: the two `needless_match` sites take `#[cfg_attr(not(feature = "surgery"), allow(clippy::needless_match))]`. The match only collapses to `match transform { Some(t) => Some(t), None => None }` when the `surgery` arm is compiled out, which is why the lint fires under `--no-default-features` and not under the default feature set. Applying clippy's suggestion would delete active-pipeline resolution from the default build, so the lint is silenced only for the builds that see the collapsed shape.

### CI

- `.github/workflows/ci.yml`: `xla-compile` now sets `RUSTFLAGS: "-D warnings"`, and the paragraph explaining the narrower `-D unused_imports` policy is replaced.
- `.github/workflows/ci.yml`: the "Deliberately NOT covered" list records the gap that remains after this change. The job runs `cargo check`, so `-D warnings` denies rustc lints only. `dead_code` and `unused_imports` are gated now, but `collapsible_if`, `needless_match`, `too_many_arguments`, `while_let_loop` and the rest of clippy's own lints are still gated by nothing in CI under these feature sets, because the `clippy` job covers default features only. That half of the backlog can regrow silently; swapping this job's `cargo check` for `cargo clippy` was deliberately left out of scope.

## No runtime behavior change

The diff is attribute additions, `cfg` additions, comments, one collapsed `if`, one doc-comment move, and the deletion of one function that has no caller. No executed code path changes.

## Test plan

Run on the GB10 host with the IREE runtime provisioned (`bash scripts/iree/setup-cuda.sh`, `eval "$(bash scripts/iree/setup-cuda.sh --env)"`, `MLX_CUDA_ARCHITECTURES=121`), and re-run on the final commit after the review follow-ups landed.

Acceptance criteria:

- [x] `cargo clippy --features cuda,xla-iree --all-targets -- -D warnings`: exit 0, no warnings.
- [x] `cargo clippy --no-default-features --features xla-diagnostics --all-targets -- -D warnings`: exit 0, no warnings.
- [x] Default-feature regression, `cargo clippy -p mlxcel --lib --tests -- -D warnings`: exit 0, no warnings.

The two commands the job itself runs, under the widened flag, because `cargo clippy -- -D warnings` applies the flag only to the primary package while `RUSTFLAGS` reaches every path-built unit including `mlxcel-core` and `mlxcel-surgery`. Clippy passing is therefore not sufficient evidence that the job will be green:

- [x] `RUSTFLAGS="-D warnings" cargo check --features cuda,xla-iree --all-targets`: exit 0.
- [x] `RUSTFLAGS="-D warnings" cargo check --no-default-features --features xla-diagnostics --all-targets`: exit 0.

Scoped and mechanical checks:

- [x] `cargo clippy -p mlxcel-xla --lib --features iree --all-targets -- -D warnings`
- [x] `cargo clippy -p mlxcel-xla --lib --features iree,diagnostics --all-targets -- -D warnings`
- [x] `cargo clippy -p mlxcel-xla --lib --features iree,micro-oracle --all-targets -- -D warnings`, confirming the `micro-oracle` cfg arm on the `AuxiliaryWeightDType` variants is not narrowed wrongly
- [x] `rustfmt --edition 2024 --check` on every changed Rust file
- [x] `.github/workflows/ci.yml` parses as YAML

End to end, this PR's own CI exercises the change it makes: `OpenXLA feature compile` ran for 7m44s under the new `RUSTFLAGS: "-D warnings"` and passed, so the widened gate is green on arrival rather than red. `OpenXLA feature link`, added by #1305, also ran because `src/lib/mlxcel-xla/**` is in its path filter.

Not verified:

- [ ] `metal,accelerate`. It cannot be built on this Linux host, so it is unverified by execution rather than confirmed. The static argument that it is unaffected: `make verify-clippy` runs `--features metal,accelerate` without `--no-default-features`, so `surgery` stays on and both `needless_match` attributes expand to nothing; `mlxcel-xla` builds with no features there, so `iree.rs`, `aux.rs`, `aux_manifest.rs` and `phi4_audio.rs` sit behind `#[cfg(feature = "iree")]` and never compile; and on the `mlxcel` side only `media.rs` and `xla_audio_preprocess.rs` compile, where every change is an `allow` attribute that cannot break a build.

## Follow-ups this surfaced, out of scope here

- `mlxcel-xla`'s `#[cfg(test)]` modules are gated by no CI job at all. There is no `default-members`, so `cargo check` in this job resolves to `-p mlxcel` and `--all-targets` expands within that package only, while the `clippy` job builds default features where `mlxcel-xla` is default-off. Recorded in the workflow's exclusion list.
- Clippy-only lints under these feature sets remain ungated, so that half of the backlog can regrow. Closing it means running clippy in this job, which was left out of scope deliberately.
- `media_tests.rs` reaches `validate_xla_raw_counts_with_audio` only through the `supports_audio = false` wrapper, so the `true` branch has no direct unit coverage, and the sign of that flag is the security-relevant bit.

Closes #1304