### PR TITLE
fix(core): refuse quantized KV modes on MLA latent caches and perform the announced Turbo4 fallback

### DIFF
--- a/TECHNICAL_REPORTS/1395-mla-latent-turbo4-20260824.en.md
+++ b/TECHNICAL_REPORTS/1395-mla-latent-turbo4-20260824.en.md
@@ -1,0 +1,151 @@
+# Technical Report: PR #1395 - stop symmetric Turbo4 reading past its sign vectors on MLA latent caches
+
+**Date**: 2026-08-24
+**Author**: Jeongkyu Shin
+**Status**: Completed
+**Languages**: Rust
+**Risk Level**: High before the fix (an out-of-bounds read in shipping binaries, and a hard panic on one supported checkpoint)
+
+---
+
+## Executive Summary
+
+`KVCache::update_turbo4_sym` built one `TurboQuantParams` from the **V** head dimension and used it for K as well, guarded only by a `debug_assert_eq!`. Neither `[profile.release]` nor `[profile.test-fast]` enables `debug-assertions`, so that guard never ran in a shipped binary or in the test gate.
+
+The MLA-latent families cache a `(kv_latent, k_pe)` pair through the shared `KVCache`, so K is `kv_lora_rank` wide (512, or 640 on the families that concatenate a DSA indexer key) and V is `qk_rope_head_dim` wide (64). The K quantizer therefore ran a 64-entry sign vector over 512 or 640 coordinates: `from_slice_f32(signs1, &[1,1,1,512])` read 448 floats past the end of a 64-element slice, and 576 past on the indexer-carrying families.
+
+Reproduced before the fix: `glm4-flash-4bit --kv-cache-mode turbo4` emitted 40 tokens of `!` where `fp16` answered normally.
+
+Three things this change turned up that the issue did not describe.
+
+**A hard panic on a supported checkpoint.** `deepseek_v2` under `--kv-cache-mode turbo4` crashed with `wht: last axis must be a non-zero power of 2; got shape=[1, 16, 18, 192]`, by a different route: its decompressed path has K=192 and V=128, so it over-read a 128-entry sign vector by 256 bytes and died in the Walsh-Hadamard transform.
+
+**A silent contract inversion that outlived the crash.** Under the asymmetric modes the "V" slot of these caches holds `k_pe`, the RoPE **key** stream, so the mode quantized a key to 3, 4 or 8 bits while the latent (which is both K and V after absorption) stayed exact. Output stayed finite, which is why it went unnoticed, and `docs/turbo-kv-cache.md` documented the contract as "FP16 K, 4-bit V", which is not what happened.
+
+**A banner that promised a fallback nobody implemented.** The `turbo4` banner has always said "non-allowlisted models fall back to Turbo4Asym". `is_symmetric_turbo_allowed`'s only non-test caller was the advisor, and `cache.rs` asked callers to consult it in a **comment**. A documented precondition with no enforcement.
+
+## 1. Problem Statement
+
+### 1.1 Background
+
+Four families store a latent/rope pair in one `KVCache`: `glm4_moe_lite`, `deepseek_v3`, `kimi_linear`, `longcat_flash_ngram`. Review found a fifth call site, `deepseek_v32.rs:381`, reached by three more `model_type` strings (`deepseek_v32`, `deepseek_v3.2`, `glm_moe_dsa`, the last wrapping `DeepSeekV32Model`), with no guard of any kind.
+
+`deepseek_v2` is the one MLA family that already guarded: `MlaLatentCache::supports` returns `Err` for any non-Fp16 mode with the reasoning this issue wanted generalised.
+
+### 1.2 Existing Issues
+
+`ffi::from_slice_f32` builds an MLX array from a raw pointer and performs an eager copy with no length check of its own, so a dimension mismatch is an out-of-bounds read rather than a wrong answer. The only thing standing between a shipped binary and that read was an assertion the profile compiled out.
+
+### 1.3 Risk Assessment
+
+High. Two shipping checkpoint families produced garbage, one panicked, and three more silently inverted the documented quantization contract. The fix itself is a refusal, so its own risk is the opposite one: refusing too much would delete working configurations.
+
+## 2. Change Summary
+
+| Area | Change |
+|---|---|
+| `cache/turbo/quant.rs` | Dimension and sign-vector-length checks promoted from `debug_assert` to `assert`, on both `quantize_into_packed` and `dequantize_from_packed` |
+| `cache/turbo/quant3.rs`, `sparse_v.rs` | Same promotion at three more `from_slice_f32(signs, ...)` sites |
+| `mla/cache.rs` | Mode rule extracted to `latent_layout_supports_mode`; `MLA_LATENT_CACHE_FAMILIES` and `caches_mla_latent_pair` |
+| `cache.rs` | Unconditional K/V head-dim `assert_eq!` in `update_turbo4_sym` |
+| CLI and server | Real allowlist fallback; effective mode reported everywhere a mode is announced |
+| `server/routes/props.rs`, `types/response.rs` | `/props` now carries `kv_cache_mode` and `kv_bits` |
+| `commands/serve.rs`, `inspect.rs` | Memory preflights resolve the effective mode |
+| `execution/kv_cache_advisor.rs` | No longer recommends a mode the resolver refuses |
+| `docs/turbo-kv-cache.md` | The latent rule, the inverted contract, and the family list |
+
+## 3. Technical Decisions
+
+### 3.1 An assertion the profile deletes is not a guard
+
+The check was `debug_assert_eq!` and both shipping profiles leave `debug-assertions` off, so the precondition was documented and unenforced. It is now `assert!`, which is defensible specifically because the alternative is an out-of-bounds read: turning a wrong answer into a crash is a bad trade, but turning a memory-safety violation into a crash is the right one, and the check is O(1) against a call dominated by a Walsh-Hadamard transform and a host readback.
+
+Review found the same hazard at three sibling sites the issue never named (`quantize_v_turbo3`, `dequantize_v_turbo3`, and three `sparse_v` launchers). None is reachable through mlxcel's own paths today, because those modes build params from the V head dim and quantize only V. They were promoted anyway: `TurboQuantParams` has all-`pub` fields and no `#[non_exhaustive]`, so a short `signs1` is constructible by a struct literal, and a stated rule applied to one file and not its siblings is worse than not stating it.
+
+One placement decision worth recording: in `sparse_v` the assert goes **after** the existing power-of-two gate, not before. That gate is a legitimate graceful fallback for Gemma 4's 192-dimension heads, and asserting ahead of it would convert a working fallback into a panic.
+
+### 3.2 One rule, not two
+
+Rather than write a parallel rule for the latent families, the mode check was lifted out of `MlaLatentCache::supports` into `latent_layout_supports_mode`, which both `supports` and `resolve_kv_cache_mode_for_model` now call. The rule text and its reasoning exist once. `supports` is behaviourally identical for its original caller: same error text, same ordering.
+
+### 3.3 The issue asked for a change that would have deleted a working configuration
+
+The issue's step 3 asks for `deepseek_v2` to be declared a latent family. It was deliberately left off.
+
+`deepseek_v2` asks `supports` per forward call and falls through to a decompressed per-head layout when the mode is quantized. On that path K is `qk_nope_head_dim + qk_rope_head_dim` and V is `v_head_dim`, and both `Int8` and `Turbo4Asym` work, because params come from V only and K never reaches the WHT. Stronger still, its absorbed path is opt-in behind an environment variable and off by default, so it runs decompressed regardless. Listing it would have refused a mode that works. `turbo4` is separately fixed for it through the allowlist, which is what stops the panic in 3.4.
+
+A regression test pins the distinction so the next reader does not "complete" the list.
+
+### 3.4 A hard panic the issue did not know about
+
+`deepseek_v2` under `turbo4` crashed before this PR. DeepSeek-V2-Lite gives K=192 and V=128 on the decompressed path, so params built from V=128 drove `quantize_k_turbo4` over a 192-wide K: a 256-byte over-read at the copy, and then the observable failure one line later in the Walsh-Hadamard transform, whose own assert produced the quoted message.
+
+The fix prevents rather than relocates it: the resolver downgrades `Turbo4` to `Turbo4Asym`, which never calls `quantize_k_turbo4` and never sends a 192-wide K through the WHT.
+
+### 3.5 The doc was wrong about the latent width, for a reason nobody had noticed
+
+Review flagged `glm_moe_dsa`'s `kv_lora_rank` as possibly 128 rather than 512. That premise did not hold: the 128 sits inside a `#[cfg(test)]` fixture, and the real serde default is 512, matching its siblings.
+
+But the doc comment **was** wrong, differently. `deepseek_v32.rs:377-380` concatenates the DSA indexer key onto the latent before caching it, so on those three families the "K" slot is `kv_lora_rank + index_head_dim`, which is 640 on the one local `glm_moe_dsa` config, not 512. The over-read figure is correspondingly 576 floats there rather than 448. Both the doc comment and `docs/turbo-kv-cache.md` were corrected.
+
+Worth recording because the review's finding was wrong and still productive: checking a claim that turned out false is what surfaced the true one next to it.
+
+### 3.6 Announcing the effective mode, and a mirror-image bug in the server
+
+The `turbo4` banner promised a fallback that no code performed. Making it real meant every surface that announces a mode had to report the **effective** one.
+
+Implementing that turned up the same class of problem one layer down: `into_startup_config` runs **before** `initialize_server_logging`, so the new warning went to no subscriber. The server did the right fallback and said nothing about it, which is the original defect mirrored. Notices now ride on `ServerStartupConfig::kv_cache_mode_notices` and are emitted after logging is up, with an `effective KV cache mode` line.
+
+Two more surfaces were resolving the requested mode rather than the effective one, both memory preflights (`serve.rs`, `inspect.rs`), the same bug already fixed in `generate.rs`. The consequence was measurable: on `glm4-flash-4bit` at 32768 tokens, `--kv-cache-mode int8` reported **14.69 GiB** of KV against a real **29.38 GiB**, a 2x under-count, and that estimate can hard-abort startup. Both now report 29.38, while the `llama-3.1-8b-4bit` control still halves correctly.
+
+`mlxcel recommend` was also advising `Int8` for MLA classes that the resolver now refuses, so it would have told operators to use a mode the binary rejects. It now branches on the latent-family predicate.
+
+## 4. Verification
+
+### 4.1 The reproduction, before and after
+
+`models/glm4-flash-4bit`, `-n 40 -t 0 --seed 1350`, against a baseline binary built from the same merge base with the change reverted by path:
+
+| Mode | Before | After |
+|---|---|---|
+| `fp16` | coherent, 46.16 tok/s | coherent, 46.67 tok/s |
+| `turbo4` | **40 tokens of `!`**, 12.06 tok/s | coherent, banner says `fp16 (requested turbo4; not supported on this model family)` |
+| `turbo4-asym` | coherent but **different from fp16** | identical to fp16 |
+
+Computed, not eyeballed: after the change `fp16 vs turbo4` and `fp16 vs turbo4-asym` are both IDENTICAL; before, both were DIFFERENT. That last comparison is the evidence for the quieter defect, which produced fluent output and so left no visible trace.
+
+### 4.2 What must not change
+
+`models/qwen3.5-0.8b-4bit` (`qwen3_5`, on the symmetric allowlist) keeps symmetric Turbo4 and is **byte-identical** before and after, as is its `fp16`. Only the banner changed, because that arm can no longer take a fallback. A full re-capture across all seven mode/model combinations after the review fixes was diffed against the first round and is identical modulo timing lines.
+
+### 4.3 Gate
+
+`cargo test --workspace --profile test-fast --features metal,accelerate`: 8399 passed, 0 failed before the review fixes. Local CI (8 of the 10 `ci.yml` jobs; GitHub Actions unavailable this session): 7 pass, 0 fail, 2 skip, the skips needing CUDA and this change touching no XLA path. Real-model gate on `glm4-flash-4bit` and `llama-3.1-8b-4bit`: both PASS.
+
+Clippy was run on `-p mlxcel --bins` as well as `--lib --tests`, which matters here: `serve.rs` and `inspect.rs` are binary-target modules that `--lib --tests` never compiles.
+
+## 5. Findings from Review
+
+One HIGH, four MEDIUM, two LOW, all applied.
+
+The HIGH was a **fifth latent call site**. `MLA_LATENT_CACHE_FAMILIES` listed four families; `deepseek_v32.rs:381` caches the same latent/rope pair with zero guards, and three `model_type` strings reach it. Because `caches_mla_latent_pair` matches exactly by design, `"deepseek_v3"` did not cover `"deepseek_v32"`.
+
+The memory-safety half was incidentally covered, since those families are not on the symmetric allowlist and so were already downgraded. But the PR's **own** second-defect claim was not true for them: the asymmetric modes and the server `--kv-bits` route still quantized their `k_pe` key stream, silently, because `k_pe` is 64 wide and therefore a valid power of two that faults on nothing.
+
+That is worth generalising: a claim of the form "this change closes defect X" needs the same enumeration discipline as the fix itself. Fixing four of five call sites and describing it as closed is the more dangerous outcome, because the description stops the next person from looking.
+
+## 6. What Remains Unverified
+
+**No `deepseek_v32` or `deepseek_v3.2` checkpoint exists locally.** The only `glm_moe_dsa` checkpoint, `models/glm-5-4bit`, is a partial download with no weights and no tokenizer. The refusal path is fully exercised on it, because the resolver runs before model load, but end-to-end generation on those three families could not be driven. Their behaviour is inferred from `glm4_moe_lite`, which shares the identical code path and was measured directly.
+
+`deepseek_v3`, `kimi_linear` and `longcat_flash_ngram` likewise have no local checkpoint; the latent rule is verified on real hardware only through `glm4_moe_lite`, with unit tests covering the rest.
+
+No perplexity or long-context quality measurement. Every real-model check here is short-prompt.
+
+## 7. Learning Points
+
+- An assertion that the shipping profile deletes is documentation, not a guard. If the precondition it protects is memory safety, the check belongs in the shipped binary, and the O(1) cost is not the deciding factor.
+- Enumerate call sites mechanically, not from the issue's list. Four of five were found by following the issue; the fifth was found by grepping for the pattern.
+- A "closes defect X" claim needs the same rigour as the fix. Closing it on four of five families and saying so is worse than saying nothing, because the claim stops the next reader from checking.
+- A refusal-shaped fix has an inverted risk profile: the danger is refusing too much. The issue asked for `deepseek_v2` to be listed, which would have deleted a configuration that works, and the reason it works only becomes visible by reading its per-call fallback.
+- A wrong review finding can still be productive. The `kv_lora_rank: 128` premise was false, and checking it surfaced the true error next to it: the indexer key makes the latent 640 wide, not 512.

