### PR TITLE
fix(server): return None for missing template map keys

### DIFF
--- a/TECHNICAL_REPORTS/1394-dict-get-jinja-none-20260824.en.md
+++ b/TECHNICAL_REPORTS/1394-dict-get-jinja-none-20260824.en.md
@@ -1,0 +1,60 @@
+# Technical Report: PR #1394 - Return None for Missing Template Map Keys
+
+**Date**: 2026-08-24
+
+**Author**: Jeongkyu Shin
+
+**Status**: Completed
+
+**Languages**: Rust, Jinja
+
+**Risk Level**: Medium
+
+## Executive Summary
+
+PR #1394 aligns mlxcel's shared Python-style `dict.get()` compatibility shim with CPython Jinja2: a missing key without an explicit default now returns Minijinja `None` instead of `Undefined`. This corrects Muse Glimmer multi-turn prompts so completed assistant messages end with `<|eot|>` rather than the continuation marker `<|eom|>`, while preserving explicit defaults, falsy values, and `or`-chain behavior.
+
+## 1. Problem Statement
+
+The Muse Glimmer checkpoint template uses `message.get('end_turn') is none` to decide whether to infer an end-of-turn marker. mlxcel returned `Undefined` for a missing key, so the `is none` guard did not run and every plain assistant message was rendered as an unfinished turn. The resulting prompt stayed syntactically valid but diverged from the byte sequence used to train and validate the checkpoint.
+
+## 2. Change Summary
+
+| Area | Change |
+|---|---|
+| `src/server/chat_template.rs` | Return `Value::from(())` for a missing one-argument `dict.get()` call and document the Python-compatible semantics |
+| Template compatibility tests | Cover missing keys as both `none` and `defined`, and preserve present JSON `null`, `false`, zero, empty strings, explicit defaults, and fallback chains |
+| Muse Glimmer fixture tests | Assert the `<|eot|>` terminator by name and update the two affected render digests to the Jinja reference values |
+
+## 3. Technical Decisions
+
+### 3.1 Correct the shared compatibility funnel
+
+The fix stays in `configure_environment`, the single callback installed by both typed and raw `ChatTemplateProcessor` render paths. A template-local workaround would leave every other checkpoint vulnerable to the same CPython compatibility trap and could create inconsistent behavior between chat completions, Responses, Anthropic translation, router, and offline CLI paths.
+
+### 3.2 Preserve falsy semantics explicitly
+
+Minijinja `None` and `Undefined` are both falsy, so existing `m.get('a') or m.get('b')` templates continue to work. The review added direct raw-JSON coverage for present `null`, `false`, `0`, and `""` values so a future refactor cannot confuse a missing key with a present falsy value.
+
+### 3.3 Pin visible behavior as well as hashes
+
+Digest assertions prove byte identity but can be mechanically updated after a regression. The Muse tests now also assert that completed assistant content contains `<|eot|>` and does not contain `<|eom|>`, keeping the semantic invariant readable during future fixture updates.
+
+## 4. Verification
+
+- `cargo fmt --all -- --check`: passed.
+- `cargo test -p mlxcel --profile test-fast --lib test_dict_get_method`: 6 passed.
+- `cargo test -p mlxcel --profile test-fast --lib muse_glimmer_template_`: 6 passed.
+- Local Jinja2 reference render: `multi_turn` is 325 bytes with SHA-256 `433d37ff14caf2f2b177d904726b34ff09cb2aad4426a237a7b27772eab47007`; `tools_and_results` is 2340 bytes with SHA-256 `dc451d3030d24f37ecc20fc0236c0b5fa7f70032d8c5331f8f6690689620d6ae`.
+- Hosted CI: formatting, Clippy, cargo-deny, OpenXLA feature compile, metadata checks, and CLA passed; change-irrelevant MLX pin extraction and OpenXLA link jobs were skipped.
+- Implementation, security/performance, and finalization reviews found no unresolved correctness or security issue after the raw-value coverage addition.
+
+## 5. Remaining Validation Boundary
+
+A real Muse Glimmer multi-turn GPU smoke test was not run because this Linux host exposed neither a usable NVIDIA driver nor a Metal backend. The deterministic render tests and Jinja reference comparison prove the corrected prompt bytes, but they are not presented as real-checkpoint generation evidence.
+
+## 6. Related Work
+
+- Issue #1383: Python-style `dict.get()` returned `Undefined` for missing keys.
+- PR #1394: implementation and review fixes documented here.
+- PR #1382 / issue #1309: adjacent `tojson` compatibility work where the pre-existing terminator defect was discovered; not changed by this PR.

