### PR TITLE
chore(ci): derive cross-repo ref boundaries live

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -307,7 +307,7 @@ jobs:
         # name can never reach shell parsing; the script reads BASE_REF as input.
         env:
           BASE_REF: origin/${{ github.base_ref }}
-          GITHUB_TOKEN: ${{ github.token }}
+          GITHUB_TOKEN: ${{ github.event.pull_request.head.repo.full_name == github.repository && github.token || '' }}
         run: |
           bash scripts/ci/check_cross_repo_refs_test.sh
           python3 scripts/ci/check_cross_repo_refs.py

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -307,7 +307,10 @@ jobs:
         # name can never reach shell parsing; the script reads BASE_REF as input.
         env:
           BASE_REF: origin/${{ github.base_ref }}
-        run: python3 scripts/ci/check_cross_repo_refs.py
+          GITHUB_TOKEN: ${{ github.token }}
+        run: |
+          bash scripts/ci/check_cross_repo_refs_test.sh
+          python3 scripts/ci/check_cross_repo_refs.py
 
   # ============================================================================
   # OpenXLA feature compile (self-hosted GB10)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -105,7 +105,17 @@ git diff origin/main...HEAD | grep -nE '#[0-9]{3,}'
 python3 scripts/ci/check_cross_repo_refs.py
 ```
 
-CI runs the same check on every pull request (advisory).
+When `GH_TOKEN` or `GITHUB_TOKEN` is available, the helper asks GitHub for the
+current highest issue/PR number in `lablup/mlxcel` and treats any larger bare
+ref as likely cross-repository. Lines that explicitly name an upstream project
+are still flagged regardless of the number. Offline, unauthenticated, or
+failed-API runs stay advisory, print the fallback reason, and leave non-upstream
+bare refs in the manual-review bucket.
+
+CI runs the same check on every pull request (advisory) and passes
+`github.token` when available so the live boundary is exercised there too. The
+same CI step also runs `scripts/ci/check_cross_repo_refs_test.sh`, the
+companion shell test for the classifier.
 
 ### Adding a new model family
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -112,10 +112,12 @@ are still flagged regardless of the number. Offline, unauthenticated, or
 failed-API runs stay advisory, print the fallback reason, and leave non-upstream
 bare refs in the manual-review bucket.
 
-CI runs the same check on every pull request (advisory) and passes
-`github.token` when available so the live boundary is exercised there too. The
-same CI step also runs `scripts/ci/check_cross_repo_refs_test.sh`, the
-companion shell test for the classifier.
+CI runs the same check on every pull request (advisory). Same-repository pull
+requests pass `github.token` so the live boundary is exercised there too; fork
+pull requests intentionally use the offline fallback rather than exposing the
+base repository's token to PR-controlled code. The same CI step also runs
+`scripts/ci/check_cross_repo_refs_test.sh`, the companion shell test for the
+classifier.
 
 ### Adding a new model family
 

--- a/TECHNICAL_REPORTS/1397-cross-repo-ref-boundaries-20260824.en.md
+++ b/TECHNICAL_REPORTS/1397-cross-repo-ref-boundaries-20260824.en.md
@@ -1,0 +1,71 @@
+# Technical Report: PR #1397 - Derive Cross-Repository Reference Boundaries Live
+
+**Date**: 2026-08-24
+
+**Author**: Jeongkyu Shin
+
+**Status**: Completed
+
+**Languages**: Python, Bash, YAML, Markdown
+
+**Risk Level**: Medium
+
+## Executive Summary
+
+PR #1397 removes the expired rule that treated every bare issue or pull-request number at or above 1000 as an upstream reference. The advisory checker now derives the current `lablup/mlxcel` number boundary from GitHub when a token is safely available and falls back to explicit manual review when it is offline or unauthenticated. Deterministic companion tests cover both modes and run in the real pull-request workflow.
+
+## 1. Problem Statement
+
+The repository grew beyond the classifier's fixed numeric assumption. References such as #1023, #1340, #1355, and #1385 are valid same-repository links, but the old `num >= 1000` branch labeled them likely upstream. On the measured PR #1386 diff this produced seven false positives; on the historical PR #1385 merge diff it produced 28 numeric-only false positives. Because the check is advisory, persistent noise eroded the review signal intended to catch genuinely unqualified upstream or private-repository references.
+
+## 2. Change Summary
+
+| Area | Change |
+|---|---|
+| Classifier | Query the newest issue/PR number through a five-second `gh api` call and remove the fixed threshold |
+| Fallback | Keep non-upstream bare refs visible in the manual-review bucket and print why live classification was unavailable |
+| Companion test | Exercise same-repo, upstream, qualified, above-boundary, offline, API-failure, and strict-mode cases in temporary repositories |
+| CI | Run the companion suite before the classifier and provide `github.token` only to same-repository PRs |
+| Contributor guide | Document live-boundary, offline, fork, and manual-review behavior |
+
+## 3. Technical Decisions
+
+### 3.1 Derive rather than retune the boundary
+
+Issue and pull-request numbers share GitHub's repository sequence, and the issues endpoint includes pull requests. Querying the newest item with explicit created-descending ordering therefore supplies one moving boundary without maintaining another number that will expire as the repository grows.
+
+### 3.2 Fail open without failing silently
+
+No token, a missing `gh` executable, timeout, API failure, or invalid response does not fail this advisory check. The classifier instead prints the fallback reason and places every non-upstream bare reference in the existing manual-review bucket. Explicit upstream-name signals still enter the likely-upstream bucket in either mode.
+
+### 3.3 Keep base-repository credentials away from fork code
+
+The workflow executes pull-request-controlled scripts. A security review therefore restricted `github.token` to same-repository PRs; fork PRs receive an empty value and intentionally exercise the documented offline fallback. This retains public-fork coverage without exposing the base repository token to changed code.
+
+### 3.4 Test evaluated behavior in isolated repositories
+
+The shell companion creates temporary Git repositories and a fake `gh` binary, which makes boundary and failure behavior deterministic without network access. Its deliberate reference corpus is excluded through the existing `IGNORE_PREFIXES` mechanism so the production classifier does not report its own fixtures.
+
+## 4. Verification
+
+- `python3 -m py_compile scripts/ci/check_cross_repo_refs.py`: passed.
+- `bash -n scripts/ci/check_cross_repo_refs_test.sh`: passed.
+- `bash scripts/ci/check_cross_repo_refs_test.sh`: all seven cases passed, including strict mode's expected non-zero result.
+- The companion suite also passed with a parent `GITHUB_TOKEN` present, proving that its no-token case removes inherited credentials explicitly.
+- Synthetic PR #1386 replay: #1340 and #1355 remained outside `Likely UPSTREAM`.
+- Historical `fb1e909cc~1...fb1e909cc` replay: the 28 numeric-only same-repository false positives disappeared; only three lines carrying explicit upstream context remained upstream-signaled, matching the issue's declared boundary.
+- Live endpoint check returned current PR number 1397 as the repository boundary.
+- Hosted `cross-repo refs` ran the companion suite and production classifier successfully after the inherited-token fixture correction.
+- Formatting, Clippy, cargo-deny, MLX-pin extraction, OpenXLA compile, repository metadata checks, and CLA passed. The final OpenXLA link job was still pending when this report was authored and must reach a terminal state before merge.
+- Correctness, security/performance, and finalization reviews found no unresolved issue after the fork-token restriction.
+
+## 5. Incident Found by Hosted Validation
+
+The first hosted run found that the companion suite's offline case inherited the workflow-level `GITHUB_TOKEN`, so it did not enter the fallback path even though local shells without a token passed. The fixture now removes both `GH_TOKEN` and `GITHUB_TOKEN` inside that case, and its environment options precede assignments for hosted GNU `env` compatibility. The replacement hosted job passed.
+
+## 6. Related Work
+
+- Issue #1387: stale numeric classification of same-repository references.
+- PR #1397: implementation and review corrections documented here.
+- PR #1386 and merge commit `fb1e909cc`: measured false-positive datasets.
+- `scripts/ci/check_crate_versions.py`: related precedent for making classification policy explicit and reviewable.

--- a/TECHNICAL_REPORTS/1397-cross-repo-ref-boundaries-20260824.ko.md
+++ b/TECHNICAL_REPORTS/1397-cross-repo-ref-boundaries-20260824.ko.md
@@ -1,0 +1,71 @@
+# 기술 보고서: PR #1397 - Cross-Repository Reference 경계 동적 산출
+
+**작성일**: 2026-08-24
+
+**작성자**: 신정규
+
+**상태**: 완료
+
+**언어**: Python, Bash, YAML, Markdown
+
+**위험도**: Medium
+
+## 요약
+
+PR #1397은 1000 이상의 모든 bare issue 또는 pull-request 번호를 upstream reference로 취급하던 만료된 규칙을 제거한다. Advisory checker는 안전하게 토큰을 사용할 수 있을 때 GitHub에서 현재 `lablup/mlxcel` 번호 경계를 산출하고, offline 또는 unauthenticated 환경에서는 명시적인 수동검토 방식으로 fallback한다. 두 모드를 검증하는 결정적 companion test도 실제 pull-request workflow에서 실행한다.
+
+## 1. 문제 정의
+
+저장소 번호가 classifier의 고정 가정을 넘어섰다. #1023, #1340, #1355, #1385는 유효한 same-repository link지만 기존 `num >= 1000` 분기는 이를 likely upstream으로 표시했다. 측정된 PR #1386 diff에서는 7개, 과거 PR #1385 merge diff에서는 숫자 규칙만으로 28개의 false positive가 발생했다. 검사가 advisory이므로 지속적인 잡음은 실제 unqualified upstream 또는 private-repository reference를 찾기 위한 리뷰 신호를 약화시켰다.
+
+## 2. 변경 요약
+
+| 영역 | 변경 |
+|---|---|
+| Classifier | 5초 제한 `gh api` 호출로 최신 issue/PR 번호를 조회하고 고정 임계값 제거 |
+| Fallback | Non-upstream bare ref를 수동검토 버킷에 계속 표시하고 live classification을 사용하지 못한 이유 출력 |
+| Companion test | 임시 저장소에서 same-repo, upstream, qualified, boundary 초과, offline, API 실패, strict mode 검증 |
+| CI | Classifier 전에 companion suite를 실행하고 same-repository PR에만 `github.token` 제공 |
+| 기여 문서 | Live boundary, offline, fork, manual-review 동작 문서화 |
+
+## 3. 기술적 선택과 그 이유
+
+### 3.1 경계를 재조정하지 않고 동적으로 산출
+
+Issue와 pull-request 번호는 GitHub 저장소 순서를 공유하고 issues endpoint에는 pull request도 포함된다. 생성일 내림차순을 명시해 최신 항목을 조회하면 저장소 성장에 따라 다시 만료될 숫자를 관리하지 않고 하나의 이동 경계를 얻을 수 있다.
+
+### 3.2 실패는 허용하되 조용히 신호를 버리지 않음
+
+토큰 없음, `gh` 실행 파일 없음, timeout, API 실패, 잘못된 응답은 advisory check 자체를 실패시키지 않는다. 대신 classifier가 fallback 이유를 출력하고 모든 non-upstream bare reference를 기존 수동검토 버킷에 넣는다. 명시적인 upstream-name signal은 두 모드 모두 likely-upstream 버킷으로 간다.
+
+### 3.3 Fork code에서 base-repository credential 분리
+
+Workflow는 pull-request가 제어하는 script를 실행한다. 따라서 보안 리뷰에서 `github.token`을 same-repository PR에만 제공하도록 제한했다. Fork PR은 빈 값을 받아 의도적으로 문서화된 offline fallback을 실행한다. 이 방식은 변경된 코드에 base repository token을 노출하지 않으면서 public fork coverage를 유지한다.
+
+### 3.4 격리된 저장소에서 실제 동작 검증
+
+Shell companion은 임시 Git 저장소와 fake `gh` binary를 만들어 network 없이 boundary 및 실패 동작을 결정적으로 검증한다. 의도적인 reference corpus는 기존 `IGNORE_PREFIXES` 경로로 제외하므로 production classifier가 자체 fixture를 보고하지 않는다.
+
+## 4. 검증
+
+- `python3 -m py_compile scripts/ci/check_cross_repo_refs.py`: 통과.
+- `bash -n scripts/ci/check_cross_repo_refs_test.sh`: 통과.
+- `bash scripts/ci/check_cross_repo_refs_test.sh`: strict mode의 예상 non-zero 결과를 포함한 7개 case 모두 통과.
+- 부모 환경에 `GITHUB_TOKEN`이 있는 상태에서도 companion suite가 통과해 no-token case가 상속 credential을 명시적으로 제거함을 확인.
+- 합성 PR #1386 replay: #1340과 #1355가 `Likely UPSTREAM` 밖에 유지됨.
+- 과거 `fb1e909cc~1...fb1e909cc` replay: 숫자 규칙만으로 발생한 same-repository false positive 28개가 사라지고, 이슈가 허용한 경계와 같이 명시적 upstream 문맥이 있는 세 줄만 upstream signal로 남음.
+- Live endpoint 확인에서 현재 PR 번호 1397을 저장소 경계로 반환.
+- Hosted `cross-repo refs`는 상속 토큰 fixture 수정 후 companion suite와 production classifier를 모두 성공적으로 실행.
+- Formatting, Clippy, cargo-deny, MLX-pin extraction, OpenXLA compile, 저장소 metadata 검사, CLA 통과. 최종 OpenXLA link job은 보고서 작성 시점에 pending이며 merge 전에 terminal 상태에 도달해야 함.
+- 정확성, 보안/성능, finalization 리뷰는 fork-token 제한 후 미해결 문제를 발견하지 못함.
+
+## 5. Hosted 검증에서 발견한 통합 문제
+
+첫 hosted run에서는 companion suite의 offline case가 workflow-level `GITHUB_TOKEN`을 상속해 fallback 경로에 진입하지 못했다. 토큰이 없는 로컬 shell에서는 통과했기 때문에 실제 환경에서만 드러난 차이였다. Fixture는 이제 해당 case 내부에서 `GH_TOKEN`과 `GITHUB_TOKEN`을 모두 제거하고, hosted GNU `env` 호환성을 위해 option을 assignment보다 앞에 둔다. 교체된 hosted job은 통과했다.
+
+## 6. 관련 작업
+
+- Issue #1387: same-repository reference의 만료된 숫자 분류.
+- PR #1397: 이 보고서가 다루는 구현 및 리뷰 교정.
+- PR #1386 및 merge commit `fb1e909cc`: 측정에 사용한 false-positive dataset.
+- `scripts/ci/check_crate_versions.py`: classification 정책을 명시적이고 reviewable하게 만드는 관련 선례.

--- a/scripts/ci/check_cross_repo_refs.py
+++ b/scripts/ci/check_cross_repo_refs.py
@@ -18,6 +18,14 @@ author/reviewer can confirm each is a genuine ``lablup/mlxcel`` reference,
 qualify an upstream reference as ``org/repo#NNN``, or drop an internal one.
 ``org/repo#NNN`` (already qualified) and corpus fixtures are ignored.
 
+When ``GH_TOKEN`` or ``GITHUB_TOKEN`` is available, the script asks GitHub for
+the newest issue/PR number in ``lablup/mlxcel`` and treats any larger bare ref
+as likely cross-repository. The issues endpoint includes pull requests and both
+share the same numbering sequence, so one bounded query is enough. When the
+token, ``gh`` CLI, or API response is unavailable, the script falls back to the
+honest manual-review bucket for refs on lines without an explicit upstream
+signal and prints which fallback path was used.
+
 Usage
 -----
     scripts/ci/check_cross_repo_refs.py [BASE_REF]
@@ -27,6 +35,7 @@ exit non-zero when any reference needs review (default is advisory: exit 0).
 """
 import os
 import re
+import shutil
 import subprocess
 import sys
 
@@ -42,7 +51,15 @@ UPSTREAM = re.compile(
     r"\bupstream\b|sglang|llama\.cpp|pytorch",
     re.IGNORECASE,
 )
-IGNORE_PREFIXES = ("tests/fixtures/", ".github/PULL_REQUEST_TEMPLATE.md")
+IGNORE_PREFIXES = (
+    "tests/fixtures/",
+    ".github/PULL_REQUEST_TEMPLATE.md",
+    "scripts/ci/check_cross_repo_refs_test.sh",
+)
+REPO = "lablup/mlxcel"
+FALLBACK_PREFIX = (
+    "cross-repo-refs: fallback to manual review for non-upstream bare refs"
+)
 
 
 def diff_base() -> str:
@@ -53,8 +70,63 @@ def diff_base() -> str:
     return mb.stdout.strip() or base
 
 
+def resolve_repo_boundary():
+    token_name = next(
+        (name for name in ("GH_TOKEN", "GITHUB_TOKEN") if os.environ.get(name)),
+        None,
+    )
+    if token_name is None:
+        return None, f"{FALLBACK_PREFIX} (no GH_TOKEN/GITHUB_TOKEN)."
+    if shutil.which("gh") is None:
+        return None, f"{FALLBACK_PREFIX} (gh CLI not found)."
+
+    try:
+        result = subprocess.run(
+            [
+                "gh",
+                "api",
+                f"repos/{REPO}/issues",
+                "--method",
+                "GET",
+                "-f",
+                "state=all",
+                "-f",
+                "sort=created",
+                "-f",
+                "direction=desc",
+                "-F",
+                "per_page=1",
+                "--jq",
+                ".[0].number",
+            ],
+            capture_output=True,
+            text=True,
+            timeout=5,
+            check=False,
+        )
+    except subprocess.TimeoutExpired:
+        return None, f"{FALLBACK_PREFIX} (gh api timed out)."
+
+    if result.returncode != 0:
+        stderr = result.stderr.strip().splitlines()
+        detail = stderr[-1] if stderr else f"gh api exited {result.returncode}"
+        return None, f"{FALLBACK_PREFIX} ({detail})."
+
+    try:
+        boundary = int(result.stdout.strip())
+    except ValueError:
+        bad = result.stdout.strip() or "<empty>"
+        return None, f"{FALLBACK_PREFIX} (invalid gh api output: {bad})."
+
+    if boundary <= 0:
+        return None, f"{FALLBACK_PREFIX} (invalid repo boundary: {boundary})."
+
+    return boundary, None
+
+
 def main() -> int:
     base = diff_base()
+    repo_boundary, fallback_message = resolve_repo_boundary()
     diff = subprocess.run(
         ["git", "diff", "--unified=0", f"{base}...HEAD"],
         capture_output=True, text=True,
@@ -72,18 +144,22 @@ def main() -> int:
             for m in BARE.finditer(content):
                 num = int(m.group(1))
                 hit = (cur, m.group(1), content.strip()[:110])
-                # >=1000 cannot be a lablup/mlxcel number (this repo is far below
-                # that), so it is always an upstream ref to qualify; below that,
-                # an upstream-naming line is upstream and the rest is same-repo.
-                if num >= 1000 or UPSTREAM.search(content):
+                if UPSTREAM.search(content) or (
+                    repo_boundary is not None and num > repo_boundary
+                ):
                     upstream_hits.append(hit)
                 else:
                     samerepo_hits.append(hit)
 
     if not upstream_hits and not samerepo_hits:
+        if fallback_message:
+            print(fallback_message)
         print("cross-repo-refs: OK — no bare 3+-digit '#NNN' added.")
         return 0
 
+    if fallback_message:
+        print(fallback_message)
+        print()
     print("cross-repo-refs: bare 3+-digit '#NNN' references were added.\n")
     print(
         "Policy: same-repo (lablup/mlxcel) refs use bare '#N'. Any reference to another\n"

--- a/scripts/ci/check_cross_repo_refs_test.sh
+++ b/scripts/ci/check_cross_repo_refs_test.sh
@@ -43,7 +43,7 @@ run_case() {
   set +e
   (
     cd "$repo"
-    env PATH="$fake_bin:$PATH" "$@" python3 "$under_test" "$status_ref"
+    env "$@" PATH="$fake_bin:$PATH" python3 "$under_test" "$status_ref"
   ) >"$stdout" 2>&1
   local status=$?
   set -e
@@ -124,7 +124,8 @@ printf 'offline fallback leaves #1355 in manual review\n' >> "$repo_offline/note
 git -C "$repo_offline" add notes.md
 git -C "$repo_offline" commit -q -m "offline fallback"
 base_offline="$(git -C "$repo_offline" rev-parse HEAD~1)"
-run_case no_token "$repo_offline" "$base_offline" 0 'printf "1387\n"'
+run_case no_token "$repo_offline" "$base_offline" 0 'printf "1387\n"' \
+  -u GH_TOKEN -u GITHUB_TOKEN
 assert_contains no_token "fallback to manual review for non-upstream bare refs (no GH_TOKEN/GITHUB_TOKEN)."
 assert_contains no_token "Verify each is a real lablup/mlxcel #N"
 assert_not_contains no_token "Likely UPSTREAM"

--- a/scripts/ci/check_cross_repo_refs_test.sh
+++ b/scripts/ci/check_cross_repo_refs_test.sh
@@ -1,0 +1,156 @@
+#!/usr/bin/env bash
+# Deterministic coverage for scripts/ci/check_cross_repo_refs.py.
+#
+# The classifier is advisory in CI and depends on diff content plus an optional
+# live GitHub boundary lookup. This companion test exercises both code paths in
+# a temporary repository with a fake gh binary, so the behavior stays stable
+# without network access or a real token.
+
+set -euo pipefail
+
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+under_test="$script_dir/check_cross_repo_refs.py"
+
+work="$(mktemp -d "${TMPDIR:-/tmp}/cross-repo-refs-test.XXXXXX")"
+trap 'rm -rf "$work"' EXIT
+
+failures=0
+
+setup_repo() {
+  local repo="$1"
+  mkdir -p "$repo"
+  git init -q "$repo"
+  git -C "$repo" config user.name "mlxcel test"
+  git -C "$repo" config user.email "mlxcel-test@example.com"
+  printf 'base\n' > "$repo/notes.md"
+  git -C "$repo" add notes.md
+  git -C "$repo" commit -q -m "base"
+}
+
+write_fake_gh() {
+  local dir="$1" body="$2"
+  mkdir -p "$dir"
+  printf '%s\n' '#!/usr/bin/env bash' "$body" > "$dir/gh"
+  chmod +x "$dir/gh"
+}
+
+run_case() {
+  local name="$1" repo="$2" status_ref="$3" expected_status="$4" gh_body="$5"
+  shift 5
+  local fake_bin="$work/$name-bin"
+  local stdout="$work/$name.stdout"
+  write_fake_gh "$fake_bin" "$gh_body"
+  set +e
+  (
+    cd "$repo"
+    env PATH="$fake_bin:$PATH" "$@" python3 "$under_test" "$status_ref"
+  ) >"$stdout" 2>&1
+  local status=$?
+  set -e
+  if [ "$status" -ne "$expected_status" ]; then
+    echo "FAIL $name: expected exit $expected_status, got $status" >&2
+    sed -n '1,120p' "$stdout" >&2
+    failures=$((failures + 1))
+  else
+    echo "ok   $name -> exit $status"
+  fi
+}
+
+assert_contains() {
+  local name="$1" needle="$2"
+  local stdout="$work/$name.stdout"
+  if ! grep -Fq "$needle" "$stdout"; then
+    echo "FAIL $name: missing '$needle'" >&2
+    sed -n '1,120p' "$stdout" >&2
+    failures=$((failures + 1))
+  fi
+}
+
+assert_not_contains() {
+  local name="$1" needle="$2"
+  local stdout="$work/$name.stdout"
+  if grep -Fq "$needle" "$stdout"; then
+    echo "FAIL $name: unexpectedly found '$needle'" >&2
+    sed -n '1,120p' "$stdout" >&2
+    failures=$((failures + 1))
+  fi
+}
+
+repo_same="$work/repo-same"
+setup_repo "$repo_same"
+printf 'same repo refs #1023 and #1355 stay bare\n' >> "$repo_same/notes.md"
+git -C "$repo_same" add notes.md
+git -C "$repo_same" commit -q -m "same repo refs"
+base_same="$(git -C "$repo_same" rev-parse HEAD~1)"
+run_case same_repo "$repo_same" "$base_same" 0 'printf "1387\n"' GH_TOKEN=token
+assert_contains same_repo "Verify each is a real lablup/mlxcel #N"
+assert_contains same_repo "#1023"
+assert_contains same_repo "#1355"
+assert_not_contains same_repo "Likely UPSTREAM"
+
+repo_upstream="$work/repo-upstream"
+setup_repo "$repo_upstream"
+printf 'mlx-lm parity note tracks #1240\n' >> "$repo_upstream/notes.md"
+git -C "$repo_upstream" add notes.md
+git -C "$repo_upstream" commit -q -m "upstream ref"
+base_upstream="$(git -C "$repo_upstream" rev-parse HEAD~1)"
+run_case upstream_line "$repo_upstream" "$base_upstream" 0 'printf "1387\n"' GH_TOKEN=token
+assert_contains upstream_line "Likely UPSTREAM"
+assert_contains upstream_line "#1240"
+
+repo_qualified="$work/repo-qualified"
+setup_repo "$repo_qualified"
+printf 'qualified ref ml-explore/mlx-lm#1240 stays ignored\n' >> "$repo_qualified/notes.md"
+git -C "$repo_qualified" add notes.md
+git -C "$repo_qualified" commit -q -m "qualified ref"
+base_qualified="$(git -C "$repo_qualified" rev-parse HEAD~1)"
+run_case qualified_ref "$repo_qualified" "$base_qualified" 0 'printf "1387\n"' GH_TOKEN=token
+assert_contains qualified_ref "OK"
+assert_not_contains qualified_ref "#1240"
+
+repo_boundary="$work/repo-boundary"
+setup_repo "$repo_boundary"
+printf 'future upstream-looking number #1400 needs review\n' >> "$repo_boundary/notes.md"
+git -C "$repo_boundary" add notes.md
+git -C "$repo_boundary" commit -q -m "boundary ref"
+base_boundary="$(git -C "$repo_boundary" rev-parse HEAD~1)"
+run_case live_boundary "$repo_boundary" "$base_boundary" 0 'printf "1387\n"' GH_TOKEN=token
+assert_contains live_boundary "Likely UPSTREAM"
+assert_contains live_boundary "#1400"
+
+repo_offline="$work/repo-offline"
+setup_repo "$repo_offline"
+printf 'offline fallback leaves #1355 in manual review\n' >> "$repo_offline/notes.md"
+git -C "$repo_offline" add notes.md
+git -C "$repo_offline" commit -q -m "offline fallback"
+base_offline="$(git -C "$repo_offline" rev-parse HEAD~1)"
+run_case no_token "$repo_offline" "$base_offline" 0 'printf "1387\n"'
+assert_contains no_token "fallback to manual review for non-upstream bare refs (no GH_TOKEN/GITHUB_TOKEN)."
+assert_contains no_token "Verify each is a real lablup/mlxcel #N"
+assert_not_contains no_token "Likely UPSTREAM"
+
+repo_api_fail="$work/repo-api-fail"
+setup_repo "$repo_api_fail"
+printf 'API failure fallback leaves #1355 in manual review\n' >> "$repo_api_fail/notes.md"
+git -C "$repo_api_fail" add notes.md
+git -C "$repo_api_fail" commit -q -m "api failure fallback"
+base_api_fail="$(git -C "$repo_api_fail" rev-parse HEAD~1)"
+run_case api_failure "$repo_api_fail" "$base_api_fail" 0 'echo "simulated gh failure" >&2; exit 1' GH_TOKEN=token
+assert_contains api_failure "fallback to manual review for non-upstream bare refs (simulated gh failure)."
+assert_contains api_failure "Verify each is a real lablup/mlxcel #N"
+
+repo_strict="$work/repo-strict"
+setup_repo "$repo_strict"
+printf 'strict mode still fails for mlx-lm #1240\n' >> "$repo_strict/notes.md"
+git -C "$repo_strict" add notes.md
+git -C "$repo_strict" commit -q -m "strict mode"
+base_strict="$(git -C "$repo_strict" rev-parse HEAD~1)"
+run_case strict_mode "$repo_strict" "$base_strict" 1 'printf "1387\n"' GH_TOKEN=token STRICT=1
+assert_contains strict_mode "Likely UPSTREAM"
+
+if [ "$failures" -ne 0 ]; then
+  echo "$failures case(s) failed" >&2
+  exit 1
+fi
+
+echo "all cases passed"


### PR DESCRIPTION
## Summary

- replace the stale `>=1000` split with a bounded live lookup of the newest `lablup/mlxcel` issue or pull-request number
- keep unauthenticated, missing-tool, timeout, invalid-response, and API-failure paths advisory through an explicit manual-review fallback
- add a deterministic shell companion suite and run it before the production classifier in the real CI job
- expose `github.token` only to same-repository PRs; fork PRs intentionally exercise the credential-free fallback
- document the behavior and include bilingual technical reports

## Testing

- `python3 -m py_compile scripts/ci/check_cross_repo_refs.py`
- `bash -n scripts/ci/check_cross_repo_refs_test.sh`
- `bash scripts/ci/check_cross_repo_refs_test.sh`
- `env GITHUB_TOKEN=ci-parent-token bash scripts/ci/check_cross_repo_refs_test.sh`
- `env -u GH_TOKEN -u GITHUB_TOKEN python3 scripts/ci/check_cross_repo_refs.py origin/main`
- synthetic PR #1386 replay: #1340 and #1355 remain outside `Likely UPSTREAM`
- archived `fb1e909cc~1...fb1e909cc` replay: all 28 numeric-only false positives are removed; only three explicit upstream-signal lines remain

## Hosted validation

- the first hosted run exposed a companion-fixture bug where the offline case inherited the job token; commit `f3817905` now removes both token variables inside that case
- the replacement `cross-repo refs` job ran both the companion suite and production classifier successfully
- correctness and finalization reviews found no unresolved issue; security review restricted live-boundary credentials to same-repository pull requests
- the final report-commit run passed every hosted check, including the 2m40s OpenXLA feature link on GB10

## Reports

- `TECHNICAL_REPORTS/1397-cross-repo-ref-boundaries-20260824.en.md`
- `TECHNICAL_REPORTS/1397-cross-repo-ref-boundaries-20260824.ko.md`

Closes #1387