--- a/TECHNICAL_REPORTS/1395-mla-latent-turbo4-20260824.ko.md
+++ b/TECHNICAL_REPORTS/1395-mla-latent-turbo4-20260824.ko.md
@@ -1,0 +1,151 @@
+# 기술 보고서: PR #1395 - MLA latent 캐시에서 symmetric Turbo4가 sign 벡터 밖을 읽던 문제 수정
+
+**날짜**: 2026-08-24
+**작성자**: 신정규
+**상태**: 완료
+**언어/기술**: Rust
+**위험도**: 수정 전 높음 (출하 바이너리의 범위 밖 읽기, 지원 체크포인트 하나에서 하드 패닉)
+
+---
+
+## 요약
+
+`KVCache::update_turbo4_sym`이 **V** head 차원으로 만든 `TurboQuantParams` 하나를 K에도 썼고, 가드는 `debug_assert_eq!` 하나였다. `[profile.release]`도 `[profile.test-fast]`도 `debug-assertions`를 켜지 않으므로 **출하 바이너리와 테스트 게이트 어디서도 그 가드가 돈 적이 없다.**
+
+MLA-latent 계열은 `(kv_latent, k_pe)` 쌍을 공유 `KVCache`로 캐시하므로 K는 `kv_lora_rank` 폭(512, DSA 인덱서 키를 이어붙이는 계열은 640)이고 V는 `qk_rope_head_dim` 폭(64)이다. 그래서 K 양자화기가 **64개짜리 sign 벡터를 512 또는 640 좌표에** 적용했다. `from_slice_f32(signs1, &[1,1,1,512])`가 64개 슬라이스 끝을 **448 float 넘어** 읽고, 인덱서 보유 계열에서는 576 넘어 읽었다.
+
+수정 전 재현: `glm4-flash-4bit --kv-cache-mode turbo4`가 40토큰 전부 `!`를 냈고 `fp16`은 정상이었다.
+
+이 변경이 드러낸, 이슈가 기술하지 않은 것 셋.
+
+**지원 체크포인트에서의 하드 패닉.** `deepseek_v2`가 `--kv-cache-mode turbo4`에서 `wht: last axis must be a non-zero power of 2; got shape=[1, 16, 18, 192]`로 죽었다. 경로가 다르다. decompressed 경로가 K=192/V=128이라 128개 sign 벡터를 256바이트 넘어 읽고 Walsh-Hadamard 변환에서 죽는다.
+
+**크래시보다 오래 살아남은 조용한 계약 역전.** 비대칭 모드에서 이 캐시들의 "V" 슬롯은 `k_pe`, 즉 RoPE **키** 스트림이다. 그래서 모드가 **키를 3·4·8비트로 양자화하고** latent(흡수 후에는 K이자 V다)는 정확한 채로 뒀다. 출력이 유한해서 아무도 못 봤고, `docs/turbo-kv-cache.md`는 계약을 "FP16 K, 4-bit V"로 문서화하고 있었다.
+
+**아무도 구현하지 않은 폴백을 약속하던 배너.** `turbo4` 배너는 늘 "non-allowlisted models fall back to Turbo4Asym"이라고 말해 왔다. `is_symmetric_turbo_allowed`의 유일한 비테스트 호출자는 advisor였고, `cache.rs`는 호출자에게 그것을 참조하라고 **주석으로** 요구했다. 강제 없는 문서화된 전제조건이다.
+
+## 1. 문제 정의
+
+### 1.1 배경
+
+네 계열이 latent/rope 쌍을 하나의 `KVCache`에 저장한다. `glm4_moe_lite`, `deepseek_v3`, `kimi_linear`, `longcat_flash_ngram`. 리뷰가 **다섯 번째 호출 지점** `deepseek_v32.rs:381`을 찾았고, 여기에 `model_type` 문자열 셋(`deepseek_v32`, `deepseek_v3.2`, `glm_moe_dsa`. 마지막은 `DeepSeekV32Model`을 감싼다)이 도달하는데 **가드가 전혀 없다.**
+
+`deepseek_v2`는 이미 가드하던 유일한 MLA 계열이다. `MlaLatentCache::supports`가 비-Fp16 모드에 대해 이 이슈가 일반화하려던 바로 그 근거로 `Err`을 돌려준다.
+
+### 1.2 기존 문제
+
+`ffi::from_slice_f32`는 raw 포인터에서 MLX 배열을 만들며 **자기 길이 검사 없이 즉시 복사**한다. 그래서 차원 불일치는 틀린 답이 아니라 범위 밖 읽기다. 출하 바이너리와 그 읽기 사이에 있던 유일한 것이 프로파일이 컴파일 아웃한 단언이었다.
+
+### 1.3 위험 평가
+
+높음. 출하 중인 체크포인트 계열 둘이 쓰레기를 냈고, 하나가 패닉했고, 셋이 더 문서화된 양자화 계약을 조용히 역전시켰다. 수정 자체는 **거절**이므로 위험이 반대다. 너무 많이 거절하면 잘 돌던 구성이 삭제된다.
+
+## 2. 변경 요약
+
+| 영역 | 변경 |
+|---|---|
+| `cache/turbo/quant.rs` | 차원·sign 벡터 길이 검사를 `debug_assert`에서 `assert`로 승격. `quantize_into_packed`와 `dequantize_from_packed` 양쪽 |
+| `cache/turbo/quant3.rs`, `sparse_v.rs` | `from_slice_f32(signs, ...)` 3곳에 같은 승격 |
+| `mla/cache.rs` | 모드 규칙을 `latent_layout_supports_mode`로 추출. `MLA_LATENT_CACHE_FAMILIES`, `caches_mla_latent_pair` |
+| `cache.rs` | `update_turbo4_sym`의 K/V head-dim 무조건 `assert_eq!` |
+| CLI·서버 | 실제 allowlist 폴백. 모드를 알리는 모든 곳에서 **실효** 모드 보고 |
+| `server/routes/props.rs`, `types/response.rs` | `/props`가 `kv_cache_mode`·`kv_bits` 노출 |
+| `commands/serve.rs`, `inspect.rs` | 메모리 preflight가 실효 모드를 해석 |
+| `execution/kv_cache_advisor.rs` | resolver가 거부하는 모드를 더는 권고하지 않음 |
+| `docs/turbo-kv-cache.md` | latent 규칙, 역전된 계약, 계열 목록 |
+
+## 3. 기술적 선택과 그 이유
+
+### 3.1 프로파일이 지우는 단언은 가드가 아니다
+
+검사가 `debug_assert_eq!`였고 출하 프로파일 둘 다 `debug-assertions`를 끄므로, 전제조건이 문서화만 되고 강제되지 않았다. 이제 `assert!`인데, 이 선택이 정당한 이유가 구체적이다. **대안이 범위 밖 읽기이기 때문이다.** 틀린 답을 크래시로 바꾸는 것은 나쁜 거래지만 메모리 안전성 위반을 크래시로 바꾸는 것은 옳은 거래이고, 이 검사는 Walsh-Hadamard 변환과 host readback이 지배하는 호출에 대해 O(1)이다.
+
+리뷰가 이슈가 언급하지 않은 형제 3곳에서 같은 위험을 찾았다(`quantize_v_turbo3`, `dequantize_v_turbo3`, `sparse_v` 런처 셋). 오늘 mlxcel 자기 경로로는 도달 불가다. 그 모드들은 V head dim으로 params를 만들고 V만 양자화하기 때문이다. 그래도 승격했다. `TurboQuantParams`가 필드 전부 `pub`이고 `#[non_exhaustive]`도 아니라 짧은 `signs1`을 구조체 리터럴로 만들 수 있고, **한 파일에만 적용하고 형제에는 적용하지 않은 규칙은 규칙을 세우지 않느니만 못하다.**
+
+기록해 둘 배치 판단 하나: `sparse_v`에서 assert를 기존 2의 거듭제곱 게이트 **뒤**에 뒀다. 그 게이트는 Gemma 4의 192차원 head에 대한 **정당한 우아한 폴백**이고, 앞에 두면 잘 돌던 폴백이 패닉이 된다.
+
+### 3.2 규칙 하나, 둘이 아니라
+
+latent 계열용 병렬 규칙을 쓰는 대신, 모드 검사를 `MlaLatentCache::supports`에서 `latent_layout_supports_mode`로 들어냈고 `supports`와 `resolve_kv_cache_mode_for_model`이 둘 다 그것을 부른다. 규칙 문장과 그 근거가 한 곳에만 존재한다. `supports`는 원래 호출자에 대해 동작이 동일하다. 같은 에러 문구, 같은 순서.
+
+### 3.3 이슈가 요구한 변경이 잘 돌던 구성을 삭제할 뻔했다
+
+이슈 3단계는 `deepseek_v2`를 latent 계열로 선언하라고 한다. **의도적으로 빼뒀다.**
+
+`deepseek_v2`는 forward 호출마다 `supports`를 묻고, 모드가 양자화면 decompressed per-head layout으로 떨어진다. 그 경로에서 K는 `qk_nope_head_dim + qk_rope_head_dim`, V는 `v_head_dim`이고 `Int8`과 `Turbo4Asym`이 **정상 동작한다.** params가 V에서만 오고 K는 WHT에 닿지 않기 때문이다. 더 강하게는, 그 계열의 흡수 경로가 환경변수 opt-in이고 기본 off라 어차피 decompressed로 돈다. 목록에 넣었으면 **동작하는 모드를 거절**했을 것이다. `turbo4`는 allowlist로 따로 고쳐지고, 그것이 3.4의 패닉을 막는다.
+
+다음 독자가 목록을 "완성"하지 않도록 회귀 테스트로 구분을 고정했다.
+
+### 3.4 이슈가 몰랐던 하드 패닉
+
+`deepseek_v2`가 이 PR 전에 `turbo4`에서 죽었다. DeepSeek-V2-Lite는 decompressed 경로에서 K=192/V=128을 준다. V=128로 만든 params가 192 폭 K에 `quantize_k_turbo4`를 돌려 복사 시점에 256바이트를 넘어 읽고, 관측되는 실패는 한 줄 뒤 Walsh-Hadamard 변환에서 그 자신의 assert가 인용된 메시지를 낸다.
+
+수정은 옮기지 않고 **막는다.** resolver가 `Turbo4`를 `Turbo4Asym`으로 강등하고, 그 모드는 `quantize_k_turbo4`를 부르지도 192 폭 K를 WHT에 보내지도 않는다.
+
+### 3.5 문서가 latent 폭에 대해 틀렸는데, 아무도 눈치채지 못한 이유로
+
+리뷰가 `glm_moe_dsa`의 `kv_lora_rank`가 512가 아니라 128일 수 있다고 지적했다. **그 전제는 틀렸다.** 128은 `#[cfg(test)]` 픽스처 안에 있고 실제 serde 기본값은 형제들과 같은 512다.
+
+그런데 doc 주석은 **다른 이유로 틀려 있었다.** `deepseek_v32.rs:377-380`이 캐시 전에 DSA 인덱서 키를 latent에 이어붙이므로, 이 세 계열의 "K" 슬롯은 `kv_lora_rank + index_head_dim`이고 로컬 `glm_moe_dsa` 설정에서는 512가 아니라 **640**이다. 범위 밖 읽기 수치도 거기서는 448이 아니라 576 float다. doc 주석과 `docs/turbo-kv-cache.md` 양쪽을 정정했다.
+
+기록할 값어치가 있는 이유: **리뷰의 지적이 틀렸는데도 생산적이었다.** 거짓으로 판명된 주장을 확인하는 과정이 그 옆의 참인 오류를 드러냈다.
+
+### 3.6 실효 모드 알리기, 그리고 서버의 거울상 버그
+
+`turbo4` 배너가 어떤 코드도 수행하지 않는 폴백을 약속했다. 그것을 실제로 만들려면 모드를 알리는 **모든** 표면이 실효 모드를 보고해야 했다.
+
+구현하다 한 층 아래에서 같은 부류의 문제가 나왔다. `into_startup_config`가 `initialize_server_logging`보다 **먼저** 돌아서 새 경고가 구독자 없는 곳으로 갔다. **서버가 올바른 폴백을 하면서 그것에 대해 아무 말도 안 한 것**이고, 이는 원래 결함의 거울상이다. 이제 통지가 `ServerStartupConfig::kv_cache_mode_notices`에 실려 로깅이 선 뒤에 방출되고 `effective KV cache mode` 줄이 함께 나간다.
+
+두 표면이 더 실효가 아닌 요청 모드를 해석하고 있었다. 둘 다 메모리 preflight(`serve.rs`, `inspect.rs`)이고 `generate.rs`에서 이미 고친 같은 버그다. 결과가 측정됐다. `glm4-flash-4bit` 32768토큰에서 `--kv-cache-mode int8`이 실제 **29.38 GiB**에 대해 **14.69 GiB**를 보고했다. **2배 과소 계상**이고, 그 추정이 기동을 하드 중단시킬 수 있다. 이제 둘 다 29.38을 보고하고, `llama-3.1-8b-4bit` 대조군은 여전히 정상적으로 절반이 된다.
+
+`mlxcel recommend`도 resolver가 이제 거부하는 MLA 분류에 `Int8`을 권고하고 있어, 운영자에게 바이너리가 거부하는 모드를 쓰라고 말할 참이었다. 이제 latent 계열 술어로 분기한다.
+
+## 4. 검증
+
+### 4.1 재현, 전과 후
+
+`models/glm4-flash-4bit`, `-n 40 -t 0 --seed 1350`, 같은 머지 베이스에서 변경을 경로별로 되돌려 만든 기준 바이너리 대조:
+
+| 모드 | 전 | 후 |
+|---|---|---|
+| `fp16` | 정상, 46.16 tok/s | 정상, 46.67 tok/s |
+| `turbo4` | **40토큰 `!`**, 12.06 tok/s | 정상, 배너 `fp16 (requested turbo4; not supported on this model family)` |
+| `turbo4-asym` | 정상이나 **fp16과 다름** | fp16과 동일 |
+
+눈으로가 아니라 계산으로: 변경 후 `fp16 vs turbo4`와 `fp16 vs turbo4-asym`이 둘 다 IDENTICAL, 변경 전에는 둘 다 DIFFERENT. **마지막 비교가 조용한 결함의 증거다.** 유창한 출력을 내서 눈에 보이는 흔적을 남기지 않았다.
+
+### 4.2 바뀌면 안 되는 것
+
+`models/qwen3.5-0.8b-4bit`(`qwen3_5`, symmetric allowlist 소속)는 symmetric Turbo4를 유지하고 변경 전후 **바이트 동일**이며 `fp16`도 그렇다. 배너만 바뀌었는데, 그 arm은 이제 폴백을 탈 수 없기 때문이다. 리뷰 수정 후 7개 모드/모델 조합 전체를 재포착해 1라운드 결과와 diff한 것도 타이밍 줄을 빼면 동일하다.
+
+### 4.3 게이트
+
+`cargo test --workspace --profile test-fast --features metal,accelerate`: 리뷰 수정 전 8399 통과, 0 실패. 로컬 CI(`ci.yml` 잡 10개 중 8개, 이번 세션 GitHub Actions 불가): 7 pass, 0 fail, 2 skip. skip 둘은 CUDA가 필요하고 이 변경은 XLA 경로를 안 건드린다. 실모델 게이트 `glm4-flash-4bit`·`llama-3.1-8b-4bit` 둘 다 PASS.
+
+clippy를 `--lib --tests`뿐 아니라 `-p mlxcel --bins`에도 돌렸다. 여기서 중요한데, `serve.rs`와 `inspect.rs`는 `--lib --tests`가 절대 컴파일하지 않는 바이너리 타깃 모듈이다.
+
+## 5. 리뷰에서 나온 지적
+
+HIGH 1건, MEDIUM 4건, LOW 2건, 전부 반영.
+
+HIGH는 **다섯 번째 latent 호출 지점**이었다. `MLA_LATENT_CACHE_FAMILIES`가 네 계열을 나열했는데 `deepseek_v32.rs:381`이 같은 latent/rope 쌍을 가드 없이 캐시하고 `model_type` 문자열 셋이 거기 도달한다. `caches_mla_latent_pair`가 설계상 정확 일치라 `"deepseek_v3"`가 `"deepseek_v32"`를 덮지 않았다.
+
+메모리 안전성 절반은 우연히 막혔다. 그 계열들이 symmetric allowlist에 없어 이미 강등되기 때문이다. 그러나 **PR 자신의 두 번째 결함 주장이 그들에 대해 참이 아니었다.** 비대칭 모드와 서버 `--kv-bits` 경로가 여전히 그들의 `k_pe` 키 스트림을 양자화했고, `k_pe`가 64 폭이라 유효한 2의 거듭제곱이고 아무것도 fault하지 않아 조용했다.
+
+일반화할 값어치가 있다. **"이 변경이 결함 X를 닫는다"는 주장은 수정 자체와 같은 열거 규율을 요구한다.** 다섯 중 넷을 고치고 닫혔다고 기술하는 것이 더 위험하다. 그 기술이 다음 사람이 들여다보는 것을 막기 때문이다.
+
+## 6. 검증하지 못한 것
+
+**`deepseek_v32`나 `deepseek_v3.2` 체크포인트가 로컬에 없다.** 유일한 `glm_moe_dsa` 체크포인트 `models/glm-5-4bit`는 가중치도 토크나이저도 없는 부분 다운로드다. resolver가 모델 로드 전에 돌기 때문에 거절 경로는 그 위에서 완전히 실행되지만, 세 계열의 종단 간 생성은 구동할 수 없었다. 동작은 동일 코드 경로를 공유하며 직접 측정된 `glm4_moe_lite`에서 추론했다.
+
+`deepseek_v3`, `kimi_linear`, `longcat_flash_ngram`도 로컬 체크포인트가 없다. latent 규칙은 실하드웨어에서 `glm4_moe_lite`로만 검증됐고 나머지는 단위 테스트가 덮는다.
+
+perplexity나 장문맥 품질 측정은 없다. 여기 모든 실모델 검사는 짧은 프롬프트다.
+
+## 7. 학습 포인트
+
+- **출하 프로파일이 지우는 단언은 가드가 아니라 문서다.** 그것이 지키는 전제조건이 메모리 안전성이라면 검사는 출하 바이너리에 있어야 하고, O(1) 비용은 판단 요소가 아니다.
+- **호출 지점은 이슈의 목록이 아니라 기계적으로 열거한다.** 다섯 중 넷은 이슈를 따라가 찾았고, 다섯째는 패턴을 grep해서 찾았다.
+- **"결함 X를 닫는다"는 주장은 수정과 같은 엄밀함을 요구한다.** 다섯 계열 중 넷에서 닫고 그렇게 말하는 것은 아무 말도 안 하느니만 못하다. 그 주장이 다음 독자의 확인을 막는다.
+- **거절 형태의 수정은 위험 프로파일이 반대다.** 위험은 너무 많이 거절하는 쪽이다. 이슈는 `deepseek_v2`를 목록에 넣으라고 했고 그러면 동작하는 구성이 삭제됐을 텐데, 그것이 동작하는 이유는 호출별 폴백을 읽어야만 보인다.
+- **틀린 리뷰 지적도 생산적일 수 있다.** `kv_lora_rank: 128` 전제는 거짓이었고, 그것을 확인하는 과정이 그 옆의 참인 오류(인덱서 키 때문에 latent가 512가 아니라 640)를 드러냈다.

--- a/docs/turbo-kv-cache.md
+++ b/docs/turbo-kv-cache.md
@@ -174,9 +174,14 @@ prefixes are:
 Do not assume `turbo4` is safe for other dense 4-bit checkpoints. The safer
 starting point is `fp16+turbo4`, which keeps K in FP16.
 
-Note: the allowlist helper exists in `mlxcel-core`, but callers still need to
-consult it before constructing a symmetric Turbo4 cache. If you are adding a new
-entry or a new caller, include a quality gate in the same change.
+The fallback is performed, not merely advertised. Every generation entry point
+resolves the requested mode through
+`cache::turbo::resolve_kv_cache_mode_for_model` before any cache is built, so
+`--kv-cache-mode turbo4` on a family outside this list serves as
+`fp16+turbo4` and says so on stderr and in the server log. The mode reported in
+the CLI banner, the server startup log and `/props` is the effective mode, not
+the requested one. If you are adding a new entry, include a quality gate in the
+same change.
 
 ## WHT head-dimension constraint
 
@@ -184,6 +189,33 @@ TurboQuant uses a Walsh-Hadamard transform. The implementation expects a
 power-of-two head dimension for the production path. Models with unsupported
 head dimensions must either reject TurboQuant for that cache path or use a
 family-specific fallback; do not silently pad without a quality test.