--- a/TECHNICAL_REPORTS/1394-dict-get-jinja-none-20260824.ko.md
+++ b/TECHNICAL_REPORTS/1394-dict-get-jinja-none-20260824.ko.md
@@ -1,0 +1,60 @@
+# 기술 보고서: PR #1394 - 누락된 템플릿 맵 키에 None 반환
+
+**작성일**: 2026-08-24
+
+**작성자**: 신정규
+
+**상태**: 완료
+
+**언어**: Rust, Jinja
+
+**위험도**: Medium
+
+## 요약
+
+PR #1394는 mlxcel의 공용 Python 스타일 `dict.get()` 호환 shim을 CPython Jinja2 의미론에 맞췄다. 명시적 기본값 없이 누락된 키를 조회하면 이제 `Undefined`가 아니라 Minijinja `None`을 반환하며, Muse Glimmer 다중 턴 프롬프트의 완료된 assistant 메시지가 연속 생성 표식 `<|eom|>` 대신 올바른 `<|eot|>`로 끝난다. 명시적 기본값, falsy 값, `or` 체인 동작은 그대로 보존된다.
+
+## 1. 문제 정의
+
+Muse Glimmer 체크포인트 템플릿은 `message.get('end_turn') is none`으로 턴 종료 표식을 추론할지 결정한다. mlxcel은 누락된 키에 `Undefined`를 반환했기 때문에 `is none` 분기가 실행되지 않았고, 모든 일반 assistant 메시지가 끝나지 않은 턴으로 렌더링됐다. 프롬프트는 문법적으로 유효했지만 체크포인트 학습 및 검증에 사용된 바이트열과 달라졌다.
+
+## 2. 변경 요약
+
+| 영역 | 변경 |
+|---|---|
+| `src/server/chat_template.rs` | 인자 하나인 `dict.get()`에서 키가 없으면 `Value::from(())`을 반환하고 Python 호환 의미론을 문서화 |
+| 템플릿 호환성 테스트 | 누락된 키가 `none`이면서 `defined`임을 검증하고, 존재하는 JSON `null`, `false`, 0, 빈 문자열, 명시적 기본값, fallback 체인을 보존 |
+| Muse Glimmer fixture 테스트 | `<|eot|>` 종료 표식을 이름으로 검증하고 영향받은 두 렌더 digest를 Jinja 기준값으로 갱신 |
+
+## 3. 기술적 선택과 그 이유
+
+### 3.1 공용 호환성 경계에서 수정
+
+수정은 typed/raw `ChatTemplateProcessor` 렌더 경로가 모두 설치하는 단일 callback인 `configure_environment`에 적용됐다. 템플릿 전용 우회는 다른 체크포인트에 같은 CPython 호환성 결함을 남기고 chat completions, Responses, Anthropic 변환, router, offline CLI 사이에 서로 다른 동작을 만들 수 있다.
+
+### 3.2 Falsy 의미론을 명시적으로 보존
+
+Minijinja의 `None`과 `Undefined`는 모두 falsy이므로 기존 `m.get('a') or m.get('b')` 템플릿은 계속 동작한다. 리뷰에서는 존재하는 `null`, `false`, `0`, `""`를 raw JSON 경로로 직접 검증해 향후 리팩터링이 누락된 키와 존재하는 falsy 값을 혼동하지 못하게 했다.
+
+### 3.3 Hash와 사용자-visible 동작을 함께 고정
+
+Digest 검증은 바이트 동일성을 증명하지만 회귀 후 기계적으로 다시 고정될 수 있다. Muse 테스트는 이제 완료된 assistant 내용이 `<|eot|>`를 포함하고 `<|eom|>`를 포함하지 않는다는 의미론적 불변식도 직접 검증한다.
+
+## 4. 검증
+
+- `cargo fmt --all -- --check`: 통과.
+- `cargo test -p mlxcel --profile test-fast --lib test_dict_get_method`: 6개 통과.
+- `cargo test -p mlxcel --profile test-fast --lib muse_glimmer_template_`: 6개 통과.
+- 로컬 Jinja2 기준 렌더: `multi_turn`은 325바이트, SHA-256 `433d37ff14caf2f2b177d904726b34ff09cb2aad4426a237a7b27772eab47007`; `tools_and_results`는 2340바이트, SHA-256 `dc451d3030d24f37ecc20fc0236c0b5fa7f70032d8c5331f8f6690689620d6ae`와 일치.
+- Hosted CI: formatting, Clippy, cargo-deny, OpenXLA feature compile, metadata 검사, CLA 통과. 변경과 무관한 MLX pin extraction과 OpenXLA link job은 skip.
+- 구현, 보안/성능, finalization 리뷰는 raw-value 커버리지 추가 후 미해결 정확성 또는 보안 결함을 발견하지 못했다.
+
+## 5. 남은 검증 경계
+
+이 Linux 호스트에는 사용 가능한 NVIDIA driver와 Metal backend가 없어 실제 Muse Glimmer 다중 턴 GPU smoke test를 실행하지 못했다. 결정적 렌더 테스트와 Jinja 기준 비교는 수정된 프롬프트 바이트를 증명하지만 real-checkpoint 생성 증거로 주장하지 않는다.
+
+## 6. 관련 작업
+
+- Issue #1383: Python 스타일 `dict.get()`이 누락된 키에 `Undefined`를 반환하던 결함.
+- PR #1394: 이 보고서가 다루는 구현 및 리뷰 수정.
+- PR #1382 / issue #1309: 기존 종료 표식 결함을 발견한 인접 `tojson` 호환성 작업이며 이 PR의 변경 범위에는 포함되지 않음.