+
+## MLA latent caches are FP16 only
+
+`glm4_moe_lite`, `deepseek_v3`, `kimi_linear` and `longcat_flash_ngram` store an
+MLA `(kv_latent, k_pe)` pair in one `KVCache`: the "K" slot holds the
+`kv_lora_rank`-wide latent (512 in every shipping checkpoint) and the "V" slot
+holds the `qk_rope_head_dim`-wide RoPE key stream (64). Neither slot is a
+per-head K/V row, so no quantized mode is calibrated for what they contain:
+
+- Symmetric `turbo4` builds its sign vectors and codebook from the "V" width and
+  applies them to the "K" slot as well, reading 448 floats past the end of a
+  64-entry sign vector. On `glm4-flash` every generated token came out `!`.
+- The asymmetric modes (`fp16+turbo4`, `fp16+turbo3`, `turbo4-delegated`)
+  quantize only the "V" slot, which here is `k_pe`. They therefore compress a
+  **key** and leave the latent exact, which is the reverse of the "FP16 K,
+  4-bit V" contract in the mode table above. Output stayed finite, which is why
+  this went unnoticed.
+
+Any non-`fp16` mode requested for one of these families resolves to `fp16` with
+one warning naming the family and the requested mode. `deepseek_v2` is not in
+this set: it asks `MlaLatentCache::supports` per cache and falls back to the
+decompressed per-head K/V layout when the mode is quantized, so a quantized mode
+there lands on ordinary per-head rows and keeps working.
+
+Making a Turbo mode work on the latent layout is a new calibration and a new
+kernel (a 512-wide codebook for the latent with `k_pe` left at FP16), not a
+configuration change.
 
 ## Paged cache and server batching
 
@@ -430,3 +462,5 @@ require local model checkouts.
   have different bottlenecks from the developer benchmark machines.
 - Experimental environment-variable paths are useful for A/B testing but should
   not appear in user-facing recommendations without fresh benchmark data.
+- No TurboQuant or INT8 mode is available on the MLA latent families listed
+  above; they serve at FP16 whatever is requested.

--- a/docs/turbo-kv-cache.md
+++ b/docs/turbo-kv-cache.md
@@ -179,9 +179,10 @@ resolves the requested mode through
 `cache::turbo::resolve_kv_cache_mode_for_model` before any cache is built, so
 `--kv-cache-mode turbo4` on a family outside this list serves as
 `fp16+turbo4` and says so on stderr and in the server log. The mode reported in
-the CLI banner, the server startup log and `/props` is the effective mode, not
-the requested one. If you are adding a new entry, include a quality gate in the
-same change.
+the CLI banner, the server startup log and the `/props` payload
+(`kv_cache_mode`, `kv_bits`, when the endpoint is enabled with `--props`) is the
+effective mode, not the requested one. If you are adding a new entry, include a
+quality gate in the same change.
 
 ## WHT head-dimension constraint
 
@@ -192,15 +193,20 @@ family-specific fallback; do not silently pad without a quality test.
 
 ## MLA latent caches are FP16 only
 
-`glm4_moe_lite`, `deepseek_v3`, `kimi_linear` and `longcat_flash_ngram` store an
-MLA `(kv_latent, k_pe)` pair in one `KVCache`: the "K" slot holds the
-`kv_lora_rank`-wide latent (512 in every shipping checkpoint) and the "V" slot
-holds the `qk_rope_head_dim`-wide RoPE key stream (64). Neither slot is a
-per-head K/V row, so no quantized mode is calibrated for what they contain:
+`glm4_moe_lite`, `deepseek_v3`, `deepseek_v32` (also spelled `deepseek_v3.2`),
+`glm_moe_dsa`, `kimi_linear` and `longcat_flash_ngram` store an MLA
+`(kv_latent, k_pe)` pair in one `KVCache`: the "K" slot holds the
+`kv_lora_rank`-wide latent (512 in the shipping checkpoints) and the "V" slot
+holds the `qk_rope_head_dim`-wide RoPE key stream (64). `deepseek_v32`,
+`deepseek_v3.2` and `glm_moe_dsa` concatenate the `index_head_dim`-wide DSA
+indexer key onto the same "K" slot, so theirs is 640 wide at the default
+`index_head_dim` of 128. Neither slot is a per-head K/V row at any of those
+widths, so no quantized mode is calibrated for what they contain:
 
 - Symmetric `turbo4` builds its sign vectors and codebook from the "V" width and
   applies them to the "K" slot as well, reading 448 floats past the end of a
-  64-entry sign vector. On `glm4-flash` every generated token came out `!`.
+  64-entry sign vector (576 on the indexer-carrying families). On `glm4-flash`
+  every generated token came out `!`.
 - The asymmetric modes (`fp16+turbo4`, `fp16+turbo3`, `turbo4-delegated`)
   quantize only the "V" slot, which here is `k_pe`. They therefore compress a
   **key** and leave the latent exact, which is the reverse of the "FP16 K,

--- a/src/bin/bench_decode.rs
+++ b/src/bin/bench_decode.rs
@@ -30,7 +30,9 @@ use std::path::{Path, PathBuf};
 
 use anyhow::{Context, Result};
 use clap::Parser;
-use mlxcel::cli::turbo_args::{TurboKvCacheArgs, resolve_kv_cache_mode};
+use mlxcel::cli::turbo_args::{
+    TurboKvCacheArgs, resolve_and_announce_kv_cache_mode, resolve_kv_cache_mode,
+};
 use mlxcel::sampling::{ResolvedSamplingParams, build_sampling_config};
 use mlxcel::server::chat_template::{ChatMessage, ChatTemplateProcessor};
 use mlxcel::tokenizer::{MlxcelTokenizer, load_tokenizer};
@@ -379,6 +381,10 @@ fn main() -> Result<()> {
         args.turbo.kv_cache_mode.as_deref(),
     )
     .map_err(|err| anyhow::anyhow!("{err}"))?;
+    // issue #1350: benchmark the mode the shipped binaries would actually
+    // build for this model, so a number reported as `turbo4` is never really
+    // an fp16 or fp16+turbo4 run.
+    let kv_cache_mode = resolve_and_announce_kv_cache_mode(kv_cache_mode, &args.model);
 
     // Keep `--turbo-boundary-v` semantics identical to `mlxcel generate`.
     // This must happen before any generator/cache construction.

--- a/src/cli/turbo_args.rs
+++ b/src/cli/turbo_args.rs
@@ -31,8 +31,11 @@
 //!
 //! See `docs/turbo-kv-cache.md` for the operator-facing reference.
 
+use std::path::Path;
+
 use clap::Args;
 use mlxcel_core::cache::KVCacheMode;
+use mlxcel_core::cache::turbo::resolve_kv_cache_mode_for_model;
 
 /// Shared TurboQuant KV-cache flag group.
 ///
@@ -319,6 +322,87 @@ fn apply_optional_string_env_fallback(value: &mut Option<String>, key: &str, fla
             *value = Some(trimmed);
         }
     }
+}
+
+/// Second stage of KV-cache mode resolution: turn the mode the operator asked
+/// for into the mode this particular model can actually run.
+///
+/// [`resolve_kv_cache_mode`] turns flags into a [`KVCacheMode`] without knowing
+/// which model is being loaded. Two rules need the model, and both were
+/// documented long before anything performed them (issue #1350):
+///
+/// * The MLA-latent families (`glm4_moe_lite`, `deepseek_v3`, `kimi_linear`,
+///   `longcat_flash_ngram`) pack a `(kv_latent, k_pe)` pair into one cache, so
+///   no quantized mode is calibrated for what they store. Symmetric `turbo4`
+///   made the K quantizer read past its sign vectors and every generated token
+///   came out `!`; the asymmetric modes quietly compressed the RoPE key stream
+///   instead of a value. They resolve to `fp16`.
+/// * `turbo4` on a family outside `ALLOWED_SYMMETRIC_TURBO_FAMILIES` resolves
+///   to `fp16+turbo4`, which is the fallback the CLI banner has always
+///   described.
+///
+/// Every generation entry point (CLI `generate`, the chat REPL, the memory
+/// preflight, `mlxcel-server`, and `bench_decode`) calls this so the mode that
+/// is announced is the mode the caches are built with. Returns the effective
+/// mode plus, when it differs from the request, one line for the operator.
+///
+/// `model_path` is a resolved local model directory. A missing or unparsable
+/// `config.json` yields `(requested, None)`: this stage must not invent a
+/// downgrade from a model it could not identify, and the unconditional head-dim
+/// assertions in `cache::turbo::quant` remain the backstop for that case.
+///
+/// Used by: `commands::generate`, `commands::chat`, `server::cli_input`,
+/// `bin/bench_decode`.
+#[must_use]
+pub fn resolve_effective_kv_cache_mode(
+    requested: KVCacheMode,
+    model_path: &Path,
+) -> (KVCacheMode, Option<String>) {
+    let Some(model_type) = read_config_model_type(model_path) else {
+        return (requested, None);
+    };
+    resolve_kv_cache_mode_for_model(requested, &model_type)
+}
+
+/// Apply [`resolve_effective_kv_cache_mode`] and report the substitution once
+/// on stderr.
+///
+/// stderr rather than stdout so a downgrade notice never lands in piped
+/// generation output, and `tracing::warn!` as well so it is captured in the
+/// server's structured log.
+///
+/// Used by: the CLI generation entry points; the server logs through
+/// `tracing` alone and calls [`resolve_effective_kv_cache_mode`] directly.
+#[must_use]
+pub fn resolve_and_announce_kv_cache_mode(
+    requested: KVCacheMode,
+    model_path: &Path,
+) -> KVCacheMode {
+    let (effective, warning) = resolve_effective_kv_cache_mode(requested, model_path);
+    if let Some(warning) = warning {
+        eprintln!("{warning}");
+        tracing::warn!(
+            requested = %requested,
+            effective = %effective,
+            "KV cache mode substituted for this model family"
+        );
+    }
+    effective
+}
+
+/// Read the raw `model_type` string from a model directory's `config.json`.
+///
+/// Deliberately the raw string rather than `models::detection::get_model_type`:
+/// the allowlist and the latent-family list are both keyed on the `config.json`
+/// value, and detection maps several distinct `model_type` values onto one
+/// enum variant.
+fn read_config_model_type(model_path: &Path) -> Option<String> {
+    let content = std::fs::read_to_string(model_path.join("config.json")).ok()?;
+    let config = serde_json::from_str::<serde_json::Value>(&content).ok()?;
+    config
+        .get("model_type")
+        .and_then(serde_json::Value::as_str)
+        .map(str::to_string)
 }
 
 #[cfg(test)]

--- a/src/cli/turbo_args_tests.rs
+++ b/src/cli/turbo_args_tests.rs
@@ -22,7 +22,7 @@
 
 use mlxcel_core::cache::KVCacheMode;
 
-use super::{TurboKvCacheArgs, resolve_kv_cache_mode};
+use super::{TurboKvCacheArgs, resolve_effective_kv_cache_mode, resolve_kv_cache_mode};
 // `std::env::set_var` / `remove_var` are not thread-safe. Tests that touch
 // the process environment must serialize through the crate-wide
 // `ENV_LOCK` — a per-module lock would race with the env
@@ -155,4 +155,100 @@ fn resolve_split_flags_symmetric_turbo3_is_rejected_with_helpful_error() {
         err.contains("fp16   / turbo3"),
         "error must list the supported `fp16 / turbo3` row, got: {err}"
     );
+}
+
+// ---------------------------------------------------------------------------
+// Model-aware second stage (issue #1350)
+// ---------------------------------------------------------------------------
+
+/// Write a minimal model directory carrying just the `model_type` the
+/// resolver reads.
+fn model_dir_with_type(model_type: &str) -> tempfile::TempDir {
+    let dir = tempfile::tempdir().expect("tempdir");
+    std::fs::write(
+        dir.path().join("config.json"),
+        format!("{{\"model_type\": \"{model_type}\"}}"),
+    )
+    .expect("write config.json");
+    dir
+}
+
+/// The reproduction from issue #1350: `--kv-cache-mode turbo4` on
+/// `glm4-flash-4bit` produced 40 tokens of `!`. The mode never reaches the
+/// cache now.
+#[test]
+fn turbo4_on_an_mla_latent_family_resolves_to_fp16_with_a_warning() {
+    let dir = model_dir_with_type("glm4_moe_lite");
+    let (mode, warning) = resolve_effective_kv_cache_mode(KVCacheMode::Turbo4, dir.path());
+    assert_eq!(mode, KVCacheMode::Fp16);
+    let warning = warning.expect("a substitution must be explained");
+    assert!(warning.contains("glm4_moe_lite"), "{warning}");
+    assert!(warning.contains("turbo4"), "{warning}");
+}
+
+/// The quieter half of the same defect: the asymmetric modes quantize `k_pe`,
+/// a key stream, on these families. They are refused too.
+#[test]
+fn asymmetric_modes_on_an_mla_latent_family_resolve_to_fp16() {
+    let dir = model_dir_with_type("kimi_linear");
+    for requested in [
+        KVCacheMode::Turbo4Asym,
+        KVCacheMode::Turbo3Asym,
+        KVCacheMode::Turbo4Delegated,
+        KVCacheMode::Int8,
+    ] {
+        let (mode, warning) = resolve_effective_kv_cache_mode(requested, dir.path());
+        assert_eq!(mode, KVCacheMode::Fp16, "{requested}");
+        assert!(warning.is_some(), "{requested}");
+    }
+}
+
+/// The fallback the CLI banner has always described.
+#[test]
+fn turbo4_on_a_non_allowlisted_family_resolves_to_turbo4_asym() {
+    let dir = model_dir_with_type("llama");
+    let (mode, warning) = resolve_effective_kv_cache_mode(KVCacheMode::Turbo4, dir.path());
+    assert_eq!(mode, KVCacheMode::Turbo4Asym);
+    assert!(warning.expect("must warn").contains("llama"));
+}
+
+#[test]
+fn turbo4_on_an_allowlisted_family_is_left_alone() {
+    let dir = model_dir_with_type("qwen3_5");
+    let (mode, warning) = resolve_effective_kv_cache_mode(KVCacheMode::Turbo4, dir.path());
+    assert_eq!(mode, KVCacheMode::Turbo4);
+    assert!(warning.is_none());
+}
+
+/// An ordinary family keeps every mode it could run before, so this stage
+/// cannot change what an existing deployment serves.
+#[test]
+fn an_ordinary_family_keeps_every_other_mode() {
+    let dir = model_dir_with_type("llama");
+    for requested in [
+        KVCacheMode::Fp16,
+        KVCacheMode::Int8,
+        KVCacheMode::Turbo4Asym,
+        KVCacheMode::Turbo3Asym,
+        KVCacheMode::Turbo4Delegated,
+    ] {
+        let (mode, warning) = resolve_effective_kv_cache_mode(requested, dir.path());
+        assert_eq!(mode, requested);
+        assert!(warning.is_none());
+    }
+}
+
+/// A directory with no readable `config.json` must pass the request through
+/// rather than invent a downgrade for a model it could not identify.
+#[test]
+fn an_unreadable_config_passes_the_requested_mode_through() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let (mode, warning) = resolve_effective_kv_cache_mode(KVCacheMode::Turbo4Asym, dir.path());
+    assert_eq!(mode, KVCacheMode::Turbo4Asym);
+    assert!(warning.is_none());
+
+    std::fs::write(dir.path().join("config.json"), "not json").expect("write");
+    let (mode, warning) = resolve_effective_kv_cache_mode(KVCacheMode::Turbo4Asym, dir.path());
+    assert_eq!(mode, KVCacheMode::Turbo4Asym);
+    assert!(warning.is_none());
 }

--- a/src/commands/chat.rs
+++ b/src/commands/chat.rs
@@ -170,7 +170,7 @@ enum SlashOutcome {
 /// Returns an error if the model cannot be resolved / loaded, the tokenizer
 /// cannot be read, or the terminal line editor cannot be initialized. Per-turn
 /// generation never aborts the loop; a `/clear` or a fresh turn always recovers.
-pub fn run_chat(opts: ChatOptions) -> Result<()> {
+pub fn run_chat(mut opts: ChatOptions) -> Result<()> {
     let runtime = initialize_runtime();
     println!("Runtime device: {}", runtime.device);
 
@@ -182,6 +182,15 @@ pub fn run_chat(opts: ChatOptions) -> Result<()> {
         opts.models_dir.as_deref(),
         opts.revision.as_deref(),
     )?;
+
+    // issue #1350: substitute the KV cache mode this model family can really
+    // run before the session (and therefore its caches) is built, so the REPL
+    // and one-shot `generate` agree on what a given `--kv-cache-mode` means.
+    // Announced once here, before the load banner, rather than per turn.
+    opts.kv_cache_mode = mlxcel::cli::turbo_args::resolve_and_announce_kv_cache_mode(
+        opts.kv_cache_mode,
+        &model_path,
+    );
 
     println!("Loading model from {model_path:?}...");
     let load_start = Instant::now();

--- a/src/commands/generate.rs
+++ b/src/commands/generate.rs
@@ -54,7 +54,7 @@ use mlxcel_core::lang_analyzer::LangBiasConfig;
 use mlxcel_core::sampling::{TokenBiasMap, sample_token_optimized};
 
 use mlxcel::cli::speculative_args::resolve_draft_block_size;
-use mlxcel::cli::turbo_args::resolve_kv_cache_mode;
+use mlxcel::cli::turbo_args::{resolve_and_announce_kv_cache_mode, resolve_kv_cache_mode};
 use mlxcel_core::drafter::{DrafterKind, load_drafter, resolve_drafter_kind};
 
 use super::generate_vlm;
@@ -303,12 +303,18 @@ fn run_memory_preflight(
         return Ok(None);
     }
 
-    let kv_cache_mode = resolve_kv_cache_mode(
+    let requested = resolve_kv_cache_mode(
         args.generation.turbo.cache_type_k.as_deref(),
         args.generation.turbo.cache_type_v.as_deref(),
         args.generation.turbo.kv_cache_mode.as_deref(),
     )
     .map_err(|e| anyhow::anyhow!("{}", e))?;
+    // Estimate against the mode that will really be built (issue #1350), not
+    // the one requested, or the preflight would size an int8 cache for a model
+    // whose caches resolve back to fp16. The substitution has already been
+    // announced by `run_generate`, so resolve quietly here.
+    let (kv_cache_mode, _) =
+        mlxcel::cli::turbo_args::resolve_effective_kv_cache_mode(requested, &args.model.model);
     let kv_int8 = matches!(kv_cache_mode, KVCacheMode::Int8);
 
     // Size the KV cache for the tokens that can actually enter the cache:
@@ -2104,12 +2110,19 @@ fn run_generate_once(mut args: GenerateArgs) -> Result<()> {
 
     validate_tensor_parallel_args(&args)?;
     validate_pipeline_parallel_args(&args)?;
-    let kv_cache_mode = resolve_kv_cache_mode(
+    let requested_kv_cache_mode = resolve_kv_cache_mode(
         args.generation.turbo.cache_type_k.as_deref(),
         args.generation.turbo.cache_type_v.as_deref(),
         args.generation.turbo.kv_cache_mode.as_deref(),
     )
     .map_err(|e| anyhow::anyhow!("{}", e))?;
+    // issue #1350: substitute the mode this model can actually run before
+    // anything reads it. `-m` was resolved to a local directory just above, so
+    // the model_type lookup is a plain file read. Everything downstream (the
+    // banner, the generator, the memory preflight) sees the effective mode, so
+    // what is printed and what is built cannot disagree.
+    let kv_cache_mode =
+        resolve_and_announce_kv_cache_mode(requested_kv_cache_mode, &args.model.model);
     validate_muse_glimmer_cli_unsupported_options(&args, kv_cache_mode)?;
 
     // Parse and validate language bias arguments early (before model load).
@@ -2312,9 +2325,13 @@ fn run_generate_once(mut args: GenerateArgs) -> Result<()> {
             println!("KV cache mode: fp16+turbo4 (asymmetric Fp16-K + Turbo4-V, ~26% KV savings)");
         }
         KVCacheMode::Turbo4 => {
+            // Reached only when the family is on
+            // `ALLOWED_SYMMETRIC_TURBO_FAMILIES`: a non-allowlisted request was
+            // already resolved to Turbo4Asym above, which is why this line no
+            // longer describes a fallback that had never been performed.
             println!(
                 "KV cache mode: turbo4 (symmetric Turbo4-K + Turbo4-V, ~73% KV savings; \
-                 allowlisted families only; non-allowlisted models fall back to Turbo4Asym)"
+                 this family is on the symmetric-Turbo4 allowlist)"
             );
         }
         KVCacheMode::Turbo4Delegated => {
@@ -2329,7 +2346,19 @@ fn run_generate_once(mut args: GenerateArgs) -> Result<()> {
                  ~5.1x total KV savings)"
             );
         }
-        KVCacheMode::Fp16 => {}
+        KVCacheMode::Fp16 => {
+            // Fp16 is the default and normally announces nothing. When it is
+            // the *result* of a substitution the operator asked for something
+            // else, so name the mode actually in force (issue #1350). The
+            // reason was printed to stderr by
+            // `resolve_and_announce_kv_cache_mode`.
+            if kv_cache_mode != requested_kv_cache_mode {
+                println!(
+                    "KV cache mode: fp16 (requested {requested_kv_cache_mode}; \
+                     not supported on this model family)"
+                );
+            }
+        }
     }
 
     // OpenXLA backend (issue #449): the engine drives generation from its own

--- a/src/commands/inspect.rs
+++ b/src/commands/inspect.rs
@@ -49,12 +49,18 @@ pub(crate) fn run_inspect(mut args: InspectArgs) -> Result<()> {
     // Translate the user-facing `--quant` label into the typed hint.
     let quant = parse_quant_hint(&args.quant)?;
 
-    let kv_cache_mode = resolve_kv_cache_mode(
+    let requested = resolve_kv_cache_mode(
         args.turbo.cache_type_k.as_deref(),
         args.turbo.cache_type_v.as_deref(),
         args.turbo.kv_cache_mode.as_deref(),
     )
     .map_err(|e| anyhow!("{}", e))?;
+    // Report the mode `generate` / `serve` would really build (issue #1350).
+    // `inspect` exists to predict their preflight, so estimating an int8 cache
+    // for a model whose caches resolve back to fp16 would make it disagree with
+    // the command it is predicting. `-m` is already a concrete directory here.
+    let (kv_cache_mode, _) =
+        mlxcel::cli::turbo_args::resolve_effective_kv_cache_mode(requested, &args.model);
     let kv_int8 = matches!(kv_cache_mode, KVCacheMode::Int8);
 
     let estimate = estimate_total_memory(&args.model, args.max_tokens, args.batch, quant, kv_int8);

--- a/src/commands/serve.rs
+++ b/src/commands/serve.rs
@@ -76,12 +76,23 @@ fn run_serve_memory_preflight(args: &crate::ServeArgs) -> anyhow::Result<()> {
         return Ok(());
     }
 
-    let kv_cache_mode = resolve_kv_cache_mode(
+    let requested = resolve_kv_cache_mode(
         args.turbo.cache_type_k.as_deref(),
         args.turbo.cache_type_v.as_deref(),
         args.turbo.kv_cache_mode.as_deref(),
     )
     .map_err(|e| anyhow::anyhow!("{}", e))?;
+    // Estimate against the mode the caches will really be built with (issue
+    // #1350), not the one requested. `--estimate-memory --kv-cache-mode int8`
+    // on an MLA latent family resolves back to fp16 at startup, so sizing an
+    // int8 cache here under-counts the KV budget, and this preflight can abort
+    // the server outright when the total exceeds the available memory.
+    // `run_serve` resolved `-m` to a concrete directory before calling us, so
+    // the `model_type` lookup is a plain file read. Resolving quietly:
+    // `into_startup_config` performs the same substitution and reports it once
+    // logging exists.
+    let (kv_cache_mode, _) =
+        mlxcel::cli::turbo_args::resolve_effective_kv_cache_mode(requested, &args.model);
     let kv_int8 = matches!(kv_cache_mode, KVCacheMode::Int8);
 
     let ctx_len = serve_preflight_ctx_len(args);

--- a/src/execution/kv_cache_advisor.rs
+++ b/src/execution/kv_cache_advisor.rs
@@ -56,6 +56,7 @@ use std::path::Path;
 
 use mlxcel_core::cache::KVCacheMode;
 use mlxcel_core::cache::turbo::is_symmetric_turbo_allowed;
+use mlxcel_core::mla::caches_mla_latent_pair;
 
 use crate::execution::config_fields;
 use crate::execution::kv_arch::{KvArchKind, estimate_kv_arch_from_config};
@@ -179,6 +180,11 @@ impl KvCacheModeAdvice {
 /// - MLA and pure-SSM families never receive a Turbo (Walsh-Hadamard) mode,
 ///   because their cache dimension is not a power of two (MLA) or absent
 ///   (SSM).
+/// - An MLA family that always caches the latent pair
+///   ([`caches_mla_latent_pair`]) never receives any quantized mode, not even
+///   [`KVCacheMode::Int8`]. Those families have their request substituted back
+///   to fp16 at startup (issue #1350), so advice to the contrary would name a
+///   mode the binary refuses.
 #[must_use]
 pub fn recommend_kv_cache_mode(
     arch_kind: KvArchKind,
@@ -206,6 +212,16 @@ pub fn recommend_kv_cache_mode(
                     Fp16,
                     None,
                     "MLA already caches a compact low-rank latent, so at short context the KV footprint is small. Keep fp16.",
+                ),
+                // A family that always caches the `(kv_latent, k_pe)` pair has
+                // no decompressed fallback, so every quantized mode (int8
+                // included) is refused and resolved back to fp16 at startup
+                // (issue #1350). Advising int8 there would name a mode the
+                // binary rejects, which is worse than advising nothing.
+                Medium | Long if caches_mla_latent_pair(model_type) => (
+                    Fp16,
+                    None,
+                    "This family caches the MLA (kv_latent, k_pe) pair in one KV cache with no decompressed fallback, so every quantized mode is mis-calibrated for it and is substituted back to fp16 at startup. See the MLA latent section of docs/turbo-kv-cache.md. Keep fp16.",
                 ),
                 Medium | Long => (
                     Int8,

--- a/src/execution/kv_cache_advisor_tests.rs
+++ b/src/execution/kv_cache_advisor_tests.rs
@@ -124,14 +124,18 @@ fn pure_ssm_is_always_fp16() {
 
 #[test]
 fn mla_uses_int8_never_turbo() {
+    // `deepseek_v2` is the MLA family that keeps a decompressed fallback, so
+    // int8 there lands on ordinary per-head K/V rows and is a real
+    // recommendation. A latent-pair family is covered by
+    // `latent_mla_families_are_advised_fp16_because_the_binary_refuses_the_rest`.
     for kind in [KvArchKind::MlaCompressed, KvArchKind::MlaDecompressed] {
         // Short stays fp16.
         assert_eq!(
-            recommend_kv_cache_mode(kind, "deepseek_v3", KvContextRange::Short).suggested,
+            recommend_kv_cache_mode(kind, "deepseek_v2", KvContextRange::Short).suggested,
             KVCacheMode::Fp16
         );
         for range in [KvContextRange::Medium, KvContextRange::Long] {
-            let advice = recommend_kv_cache_mode(kind, "deepseek_v3", range);
+            let advice = recommend_kv_cache_mode(kind, "deepseek_v2", range);
             assert_eq!(advice.suggested, KVCacheMode::Int8);
             // MLA must never get a Walsh-Hadamard Turbo mode.
             for mode in [
@@ -146,6 +150,30 @@ fn mla_uses_int8_never_turbo() {
     }
 }
 
+/// `mlxcel recommend` must not advise a mode the binary refuses.
+///
+/// Every family in `MLA_LATENT_CACHE_FAMILIES` has any non-fp16 request
+/// substituted back to fp16 before a cache is built (issue #1350), and
+/// `kv_arch` classifies anything carrying `kv_lora_rank` as MLA, so without
+/// this branch the advisor recommended int8 at medium and long context for
+/// exactly the families that reject it.
+#[test]
+fn latent_mla_families_are_advised_fp16_because_the_binary_refuses_the_rest() {
+    for &family in mlxcel_core::mla::MLA_LATENT_CACHE_FAMILIES {
+        for kind in [KvArchKind::MlaCompressed, KvArchKind::MlaDecompressed] {
+            for range in KvContextRange::all() {
+                let advice = recommend_kv_cache_mode(kind, family, range);
+                assert_eq!(
+                    advice.suggested,
+                    KVCacheMode::Fp16,
+                    "{family}/{kind:?}/{range:?} advised a mode the binary refuses"
+                );
+                assert_eq!(advice.also_consider, None, "{family}/{kind:?}/{range:?}");
+            }
+        }
+    }
+}
+
 /// Every recommendation is one of the allowed KV-cache modes, and never
 /// `Turbo3Asym` (a documented memory-extremis last resort, not an advisory
 /// pick). Because the output is always a `KVCacheMode` (a KV-cache-only storage
@@ -153,7 +181,16 @@ fn mla_uses_int8_never_turbo() {
 /// (the #289 landmine).
 #[test]
 fn recommendation_is_always_an_allowed_kv_cache_mode() {
-    let model_types = ["llama", "qwen3_5", "deepseek_v3", "mamba", "gemma3", ""];
+    let model_types = [
+        "llama",
+        "qwen3_5",
+        "deepseek_v2",
+        "deepseek_v3",
+        "glm_moe_dsa",
+        "mamba",
+        "gemma3",
+        "",
+    ];
     for kind in ALL_ARCH_KINDS {
         for range in KvContextRange::all() {
             for mt in model_types {

--- a/src/lib/mlxcel-core/src/cache.rs
+++ b/src/lib/mlxcel-core/src/cache.rs
@@ -1370,9 +1370,14 @@ impl KVCache {
     /// tensors are reconstructed lazily on `update_and_fetch` via
     /// [`turbo::quant::dequantize_k_turbo4`] / [`turbo::quant::dequantize_v_turbo4`].
     ///
-    /// **Safety**: callers must consult [`turbo::is_symmetric_turbo_allowed`]
-    /// before constructing a cache in this mode for an arbitrary model — see
-    /// [`turbo::allowlist`] for the rationale.
+    /// **Safety**: callers must consult
+    /// [`turbo::resolve_kv_cache_mode_for_model`] before constructing a cache
+    /// in this mode for an arbitrary model. That function performs the
+    /// symmetric-Turbo4 allowlist fallback and refuses the MLA latent families
+    /// outright; see [`turbo::allowlist`] for the rationale. The head-dim
+    /// `assert_eq!` below is the backstop for a caller that skips it, and is
+    /// unconditional because a mismatch makes the K quantizer read past its
+    /// sign vectors rather than merely return a poor answer.
     ///
     /// Used by: `KVCache::update` dispatch when `mode == KVCacheMode::Turbo4`
     fn update_turbo4_sym(
@@ -1392,12 +1397,15 @@ impl KVCache {
         // this assumption.
         let v_shape = ffi::array_shape(&new_values_f16);
         let k_shape_in = ffi::array_shape(&new_keys_f16);
-        debug_assert_eq!(
+        assert_eq!(
             k_shape_in[3], v_shape[3],
             "symmetric Turbo4 requires K and V head_dim to match; \
-             got K head_dim={} V head_dim={} — this model likely uses \
-             differently-sized K/V projections and is incompatible with \
-             this mode.",
+             got K head_dim={} V head_dim={}. This cache holds two \
+             differently-shaped streams (an MLA (kv_latent, k_pe) pair, or a \
+             family whose K and V projections differ) and is incompatible \
+             with this mode. Entry points resolve this to a supported mode \
+             before the cache is built; see \
+             `cache::turbo::resolve_kv_cache_mode_for_model`.",
             k_shape_in[3], v_shape[3],
         );
         if self.turbo_params.is_none() {

--- a/src/lib/mlxcel-core/src/cache/turbo/allowlist.rs
+++ b/src/lib/mlxcel-core/src/cache/turbo/allowlist.rs
@@ -78,9 +78,12 @@
 //! straight string-prefix match so config variants like
 //! `"qwen3_5_moe"` still match the `"qwen3_5"` family entry.
 //!
-//! Used by: `src/commands/generate.rs` (CLI fallback warning),
-//! `KVCache::new_with_mode_and_seed` (cache initialization), and
-//! `tests/turbo_kv_e2e.rs` (allowlist regression tests).
+//! Used by: [`resolve_kv_cache_mode_for_model`] (the one place a requested
+//! mode becomes an effective mode), `src/execution/kv_cache_advisor.rs`
+//! (`mlxcel recommend` advice), and `tests/turbo_kv_e2e.rs` (allowlist
+//! regression tests).
+
+use crate::cache::KVCacheMode;
 
 /// Hard-coded list of `model_type` values where symmetric `KVCacheMode::Turbo4`
 /// is known to stay within +2.0% PPL of the FP16 baseline.
@@ -125,8 +128,9 @@ pub static ALLOWED_SYMMETRIC_TURBO_FAMILIES: &[&str] = &[
 /// the entire Qwen3.5 family (dense + MoE + VLM) shares the same
 /// hybrid-cache property.
 ///
-/// Used by: CLI fallback warning in `src/commands/generate.rs`, allowlist
-/// regression tests in `tests/turbo_kv_e2e.rs`.
+/// Used by: [`resolve_kv_cache_mode_for_model`], the KV-cache advisor in
+/// `src/execution/kv_cache_advisor.rs`, and the allowlist regression tests in
+/// `tests/turbo_kv_e2e.rs`.
 pub fn is_symmetric_turbo_allowed(model_type: &str) -> bool {
     let needle = model_type.trim().to_ascii_lowercase();
     if needle.is_empty() {
@@ -143,13 +147,73 @@ pub fn is_symmetric_turbo_allowed(model_type: &str) -> bool {
 /// users who hit the warning in one context can search it directly.
 /// Includes the rejected `model_type` and the recommended fallback.
 ///
-/// Used by: `src/commands/generate.rs::resolve_kv_cache_mode_with_allowlist`.
+/// Used by: [`resolve_kv_cache_mode_for_model`].
 pub fn symmetric_turbo_warning_message(model_type: &str) -> String {
     format!(
         "warning: symmetric turbo4 is risky on this model family \
          (model_type=\"{model_type}\"; Q4_K_M dense models can produce PPL 200+).\n\
-         \tFalling back to --kv-cache-mode fp16+turbo4. Override with --force."
+         \tFalling back to --kv-cache-mode fp16+turbo4. To keep symmetric turbo4, add this \
+         model_type to ALLOWED_SYMMETRIC_TURBO_FAMILIES after a quality-gate pass."
     )
+}
+
+/// Resolve the KV cache mode a model may actually run, from the mode the
+/// operator requested.
+///
+/// This is the single place an entry point turns a requested
+/// [`KVCacheMode`] into the mode the caches are really built with, so the CLI
+/// banner, the server startup log and the allocated caches cannot disagree.
+/// Returns the effective mode and, when it differs from the request, one
+/// operator-facing line explaining the substitution.
+///
+/// Two rules apply, in this order:
+///
+/// 1. **MLA latent families.** A family in
+///    [`crate::mla::MLA_LATENT_CACHE_FAMILIES`] stores a `(kv_latent, k_pe)`
+///    pair in one cache, so every quantized mode is mis-calibrated for it (see
+///    [`crate::mla::latent_layout_supports_mode`] for what each mode gets
+///    wrong). Any non-FP16 request resolves to [`KVCacheMode::Fp16`]. This is
+///    the rule `deepseek_v2` has always applied per cache through
+///    [`crate::mla::MlaLatentCache::supports`]; the four families that have no
+///    decompressed fallback need it applied per model instead.
+/// 2. **Symmetric Turbo4 allowlist.** [`KVCacheMode::Turbo4`] on a family that
+///    is not in [`ALLOWED_SYMMETRIC_TURBO_FAMILIES`] resolves to
+///    [`KVCacheMode::Turbo4Asym`], carrying
+///    [`symmetric_turbo_warning_message`]. This is the fallback the CLI banner
+///    has always described.
+///
+/// Rule 1 runs first because it is a correctness bound, not a quality one: for
+/// a latent family the Turbo4Asym that rule 2 would pick still quantizes
+/// `k_pe`. An empty or unknown `model_type` matches neither rule and passes
+/// through unchanged, which keeps a model whose `config.json` could not be read
+/// on exactly its previous behaviour.
+///
+/// Used by: `mlxcel::cli::turbo_args::resolve_effective_kv_cache_mode`, which
+/// is the shared entry point for the CLI, the chat REPL, the server and the
+/// decode benchmark.
+#[must_use]
+pub fn resolve_kv_cache_mode_for_model(
+    requested: KVCacheMode,
+    model_type: &str,
+) -> (KVCacheMode, Option<String>) {
+    if crate::mla::caches_mla_latent_pair(model_type)
+        && let Err(reason) = crate::mla::latent_layout_supports_mode(requested)
+    {
+        return (
+            KVCacheMode::Fp16,
+            Some(format!(
+                "warning: --kv-cache-mode {requested} is not supported on this model family \
+                 (model_type=\"{model_type}\"): {reason}.\n\tUsing fp16 for this model's KV caches."
+            )),
+        );
+    }
+    if requested == KVCacheMode::Turbo4 && !is_symmetric_turbo_allowed(model_type) {
+        return (
+            KVCacheMode::Turbo4Asym,
+            Some(symmetric_turbo_warning_message(model_type)),
+        );
+    }
+    (requested, None)
 }
 
 #[cfg(test)]
@@ -204,8 +268,114 @@ mod tests {
         let msg = symmetric_turbo_warning_message("llama");
         assert!(msg.contains("model_type=\"llama\""));
         assert!(msg.contains("fp16+turbo4"));
-        assert!(msg.contains("--force"));
+        assert!(msg.contains("ALLOWED_SYMMETRIC_TURBO_FAMILIES"));
+        // The old text told operators to "Override with --force". No such
+        // override exists: `--force` is the memory-preflight bypass. The
+        // message never reached a user while the fallback was unimplemented;
+        // now that it does, it must not name a flag that does something else.
+        assert!(!msg.contains("--force"));
         // We want the text "warning:" so users grepping logs find it.
         assert!(msg.starts_with("warning:"));
+    }
+
+    /// Every non-FP16 mode is refused on a family that always caches an MLA
+    /// latent pair. This is the rule that keeps `glm4-flash` off the K
+    /// quantizer that reads past its 64-entry sign vectors.
+    #[test]
+    fn latent_family_resolves_every_quantized_mode_to_fp16() {
+        for &family in crate::mla::MLA_LATENT_CACHE_FAMILIES {
+            for requested in [
+                KVCacheMode::Int8,
+                KVCacheMode::Turbo4Asym,
+                KVCacheMode::Turbo3Asym,
+                KVCacheMode::Turbo4,
+                KVCacheMode::Turbo4Delegated,
+            ] {
+                let (effective, warning) = resolve_kv_cache_mode_for_model(requested, family);
+                assert_eq!(
+                    effective,
+                    KVCacheMode::Fp16,
+                    "{family} requested {requested} and got {effective}"
+                );
+                let warning = warning.expect("a substituted mode must explain itself");
+                assert!(warning.contains(family), "{warning}");
+                assert!(warning.contains(&requested.to_string()), "{warning}");
+            }
+        }
+    }
+
+    /// Rule 1 must beat rule 2: `Turbo4Asym` is not a safe landing place for a
+    /// latent family, because its "V" slot is the RoPE key stream.
+    #[test]
+    fn latent_family_turbo4_lands_on_fp16_not_turbo4_asym() {
+        let (effective, _) = resolve_kv_cache_mode_for_model(KVCacheMode::Turbo4, "glm4_moe_lite");
+        assert_eq!(effective, KVCacheMode::Fp16);
+    }
+
+    /// FP16 is what a latent family already runs, so it is not a substitution
+    /// and must not warn.
+    #[test]
+    fn latent_family_keeps_fp16_without_a_warning() {
+        let (effective, warning) =
+            resolve_kv_cache_mode_for_model(KVCacheMode::Fp16, "deepseek_v3");
+        assert_eq!(effective, KVCacheMode::Fp16);
+        assert!(warning.is_none());
+    }
+
+    /// `deepseek_v2` asks `MlaLatentCache::supports` per cache and falls back to
+    /// the decompressed per-head layout when the mode is quantized, so a
+    /// family-level override would remove a configuration that works.
+    #[test]
+    fn deepseek_v2_is_not_treated_as_a_latent_family() {
+        let (effective, _) =
+            resolve_kv_cache_mode_for_model(KVCacheMode::Turbo4Asym, "deepseek_v2");
+        assert_eq!(effective, KVCacheMode::Turbo4Asym);
+    }
+
+    /// The fallback the CLI banner has always promised, now performed.
+    #[test]
+    fn non_allowlisted_turbo4_falls_back_to_asym() {
+        for family in ["llama", "qwen2", "gemma3", "deepseek_v2"] {
+            let (effective, warning) = resolve_kv_cache_mode_for_model(KVCacheMode::Turbo4, family);
+            assert_eq!(effective, KVCacheMode::Turbo4Asym, "{family}");
+            assert!(warning.expect("must warn").contains(family));
+        }
+    }
+
+    #[test]
+    fn allowlisted_turbo4_keeps_symmetric() {
+        for family in ["qwen3_5", "qwen3_5_moe", "qwen3_next"] {
+            let (effective, warning) = resolve_kv_cache_mode_for_model(KVCacheMode::Turbo4, family);
+            assert_eq!(effective, KVCacheMode::Turbo4, "{family}");
+            assert!(warning.is_none(), "{family}");
+        }
+    }
+
+    /// Only symmetric Turbo4 consults the allowlist. Every other mode on an
+    /// ordinary family passes through untouched, so this change cannot alter
+    /// what a non-MLA model has been running.
+    #[test]
+    fn other_modes_on_an_ordinary_family_pass_through() {
+        for requested in [
+            KVCacheMode::Fp16,
+            KVCacheMode::Int8,
+            KVCacheMode::Turbo4Asym,
+            KVCacheMode::Turbo3Asym,
+            KVCacheMode::Turbo4Delegated,
+        ] {
+            let (effective, warning) = resolve_kv_cache_mode_for_model(requested, "llama");
+            assert_eq!(effective, requested);
+            assert!(warning.is_none());
+        }
+    }
+
+    /// An unreadable or absent `model_type` must not silently downgrade a
+    /// mode the operator asked for; the unconditional dimension asserts in
+    /// `quantize_into_packed` remain the backstop for that case.
+    #[test]
+    fn unknown_model_type_passes_non_turbo4_modes_through() {
+        let (effective, warning) = resolve_kv_cache_mode_for_model(KVCacheMode::Int8, "");
+        assert_eq!(effective, KVCacheMode::Int8);
+        assert!(warning.is_none());
     }
 }

--- a/src/lib/mlxcel-core/src/cache/turbo/mod.rs
+++ b/src/lib/mlxcel-core/src/cache/turbo/mod.rs
@@ -53,7 +53,8 @@ pub mod quant3;
 pub mod sparse_v;
 
 pub use allowlist::{
-    ALLOWED_SYMMETRIC_TURBO_FAMILIES, is_symmetric_turbo_allowed, symmetric_turbo_warning_message,
+    ALLOWED_SYMMETRIC_TURBO_FAMILIES, is_symmetric_turbo_allowed, resolve_kv_cache_mode_for_model,
+    symmetric_turbo_warning_message,
 };
 pub use boundary::{
     BOUNDARY_V_ENV, BOUNDARY_V_ENV_ALT, DEFAULT_BOUNDARY_V_LAYERS, boundary_mode_for,

--- a/src/lib/mlxcel-core/src/cache/turbo/quant.rs
+++ b/src/lib/mlxcel-core/src/cache/turbo/quant.rs
@@ -281,23 +281,32 @@ fn quantize_into_packed(
     // well-conditioned even for very small / very large magnitudes.
     let v_f32 = ffi::astype(x, dtype::FLOAT32);
     let shape = ffi::array_shape(&v_f32);
-    debug_assert_eq!(shape.len(), 4, "input must be 4-D [B, H, T, D]");
+    // These four are `assert!`, not `debug_assert!`, on purpose. `signs1` and
+    // `signs2` are host slices handed to `ffi::from_slice_f32(signs, &[1, 1,
+    // 1, d])` below, which builds an MLX array by reading `d` floats from the
+    // raw pointer with no length check of its own. A `d` larger than
+    // `signs.len()` is therefore an out-of-bounds read, not a wrong answer,
+    // and neither `[profile.release]` nor `[profile.test-fast]` enables
+    // debug assertions, so a `debug_assert!` here guards nothing that ships or
+    // that the test gate runs. The checks are O(1) against a per-quantize-call
+    // cost dominated by a WHT and a host readback.
+    assert_eq!(shape.len(), 4, "input must be 4-D [B, H, T, D]");
     let _b = shape[0];
     let _h = shape[1];
     let t = shape[2];
     let d = shape[3];
-    debug_assert_eq!(
+    assert_eq!(
         d as u32, params.head_dim,
         "input last dim ({d}) must match TurboQuantParams head_dim ({})",
         params.head_dim
     );
-    debug_assert_eq!(
+    assert_eq!(
         signs1.len(),
         d as usize,
         "signs1 length ({}) must match head_dim ({d})",
         signs1.len()
     );
-    debug_assert_eq!(
+    assert_eq!(
         signs2.len(),
         d as usize,
         "signs2 length ({}) must match head_dim ({d})",
@@ -360,7 +369,7 @@ fn quantize_into_packed(
 
     // 4. Pack two consecutive 4-bit indices into one byte.
     //    Layout: byte[i] low nibble = indices[2*i], high nibble = indices[2*i+1].
-    debug_assert!(d % 2 == 0, "head_dim must be even for nibble-packing");
+    assert!(d % 2 == 0, "head_dim must be even for nibble-packing");
     let coords_per_token = d as usize;
     let bytes_per_token = coords_per_token / 2;
     let total_tokens = (shape[0] * shape[1] * t) as usize;
@@ -503,14 +512,18 @@ fn dequantize_from_packed(
     signs2: &[f32],
 ) -> UniquePtr<MlxArray> {
     let (indices_u8, _b, _h, _t, d) = unpack_turbo4_indices(packed);
-    debug_assert_eq!(d as u32, params.head_dim, "head_dim mismatch on dequantize");
-    debug_assert_eq!(
+    // Unconditional for the same reason as in `quantize_into_packed`: the
+    // inverse rotation below hands `signs1` / `signs2` to
+    // `ffi::from_slice_f32(signs, &[1, 1, 1, d])`, which reads `d` floats out
+    // of a `signs.len()`-element host slice.
+    assert_eq!(d as u32, params.head_dim, "head_dim mismatch on dequantize");
+    assert_eq!(
         signs1.len(),
         d as usize,
         "signs1 length ({}) must match head_dim ({d})",
         signs1.len()
     );
-    debug_assert_eq!(
+    assert_eq!(
         signs2.len(),
         d as usize,
         "signs2 length ({}) must match head_dim ({d})",

--- a/src/lib/mlxcel-core/src/cache/turbo/quant3.rs
+++ b/src/lib/mlxcel-core/src/cache/turbo/quant3.rs
@@ -160,15 +160,38 @@ pub fn quantize_v_turbo3(
 ) -> (UniquePtr<MlxArray>, UniquePtr<MlxArray>) {
     let v_f32 = ffi::astype(v, dtype::FLOAT32);
     let shape = ffi::array_shape(&v_f32);
-    debug_assert_eq!(shape.len(), 4, "input must be 4-D [B, H, T, D]");
+    // Unconditional, for the reason spelled out in `quant::quantize_into_packed`:
+    // `params.signs1` / `params.signs2` are host slices handed to
+    // `ffi::from_slice_f32(signs, &[1, 1, 1, d])` below, which reads `d` floats
+    // through the raw pointer with no length check of its own. A `d` larger
+    // than `signs.len()` is an out-of-bounds read rather than a wrong answer,
+    // and neither `[profile.release]` nor `[profile.test-fast]` turns debug
+    // assertions on, so a `debug_assert!` here would guard nothing that ships
+    // or that the test gate runs. `TurboQuantParams3` has all-`pub` fields and
+    // no `#[non_exhaustive]`, so a struct literal with a short sign vector is
+    // constructible. The checks are O(1) against a per-call cost dominated by a
+    // WHT and a host readback.
+    assert_eq!(shape.len(), 4, "input must be 4-D [B, H, T, D]");
     let _b = shape[0];
     let _h = shape[1];
     let t = shape[2];
     let d = shape[3];
-    debug_assert_eq!(
+    assert_eq!(
         d as u32, params.head_dim,
         "input last dim ({d}) must match TurboQuantParams3 head_dim ({})",
         params.head_dim
+    );
+    assert_eq!(
+        params.signs1.len(),
+        d as usize,
+        "signs1 length ({}) must match head_dim ({d})",
+        params.signs1.len()
+    );
+    assert_eq!(
+        params.signs2.len(),
+        d as usize,
+        "signs2 length ({}) must match head_dim ({d})",
+        params.signs2.len()
     );
 
     // 1. Per-token L2 norm with a `where`-guarded zero fallback (matches the
@@ -275,16 +298,34 @@ pub fn dequantize_v_turbo3(
     let t = packed_shape[2];
     let bytes_per_token = packed_shape[3];
     let d = bytes_per_token * 8 / 3; // inverse of head_dim * 3 / 8
-    debug_assert_eq!(
+    // Unconditional for the same reason as in `quantize_v_turbo3`: the inverse
+    // rotation below hands `params.signs1` / `params.signs2` to
+    // `ffi::from_slice_f32(signs, &[1, 1, 1, d])`, which reads `d` floats out
+    // of a `signs.len()`-element host slice. Here `d` is derived from the
+    // packed byte count, so nothing but this check ties it to the params the
+    // caller passed.
+    assert_eq!(
         d as u32, params.head_dim,
         "head_dim mismatch on dequantize: derived {d} from {bytes_per_token} packed bytes, \
          expected {}",
         params.head_dim
     );
-    debug_assert_eq!(
+    assert_eq!(
         d % 8,
         0,
         "head_dim must be a multiple of 8 for 3-bit dequant; got {d}"
+    );
+    assert_eq!(
+        params.signs1.len(),
+        d as usize,
+        "signs1 length ({}) must match head_dim ({d})",
+        params.signs1.len()
+    );
+    assert_eq!(
+        params.signs2.len(),
+        d as usize,
+        "signs2 length ({}) must match head_dim ({d})",
+        params.signs2.len()
     );
 
     // 1. Pull the packed bytes back to host memory and unpack to one-byte-

--- a/src/lib/mlxcel-core/src/cache/turbo/sparse_v.rs
+++ b/src/lib/mlxcel-core/src/cache/turbo/sparse_v.rs
@@ -515,6 +515,44 @@ pub fn compute_alive_mask(
     ffi::astype(&alive_bool, dtype::FLOAT32)
 }
 
+/// Assert that `params`' sign vectors really cover a `head_dim`-wide slice.
+///
+/// The fused launchers below rebuild the inverse Turbo4 rotation with
+/// `ffi::from_slice_f32(&params.signs1, &[1, 1, 1, head_dim])`, which reads
+/// `head_dim` floats through the slice's raw pointer and performs no length
+/// check of its own. `head_dim` there is `q_shape[3]`, the query head dim of a
+/// caller-supplied tensor, and nothing else ties it to `params.head_dim`, so a
+/// mismatch is an out-of-bounds read rather than a wrong answer.
+///
+/// Unconditional rather than `debug_assert!`: neither `[profile.release]` nor
+/// `[profile.test-fast]` enables debug assertions, so a debug-only check here
+/// would guard neither the shipped binary nor the test gate. `TurboQuantParams`
+/// has all-`pub` fields and no `#[non_exhaustive]`, so a struct literal
+/// carrying a short sign vector is constructible. The cost is O(1) against a
+/// launcher dominated by an SDPA and a Metal dispatch.
+///
+/// Used by: [`attention_sparse_v_turbo4_fused`],
+/// [`attention_turbo4_delegated_fused`], [`attention_turbo4_delegated_steel`].
+fn assert_sign_vectors_cover_head_dim(head_dim: i32, params: &TurboQuantParams) {
+    assert_eq!(
+        head_dim as u32, params.head_dim,
+        "q head_dim ({head_dim}) must match TurboQuantParams head_dim ({})",
+        params.head_dim
+    );
+    assert_eq!(
+        params.signs1.len(),
+        head_dim as usize,
+        "signs1 length ({}) must match head_dim ({head_dim})",
+        params.signs1.len()
+    );
+    assert_eq!(
+        params.signs2.len(),
+        head_dim as usize,
+        "signs2 length ({}) must match head_dim ({head_dim})",
+        params.signs2.len()
+    );
+}
+
 /// Split-SDPA reference path with attention-gated V-side masking.
 ///
 /// **Correctness scaffolding only.** Computes attention scores explicitly,
@@ -739,6 +777,9 @@ pub fn attention_sparse_v_turbo4_fused(
     if !(head_dim as u32).is_power_of_two() {
         return None;
     }
+    // Past this point the inverse rotation below reads `head_dim` floats out
+    // of each of `params.signs1` / `params.signs2`.
+    assert_sign_vectors_cover_head_dim(head_dim, params);
 
     // 1. Compute attention scores via the standard graph path. We keep this
     //    in MLX so the score matrix benefits from steel-attention SDPA and
@@ -920,6 +961,9 @@ pub fn attention_turbo4_delegated_fused(
     if !(head_dim as u32).is_power_of_two() {
         return None;
     }
+    // Past this point the cold-branch inverse rotation reads `head_dim` floats
+    // out of each of `params.signs1` / `params.signs2`.
+    assert_sign_vectors_cover_head_dim(head_dim, params);
 
     // 1. Compute attention scores via the standard graph path. The unified K
     //    buffer is FP16; we cast to FP32 for a stable softmax. Repeat KV
@@ -1300,6 +1344,9 @@ pub fn attention_turbo4_delegated_steel(
     if !(head_dim as u32).is_power_of_two() {
         return None;
     }
+    // Past this point the cold-branch inverse rotation reads `head_dim` floats
+    // out of each of `params.signs1` / `params.signs2`.
+    assert_sign_vectors_cover_head_dim(head_dim, params);
 
     // Both ranges empty would imply a decode step with no context, which is
     // structurally impossible after `KVCache::update`. Guard defensively.

--- a/src/lib/mlxcel-core/src/cache/turbo_tests.rs
+++ b/src/lib/mlxcel-core/src/cache/turbo_tests.rs
@@ -3515,3 +3515,55 @@ fn turbo4_asym_continuous_batching_grow_shrink_matches_sequential() {
         );
     }
 }
+
+// ===========================================================================
+// Symmetric Turbo4 head-dimension precondition (issue #1350)
+// ===========================================================================
+
+/// The exact geometry the MLA-latent families hand the shared `KVCache`:
+/// K is the `kv_lora_rank = 512` latent and V is the `qk_rope_head_dim = 64`
+/// rope stream.
+///
+/// Before #1350 the only guard was a `debug_assert_eq!`, which neither
+/// `[profile.release]` nor `[profile.test-fast]` compiles in, so this call
+/// built a 64-entry sign vector and handed it to
+/// `ffi::from_slice_f32(signs1, &[1, 1, 1, 512])`, reading 448 floats past the
+/// end of the slice and producing 4-bit indices from whatever was there. On
+/// `glm4-flash-4bit` that surfaced as every generated token being `!`.
+///
+/// This test must fail in every profile the project builds, which is why the
+/// check is `assert_eq!`. It is the backstop; the mode never reaches a latent
+/// family in the first place once
+/// `turbo::resolve_kv_cache_mode_for_model` has run.
+#[test]
+#[should_panic(expected = "symmetric Turbo4 requires K and V head_dim to match")]
+fn symmetric_turbo4_rejects_mismatched_k_and_v_head_dims() {
+    let mut cache = KVCache::new_with_mode(KVCacheMode::Turbo4);
+    let kv_latent = synth_kv_tensor(1, 1, 4, 512, 1350);
+    let k_pe = synth_kv_tensor(1, 1, 4, 64, 1351);
+    let _ = cache.update_and_fetch(kv_latent, k_pe);
+}
+
+/// `quantize_into_packed` is reached through `quantize_k_turbo4`, so drive the
+/// same precondition from the quantizer side: params calibrated for one head
+/// dimension must refuse a wider tensor rather than over-read the sign vector.
+#[test]
+#[should_panic(expected = "input last dim (512) must match TurboQuantParams head_dim (64)")]
+fn quantize_k_turbo4_rejects_a_tensor_wider_than_its_params() {
+    let params = turbo::TurboQuantParams::new(64, 0);
+    let wide = synth_kv_tensor(1, 1, 4, 512, 1352);
+    let _ = turbo::quant::quantize_k_turbo4(&wide, &params);
+}
+
+/// Matching head dims still work, so the new assertion did not narrow the
+/// supported geometry. 64 is what an allowlisted family actually uses.
+#[test]
+fn symmetric_turbo4_accepts_matching_head_dims() {
+    let mut cache = KVCache::new_with_mode(KVCacheMode::Turbo4);
+    let k = synth_kv_tensor(1, 1, 4, 64, 1353);
+    let v = synth_kv_tensor(1, 1, 4, 64, 1354);
+    let (out_k, out_v) = cache.update_and_fetch(k, v);
+    assert_eq!(ffi::array_shape(&out_k)[3], 64);
+    assert_eq!(ffi::array_shape(&out_v)[3], 64);
+    assert_eq!(cache.seq_len(), 4);
+}

--- a/src/lib/mlxcel-core/src/mla/cache.rs
+++ b/src/lib/mlxcel-core/src/mla/cache.rs
@@ -48,12 +48,12 @@
 //!
 //! Only `KVCacheMode::Fp16` and non-paged backing. The INT8 and Turbo3/Turbo4
 //! modes quantize along the head dimension with a per-token scale, which is
-//! calibrated for a per-head K/V row, not for a 512-wide shared latent whose
-//! reconstruction error is amplified by every one of the `num_heads` query
-//! heads that read it. The paged pool allocates `[num_blocks, page_size, Hkv,
-//! head_dim]` tensors with one head dim for both sides, which the asymmetric
-//! `(512, 64)` split cannot fill. Both are declined at wrap time with a
-//! message rather than silently mis-served.
+//! calibrated for a per-head K/V row, not for a shared latent hundreds of
+//! elements wide whose reconstruction error is amplified by every one of the
+//! `num_heads` query heads that read it. The paged pool allocates
+//! `[num_blocks, page_size, Hkv, head_dim]` tensors with one head dim for both
+//! sides, which the asymmetric `(512, 64)` split cannot fill. Both are declined
+//! at wrap time with a message rather than silently mis-served.
 
 use cxx::UniquePtr;
 
@@ -87,10 +87,19 @@ pub const fn decompressed_bytes_per_token(
 /// in one shared [`KVCache`] on **every** step, with no decompressed fallback.
 ///
 /// Each of these families calls `cache.update_and_fetch(kv_latent, k_pe)`
-/// unconditionally, so the cache's "K" slot is `kv_lora_rank` wide (512 in
-/// every shipping checkpoint) and its "V" slot is `qk_rope_head_dim` wide (64).
-/// That is the packing [`MlaLatentCache`] names, and the reason
+/// unconditionally, so the cache's "K" slot is at least `kv_lora_rank` wide and
+/// its "V" slot is `qk_rope_head_dim` wide (64). Neither slot is a per-head K/V
+/// row. That is the packing [`MlaLatentCache`] names, and the reason
 /// [`latent_layout_supports_mode`] is the rule for all of them.
+///
+/// The "K" slot is not one fixed width across the list. `kv_lora_rank` is 512
+/// in the shipping checkpoints of every family here, and it is the serde
+/// default wherever one is declared. On top of that, `deepseek_v32`,
+/// `deepseek_v3.2` and `glm_moe_dsa` concatenate the `index_head_dim`-wide DSA
+/// indexer key onto the same slot before caching it
+/// (`src/models/deepseek_v32.rs`), which makes it 640 wide at the default
+/// `index_head_dim` of 128. A codebook and a sign vector calibrated from the
+/// 64-wide "V" slot are wrong for any of those widths.
 ///
 /// `deepseek_v2` is deliberately **absent**. It asks
 /// [`MlaLatentCache::supports`] first and falls back to the decompressed
@@ -103,6 +112,17 @@ pub const fn decompressed_bytes_per_token(
 pub static MLA_LATENT_CACHE_FAMILIES: &[&str] = &[
     "glm4_moe_lite",
     "deepseek_v3",
+    // `deepseek_v32` and the `deepseek_v3.2` spelling of the same
+    // `config.json` value both resolve to `DeepSeekV32Model`
+    // (`src/models/detection.rs`), and `glm_moe_dsa` wraps that model
+    // wholesale (`src/models/glm_moe_dsa.rs`). All three share the single
+    // unconditional `cache.update_and_fetch(cache_keys, k_pe)` in
+    // `src/models/deepseek_v32.rs` and consult neither
+    // [`MlaLatentCache::supports`] nor the cache's mode, so they have no
+    // decompressed fallback to land on.
+    "deepseek_v32",
+    "deepseek_v3.2",
+    "glm_moe_dsa",
     "kimi_linear",
     "longcat_flash_ngram",
 ];
@@ -354,6 +374,9 @@ mod tests {
         for family in [
             "glm4_moe_lite",
             "deepseek_v3",
+            "deepseek_v32",
+            "deepseek_v3.2",
+            "glm_moe_dsa",
             "kimi_linear",
             "longcat_flash_ngram",
         ] {
@@ -364,14 +387,31 @@ mod tests {
         assert!(!caches_mla_latent_pair(""));
     }
 
+    /// The DSA trio needs its own entries, not coverage inherited from
+    /// `deepseek_v3`. `caches_mla_latent_pair` matches exactly, so a family
+    /// whose `model_type` merely extends an entry is not covered by it, and
+    /// `glm_moe_dsa` shares nothing textual with the model it wraps.
+    #[test]
+    fn the_dsa_families_are_listed_in_their_own_right() {
+        for family in ["deepseek_v32", "deepseek_v3.2", "glm_moe_dsa"] {
+            assert!(
+                MLA_LATENT_CACHE_FAMILIES.contains(&family),
+                "{family} must be listed explicitly; `deepseek_v3` does not cover it"
+            );
+        }
+    }
+
     /// Exact match, not a prefix walk: the latent packing belongs to one
     /// concrete attention implementation, and a neighbouring `model_type` that
     /// happens to share a prefix must not inherit the answer.
     #[test]
     fn latent_family_lookup_is_exact_and_case_insensitive() {
         assert!(caches_mla_latent_pair("  GLM4_MoE_Lite  "));
+        assert!(caches_mla_latent_pair("  DeepSeek_V3.2  "));
         assert!(!caches_mla_latent_pair("glm4_moe_lite_vl"));
         assert!(!caches_mla_latent_pair("glm4_moe"));
+        assert!(!caches_mla_latent_pair("glm_moe"));
+        assert!(!caches_mla_latent_pair("deepseek_v32_vl"));
     }
 
     /// The rule `MlaLatentCache::supports` has always applied, now callable on

--- a/src/lib/mlxcel-core/src/mla/cache.rs
+++ b/src/lib/mlxcel-core/src/mla/cache.rs
@@ -83,6 +83,77 @@ pub const fn decompressed_bytes_per_token(
     geometry.num_heads * (geometry.q_head_dim() + geometry.v_head_dim) * bytes_per_element
 }
 
+/// `model_type` values whose attention stores an MLA `(kv_latent, k_pe)` pair
+/// in one shared [`KVCache`] on **every** step, with no decompressed fallback.
+///
+/// Each of these families calls `cache.update_and_fetch(kv_latent, k_pe)`
+/// unconditionally, so the cache's "K" slot is `kv_lora_rank` wide (512 in
+/// every shipping checkpoint) and its "V" slot is `qk_rope_head_dim` wide (64).
+/// That is the packing [`MlaLatentCache`] names, and the reason
+/// [`latent_layout_supports_mode`] is the rule for all of them.
+///
+/// `deepseek_v2` is deliberately **absent**. It asks
+/// [`MlaLatentCache::supports`] first and falls back to the decompressed
+/// per-head K/V layout when the cache is not FP16 (`src/models/deepseek_v2.rs`),
+/// so a quantized mode there is applied to ordinary per-head rows and needs no
+/// family-level override. Adding it here would take away a working
+/// configuration rather than fixing a broken one.
+///
+/// Used by: [`caches_mla_latent_pair`].
+pub static MLA_LATENT_CACHE_FAMILIES: &[&str] = &[
+    "glm4_moe_lite",
+    "deepseek_v3",
+    "kimi_linear",
+    "longcat_flash_ngram",
+];
+
+/// Whether `model_type` names a family that always caches an MLA latent pair.
+///
+/// `model_type` is the lowercase `config.json` string, matching the canonical
+/// key used by the model detection path. The comparison is exact rather than a
+/// prefix walk: the latent packing is a property of one concrete attention
+/// implementation, so a neighbouring `model_type` that merely shares a prefix
+/// must not inherit the answer.
+///
+/// Used by: `cache::turbo::allowlist::resolve_kv_cache_mode_for_model`.
+#[must_use]
+pub fn caches_mla_latent_pair(model_type: &str) -> bool {
+    let needle = model_type.trim().to_ascii_lowercase();
+    MLA_LATENT_CACHE_FAMILIES
+        .iter()
+        .any(|&family| needle == family)
+}
+
+/// The rule: an MLA latent cache holds FP16 and nothing else.
+///
+/// Every quantized [`KVCacheMode`] calibrates a per-token codebook from one
+/// head dimension and applies it to both stored streams. A latent cache has two
+/// different widths in those two slots (`kv_lora_rank` and
+/// `qk_rope_head_dim`), and neither slot is a per-head K/V row:
+///
+/// * Symmetric `Turbo4` derives its sign vectors and codebook from the "V"
+///   width and then applies them to the "K" slot as well, which is
+///   `kv_lora_rank` wide. The sign vectors are read past their end.
+/// * The asymmetric modes quantize only the "V" slot, but here that slot holds
+///   `k_pe`, the RoPE **key** stream. They therefore compress a key and leave
+///   the latent (which is both K and V after absorption) exact, which is the
+///   opposite of the "FP16 K, quantized V" contract those modes document.
+///
+/// Stated once here so [`MlaLatentCache::supports`] and the model-level mode
+/// resolver cannot drift apart. Returns the operator-facing reason on refusal.
+///
+/// Used by: [`MlaLatentCache::supports`],
+/// `cache::turbo::allowlist::resolve_kv_cache_mode_for_model`.
+pub fn latent_layout_supports_mode(mode: KVCacheMode) -> Result<(), String> {
+    if mode == KVCacheMode::Fp16 {
+        return Ok(());
+    }
+    Err(format!(
+        "mla: absorbed decode needs an FP16 KV cache; this cache is {mode} and its per-token \
+         quantization is calibrated for per-head K/V rows, not a shared latent"
+    ))
+}
+
 /// A [`KVCache`] used as a compressed-latent MLA cache.
 ///
 /// Borrowed rather than owned so a family keeps handing `&mut [KVCache]`
@@ -107,13 +178,7 @@ impl<'a> MlaLatentCache<'a> {
     /// and decompressed rows.
     pub fn supports(cache: &KVCache, geometry: MlaGeometry) -> Result<(), String> {
         geometry.check()?;
-        if cache.mode != KVCacheMode::Fp16 {
-            return Err(format!(
-                "mla: absorbed decode needs an FP16 KV cache; this cache is {} and its per-token \
-                 quantization is calibrated for per-head K/V rows, not a shared latent",
-                cache.mode
-            ));
-        }
+        latent_layout_supports_mode(cache.mode)?;
         if cache.is_paged_backed() {
             return Err(
                 "mla: absorbed decode cannot use a paged-backed cache; the pool's \
@@ -279,6 +344,52 @@ mod tests {
         assert_eq!(cache.trim(2), 2);
         let view = MlaLatentCache::wrap(&mut cache, G).unwrap();
         assert_eq!(view.seq_len(), 4);
+    }
+
+    /// The four families that always cache a latent pair, and the one that
+    /// does not. `deepseek_v2` has a decompressed fallback, so a quantized
+    /// mode there lands on ordinary per-head K/V rows and must keep working.
+    #[test]
+    fn only_the_fallback_less_families_are_latent_families() {
+        for family in [
+            "glm4_moe_lite",
+            "deepseek_v3",
+            "kimi_linear",
+            "longcat_flash_ngram",
+        ] {
+            assert!(caches_mla_latent_pair(family), "{family}");
+        }
+        assert!(!caches_mla_latent_pair("deepseek_v2"));
+        assert!(!caches_mla_latent_pair("llama"));
+        assert!(!caches_mla_latent_pair(""));
+    }
+
+    /// Exact match, not a prefix walk: the latent packing belongs to one
+    /// concrete attention implementation, and a neighbouring `model_type` that
+    /// happens to share a prefix must not inherit the answer.
+    #[test]
+    fn latent_family_lookup_is_exact_and_case_insensitive() {
+        assert!(caches_mla_latent_pair("  GLM4_MoE_Lite  "));
+        assert!(!caches_mla_latent_pair("glm4_moe_lite_vl"));
+        assert!(!caches_mla_latent_pair("glm4_moe"));
+    }
+
+    /// The rule `MlaLatentCache::supports` has always applied, now callable on
+    /// its own so the model-level resolver states it once rather than twice.
+    #[test]
+    fn latent_layout_accepts_fp16_and_nothing_else() {
+        assert!(latent_layout_supports_mode(KVCacheMode::Fp16).is_ok());
+        for mode in [
+            KVCacheMode::Int8,
+            KVCacheMode::Turbo4Asym,
+            KVCacheMode::Turbo3Asym,
+            KVCacheMode::Turbo4,
+            KVCacheMode::Turbo4Delegated,
+        ] {
+            let err = latent_layout_supports_mode(mode).unwrap_err();
+            assert!(err.contains("FP16"), "{err}");
+            assert!(err.contains(&mode.to_string()), "{err}");
+        }
     }
 
     #[test]

--- a/src/lib/mlxcel-core/src/mla/mod.rs
+++ b/src/lib/mlxcel-core/src/mla/mod.rs
@@ -90,7 +90,10 @@ pub mod stats;
 pub(crate) mod testkit;
 
 pub use absorb::MlaAbsorbedProjections;
-pub use cache::{MlaLatentCache, decompressed_bytes_per_token, latent_bytes_per_token};
+pub use cache::{
+    MLA_LATENT_CACHE_FAMILIES, MlaLatentCache, caches_mla_latent_pair,
+    decompressed_bytes_per_token, latent_bytes_per_token, latent_layout_supports_mode,
+};
 pub use decode::{absorb_queries, absorbed_decode};
 pub use split_kv::{MlaSplitPlan, absorbed_decode_split_kv};
 pub use stats::{MlaDecodePath, MlaDispatchCounts};

--- a/src/server/cli_input.rs
+++ b/src/server/cli_input.rs
@@ -553,16 +553,30 @@ impl ServerStartupInput {
             );
         kv_cache_mode_notices.extend(kv_mode_warning);
         if batch_kv_quant.is_enabled() {
-            let (batch_effective, batch_warning) =
-                crate::cli::turbo_args::resolve_effective_kv_cache_mode(
-                    batch_kv_quant.base_mode(),
-                    &self.model_path,
-                );
-            if batch_effective == mlxcel_core::cache::KVCacheMode::Fp16 {
-                kv_cache_mode_notices.extend(batch_warning);
+            let requested_batch_mode = batch_kv_quant.base_mode();
+            // The resolver's own warning is deliberately discarded here. It is
+            // phrased for `--kv-cache-mode`, so an operator who passed
+            // `--kv-bits 4 --kv-quant-scheme turboquant` would be told that
+            // `--kv-cache-mode fp16+turbo4` was refused: a flag they never
+            // passed, on a line nearly identical to the one below. The line
+            // below names the flag that was actually set.
+            let (batch_effective, _) = crate::cli::turbo_args::resolve_effective_kv_cache_mode(
+                requested_batch_mode,
+                &self.model_path,
+            );
+            // `!=` rather than `== Fp16`. Fp16 is the only landing place a
+            // `--kv-bits` request can have today (rule 2 of
+            // `resolve_kv_cache_mode_for_model` fires only on a `Turbo4`
+            // request and `base_mode` never returns one), but the condition
+            // that matters is "the batch table asked for a mode this family
+            // cannot hold", not which mode it was moved to. Written this way,
+            // a future rule that substitutes something other than Fp16 still
+            // disables the batch table instead of silently keeping it.
+            if batch_effective != requested_batch_mode {
                 kv_cache_mode_notices.push(format!(
                     "warning: disabling batched KV quantization (--kv-bits {}) for this model \
-                     family; serving its KV caches at fp16",
+                     family; it selects a {requested_batch_mode} KV cache, which this family \
+                     cannot hold. Serving its KV caches at fp16",
                     self.kv_bits
                 ));
                 batch_kv_quant.bits = 0;

--- a/src/server/cli_input.rs
+++ b/src/server/cli_input.rs
@@ -521,13 +521,51 @@ impl ServerStartupInput {
         // `--kv-skip-last-layer` flags. When `kv_bits == 0` this falls
         // through to the disabled default which is bit-exact equivalent
         // to the legacy `kv_cache_mode`-only path.
-        let batch_kv_quant = resolve_batch_kv_quant_config(
+        let mut batch_kv_quant = resolve_batch_kv_quant_config(
             self.kv_bits,
             self.kv_group_size,
             self.kv_quant_scheme.as_deref(),
             self.kv_skip_last_layer,
         )
         .map_err(|e| anyhow::anyhow!("batch KV cache quant error: {e}"))?;
+
+        // issue #1350: substitute the KV cache mode this model family can
+        // really run. Done here, at the single fallible startup boundary, so
+        // `ServerStartupConfig::kv_cache_mode` is already the effective mode by
+        // the time the scheduler, the paged layout and `/props` read it, and
+        // the server cannot log one mode while allocating another.
+        //
+        // `--kv-bits` is a second, independent route to a quantized cache
+        // (`BatchKvQuantConfig::base_mode` maps `--kv-quant-scheme turboquant`
+        // to Turbo4Asym and `--kv-bits 8` to Int8, and the scheduler prefers
+        // that table over `kv_cache_mode`), so a family that cannot hold a
+        // quantized cache has to be taken off both.
+        let (kv_cache_mode, kv_mode_warning) =
+            crate::cli::turbo_args::resolve_effective_kv_cache_mode(
+                kv_cache_mode,
+                &self.model_path,
+            );
+        if let Some(warning) = kv_mode_warning {
+            tracing::warn!("{warning}");
+        }
+        if batch_kv_quant.is_enabled() {
+            let (batch_effective, batch_warning) =
+                crate::cli::turbo_args::resolve_effective_kv_cache_mode(
+                    batch_kv_quant.base_mode(),
+                    &self.model_path,
+                );
+            if batch_effective == mlxcel_core::cache::KVCacheMode::Fp16 {
+                if let Some(warning) = batch_warning {
+                    tracing::warn!("{warning}");
+                }
+                tracing::warn!(
+                    kv_bits = self.kv_bits,
+                    "disabling batched KV quantization for this model family; \
+                     serving its KV caches at fp16"
+                );
+                batch_kv_quant.bits = 0;
+            }
+        }
 
         // H1: validate `--max-kv-size` bounds before we lower
         // the raw `usize` into the semantic `Option<usize>` downstream.

--- a/src/server/cli_input.rs
+++ b/src/server/cli_input.rs
@@ -540,14 +540,18 @@ impl ServerStartupInput {
         // to Turbo4Asym and `--kv-bits 8` to Int8, and the scheduler prefers
         // that table over `kv_cache_mode`), so a family that cannot hold a
         // quantized cache has to be taken off both.
+        //
+        // The notices are collected rather than logged: this runs before
+        // `initialize_server_logging` installs a tracing subscriber, so a
+        // `tracing::warn!` here would be written to nothing. `start_server`
+        // emits them once logging exists.
+        let mut kv_cache_mode_notices = Vec::new();
         let (kv_cache_mode, kv_mode_warning) =
             crate::cli::turbo_args::resolve_effective_kv_cache_mode(
                 kv_cache_mode,
                 &self.model_path,
             );
-        if let Some(warning) = kv_mode_warning {
-            tracing::warn!("{warning}");
-        }
+        kv_cache_mode_notices.extend(kv_mode_warning);
         if batch_kv_quant.is_enabled() {
             let (batch_effective, batch_warning) =
                 crate::cli::turbo_args::resolve_effective_kv_cache_mode(
@@ -555,14 +559,12 @@ impl ServerStartupInput {
                     &self.model_path,
                 );
             if batch_effective == mlxcel_core::cache::KVCacheMode::Fp16 {
-                if let Some(warning) = batch_warning {
-                    tracing::warn!("{warning}");
-                }
-                tracing::warn!(
-                    kv_bits = self.kv_bits,
-                    "disabling batched KV quantization for this model family; \
-                     serving its KV caches at fp16"
-                );
+                kv_cache_mode_notices.extend(batch_warning);
+                kv_cache_mode_notices.push(format!(
+                    "warning: disabling batched KV quantization (--kv-bits {}) for this model \
+                     family; serving its KV caches at fp16",
+                    self.kv_bits
+                ));
                 batch_kv_quant.bits = 0;
             }
         }
@@ -693,6 +695,7 @@ impl ServerStartupInput {
             chat_template_kwargs,
             prompt_cache,
             kv_cache_mode,
+            kv_cache_mode_notices,
             batch_kv_quant,
             // lower the raw `usize` (0 = disabled) into a
             // semantic `Option<usize>` after `resolve_max_kv_size` has

--- a/src/server/routes/props.rs
+++ b/src/server/routes/props.rs
@@ -58,6 +58,14 @@ pub async fn props(State(state): State<AppState>) -> Json<PropsResponse> {
     Json(PropsResponse {
         default_generation_settings: default_generation_settings(&state.config),
         total_slots: state.config.n_parallel,
+        // The effective mode, not the requested one: `ServerStartupInput::
+        // into_startup_config` has already substituted anything this model
+        // family cannot hold (issue #1350), and `ServerConfig` carries the
+        // result. Reporting it here is what makes "the mode announced is the
+        // mode in force" checkable by a client rather than only greppable in
+        // the startup log.
+        kv_cache_mode: state.config.kv_cache_mode.to_string(),
+        kv_bits: state.config.batch_kv_quant.bits,
     })
 }
 

--- a/src/server/routes/props_tests.rs
+++ b/src/server/routes/props_tests.rs
@@ -14,6 +14,7 @@
 
 use super::default_generation_settings;
 use crate::server::config::ServerConfig;
+use crate::server::types::PropsResponse;
 
 #[test]
 fn props_reports_the_resolved_dry_sequence_breakers() {
@@ -110,4 +111,47 @@ fn props_reports_all_five_dry_fields() {
     assert_eq!(settings["dry_allowed_length"], serde_json::json!(3));
     assert_eq!(settings["dry_penalty_last_n"], serde_json::json!(64));
     assert_eq!(settings["dry_sequence_breakers"], serde_json::json!([198]));
+}
+
+/// `/props` reports the KV cache mode and `--kv-bits` the server actually
+/// resolved (issue #1350).
+///
+/// `docs/turbo-kv-cache.md` tells operators that the mode announced by the CLI
+/// banner, the startup log and `/props` is the effective mode rather than the
+/// requested one. `ServerStartupInput::into_startup_config` performs the
+/// substitution before `ServerConfig` is built, so the payload only has to
+/// carry the resolved value; this test is what keeps the field from being
+/// dropped and the doc sentence from going stale.
+#[test]
+fn props_reports_the_effective_kv_cache_mode_and_kv_bits() {
+    let response = PropsResponse {
+        default_generation_settings: default_generation_settings(&ServerConfig::default()),
+        total_slots: 1,
+        kv_cache_mode: mlxcel_core::cache::KVCacheMode::Turbo4Asym.to_string(),
+        kv_bits: 4,
+    };
+
+    let payload = serde_json::to_value(&response).expect("PropsResponse serializes");
+    // The `--kv-cache-mode` spelling, not the Rust variant name: an operator
+    // has to be able to paste it straight back onto the flag.
+    assert_eq!(payload["kv_cache_mode"], serde_json::json!("fp16+turbo4"));
+    assert_eq!(payload["kv_bits"], serde_json::json!(4));
+}
+
+/// The default server reports `fp16` and `0`, not an absent key. Present-but-
+/// default and absent are different answers to "is a quantized KV cache in
+/// force", which is the same gap #1103 closed for `dry_sequence_breakers`.
+#[test]
+fn props_reports_the_kv_keys_even_on_a_default_server() {
+    let config = ServerConfig::default();
+    let response = PropsResponse {
+        default_generation_settings: default_generation_settings(&config),
+        total_slots: config.n_parallel,
+        kv_cache_mode: config.kv_cache_mode.to_string(),
+        kv_bits: config.batch_kv_quant.bits,
+    };
+
+    let payload = serde_json::to_value(&response).expect("PropsResponse serializes");
+    assert_eq!(payload["kv_cache_mode"], serde_json::json!("fp16"));
+    assert_eq!(payload["kv_bits"], serde_json::json!(0));
 }

--- a/src/server/startup.rs
+++ b/src/server/startup.rs
@@ -314,6 +314,17 @@ pub struct ServerStartupConfig {
     /// Unsupported K/V combinations are rejected at startup.
     pub kv_cache_mode: mlxcel_core::cache::KVCacheMode,
 
+    /// Operator-facing notices explaining why [`Self::kv_cache_mode`] or
+    /// [`Self::batch_kv_quant`] differ from what was requested (issue #1350).
+    ///
+    /// `ServerStartupInput::into_startup_config` resolves the requested mode
+    /// against the model family, but it runs before
+    /// [`initialize_server_logging`] installs a tracing subscriber, so a
+    /// `tracing::warn!` there is written to nothing. The notices are carried
+    /// here and emitted by [`start_server`] once logging exists. Empty when the
+    /// requested mode was used as-is.
+    pub kv_cache_mode_notices: Vec<String>,
+
     /// resolved batch KV cache quantization configuration
     /// (uniform `mx.quantize` or TurboQuant variant) for the
     /// continuous-batching path.
@@ -492,6 +503,7 @@ impl Default for ServerStartupConfig {
             chat_template_kwargs: None,
             prompt_cache: super::prompt_cache::PromptCacheConfig::default(),
             kv_cache_mode: mlxcel_core::cache::KVCacheMode::Fp16,
+            kv_cache_mode_notices: Vec::new(),
             batch_kv_quant: mlxcel_core::cache::BatchKvQuantConfig::default(),
             max_kv_size: None,
             // Serving-throughput default guard (#628): `auto` paged KV budget
@@ -1685,6 +1697,19 @@ fn install_surgery_pipeline_for_server(startup: &ServerStartupConfig) -> Result<
 /// Shared entry point used by both `mlxcel serve` and `mlxcel-server`.
 pub async fn start_server(mut startup: ServerStartupConfig) -> Result<()> {
     initialize_server_logging(&startup)?;
+
+    // issue #1350: the KV cache mode was resolved against the model family in
+    // `into_startup_config`, which runs before the subscriber above exists.
+    // Report the substitution now, so the log states the mode the caches are
+    // really built with rather than the one that was asked for.
+    for notice in &startup.kv_cache_mode_notices {
+        tracing::warn!("{notice}");
+    }
+    tracing::info!(
+        kv_cache_mode = %startup.kv_cache_mode,
+        kv_bits = startup.batch_kv_quant.bits,
+        "effective KV cache mode"
+    );
 
     // Florence-2 (issue #1073): the encoder-decoder (seq2seq) family is
     // served on its dedicated worker loop (`server/florence2_worker.rs`),

--- a/src/server/types/response.rs
+++ b/src/server/types/response.rs
@@ -595,6 +595,21 @@ pub struct AudioTranscriptionResponse {
 pub struct PropsResponse {
     pub default_generation_settings: serde_json::Value,
     pub total_slots: usize,
+    /// The KV cache mode the caches were really built with, as the
+    /// `--kv-cache-mode` spelling (`fp16`, `int8`, `fp16+turbo4`, `turbo4`,
+    /// `turbo4-delegated`, `fp16+turbo3`).
+    ///
+    /// The *effective* mode, not the requested one (issue #1350). A model
+    /// family that cannot hold a quantized cache has its request substituted
+    /// during startup, and until this field existed the only record of that was
+    /// one `tracing::warn!` line, invisible to a client and gone after log
+    /// rotation. An operator reads this to answer "what am I actually running".
+    pub kv_cache_mode: String,
+    /// Effective batched KV quantization width (`--kv-bits`), `0` when batched
+    /// KV quantization is off. Reported alongside [`Self::kv_cache_mode`]
+    /// because it is an independent second route to a quantized cache and is
+    /// subject to the same startup substitution.
+    pub kv_bits: i32,
 }
 
 /// Slot information (GET /slots)


### PR DESCRIPTION
## Summary

`KVCache::update_turbo4_sym` built one `TurboQuantParams` from the V head dimension and used it for K as well, guarded only by a `debug_assert_eq!`. Neither `[profile.release]` nor `[profile.test-fast]` enables debug assertions, so nothing that ships and nothing the test gate runs ever evaluated it. The seven families that cache an MLA `(kv_latent, k_pe)` pair in one `KVCache` hand it K of width `kv_lora_rank` (512) and V of width `qk_rope_head_dim` (64), so the K quantizer ran a 64-entry sign vector over 512 coordinates and `ffi::from_slice_f32(signs1, &[1, 1, 1, 512])` read 448 floats past the end of the slice.

This makes the dimension check unconditional, refuses every quantized mode on the MLA latent families through the rule `deepseek_v2` has always applied, and performs the symmetric-Turbo4 allowlist fallback that the CLI banner has advertised since the allowlist landed while no code did it.

## The second defect, which is quieter and easy to miss

The same families were also wrong under the **asymmetric** modes, silently, and fixing only the `!!!!` crash would have left that in place. Their "V" slot holds `k_pe`, the RoPE **key** stream, so `fp16+turbo4`, `fp16+turbo3` and `turbo4-delegated` compressed a key to 4 or 3 bits and left the latent (which is both K and V after absorption) exact. That is the reverse of the "FP16 K, 4-bit V" contract documented at `docs/turbo-kv-cache.md`. Output stayed finite and fluent, which is exactly why nobody noticed. Refusing all non-FP16 modes on these families resolves it, and the measurement below shows `turbo4-asym` on `glm4-flash-4bit` really did produce different text from `fp16` before this change.

This now covers `deepseek_v32` and `glm_moe_dsa` as well. Review found a fifth latent call site, `src/models/deepseek_v32.rs`, which caches a `(cache_keys, k_pe)` pair unconditionally and consults neither `MlaLatentCache::supports` nor the cache mode. Three `model_type` strings reach it: `deepseek_v32`, `deepseek_v3.2`, and `glm_moe_dsa` through `GlmMoeDsaModel` wrapping `DeepSeekV32Model`. `caches_mla_latent_pair` matches exactly by design, so `deepseek_v3` did not cover any of them. The memory-safety half was already covered there by accident, because none of the three is allowlisted and rule 2 downgraded `Turbo4` to `Turbo4Asym` before the over-read, but the second defect stayed fully live on both shipping families and stayed silent because `k_pe` is 64 wide, a power of two. Their "K" slot is also wider than the other families': `deepseek_v32` concatenates the `index_head_dim`-wide DSA indexer key onto the latent before caching it, which is `512 + 128 = 640` on `models/glm-5-4bit`.

## A third family the issue does not name

`deepseek_v2` is broken under `--kv-cache-mode turbo4` too, by a different route. It declines the latent layout for a quantized cache and falls back to the decompressed per-head path, where K is `qk_nope + qk_rope = 192` wide and V is `v_head_dim = 128`. Symmetric Turbo4 over-reads the 128-entry sign vector and then dies in the WHT, since 192 is not a power of two. On `models/deepseek-v2-lite-4bit` the baseline binary panics with `wht: last axis must be a non-zero power of 2; got shape=[1, 16, 18, 192]`. The allowlist fallback fixes it, because `deepseek_v2` is not allowlisted.

## Deviation from the issue's implementation plan

The plan's step 3 asks for `deepseek_v2` to declare the latent layout alongside the other four. It is deliberately **not** on the list. It asks `MlaLatentCache::supports` per cache and falls back to the decompressed layout when the mode is quantized, so a quantized mode there lands on ordinary per-head K/V rows and works. Forcing it to FP16 would remove a working configuration rather than fix a broken one. `turbo4` specifically is still fixed for it, by the allowlist rule, and there is a regression test pinning that distinction.

## What changed

- `src/lib/mlxcel-core/src/cache/turbo/quant.rs`: `quantize_into_packed` and `dequantize_from_packed` promote their head-dim and sign-length `debug_assert_eq!` to `assert_eq!`. These guard host slices handed to `from_slice_f32`, which builds an MLX array from a raw pointer with no length check of its own, so a mismatch is an out-of-bounds read rather than a poor answer. All are O(1) against a call cost dominated by a WHT and a host readback.
- `src/lib/mlxcel-core/src/cache.rs`: the K/V head-dim check in `update_turbo4_sym` becomes `assert_eq!`, with a message naming the resolver that should have prevented reaching it.
- `src/lib/mlxcel-core/src/mla/cache.rs`: the mode check inside `MlaLatentCache::supports` moves out into `latent_layout_supports_mode`, which `supports` now calls, so there is one rule rather than two. Adds `MLA_LATENT_CACHE_FAMILIES` / `caches_mla_latent_pair` naming the seven families that always cache a latent pair: `glm4_moe_lite`, `deepseek_v3`, `deepseek_v32`, `deepseek_v3.2`, `glm_moe_dsa`, `kimi_linear`, `longcat_flash_ngram`.
- `src/lib/mlxcel-core/src/cache/turbo/allowlist.rs`: `resolve_kv_cache_mode_for_model` composes the MLA rule (first, because it is a correctness bound) with the symmetric-Turbo4 allowlist, returning the effective mode and one operator-facing line. An unknown `model_type` passes through unchanged.
- `src/cli/turbo_args.rs`: `resolve_effective_kv_cache_mode` reads `model_type` from `config.json` and applies the resolver; `resolve_and_announce_kv_cache_mode` prints the substitution once.
- Entry points wired: `mlxcel generate`, the chat REPL, all three memory preflights (`generate`, `serve --estimate-memory`, `mlxcel inspect`, so none sizes an int8 cache for a model that resolves back to fp16), `bench_decode`, and `ServerStartupInput::into_startup_config`.
- Server: the `--kv-bits` batch route is a second, independent path to a quantized cache that the scheduler prefers over `kv_cache_mode`, so it is disabled for a latent family too. `into_startup_config` runs before `initialize_server_logging`, so its notices are carried on `ServerStartupConfig::kv_cache_mode_notices` and emitted by `start_server` once a subscriber exists, followed by an `effective KV cache mode` info line.
- `symmetric_turbo_warning_message` no longer tells operators to "Override with --force". No such override exists (`--force` is the memory-preflight bypass); the message simply never reached a user while the fallback was unimplemented.
- The `turbo4` CLI banner no longer describes a fallback it does not perform, because that arm is now only reachable for an allowlisted family.

## Before and after, `models/glm4-flash-4bit`

Same prompt, `-n 40 -t 0 --seed 1350 --show-reasoning`. Baseline binary built from `6ecf756ec` with the change reverted, so the only difference is this PR.

Before:

```
--- --kv-cache-mode fp16
Explain in two sentences why the sky is blue.The user wants an explanation of why the sky is blue, but with a strict constraint: it must be exactly two sentences long.
[Generated 40 tokens in 0.87s = 46.16 tok/s]

--- --kv-cache-mode turbo4
KV cache mode: turbo4 (symmetric Turbo4-K + Turbo4-V, ~73% KV savings; allowlisted families only; non-allowlisted models fall back to Turbo4Asym)
Explain in two sentences why the sky is blue.!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
[Generated 40 tokens in 3.32s = 12.06 tok/s]

--- --kv-cache-mode turbo4-asym
KV cache mode: fp16+turbo4 (asymmetric Fp16-K + Turbo4-V, ~26% KV savings)
Explain in two sentences why the sky is blue.The user wants an explanation of why the sky is blue, constrained to exactly two sentences.
[Generated 40 tokens in 2.36s = 16.96 tok/s]
```

After:

```
--- --kv-cache-mode fp16
Explain in two sentences why the sky is blue.The user wants an explanation of why the sky is blue, but with a strict constraint: it must be exactly two sentences long.
[Generated 40 tokens in 0.86s = 46.67 tok/s]

--- --kv-cache-mode turbo4
warning: --kv-cache-mode turbo4 is not supported on this model family (model_type="glm4_moe_lite"): mla: absorbed decode needs an FP16 KV cache; this cache is turbo4 and its per-token quantization is calibrated for per-head K/V rows, not a shared latent.
	Using fp16 for this model's KV caches.
KV cache mode: fp16 (requested turbo4; not supported on this model family)
Explain in two sentences why the sky is blue.The user wants an explanation of why the sky is blue, but with a strict constraint: it must be exactly two sentences long.
[Generated 40 tokens in 0.85s = 47.07 tok/s]

--- --kv-cache-mode turbo4-asym
warning: --kv-cache-mode fp16+turbo4 is not supported on this model family (model_type="glm4_moe_lite"): mla: absorbed decode needs an FP16 KV cache; this cache is fp16+turbo4 and its per-token quantization is calibrated for per-head K/V rows, not a shared latent.
	Using fp16 for this model's KV caches.
KV cache mode: fp16 (requested fp16+turbo4; not supported on this model family)
Explain in two sentences why the sky is blue.The user wants an explanation of why the sky is blue, but with a strict constraint: it must be exactly two sentences long.
[Generated 40 tokens in 0.86s = 46.63 tok/s]
```

Text comparison, computed rather than eyeballed: after the change `fp16` vs `turbo4` is IDENTICAL and `fp16` vs `turbo4-asym` is IDENTICAL; before the change both were DIFFERENT. The `turbo4-asym` row is the evidence for the second defect: it was quietly changing the output, not merely wasting memory.

## Allowlisted family, unchanged

`models/qwen3.5-0.8b-4bit` (`model_type: qwen3_5`, on `ALLOWED_SYMMETRIC_TURBO_FAMILIES`) keeps symmetric Turbo4, and its `turbo4` output is byte-identical before and after this change, as is its `fp16` output. The banner is the only difference:

```
KV cache mode: turbo4 (symmetric Turbo4-K + Turbo4-V, ~73% KV savings; this family is on the symmetric-Turbo4 allowlist)
```

## Server startup log

```
WARN mlxcel::server::startup: warning: --kv-cache-mode turbo4 is not supported on this model family (model_type="glm4_moe_lite"): ...
INFO mlxcel::server::startup: effective KV cache mode kv_cache_mode=fp16 kv_bits=0

WARN mlxcel::server::startup: warning: --kv-cache-mode fp16+turbo3 is not supported on this model family (model_type="glm4_moe_lite"): ...
INFO mlxcel::server::startup: effective KV cache mode kv_cache_mode=fp16 kv_bits=0

WARN mlxcel::server::startup: warning: symmetric turbo4 is risky on this model family (model_type="llama"; Q4_K_M dense models can produce PPL 200+).
INFO mlxcel::server::startup: effective KV cache mode kv_cache_mode=fp16+turbo4 kv_bits=0
```

`mlxcel-server -m models/glm4-flash-4bit --kv-cache-mode turbo4` also now answers coherently over HTTP where it previously served `!`.

The `--kv-bits` route is disabled for a latent family and left alone for everything else:

```
$ mlxcel-server -m models/glm4-flash-4bit --kv-bits 4 --kv-quant-scheme turboquant
WARN  warning: --kv-cache-mode fp16+turbo4 is not supported on this model family (model_type="glm4_moe_lite"): ...
WARN  warning: disabling batched KV quantization (--kv-bits 4) for this model family; serving its KV caches at fp16
INFO  effective KV cache mode kv_cache_mode=fp16 kv_bits=0
  reply: 'The user is asking for the name of the largest planet, with a constraint of'

$ mlxcel-server -m models/llama-3.1-8b-4bit --kv-bits 4 --kv-quant-scheme turboquant
INFO  effective KV cache mode kv_cache_mode=fp16 kv_bits=4
  reply: '<|python_tag|>{"name": "get_largest_planet", "parameters": {}}'
```

## `/props` reports the effective mode

`docs/turbo-kv-cache.md` and a comment in `cli_input.rs` both said the mode announced in `/props` is the effective one, and the payload carried neither `kv_cache_mode` nor `kv_bits`. The claim was true only because `/props` announced nothing, leaving one `tracing::info!` line as the sole server-side record. Both fields are now in the payload, so the claim is checkable by a client rather than only greppable in a log that rotates. The doc also notes the endpoint is opt-in behind `--props`.

```
$ mlxcel-server -m models/glm4-flash-4bit --props --kv-bits 4 --kv-quant-scheme turboquant
  /props -> kv_cache_mode='fp16' kv_bits=0
  log: warning: disabling batched KV quantization (--kv-bits 4) for this model family; it selects a fp16+turbo4 KV cache, which this family cannot hold. Serving its KV caches at fp16
  log: effective KV cache mode kv_cache_mode=fp16 kv_bits=0

$ mlxcel-server -m models/llama-3.1-8b-4bit --props --kv-bits 4 --kv-quant-scheme turboquant
  /props -> kv_cache_mode='fp16' kv_bits=4
  log: effective KV cache mode kv_cache_mode=fp16 kv_bits=4

$ mlxcel-server -m models/llama-3.1-8b-4bit --props --kv-cache-mode turbo4
  /props -> kv_cache_mode='fp16+turbo4' kv_bits=0
  log: warning: symmetric turbo4 is risky on this model family (model_type="llama"; ...)
  log: effective KV cache mode kv_cache_mode=fp16+turbo4 kv_bits=0
```

That `--kv-bits` line is also the only one emitted now. It previously came paired with a resolver warning phrased for `--kv-cache-mode fp16+turbo4`, a flag the operator never passed.

## The memory preflight no longer sizes a mode the binary refuses

`serve --estimate-memory` and `mlxcel inspect` still derived `kv_int8` from the requested mode. On a latent family that under-counts the KV budget by half, and the `serve` preflight can hard-abort startup on that number before the server ever loads.

```
models/glm4-flash-4bit, --max-tokens 32768

                                       before        after
inspect --kv-cache-mode fp16       29.38 GiB     29.38 GiB
inspect --kv-cache-mode int8       14.69 GiB     29.38 GiB
serve --estimate-memory int8       14.69 GiB     29.38 GiB

models/llama-3.1-8b-4bit (non-latent control, unchanged)
inspect --kv-cache-mode fp16        4.00 GiB      4.00 GiB
inspect --kv-cache-mode int8        2.00 GiB      2.00 GiB
```

## `mlxcel recommend` no longer advises a refused mode

`kv_arch` classifies any config carrying `kv_lora_rank` as MLA, and the advisor returned `int8` for MLA at medium and long context, so it named a mode the binary now rejects for every latent family.

```
                                 before                  after
glm4-flash-4bit  medium          int8                    fp16
glm4-flash-4bit  long            int8                    fp16
deepseek-v2-lite medium          int8                    int8
deepseek-v2-lite long            int8                    int8
llama-3.1-8b     medium          int8                    int8
llama-3.1-8b     long            turbo4-delegated        turbo4-delegated
```

`deepseek_v2` keeps its int8 advice because it keeps a decompressed fallback, which is the same distinction the resolver draws.

## Exercising the refusal on a real `glm_moe_dsa` checkpoint

`models/glm-5-4bit` carries a real `glm_moe_dsa` `config.json` (`kv_lora_rank` 512, `index_head_dim` 128, `qk_rope_head_dim` 64). The pre-fix binary is silent on every quantized mode; this branch refuses all three:

```
--- turbo4
warning: --kv-cache-mode turbo4 is not supported on this model family (model_type="glm_moe_dsa"): mla: absorbed decode needs an FP16 KV cache; this cache is turbo4 and its per-token quantization is calibrated for per-head K/V rows, not a shared latent.
	Using fp16 for this model's KV caches.

--- turbo4-asym
warning: --kv-cache-mode fp16+turbo4 is not supported on this model family (model_type="glm_moe_dsa"): ...

--- int8
warning: --kv-cache-mode int8 is not supported on this model family (model_type="glm_moe_dsa"): ...
```

That checkpoint is a partial download (config and chat template only, no weights and no tokenizer), so generation could not be driven end to end on it. The resolver runs before model load, so the refusal path itself is fully exercised. No `deepseek_v32` / `deepseek_v3.2` checkpoint is present locally at all.

## Test plan

New tests, all of which fail on the baseline:

- `symmetric_turbo4_rejects_mismatched_k_and_v_head_dims` drives the exact 512/64 geometry through `KVCache::update_and_fetch` and requires a panic in every profile.
- `quantize_k_turbo4_rejects_a_tensor_wider_than_its_params` drives the same precondition from the quantizer side.
- `symmetric_turbo4_accepts_matching_head_dims` pins that the new assertion did not narrow the supported geometry.
- 8 resolver tests in `cache::turbo::allowlist::tests`, including `deepseek_v2_is_not_treated_as_a_latent_family` and `latent_family_turbo4_lands_on_fp16_not_turbo4_asym` (rule ordering).
- 3 rule tests in `mla::cache::tests` and 5 entry-point tests in `cli::turbo_args::tests`.

Commands run:

- [x] `cargo test --profile test-fast -p mlxcel-core --features metal,accelerate --lib -- allowlist --test-threads=1` (17 passed)
- [x] `cargo test --profile test-fast -p mlxcel-core --features metal,accelerate --lib -- ... turbo_tests mla::cache::tests --test-threads=1` (129 passed)
- [x] `cargo test --profile test-fast --features metal,accelerate --lib -- turbo_args --test-threads=1` (13 passed)
- [x] `cargo clippy -p mlxcel-core --features metal,accelerate --all-targets` (clean)
- [x] `cargo clippy -p mlxcel --features metal,accelerate --all-targets` (clean)
- [x] `cargo fmt --all -- --check`
- [x] Real-model gate, `models/glm4-flash-4bit`: RESULT PASS (all 9 checks, prompt cache on vs off identical on every token)
- [x] Real-model gate, `models/llama-3.1-8b-4bit`: RESULT PASS (all 9 checks)
- [x] `mlxcel-server` startups on `glm4-flash-4bit` (`turbo4`, `fp16+turbo3`, `--kv-bits 4`) and `llama-3.1-8b-4bit` (`turbo4`, `--kv-bits 4`), log lines quoted above

Review-fix round, additionally:

- [x] `cargo test --profile test-fast -p mlxcel-core --features metal,accelerate mla::` (37 passed) and `turbo` (217 passed)
- [x] `cargo test --profile test-fast -p mlxcel --lib --features metal,accelerate kv_cache_advisor` (22 passed)
- [x] `cargo test --profile test-fast -p mlxcel --lib --features metal,accelerate -- props turbo_args cli_input` (117 passed)
- [x] `cargo clippy -p mlxcel-core --lib --tests --features metal,accelerate -- -D warnings` and the same for `-p mlxcel`, plus `-p mlxcel --bins` (all clean)
- [x] `cargo fmt --all -- --check`
- [x] Real-model gate, `models/glm4-flash-4bit`: RESULT PASS (9/9, prompt cache on vs off identical on every token)
- [x] `fp16` / `turbo4` / `turbo4-asym` capture across `glm4-flash-4bit`, `deepseek-v2-lite-4bit` and `qwen3.5-0.8b-4bit` is identical to the pre-review-fix branch, so the four already-covered families and the allowlisted family are untouched

New regression tests: `the_dsa_families_are_listed_in_their_own_right` and two added assertions in `latent_family_lookup_is_exact_and_case_insensitive` (`mla::cache::tests`); `latent_mla_families_are_advised_fp16_because_the_binary_refuses_the_rest` (`execution::kv_cache_advisor`); `props_reports_the_effective_kv_cache_mode_and_kv_bits` and `props_reports_the_kv_keys_even_on_a_default_server` (`server::routes::props`). `latent_family_resolves_every_quantized_mode_to_fp16` iterates `MLA_LATENT_CACHE_FAMILIES`, so it picked up the three new families without editing.

The full `cargo test --workspace --profile test-fast` and `cargo clippy --workspace --all-targets` remain for the merge gate; per-package clippy was run on both packages this PR touches.

Closes #1350