--- a/src/server/chat_template.rs
+++ b/src/server/chat_template.rs
@@ -2270,6 +2270,27 @@ mod tests {
     }
 
     #[test]
+    fn test_dict_get_method_preserves_present_null_and_falsy_values() {
+        let template = r#"null_none={{ messages[0].get('null_value') is none }} false_value={{ messages[0].get('flag') == false }} zero_value={{ messages[0].get('count') == 0 }} empty_value={{ messages[0].get('label') == '' }}"#;
+        let processor = ChatTemplateProcessor::with_template(template.to_string());
+        let messages = serde_json::json!([{
+            "role": "user",
+            "content": "hi",
+            "null_value": null,
+            "flag": false,
+            "count": 0,
+            "label": ""
+        }]);
+        let result = processor
+            .apply_raw_with_kwargs(&messages, None, &ChatTemplateKwargs::new())
+            .unwrap();
+        assert_eq!(
+            result.trim(),
+            "null_none=True false_value=True zero_value=True empty_value=True"
+        );
+    }
+
+    #[test]
     fn test_dict_get_method_or_chain() {
         // `m.get('a') or m.get('b')` — the Gemma 4 idiom.
         let template = r#"{{ messages[0].get('reasoning') or messages[0].get('content') }}"#;

--- a/src/server/chat_template.rs
+++ b/src/server/chat_template.rs
@@ -1347,9 +1347,11 @@ fn configure_environment(env: &mut Environment<'_>) {
         if value.kind() == ValueKind::Map {
             match method {
                 // Python-style `dict.get(key[, default])`: returns the
-                // value at `key` or `default` (or Undefined) when absent.
-                // Jinja2 treats Undefined as falsy, matching Python's
-                // `None` semantics in `m.get('a') or m.get('b')` chains.
+                // value at `key` or `default`, or Python `None` when the
+                // key is absent and no explicit default was supplied.
+                // `None` remains falsy, so `m.get('a') or m.get('b')`
+                // chains keep working while `is none` / `is defined`
+                // now match CPython Jinja semantics for missing keys.
                 "get" => {
                     let Some(key) = args.first() else {
                         return Err(minijinja::Error::new(
@@ -1357,7 +1359,7 @@ fn configure_environment(env: &mut Environment<'_>) {
                             "dict.get() requires at least one argument",
                         ));
                     };
-                    let default = args.get(1).cloned().unwrap_or(Value::UNDEFINED);
+                    let default = args.get(1).cloned().unwrap_or_else(|| Value::from(()));
                     return match value.get_item(key) {
                         Ok(v) if v.is_undefined() => Ok(default),
                         Ok(v) => Ok(v),
@@ -2253,6 +2255,18 @@ mod tests {
         }];
         let result = processor.apply(&messages, None).unwrap();
         assert_eq!(result.trim(), "NONE");
+    }
+
+    #[test]
+    fn test_dict_get_method_missing_key_is_none_and_defined() {
+        let template = r#"none={{ messages[0].get('missing_field') is none }} defined={{ messages[0].get('missing_field') is defined }}"#;
+        let processor = ChatTemplateProcessor::with_template(template.to_string());
+        let messages = vec![ChatMessage {
+            role: "user".to_string(),
+            content: "hi".to_string(),
+        }];
+        let result = processor.apply(&messages, None).unwrap();
+        assert_eq!(result.trim(), "none=True defined=True");
     }
 
     #[test]

--- a/src/server/muse_glimmer_template_tests.rs
+++ b/src/server/muse_glimmer_template_tests.rs
@@ -194,12 +194,13 @@ fn muse_glimmer_template_renders_default_system_text_image_and_turns() {
         None,
         &base,
     );
-    assert!(multi_turn.contains("Hello!"));
+    assert!(multi_turn.contains("<|message|>Hello!<|eot|>"));
+    assert!(!multi_turn.contains("<|message|>Hello!<|eom|>"));
     assert_render_hash(
         "multi_turn",
         &multi_turn,
         325,
-        "0b659b810b68a4162de9ae35c764b04ee67727eed81ac21ba93e01930a0bb119",
+        "433d37ff14caf2f2b177d904726b34ff09cb2aad4426a237a7b27772eab47007",
     );
 }
 
@@ -235,11 +236,13 @@ fn muse_glimmer_template_renders_tools_calls_and_results() {
     assert!(rendered.contains("// Function schemas"));
     assert!(rendered.contains("<atem:invoke name=\"weather.get_current\">"));
     assert!(rendered.contains("<tool_output name=\"weather.get_current\">"));
+    assert!(rendered.contains("<|message|>It is 29 C.<|eot|>"));
+    assert!(!rendered.contains("<|message|>It is 29 C.<|eom|>"));
     assert_render_hash(
         "tools_and_results",
         &rendered,
         2340,
-        "3d860a2454537255404bc2a68b757605f5d2f6d6e513b7fbe2dad6527cea42f5",
+        "dc451d3030d24f37ecc20fc0236c0b5fa7f70032d8c5331f8f6690689620d6ae",
     );
 }
 


### PR DESCRIPTION
## Summary

Align the shared Python-style `dict.get()` template shim with CPython Jinja2 so missing keys without an explicit default return `None`, allowing Muse Glimmer assistant turns to render the correct `<|eot|>` terminator.

## What changed

- Return Minijinja `None` for missing one-argument `dict.get()` calls while preserving falsy `or` chains and explicit defaults.
- Add direct coverage for `is none` and `is defined` behavior on a missing key, plus present JSON `null`, `false`, zero, and empty-string values through the raw render path.
- Re-pin the two affected Muse Glimmer reference renders to the exact Jinja2 3.1.6 digests and assert `<|eot|>` rather than `<|eom|>` by name.

## Test plan

- [x] `cargo fmt --all -- --check`
- [x] `cargo test -p mlxcel --profile test-fast --lib test_dict_get_method` (6 passed)
- [x] `cargo test -p mlxcel --profile test-fast --lib muse_glimmer_template_` (6 passed)
- [x] Jinja2 reference render: 325 bytes, SHA-256 `433d37ff14caf2f2b177d904726b34ff09cb2aad4426a237a7b27772eab47007`
- [ ] Real Muse Glimmer GPU smoke test (unavailable on this host: no usable NVIDIA driver or Metal backend)

Closes #1383
