### PR TITLE
fix: apply KV modes to model-owned caches

### DIFF
--- a/TECHNICAL_REPORTS/1400-model-owned-kv-cache-modes-20260825.en.md
+++ b/TECHNICAL_REPORTS/1400-model-owned-kv-cache-modes-20260825.en.md
@@ -1,0 +1,149 @@
+# Technical Report: PR #1400 - Apply KV Modes to Model-Owned Caches
+
+**Date**: 2026-08-25
+**Author**: mlxcel contributors
+**Status**: Completed
+**Languages**: Rust, Markdown
+**Risk Level**: High
+
+---
+
+## Executive Summary
+
+PR #1400 makes the resolved KV-cache policy reach model families that allocate heterogeneous sequence state internally. It also aligns CLI/server observability, cache statistics, snapshot refusal, and dense prompt-cache adoption with the mode that is actually active, eliminating a silent configuration no-op across Gemma, Qwen, LFM2, Llama 4, AFMoE, and related VLM wrappers.
+
+---
+
+## 1. Problem Statement
+
+### 1.1 Background
+
+The CLI generator and server cache pool already resolved `--kv-cache-mode`, Boundary-V, and `--kv-bits` into per-layer policies, but this policy was applied only to the external `Vec<KVCache>` passed through `LanguageModel::forward`. Model-owned families ignored that homogeneous slice and constructed their own attention caches with FP16 defaults because they also needed recurrent, convolutional, sliding-window, or other heterogeneous state.
+
+### 1.2 Existing Issues
+
+- **Silent no-op**: Operators could request Int8 or Turbo modes while model-owned families continued to allocate FP16 attention caches without an error.
+- **Misleading observability**: Banners and statistics could describe the requested or legacy mode even when batch KV quantization selected another effective mode.
+- **Unsafe reuse boundary**: Snapshot serializers that copied only ordinary keys and values could truncate quantization sidecars, and dense prompt-cache adoption did not reject per-layer KV-mode mismatches.
+- **Incomplete family coverage**: The documented symmetric Turbo4 allowlist named Qwen families whose internal caches never consumed the resolved policy.
+
+### 1.3 Risk Assessment
+
+| Risk | Impact | Likelihood before fix |
+|------|--------|-----------------------|
+| Production memory sizing differs from announced configuration | High | High |
+| Prompt or snapshot reuse crosses incompatible KV representations | High | Medium |
+| Operators tune performance from inaccurate cache statistics | Medium | High |
+
+---
+
+## 2. Change Summary
+
+### 2.1 Policy Injection
+
+`LanguageModel` now exposes hooks for installing and reading a resolved per-layer KV-mode table. A shared `KvCacheLayerModes` holder stores the table next to model-owned sequence state, while `LoadedModel` and applicable VLM wrappers delegate the hooks to their underlying text models.
+
+Both execution surfaces inject policy after effective-mode resolution: `CxxGenerator` does so for offline generation, and the batch scheduler does so for server inference. Boundary-V and batch KV quantization continue to use their existing resolution logic, so this change extends one source of truth rather than introducing another requested-mode path.
+
+### 2.2 Family Coverage
+
+Gemma 3, AFMoE, Gemma 4, Qwen 3.5, Qwen3-Next, Bailing MoE Linear, LFM2, and Llama 4 regular attention constructors now select the configured mode by layer index. Recurrent, convolutional, gated-delta, and Llama 4 `ChunkedKVCache` state remain FP16; Llama 4 emits a one-time warning when a non-FP16 policy reaches an unsupported chunked layer.
+
+### 2.3 Reuse Safety
+
+Dense detached prompt-cache entries are compared against the resolved mode for every layer. A mismatch is rejected through the named `kv_mode_mismatch` reason and its metric instead of being adopted into a live scheduler with a different representation.
+
+Model-owned exact-prefix snapshot paths now reject non-FP16 state unless they can preserve the required representation. The PR intentionally chooses explicit refusal over silently restoring only keys and values while losing Int8 or Turbo sidecars.
+
+### 2.4 Observability
+
+The CLI banner and server startup log report how many layers received the effective mode. `/v1/cache/stats` exposes `kv_cache_mode_effective`, and the review fix makes it prefer `BatchKvQuantConfig::base_mode()` when `--kv-bits` is enabled rather than incorrectly reporting the legacy FP16 field.
+
+---
+
+## 3. Technical Decisions
+
+### 3.1 Inject a Resolved Table, Not Raw Flags
+
+**Decision:** Store a vector of resolved modes indexed by model layer.
+
+**Rationale:** A scalar raw flag cannot represent Boundary-V or per-layer batch KV policy and would reintroduce the requested-versus-effective divergence fixed immediately before this issue. The table also lets heterogeneous model wrappers apply the policy only to attention-bearing layers while leaving recurrent state unchanged.
+
+**Trade-off:** Models now carry a small piece of configuration state and wrapper delegation must remain complete when new VLM families are added.
+
+### 3.2 Refuse Unsupported Snapshots
+
+**Decision:** Fail closed for non-FP16 model-owned snapshots instead of partially serializing them.
+
+**Rationale:** A complete Turbo or Int8 snapshot requires packed tensors, norms, scales, seeds, offsets, and thresholds. Copying only ordinary keys and values creates a cache that appears valid but has a different representation. Explicit refusal preserves correctness while leaving full sidecar serialization for a future change.
+
+**Trade-off:** Some non-FP16 exact-prefix cache hits fall back to cold prefill.
+
+### 3.3 Keep Chunked KV State in FP16
+
+**Decision:** Quantize only Llama 4 regular attention caches and warn for unsupported `ChunkedKVCache` layers.
+
+**Rationale:** Chunked caches do not yet implement quantized sidecar storage. Partial, explicit application is safer than either silently claiming complete coverage or changing the chunked cache format in this issue.
+
+---
+
+## 4. Review and Quality Findings
+
+### 4.1 Implementation Review
+
+The implementation review found one HIGH issue: cache statistics still read the legacy effective-mode field when server-side batch KV quantization was active. Commit `01773044a` fixed the route to prefer the batch quantization base mode and added Int8, Turbo, and legacy fallback coverage.
+
+### 4.2 Security and Performance Review
+
+No unresolved CRITICAL or HIGH security/performance findings remained. The security review confirmed that the new reuse boundaries fail closed, the mode table is derived from validated runtime configuration, and no untrusted input is used to index beyond the resolved layer count.
+
+### 4.3 Compatibility
+
+- **Breaking changes**: None to CLI flags or public HTTP request formats.
+- **New dependencies**: None.
+- **Behavior change**: Existing non-FP16 flags now take effect for model-owned attention caches; unsupported model-owned snapshot reuse may cold-prefill instead of accepting incomplete state.
+
+---
+
+## 5. Validation
+
+- `cargo test --workspace --profile test-fast --features metal,accelerate` passed after final review changes.
+- `cargo clippy --workspace --all-targets -- -D warnings` passed.
+- `cargo fmt --all -- --check` and `git diff --check` passed.
+- Focused tests passed for generator mode forwarding, Qwen3-Next snapshot mismatch refusal, dense prompt-cache KV-mode rejection, and effective cache-stat reporting.
+- Real Gemma 3 generation passed on Metal with both FP16 and Int8. Both banners reported `applied to 26 of 26 layers`, both outputs were fluent and finite, and the greedy token streams differed, demonstrating that Int8 reached the internal attention caches.
+
+---
+
+## 6. Change Statistics
+
+| Item | Value |
+|------|-------|
+| Files changed | 26 |
+| Lines added | 1,009 |
+| Lines deleted | 204 |
+| Implementation commits | 2 |
+
+### Related Commits
+
+| Hash | Type | Message |
+|------|------|---------|
+| `b3536bff9` | fix | Apply KV modes to model-owned caches |
+| `01773044a` | fix | Report batch KV mode in cache stats |
+
+---
+
+## 7. Follow-up Considerations
+
+- Implement full quantized sidecar serialization for model-owned exact-prefix snapshots if cache-hit performance justifies the additional format surface.
+- Add quantized representations for Llama 4 `ChunkedKVCache` and ring-sliding caches in separately scoped work.
+- Monitor `mlxcel_prompt_cache_reject_total{reason="kv_mode_mismatch"}` to distinguish expected configuration changes from unexpected policy drift.
+- Preserve delegation of the `LanguageModel` KV-mode hooks when introducing new VLM wrappers or model-owned families.
+
+---
+
+## References
+
+- Issue #1330: model-owned KV-cache mode no-op and reuse safety requirements
+- PR #1400: final implementation and review fix
+- `docs/turbo-kv-cache.md`: supported modes, model-owned behavior, and current exceptions

--- a/TECHNICAL_REPORTS/1400-model-owned-kv-cache-modes-20260825.ko.md
+++ b/TECHNICAL_REPORTS/1400-model-owned-kv-cache-modes-20260825.ko.md
@@ -1,0 +1,149 @@
+# 기술 보고서: PR #1400 - 모델 소유 캐시에 KV 모드 적용
+
+**작성일**: 2026-08-25
+**작성자**: mlxcel 기여자
+**상태**: 완료
+**언어**: Rust, Markdown
+**위험도**: High
+
+---
+
+## 요약
+
+PR #1400은 이질적인 시퀀스 상태를 모델 내부에서 할당하는 모델군에도 해석 완료된 KV 캐시 정책을 전달한다. CLI/서버 관측 정보, 캐시 통계, 스냅샷 거부 정책, dense 프롬프트 캐시 채택을 실제 활성 모드와 일치시켜 Gemma, Qwen, LFM2, Llama 4, AFMoE 및 관련 VLM 래퍼에서 발생하던 조용한 설정 무효화를 제거했다.
+
+---
+
+## 1. 문제 정의
+
+### 1.1 배경
+
+CLI 생성기와 서버 캐시 풀은 이미 `--kv-cache-mode`, Boundary-V, `--kv-bits`를 계층별 정책으로 해석하고 있었지만, 이 정책은 `LanguageModel::forward`에 전달되는 외부 `Vec<KVCache>`에만 적용됐다. 모델 소유 계열은 순환, 합성곱, 슬라이딩 윈도우 등 서로 다른 상태를 함께 관리해야 하므로 해당 균질 슬라이스를 사용하지 않고 내부 attention 캐시를 FP16 기본값으로 생성했다.
+
+### 1.2 기존 문제점
+
+- **조용한 무효화**: 운영자가 Int8 또는 Turbo 모드를 요청해도 모델 소유 계열은 오류 없이 FP16 attention 캐시를 계속 할당했다.
+- **잘못된 관측 정보**: 배너와 통계가 batch KV 양자화가 선택한 실제 모드가 아니라 요청 모드 또는 레거시 모드를 표시할 수 있었다.
+- **안전하지 않은 재사용 경계**: 일반 key/value만 복사하는 스냅샷 직렬화가 양자화 sidecar를 누락할 수 있었고, dense 프롬프트 캐시 채택은 계층별 KV 모드 불일치를 거부하지 않았다.
+- **불완전한 모델군 지원**: 문서화된 대칭 Turbo4 allowlist의 Qwen 계열도 내부 캐시에 해석 완료 정책을 적용하지 못했다.
+
+### 1.3 위험성
+
+| 위험 | 영향도 | 수정 전 가능성 |
+|------|--------|----------------|
+| 운영 메모리 사용량이 공지된 설정과 불일치 | High | High |
+| 프롬프트 또는 스냅샷 재사용이 호환되지 않는 KV 표현을 혼합 | High | Medium |
+| 부정확한 캐시 통계를 기반으로 성능 튜닝 | Medium | High |
+
+---
+
+## 2. 변경 요약
+
+### 2.1 정책 주입
+
+`LanguageModel`은 이제 해석 완료된 계층별 KV 모드 테이블을 설정하고 조회하는 훅을 제공한다. 공용 `KvCacheLayerModes` 저장소가 모델 소유 시퀀스 상태 옆에 테이블을 보관하고, `LoadedModel`과 해당 VLM 래퍼가 기반 텍스트 모델로 훅을 위임한다.
+
+두 실행 경로 모두 effective-mode 해석 뒤 정책을 주입한다. 오프라인 생성에서는 `CxxGenerator`, 서버 추론에서는 batch scheduler가 이를 담당한다. Boundary-V와 batch KV 양자화는 기존 해석 로직을 계속 사용하므로 새로운 requested-mode 경로를 만들지 않고 하나의 진실 원천을 확장한다.
+
+### 2.2 모델군 적용 범위
+
+Gemma 3, AFMoE, Gemma 4, Qwen 3.5, Qwen3-Next, Bailing MoE Linear, LFM2, Llama 4 일반 attention 생성자는 계층 인덱스에 맞는 설정 모드를 선택한다. 순환, 합성곱, gated-delta, Llama 4 `ChunkedKVCache` 상태는 FP16을 유지하며, Llama 4는 비-FP16 정책이 지원되지 않는 chunked 계층에 도달하면 한 번 경고한다.
+
+### 2.3 재사용 안전성
+
+Dense detached 프롬프트 캐시는 모든 계층에서 해석 완료 모드와 비교된다. 불일치는 다른 표현을 사용하는 live scheduler에 채택되지 않고 명시적인 `kv_mode_mismatch` 사유와 메트릭으로 거부된다.
+
+모델 소유 exact-prefix 스냅샷 경로는 필요한 표현을 보존할 수 없는 비-FP16 상태를 거부한다. 이 PR은 Int8 또는 Turbo sidecar를 잃은 채 key/value만 복원하는 대신 명시적으로 거부하는 보수적 정책을 선택했다.
+
+### 2.4 관측 가능성
+
+CLI 배너와 서버 시작 로그는 effective mode가 적용된 계층 수를 보고한다. `/v1/cache/stats`는 `kv_cache_mode_effective`를 제공하며, 리뷰 수정으로 `--kv-bits`가 활성화된 경우 레거시 FP16 필드가 아니라 `BatchKvQuantConfig::base_mode()`를 우선 사용한다.
+
+---
+
+## 3. 기술적 선택과 그 이유
+
+### 3.1 원시 플래그가 아니라 해석 완료 테이블 주입
+
+**결정:** 모델 계층 인덱스에 대응하는 해석 완료 모드 벡터를 저장한다.
+
+**근거:** 단일 원시 플래그는 Boundary-V 또는 계층별 batch KV 정책을 표현할 수 없으며 직전 이슈에서 제거한 requested/effective 불일치를 다시 만들 수 있다. 테이블을 사용하면 이질적 모델 래퍼가 attention 계층에만 정책을 적용하고 순환 상태는 그대로 유지할 수 있다.
+
+**트레이드오프:** 모델이 작은 설정 상태를 보유하며, 새 VLM 계열을 추가할 때 래퍼 위임을 빠뜨리지 않아야 한다.
+
+### 3.2 지원되지 않는 스냅샷은 거부
+
+**결정:** 비-FP16 모델 소유 스냅샷을 부분 직렬화하지 않고 fail-closed 한다.
+
+**근거:** 완전한 Turbo 또는 Int8 스냅샷에는 packed tensor, norm, scale, seed, offset, threshold가 필요하다. 일반 key/value만 복사하면 유효해 보이지만 표현이 다른 캐시가 만들어진다. 명시적 거부로 정확성을 지키고 전체 sidecar 직렬화는 별도 변경으로 남긴다.
+
+**트레이드오프:** 일부 비-FP16 exact-prefix 캐시 hit가 cold prefill로 대체된다.
+
+### 3.3 Chunked KV 상태는 FP16 유지
+
+**결정:** Llama 4 일반 attention 캐시만 양자화하고 지원되지 않는 `ChunkedKVCache` 계층에는 경고한다.
+
+**근거:** Chunked 캐시는 아직 양자화 sidecar 저장소를 구현하지 않았다. 부분 적용을 명시하는 것이 완전 지원을 조용히 주장하거나 이 이슈에서 캐시 형식을 바꾸는 것보다 안전하다.
+
+---
+
+## 4. 리뷰 및 품질 검토
+
+### 4.1 구현 리뷰
+
+구현 리뷰에서 HIGH 이슈 한 건을 발견했다. 서버 batch KV 양자화가 활성화된 경우에도 캐시 통계가 레거시 effective-mode 필드를 읽고 있었다. 커밋 `01773044a`는 route가 batch 양자화 base mode를 우선 사용하도록 수정하고 Int8, Turbo, 레거시 fallback 테스트를 추가했다.
+
+### 4.2 보안 및 성능 리뷰
+
+해결되지 않은 CRITICAL 또는 HIGH 보안/성능 이슈는 없었다. 보안 리뷰는 새 재사용 경계가 fail-closed 하며, 모드 테이블이 검증된 런타임 설정에서 유도되고, 비신뢰 입력으로 해석된 계층 수를 넘어 인덱싱하지 않음을 확인했다.
+
+### 4.3 호환성
+
+- **Breaking change**: CLI 플래그와 공개 HTTP 요청 형식에는 없음.
+- **새 의존성**: 없음.
+- **동작 변경**: 기존 비-FP16 플래그가 모델 소유 attention 캐시에 실제 적용되며, 지원되지 않는 모델 소유 스냅샷 재사용은 불완전 상태를 허용하는 대신 cold prefill로 전환될 수 있다.
+
+---
+
+## 5. 검증
+
+- 최종 리뷰 변경 뒤 `cargo test --workspace --profile test-fast --features metal,accelerate`가 통과했다.
+- `cargo clippy --workspace --all-targets -- -D warnings`가 통과했다.
+- `cargo fmt --all -- --check`와 `git diff --check`가 통과했다.
+- 생성기 모드 전달, Qwen3-Next 스냅샷 모드 불일치 거부, dense 프롬프트 캐시 KV 모드 거부, effective cache-stat 보고에 대한 집중 테스트가 통과했다.
+- 실제 Gemma 3 모델로 Metal에서 FP16과 Int8 생성을 검증했다. 두 배너 모두 `applied to 26 of 26 layers`를 보고했고, 출력은 유창하고 유한했으며, greedy 토큰 스트림이 달라 Int8이 내부 attention 캐시에 도달했음을 확인했다.
+
+---
+
+## 6. 변경 통계
+
+| 항목 | 값 |
+|------|----|
+| 변경 파일 | 26 |
+| 추가 줄 | 1,009 |
+| 삭제 줄 | 204 |
+| 구현 커밋 | 2 |
+
+### 관련 커밋
+
+| 해시 | 유형 | 메시지 |
+|------|------|--------|
+| `b3536bff9` | fix | 모델 소유 캐시에 KV 모드 적용 |
+| `01773044a` | fix | 캐시 통계에 batch KV 모드 보고 |
+
+---
+
+## 7. 후속 고려 사항
+
+- 캐시 hit 성능이 추가 포맷 복잡성을 정당화하면 모델 소유 exact-prefix 스냅샷에 완전한 양자화 sidecar 직렬화를 구현한다.
+- Llama 4 `ChunkedKVCache`와 ring-sliding 캐시의 양자화 표현은 별도 범위에서 추가한다.
+- `mlxcel_prompt_cache_reject_total{reason="kv_mode_mismatch"}`를 관찰해 의도된 설정 변경과 예기치 않은 정책 드리프트를 구분한다.
+- 새 VLM 래퍼 또는 모델 소유 계열을 추가할 때 `LanguageModel` KV 모드 훅 위임을 유지한다.
+
+---
+
+## 참고
+
+- 이슈 #1330: 모델 소유 KV 캐시 모드 무효화 및 재사용 안전성 요구사항
+- PR #1400: 최종 구현 및 리뷰 수정
+- `docs/turbo-kv-cache.md`: 지원 모드, 모델 소유 동작, 현재 예외

--- a/docs/turbo-kv-cache.md
+++ b/docs/turbo-kv-cache.md
@@ -184,6 +184,14 @@ the CLI banner, the server startup log and the `/props` payload
 effective mode, not the requested one. If you are adding a new entry, include a
 quality gate in the same change.
 
+## Model-owned cache families
+
+Some families do not use the homogeneous `&mut [KVCache]` slice handed to `forward`; they keep heterogeneous attention, sliding-window, recurrent, or convolutional state inside the model wrapper. The CLI generator and server scheduler resolve the effective per-layer KV-mode table once (including Boundary-V and `--kv-bits` / batch-KV policy) and inject that table into model-owned attention-cache constructors too. The CLI banner and server startup log report the effective mode and `applied to N of M layers`, and `GET /v1/cache/stats` includes `kv_cache_mode_effective`.
+
+Attention KV caches owned by Gemma 3, AFMoE, Gemma 4 text/VLM/Unified, Qwen 3.5 text/MoE/VLM, Qwen3-Next, Bailing MoE Linear, LFM2/LFM2-VL, and the regular-attention arms of Llama 4 use the injected mode for their layer index and fall back to FP16 only when no table is available. Recurrent, convolutional, and gated-delta state is not a KV tensor and remains unchanged.
+
+Llama 4 `ChunkedKVCache` layers remain FP16. They do not yet have quantized sidecar storage, and the wrapper warns once when a non-FP16 table would otherwise apply to those chunked layers. Muse Glimmer still rejects non-FP16 modes at startup rather than silently running a partial mode.
+
 ## WHT head-dimension constraint
 
 TurboQuant uses a Walsh-Hadamard transform. The implementation expects a
@@ -275,9 +283,14 @@ issue #1346 turned into a wrong turn-2 answer). The decline is visible, not
 silent: `GET /v1/cache/stats` reports `reject_model_owned_state` and `/metrics`
 carries `mlxcel_prompt_cache_reject_total{reason="model_owned_state"}`, so a
 family whose store legitimately stays empty is distinguishable from a cache that
-is broken. Real cross-request reuse for these families comes through the
-model-state snapshot path (#1335), described next; a family that opts into
-`supports_snapshot_reuse()` is handled by that branch first and keeps donating.
+is broken. Dense prompt-cache adoption also compares every detached layer's KV
+mode against the currently resolved per-layer table; mismatches decline with
+`reject_kv_mode_mismatch` and
+`mlxcel_prompt_cache_reject_total{reason="kv_mode_mismatch"}` instead of
+installing a stale-mode cache. Real cross-request reuse for these families
+comes through the model-state snapshot path (#1335), described next; a family
+that opts into `supports_snapshot_reuse()` is handled by that branch first and
+keeps donating.
 
 ### Exact-prefix snapshots for recurrent state
 
@@ -291,6 +304,15 @@ tokens begin with that exact stored prefix under the same session key. As of
 v0.2.1, the supported snapshot families are Mamba, Mamba2, Jamba, Nemotron-H,
 Qwen 3.5 / 3.6 text, MoE, and VLM wrappers, and Gemma 4 text, VLM, and Unified
 wrappers.
+
+Snapshot reuse is deliberately conservative with quantized attention caches.
+Gemma 4, Qwen3-Next/Qwen 3.5, Bailing MoE Linear, and LFM2 serialize FP16
+model-owned attention KV state only; if a live layer is configured for Int8 or
+Turbo mode, donation/restoration is refused with an explicit error rather than
+copying only `keys`/`values` and restoring them as FP16. Restores also compare
+the serialized snapshot mode with the live per-layer table, so a snapshot
+captured under a different KV mode falls back to cold prefill instead of
+corrupting the cache.
 
 The snapshot bucket has its own byte cap, entry cap, TTL, LRU counters, and
 hit/miss metrics. `GET /v1/cache/stats` reports `snapshot_*` fields, while

--- a/src/commands/generate.rs
+++ b/src/commands/generate.rs
@@ -444,6 +444,24 @@ fn resolve_cli_pipeline_num_layers(model_dir: &Path) -> Result<usize> {
     resolve_in_process_pipeline_num_layers(model_dir).map_err(|err| anyhow!("{err}"))
 }
 
+fn kv_cache_mode_banner_suffix(
+    requested: KVCacheMode,
+    effective: KVCacheMode,
+    num_layers: usize,
+) -> String {
+    let boundary = mlxcel_core::cache::turbo::boundary_v_layers_from_env();
+    let modes = mlxcel_core::cache::turbo::resolve_layer_modes(effective, num_layers, boundary);
+    let applied = modes.iter().filter(|mode| **mode == effective).count();
+    if requested != effective {
+        format!(
+            " (requested {requested}; effective {effective}; applied to {applied} of {} layers)",
+            modes.len()
+        )
+    } else {
+        format!(" (applied to {applied} of {} layers)", modes.len())
+    }
+}
+
 fn generate_pipeline_text(
     model_dir: &Path,
     num_layers: usize,
@@ -2316,13 +2334,20 @@ fn run_generate_once(mut args: GenerateArgs) -> Result<()> {
     {
         println!("Boundary-V: protecting {boundary} layer(s) on each end at Fp16");
     }
+    let kv_cache_mode_suffix = kv_cache_mode_banner_suffix(
+        requested_kv_cache_mode,
+        kv_cache_mode,
+        resolve_cli_pipeline_num_layers(&args.model.model).unwrap_or(0),
+    );
 
     match kv_cache_mode {
         KVCacheMode::Int8 => {
-            println!("KV cache mode: int8 (per-token absmax quantization)");
+            println!("KV cache mode: int8 (per-token absmax quantization){kv_cache_mode_suffix}");
         }
         KVCacheMode::Turbo4Asym => {
-            println!("KV cache mode: fp16+turbo4 (asymmetric Fp16-K + Turbo4-V, ~26% KV savings)");
+            println!(
+                "KV cache mode: fp16+turbo4 (asymmetric Fp16-K + Turbo4-V, ~26% KV savings){kv_cache_mode_suffix}"
+            );
         }
         KVCacheMode::Turbo4 => {
             // Reached only when the family is on
@@ -2331,19 +2356,19 @@ fn run_generate_once(mut args: GenerateArgs) -> Result<()> {
             // longer describes a fallback that had never been performed.
             println!(
                 "KV cache mode: turbo4 (symmetric Turbo4-K + Turbo4-V, ~73% KV savings; \
-                 this family is on the symmetric-Turbo4 allowlist)"
+                 this family is on the symmetric-Turbo4 allowlist){kv_cache_mode_suffix}"
             );
         }
         KVCacheMode::Turbo4Delegated => {
             println!(
                 "KV cache mode: turbo4-delegated (Fp16-K + Turbo4-V with hot/cold split, \
-                 ~26% KV savings + 97-100% FP16 decode speed at long context)"
+                 ~26% KV savings + 97-100% FP16 decode speed at long context){kv_cache_mode_suffix}"
             );
         }
         KVCacheMode::Turbo3Asym => {
             println!(
                 "KV cache mode: fp16+turbo3 (asymmetric Fp16-K + Turbo3-V, \
-                 ~5.1x total KV savings)"
+                 ~5.1x total KV savings){kv_cache_mode_suffix}"
             );
         }
         KVCacheMode::Fp16 => {
@@ -2352,12 +2377,7 @@ fn run_generate_once(mut args: GenerateArgs) -> Result<()> {
             // else, so name the mode actually in force (issue #1350). The
             // reason was printed to stderr by
             // `resolve_and_announce_kv_cache_mode`.
-            if kv_cache_mode != requested_kv_cache_mode {
-                println!(
-                    "KV cache mode: fp16 (requested {requested_kv_cache_mode}; \
-                     not supported on this model family)"
-                );
-            }
+            println!("KV cache mode: fp16{kv_cache_mode_suffix}");
         }
     }
 

--- a/src/lib/mlxcel-core/src/generate.rs
+++ b/src/lib/mlxcel-core/src/generate.rs
@@ -340,6 +340,19 @@ pub trait LanguageModel {
     /// Create KV caches for all layers
     fn make_caches(&self) -> Vec<KVCache>;
 
+    /// Inject a resolved per-layer KV cache mode table for model-owned caches.
+    ///
+    /// Most dense models keep caches in the generator-provided slice and use
+    /// the default no-op. Hybrid / sliding / VLM families that own attention
+    /// caches internally override this and build those caches from the same
+    /// resolved table used for dense external caches.
+    fn set_kv_cache_layer_modes(&self, _modes: Vec<KVCacheMode>) {}
+
+    /// Return the currently injected model-owned KV cache mode table, if any.
+    fn kv_cache_layer_modes(&self) -> Option<Vec<KVCacheMode>> {
+        None
+    }
+
     /// Get the number of layers
     fn num_layers(&self) -> usize;
 
@@ -1148,9 +1161,10 @@ impl CxxGenerator {
     pub fn reset_with_model<M: LanguageModel + ?Sized>(&mut self, model: &M) {
         model.reset_runtime_state();
         self.caches = model.make_caches();
-        // Apply the configured KV cache mode (with Boundary-V upgrade) to
-        // all freshly created caches.
-        self.apply_kv_cache_mode_with_boundary_policy();
+        // Apply the configured KV cache mode (with Boundary-V upgrade) to all
+        // freshly created external caches, and inject the same resolved table
+        // into model-owned cache families.
+        self.apply_kv_cache_mode_with_boundary_policy_for_model(model);
         self.generated_tokens.clear();
     }
 
@@ -1168,19 +1182,27 @@ impl CxxGenerator {
     /// Boundary-V policy survives the entire generation lifecycle
     /// including `reset_with_model` boundary cases.
     ///
-    /// No-op when `self.kv_cache_mode == Fp16` — every layer is already FP16
-    /// so there is nothing to apply.
-    fn apply_kv_cache_mode_with_boundary_policy(&mut self) {
+    fn resolved_layer_modes_for(&self, n_layers: usize) -> Vec<KVCacheMode> {
         let nominal = self.kv_cache_mode;
-        if nominal == KVCacheMode::Fp16 {
-            return;
-        }
-        let n_layers = self.caches.len();
         let requested = crate::cache::turbo::boundary_v_layers_from_env();
-        let layer_modes = crate::cache::turbo::resolve_layer_modes(nominal, n_layers, requested);
-        for (cache, mode) in self.caches.iter_mut().zip(layer_modes) {
+        crate::cache::turbo::resolve_layer_modes(nominal, n_layers, requested)
+    }
+
+    fn apply_kv_cache_mode_with_boundary_policy(&mut self) -> Vec<KVCacheMode> {
+        let layer_modes = self.resolved_layer_modes_for(self.caches.len());
+        for (cache, mode) in self.caches.iter_mut().zip(layer_modes.iter().copied()) {
             cache.mode = mode;
         }
+        layer_modes
+    }
+
+    fn apply_kv_cache_mode_with_boundary_policy_for_model<M: LanguageModel + ?Sized>(
+        &mut self,
+        model: &M,
+    ) {
+        self.apply_kv_cache_mode_with_boundary_policy();
+        let model_modes = self.resolved_layer_modes_for(model.num_layers());
+        model.set_kv_cache_layer_modes(model_modes);
     }
 
     /// Generate tokens from the model (original implementation)
@@ -1232,7 +1254,7 @@ impl CxxGenerator {
         // Honor the Boundary-V policy when applying the
         // nominal mode to per-layer caches: the first/last N layers stay
         // at FP16 to recover the V-quantization quality gap.
-        self.apply_kv_cache_mode_with_boundary_policy();
+        self.apply_kv_cache_mode_with_boundary_policy_for_model(model);
 
         // Set generation stream as default for better pipelining
         install_thread_local_default_stream(self.generation_stream.as_ref());
@@ -1571,7 +1593,7 @@ impl CxxGenerator {
         // Honor the Boundary-V policy when applying the
         // nominal mode to per-layer caches: the first/last N layers stay
         // at FP16 to recover the V-quantization quality gap.
-        self.apply_kv_cache_mode_with_boundary_policy();
+        self.apply_kv_cache_mode_with_boundary_policy_for_model(model);
 
         install_thread_local_default_stream(self.generation_stream.as_ref());
 
@@ -1748,7 +1770,7 @@ impl CxxGenerator {
         // Honor the Boundary-V policy when applying the
         // nominal mode to per-layer caches: the first/last N layers stay
         // at FP16 to recover the V-quantization quality gap.
-        self.apply_kv_cache_mode_with_boundary_policy();
+        self.apply_kv_cache_mode_with_boundary_policy_for_model(model);
         install_thread_local_default_stream(self.generation_stream.as_ref());
 
         let eos_tokens = merged_eos_token_ids(model.eos_token_ids(), &sampling.stop_token_ids);
@@ -1930,7 +1952,7 @@ impl CxxGenerator {
         // Honor the Boundary-V policy when applying the
         // nominal mode to per-layer caches: the first/last N layers stay
         // at FP16 to recover the V-quantization quality gap.
-        self.apply_kv_cache_mode_with_boundary_policy();
+        self.apply_kv_cache_mode_with_boundary_policy_for_model(model);
 
         // Set generation stream as default for better pipelining
         install_thread_local_default_stream(self.generation_stream.as_ref());
@@ -2909,6 +2931,67 @@ mod tests {
             model.reset_call_count.get(),
             1,
             "reset_with_model must reset model-owned fallback state"
+        );
+    }
+
+    struct TrackingKvModeModel {
+        modes: std::cell::RefCell<Option<Vec<KVCacheMode>>>,
+    }
+
+    impl TrackingKvModeModel {
+        fn new() -> Self {
+            Self {
+                modes: std::cell::RefCell::new(None),
+            }
+        }
+    }
+
+    impl LanguageModel for TrackingKvModeModel {
+        fn forward(
+            &self,
+            input_ids: &MlxArray,
+            _caches: &mut [KVCache],
+            _mask: Option<&MlxArray>,
+        ) -> UniquePtr<MlxArray> {
+            ffi::eval(input_ids);
+            ffi::zeros(&[1, 1, 4], crate::dtype::FLOAT32)
+        }
+
+        fn make_caches(&self) -> Vec<KVCache> {
+            Vec::new()
+        }
+
+        fn set_kv_cache_layer_modes(&self, modes: Vec<KVCacheMode>) {
+            *self.modes.borrow_mut() = Some(modes);
+        }
+
+        fn kv_cache_layer_modes(&self) -> Option<Vec<KVCacheMode>> {
+            self.modes.borrow().clone()
+        }
+
+        fn num_layers(&self) -> usize {
+            3
+        }
+
+        fn eos_token_ids(&self) -> Vec<i32> {
+            vec![99]
+        }
+    }
+
+    #[test]
+    fn reset_with_model_forwards_resolved_modes_to_model_owned_caches() {
+        let model = TrackingKvModeModel::new();
+        let mut generator = CxxGenerator::new_with_kv_mode(0, KVCacheMode::Int8);
+
+        generator.reset_with_model(&model);
+
+        assert_eq!(
+            model.kv_cache_layer_modes(),
+            Some(vec![
+                KVCacheMode::Int8,
+                KVCacheMode::Int8,
+                KVCacheMode::Int8
+            ])
         );
     }
 

--- a/src/loaded_model.rs
+++ b/src/loaded_model.rs
@@ -398,6 +398,14 @@ impl LanguageModel for LoadedModel {
         delegate_language_model!(self, make_caches())
     }
 
+    fn set_kv_cache_layer_modes(&self, modes: Vec<mlxcel_core::cache::KVCacheMode>) {
+        delegate_language_model!(self, set_kv_cache_layer_modes(modes))
+    }
+
+    fn kv_cache_layer_modes(&self) -> Option<Vec<mlxcel_core::cache::KVCacheMode>> {
+        delegate_language_model!(self, kv_cache_layer_modes())
+    }
+
     fn forward(
         &self,
         input_ids: &mlxcel_core::MlxArray,

--- a/src/models/afmoe.rs
+++ b/src/models/afmoe.rs
@@ -101,7 +101,7 @@
 //! crossing the cxx bridge is an uncatchable `std::terminate` at the first
 //! forward pass, not a Rust error.
 
-use mlxcel_core::cache::{SequenceId, SequenceStateLayout};
+use mlxcel_core::cache::{KVCacheMode, SequenceId, SequenceStateLayout};
 use mlxcel_core::generate::LanguageModel;
 use mlxcel_core::layers::{KVCache, RMSNorm, RotatingKVCache, UnifiedEmbedding, UnifiedLinear};
 use mlxcel_core::utils::{create_causal_mask, create_sliding_window_prefill_mask, slice_axis};
@@ -113,7 +113,7 @@ use std::path::Path;
 
 use crate::models::gemma3::{Cache, CacheInterface};
 use crate::models::gpt2::{dim_eq, validate_embedding_table};
-use crate::models::model_owned::ModelOwnedSequenceState;
+use crate::models::model_owned::{KvCacheLayerModes, ModelOwnedSequenceState};
 use crate::models::switch_layers::{SwitchGLU, fused_moe_enabled, group_mask_scores};
 
 // Configuration.
@@ -1147,6 +1147,7 @@ pub struct AfmoeModel {
     /// which does not fit the trait's homogeneous `&mut [KVCache]`, so the model
     /// owns its heterogeneous cache here and persists it across forward calls.
     sequence_state: ModelOwnedSequenceState<Cache>,
+    kv_cache_layer_modes: KvCacheLayerModes,
 }
 
 impl AfmoeModel {
@@ -1204,11 +1205,13 @@ impl AfmoeModel {
     fn make_internal_caches(&self) -> Vec<Cache> {
         self.layers
             .iter()
-            .map(|layer| {
+            .enumerate()
+            .map(|(layer_idx, layer)| {
+                let mode = self.kv_cache_layer_modes.mode_for_layer(layer_idx);
                 if layer.uses_sliding {
-                    Cache::Rotating(RotatingKVCache::new(self.sliding_window))
+                    Cache::Rotating(RotatingKVCache::new_with_mode(self.sliding_window, mode))
                 } else {
-                    Cache::Standard(KVCache::new())
+                    Cache::Standard(KVCache::new_with_mode(mode))
                 }
             })
             .collect()
@@ -1302,6 +1305,7 @@ impl AfmoeModel {
             sliding_index: args.sliding_index(),
             eos_token_ids: args.eos_token_ids(),
             sequence_state: ModelOwnedSequenceState::new(internal_caches),
+            kv_cache_layer_modes: KvCacheLayerModes::new(),
         })
     }
 }
@@ -1662,6 +1666,16 @@ impl LanguageModel for AfmoeModel {
     fn prepare_sequence_state(&self, seq_id: SequenceId) {
         self.sequence_state
             .prepare_sequence_state(seq_id, self.make_internal_caches());
+    }
+
+    fn set_kv_cache_layer_modes(&self, modes: Vec<KVCacheMode>) {
+        self.kv_cache_layer_modes.set(modes);
+        self.sequence_state
+            .replace_internal(self.make_internal_caches());
+    }
+
+    fn kv_cache_layer_modes(&self) -> Option<Vec<KVCacheMode>> {
+        self.kv_cache_layer_modes.clone_modes()
     }
 
     fn release_sequence_state_by_id(&self, seq_id: SequenceId) {

--- a/src/models/bailing_moe_linear.rs
+++ b/src/models/bailing_moe_linear.rs
@@ -113,7 +113,7 @@
 //! `std::terminate` at the first forward pass, not a Rust error, so a check that
 //! happens at the first forward pass is not a check.
 
-use mlxcel_core::cache::{SequenceId, SequenceStateLayout};
+use mlxcel_core::cache::{KVCacheMode, SequenceId, SequenceStateLayout};
 use mlxcel_core::generate::LanguageModel;
 use mlxcel_core::layers::{KVCache, RMSNorm, UnifiedEmbedding, UnifiedLinear};
 use mlxcel_core::utils::{create_causal_mask, slice_axis};
@@ -127,7 +127,7 @@ use crate::models::bailing_moe::{
     BailingMoeGate, BailingMoeMLP, BailingMoeSparseBlock, ScoreFunction, router_prefix,
 };
 use crate::models::gpt2::{dim_eq, validate_embedding_table};
-use crate::models::model_owned::ModelOwnedSequenceState;
+use crate::models::model_owned::{KvCacheLayerModes, ModelOwnedSequenceState};
 use crate::models::switch_layers::SwitchGLU;
 
 /// Chunk length for [`gla_chunked`].
@@ -1511,9 +1511,20 @@ impl BailingLinearCache {
         &self,
         snapshot: &mut mlxcel_core::generate::ModelStateSnapshot,
         prefix: &str,
-    ) {
+    ) -> Result<(), String> {
         match self {
             Self::Attention(kv) => {
+                if kv.mode != KVCacheMode::Fp16 {
+                    return Err(format!(
+                        "{prefix}.attention: model-state snapshots do not yet serialize {:?} KV sidecars",
+                        kv.mode
+                    ));
+                }
+                super::recurrent_snapshot::push_kv_cache_mode(
+                    snapshot,
+                    format!("{prefix}.attention.mode"),
+                    kv.mode,
+                );
                 super::recurrent_snapshot::push_optional(
                     snapshot,
                     format!("{prefix}.attention.keys"),
@@ -1524,18 +1535,43 @@ impl BailingLinearCache {
                     format!("{prefix}.attention.values"),
                     &kv.values,
                 );
+                Ok(())
             }
-            Self::Linear(linear) => super::recurrent_snapshot::push_optional(
-                snapshot,
-                format!("{prefix}.linear.state"),
-                &linear.state,
-            ),
+            Self::Linear(linear) => {
+                super::recurrent_snapshot::push_optional(
+                    snapshot,
+                    format!("{prefix}.linear.state"),
+                    &linear.state,
+                );
+                Ok(())
+            }
         }
     }
 
-    fn restore_from(&mut self, snapshot: &mlxcel_core::generate::ModelStateSnapshot, prefix: &str) {
+    fn restore_from(
+        &mut self,
+        snapshot: &mlxcel_core::generate::ModelStateSnapshot,
+        prefix: &str,
+    ) -> Result<(), String> {
         match self {
             Self::Attention(kv) => {
+                let snapshot_mode = super::recurrent_snapshot::restore_kv_cache_mode(
+                    snapshot,
+                    format!("{prefix}.attention.mode"),
+                )?
+                .unwrap_or(KVCacheMode::Fp16);
+                if snapshot_mode != kv.mode {
+                    return Err(format!(
+                        "{prefix}.attention: snapshot KV mode {:?} does not match configured mode {:?}",
+                        snapshot_mode, kv.mode
+                    ));
+                }
+                if kv.mode != KVCacheMode::Fp16 {
+                    return Err(format!(
+                        "{prefix}.attention: model-state restores do not yet deserialize {:?} KV sidecars",
+                        kv.mode
+                    ));
+                }
                 kv.keys = super::recurrent_snapshot::restore_optional(
                     snapshot,
                     format!("{prefix}.attention.keys"),
@@ -1545,6 +1581,7 @@ impl BailingLinearCache {
                     format!("{prefix}.attention.values"),
                 );
                 kv.offset = snapshot.token_len() as i32;
+                Ok(())
             }
             Self::Linear(linear) => {
                 linear.state = super::recurrent_snapshot::restore_optional(
@@ -1552,6 +1589,7 @@ impl BailingLinearCache {
                     format!("{prefix}.linear.state"),
                 );
                 linear.offset = snapshot.token_len() as i32;
+                Ok(())
             }
         }
     }
@@ -2408,6 +2446,7 @@ pub struct BailingMoeLinearModel {
     /// owns the heterogeneous cache here and persists it across forward calls;
     /// recreating it per call would make decode stateless.
     sequence_state: ModelOwnedSequenceState<BailingLinearCache>,
+    kv_cache_layer_modes: KvCacheLayerModes,
 }
 
 impl BailingMoeLinearModel {
@@ -2442,9 +2481,12 @@ impl BailingMoeLinearModel {
     fn make_internal_caches(&self) -> Vec<BailingLinearCache> {
         self.layers
             .iter()
-            .map(|layer| {
+            .enumerate()
+            .map(|(layer_idx, layer)| {
                 if layer.is_global() {
-                    BailingLinearCache::Attention(KVCache::new())
+                    BailingLinearCache::Attention(KVCache::new_with_mode(
+                        self.kv_cache_layer_modes.mode_for_layer(layer_idx),
+                    ))
                 } else {
                     BailingLinearCache::Linear(LinearAttentionCache::new())
                 }
@@ -2558,6 +2600,7 @@ impl BailingMoeLinearModel {
             global_layer_index: args.global_layer_index(),
             eos_token_ids: args.eos_token_ids(),
             sequence_state: ModelOwnedSequenceState::new(internal_caches),
+            kv_cache_layer_modes: KvCacheLayerModes::new(),
         })
     }
 }
@@ -2610,6 +2653,16 @@ impl LanguageModel for BailingMoeLinearModel {
             .prepare_sequence_state(seq_id, self.make_internal_caches());
     }
 
+    fn set_kv_cache_layer_modes(&self, modes: Vec<KVCacheMode>) {
+        self.kv_cache_layer_modes.set(modes);
+        self.sequence_state
+            .replace_internal(self.make_internal_caches());
+    }
+
+    fn kv_cache_layer_modes(&self) -> Option<Vec<KVCacheMode>> {
+        self.kv_cache_layer_modes.clone_modes()
+    }
+
     fn release_sequence_state_by_id(&self, seq_id: SequenceId) {
         self.sequence_state.release_sequence_state(seq_id);
     }
@@ -2628,10 +2681,14 @@ impl LanguageModel for BailingMoeLinearModel {
                 let mut snapshot =
                     mlxcel_core::generate::ModelStateSnapshot::new("bailing_moe_linear", token_len);
                 for (idx, cache) in state.iter().enumerate() {
-                    cache.snapshot_into(&mut snapshot, &format!("layer{idx}"));
+                    if let Err(err) = cache.snapshot_into(&mut snapshot, &format!("layer{idx}")) {
+                        tracing::warn!("Bailing MoE Linear prompt-cache snapshot skipped: {err}");
+                        return None;
+                    }
                 }
-                snapshot
+                Some(snapshot)
             })
+            .flatten()
     }
 
     fn restore_sequence_state(
@@ -2647,7 +2704,7 @@ impl LanguageModel for BailingMoeLinearModel {
         }
         let mut state = self.make_internal_caches();
         for (idx, cache) in state.iter_mut().enumerate() {
-            cache.restore_from(snapshot, &format!("layer{idx}"));
+            cache.restore_from(snapshot, &format!("layer{idx}"))?;
         }
         self.sequence_state.replace_sequence_state(seq_id, state);
         Ok(())

--- a/src/models/gemma3.rs
+++ b/src/models/gemma3.rs
@@ -28,10 +28,12 @@ use crate::distributed::pipeline::LayerFilter;
 use crate::distributed::pipeline::StageExecutionOutput;
 use crate::distributed::pipeline::partial_loading::filter_weight_map;
 use crate::models::model_owned::{
-    ModelOwnedSequenceState, dispatch_paged_decode_from_visible_caches,
+    KvCacheLayerModes, ModelOwnedSequenceState, dispatch_paged_decode_from_visible_caches,
 };
 use crate::models::rope_utils::{RopeScalingSpec, printable_label};
-use mlxcel_core::cache::{CachePool, RotatingPagedDecodeMetadata, SequenceId, SequenceStateLayout};
+use mlxcel_core::cache::{
+    CachePool, KVCacheMode, RotatingPagedDecodeMetadata, SequenceId, SequenceStateLayout,
+};
 use mlxcel_core::generate::DecodeBatchContext;
 use mlxcel_core::layers::{
     FusedQKVLinear, GemmaRMSNorm, KVCache, RotatingKVCache, UnifiedEmbedding, UnifiedLinear,
@@ -966,14 +968,24 @@ impl Gemma3Model {
 
     /// Create KV caches for all layers
     pub(crate) fn make_caches(&self) -> Vec<Cache> {
+        self.make_caches_with_modes(None)
+    }
+
+    pub(crate) fn make_caches_with_modes(&self, modes: Option<&KvCacheLayerModes>) -> Vec<Cache> {
         (0..self.layers.len())
             .map(|i| {
                 let is_global =
                     (i % self.sliding_window_pattern) == (self.sliding_window_pattern - 1);
+                let mode = modes
+                    .map(|modes| modes.mode_for_layer(i))
+                    .unwrap_or(KVCacheMode::Fp16);
                 if is_global {
-                    Cache::Standard(KVCache::new())
+                    Cache::Standard(KVCache::new_with_mode(mode))
                 } else {
-                    Cache::Rotating(RotatingKVCache::new(self.sliding_window as i32))
+                    Cache::Rotating(RotatingKVCache::new_with_mode(
+                        self.sliding_window as i32,
+                        mode,
+                    ))
                 }
             })
             .collect()
@@ -1288,6 +1300,7 @@ fn get_weight_copy(weights: &WeightMap, name: &str) -> Result<UniquePtr<MlxArray
 pub struct Gemma3Wrapper {
     model: Gemma3Model,
     sequence_state: ModelOwnedSequenceState<Cache>,
+    kv_cache_layer_modes: KvCacheLayerModes,
 }
 
 impl Gemma3Wrapper {
@@ -1296,12 +1309,18 @@ impl Gemma3Wrapper {
         Self {
             model,
             sequence_state: ModelOwnedSequenceState::new(caches),
+            kv_cache_layer_modes: KvCacheLayerModes::new(),
         }
+    }
+
+    fn make_configured_caches(&self) -> Vec<Cache> {
+        self.model
+            .make_caches_with_modes(Some(&self.kv_cache_layer_modes))
     }
 
     pub fn reset_caches(&self) {
         self.sequence_state
-            .replace_internal(self.model.make_caches());
+            .replace_internal(self.make_configured_caches());
     }
 }
 
@@ -1344,6 +1363,15 @@ impl mlxcel_core::generate::LanguageModel for Gemma3Wrapper {
         Vec::new()
     }
 
+    fn set_kv_cache_layer_modes(&self, modes: Vec<KVCacheMode>) {
+        self.kv_cache_layer_modes.set(modes);
+        self.reset_caches();
+    }
+
+    fn kv_cache_layer_modes(&self) -> Option<Vec<KVCacheMode>> {
+        self.kv_cache_layer_modes.clone_modes()
+    }
+
     fn num_layers(&self) -> usize {
         self.model.layers.len()
     }
@@ -1362,7 +1390,7 @@ impl mlxcel_core::generate::LanguageModel for Gemma3Wrapper {
 
     fn prepare_sequence_state(&self, seq_id: SequenceId) {
         self.sequence_state
-            .prepare_sequence_state(seq_id, self.model.make_caches());
+            .prepare_sequence_state(seq_id, self.make_configured_caches());
     }
 
     fn reset_runtime_state(&self) {
@@ -1388,7 +1416,7 @@ impl mlxcel_core::generate::LanguageModel for Gemma3Wrapper {
     ) -> UniquePtr<MlxArray> {
         self.sequence_state.with_or_create_sequence_state(
             seq_id,
-            || self.model.make_caches(),
+            || self.make_configured_caches(),
             |sequence_caches| self.model.forward_with_caches(input_ids, sequence_caches),
         )
     }
@@ -1403,7 +1431,7 @@ impl mlxcel_core::generate::LanguageModel for Gemma3Wrapper {
     ) -> UniquePtr<MlxArray> {
         self.sequence_state.with_or_create_sequence_state(
             seq_id,
-            || self.model.make_caches(),
+            || self.make_configured_caches(),
             |sequence_caches| {
                 self.model.forward_with_caches_and_embeddings(
                     input_ids,

--- a/src/models/gemma4.rs
+++ b/src/models/gemma4.rs
@@ -27,7 +27,7 @@
 use crate::distributed::pipeline::LayerFilter;
 use crate::distributed::pipeline::StageExecutionOutput;
 use crate::distributed::pipeline::partial_loading::filter_weight_map;
-use crate::models::model_owned::ModelOwnedSequenceState;
+use crate::models::model_owned::{KvCacheLayerModes, ModelOwnedSequenceState};
 use crate::models::recurrent_snapshot::{push_i32, push_optional, restore_i32, restore_optional};
 use crate::models::speculative_exactness::{
     BlockChainExactness, ProbeKey, compare_block_against_chain, mtp_exactness_gate,
@@ -1303,11 +1303,16 @@ impl Cache {
                         mode
                     ));
                 }
+                if cache.mode != mode {
+                    return Err(format!(
+                        "Gemma 4 restore {prefix}: standard snapshot mode {:?} does not match configured cache mode {:?}",
+                        mode, cache.mode
+                    ));
+                }
                 cache.keys = keys;
                 cache.values = values;
                 cache.offset = restore_i32(snapshot, format!("{prefix}.standard.offset"))
                     .unwrap_or(snapshot.token_len() as i32);
-                cache.mode = KVCacheMode::Fp16;
             }
             Self::Rotating(cache) => {
                 let keys = restore_optional(snapshot, format!("{prefix}.rotating.keys"));
@@ -1325,6 +1330,12 @@ impl Cache {
                     .map(kv_cache_mode_from_i32)
                     .transpose()?
                     .unwrap_or(KVCacheMode::Fp16);
+                if mode != current.mode {
+                    return Err(format!(
+                        "Gemma 4 restore {prefix}: rotating snapshot mode {:?} does not match configured cache mode {:?}",
+                        mode, current.mode
+                    ));
+                }
                 let state = RotatingKVCacheSnapshotState {
                     max_size: restore_i32(snapshot, format!("{prefix}.rotating.max_size"))
                         .unwrap_or(current.max_size),
@@ -4003,14 +4014,25 @@ impl Gemma4TextModel {
     }
 
     pub(crate) fn make_caches(&self) -> Vec<Cache> {
+        self.make_caches_with_modes(None)
+    }
+
+    pub(crate) fn make_caches_with_modes(&self, modes: Option<&KvCacheLayerModes>) -> Vec<Cache> {
         self.config
             .layer_types
             .iter()
-            .map(|layer_type| {
+            .enumerate()
+            .map(|(idx, layer_type)| {
+                let mode = modes
+                    .map(|modes| modes.mode_for_layer(idx))
+                    .unwrap_or(KVCacheMode::Fp16);
                 if layer_type == "full_attention" {
-                    Cache::Standard(KVCache::new())
+                    Cache::Standard(KVCache::new_with_mode(mode))
                 } else {
-                    Cache::Rotating(RotatingKVCache::new(self.config.sliding_window as i32))
+                    Cache::Rotating(RotatingKVCache::new_with_mode(
+                        self.config.sliding_window as i32,
+                        mode,
+                    ))
                 }
             })
             .collect()
@@ -4503,6 +4525,10 @@ impl Gemma4Model {
 
     pub(crate) fn make_caches(&self) -> Vec<Cache> {
         self.text_model.make_caches()
+    }
+
+    pub(crate) fn make_caches_with_modes(&self, modes: &KvCacheLayerModes) -> Vec<Cache> {
+        self.text_model.make_caches_with_modes(Some(modes))
     }
 }
 
@@ -5048,6 +5074,7 @@ impl Gemma4StageModel {
 pub struct Gemma4Wrapper {
     model: Gemma4Model,
     sequence_state: ModelOwnedSequenceState<Cache>,
+    kv_cache_layer_modes: KvCacheLayerModes,
 }
 
 impl Gemma4Wrapper {
@@ -5056,7 +5083,13 @@ impl Gemma4Wrapper {
         Self {
             model,
             sequence_state: ModelOwnedSequenceState::new(caches),
+            kv_cache_layer_modes: KvCacheLayerModes::new(),
         }
+    }
+
+    fn make_configured_caches(&self) -> Vec<Cache> {
+        self.model
+            .make_caches_with_modes(&self.kv_cache_layer_modes)
     }
 
     /// Reset the wrapper's fallback cache slot (the `internal` slot used
@@ -5069,7 +5102,7 @@ impl Gemma4Wrapper {
     /// a fresh request that does not flow through the server scheduler.
     pub fn reset_caches(&self) {
         self.sequence_state
-            .replace_internal(self.model.make_caches());
+            .replace_internal(self.make_configured_caches());
     }
 
     /// Whether MTP may engage on this loaded checkpoint at `block_size`,
@@ -5151,7 +5184,7 @@ impl Gemma4Wrapper {
 
             // Chain arm: prefill, then one token at a time — the shape
             // classic decode runs, and the contract's reference.
-            let mut chain_caches = self.model.make_caches();
+            let mut chain_caches = self.make_configured_caches();
             let _ = self.model.forward_with_caches_and_embeddings(
                 &as_input(&prompt),
                 None,
@@ -5172,7 +5205,7 @@ impl Gemma4Wrapper {
             }
 
             // Block arm: fresh caches, same prefill, the whole block at once.
-            let mut block_caches = self.model.make_caches();
+            let mut block_caches = self.make_configured_caches();
             let _ = self.model.forward_with_caches_and_embeddings(
                 &as_input(&prompt),
                 None,
@@ -5246,7 +5279,7 @@ impl Gemma4Wrapper {
     ) -> UniquePtr<MlxArray> {
         self.sequence_state.with_or_create_sequence_state(
             seq_id,
-            || self.model.make_caches(),
+            || self.make_configured_caches(),
             |sequence_caches| {
                 self.model.forward_with_caches_and_embeddings(
                     input_ids,
@@ -5279,7 +5312,7 @@ impl Gemma4Wrapper {
     ) -> UniquePtr<MlxArray> {
         self.sequence_state.with_or_create_sequence_state(
             seq_id,
-            || self.model.make_caches(),
+            || self.make_configured_caches(),
             |sequence_caches| {
                 self.model.forward_unified_with_caches_and_embeddings(
                     input_ids,
@@ -5331,7 +5364,7 @@ impl Gemma4Wrapper {
     ) -> i32 {
         self.sequence_state.with_or_create_sequence_state(
             seq_id,
-            || self.model.make_caches(),
+            || self.make_configured_caches(),
             |sequence_caches| first_cache_offset(sequence_caches, layer_type),
         )
     }
@@ -5351,7 +5384,7 @@ impl Gemma4Wrapper {
     ) {
         self.sequence_state.with_or_create_sequence_state(
             seq_id,
-            || self.model.make_caches(),
+            || self.make_configured_caches(),
             |sequence_caches| {
                 for cache in sequence_caches.iter_mut() {
                     if let Err(error) = cache.enable_mtp_rotating_buffer(buffer_size) {
@@ -5413,7 +5446,7 @@ impl Gemma4Wrapper {
     ) -> UniquePtr<MlxArray> {
         self.sequence_state.with_or_create_sequence_state(
             seq_id,
-            || self.model.make_caches(),
+            || self.make_configured_caches(),
             |sequence_caches| {
                 self.model.forward_with_caches_and_speculative_sinks(
                     input_ids,
@@ -5495,7 +5528,7 @@ impl Gemma4Wrapper {
     pub(crate) fn sequence_kv_offset(&self, seq_id: Option<SequenceId>) -> i32 {
         self.sequence_state.with_or_create_sequence_state(
             seq_id,
-            || self.model.make_caches(),
+            || self.make_configured_caches(),
             |caches| first_present_cache_offset(caches),
         )
     }
@@ -5522,7 +5555,7 @@ impl Gemma4Wrapper {
     ///
     /// Used by: [`crate::models::gemma4_mtp_target::Gemma4MtpBatchedTargetAdapter`].
     pub fn make_speculative_caches(&self) -> Vec<Cache> {
-        self.model.make_caches()
+        self.make_configured_caches()
     }
 
     /// Rewind the per-sequence target KV caches after a Gemma 4 MTP
@@ -5595,7 +5628,7 @@ impl Gemma4Wrapper {
 
         self.sequence_state.with_or_create_sequence_state(
             seq_id,
-            || self.model.make_caches(),
+            || self.make_configured_caches(),
             |sequence_caches| -> Result<(), String> {
                 for cache in sequence_caches.iter_mut() {
                     if trim > 0 {
@@ -5623,7 +5656,7 @@ impl Gemma4Wrapper {
     pub fn can_gather_speculative_cache(&self, seq_id: Option<SequenceId>) -> bool {
         self.sequence_state.with_or_create_sequence_state(
             seq_id,
-            || self.model.make_caches(),
+            || self.make_configured_caches(),
             |sequence_caches| {
                 sequence_caches
                     .iter()
@@ -5665,7 +5698,7 @@ impl Gemma4Wrapper {
         }
         self.sequence_state.with_or_create_sequence_state(
             seq_id,
-            || self.model.make_caches(),
+            || self.make_configured_caches(),
             |sequence_caches| -> Result<(), String> {
                 for cache in sequence_caches.iter_mut() {
                     cache.gather_speculative(block_size, kept)?;
@@ -5840,7 +5873,7 @@ impl LanguageModel for Gemma4Wrapper {
     ) -> UniquePtr<MlxArray> {
         self.sequence_state.with_or_create_sequence_state(
             seq_id,
-            || self.model.make_caches(),
+            || self.make_configured_caches(),
             |sequence_caches| {
                 self.model.forward_with_caches_and_embeddings(
                     input_ids,
@@ -5883,7 +5916,7 @@ impl LanguageModel for Gemma4Wrapper {
         }
         self.sequence_state.with_or_create_sequence_state(
             None,
-            || self.model.make_caches(),
+            || self.make_configured_caches(),
             |sequence_caches| {
                 self.model.forward_last_with_caches_and_embeddings(
                     input_ids,
@@ -5907,7 +5940,7 @@ impl LanguageModel for Gemma4Wrapper {
     ) -> UniquePtr<MlxArray> {
         self.sequence_state.with_or_create_sequence_state(
             seq_id,
-            || self.model.make_caches(),
+            || self.make_configured_caches(),
             |sequence_caches| {
                 self.model.forward_with_caches_and_embeddings(
                     input_ids,
@@ -5944,13 +5977,22 @@ impl LanguageModel for Gemma4Wrapper {
         Vec::new()
     }
 
+    fn set_kv_cache_layer_modes(&self, modes: Vec<KVCacheMode>) {
+        self.kv_cache_layer_modes.set(modes);
+        self.reset_caches();
+    }
+
+    fn kv_cache_layer_modes(&self) -> Option<Vec<KVCacheMode>> {
+        self.kv_cache_layer_modes.clone_modes()
+    }
+
     fn sequence_state_layout(&self) -> SequenceStateLayout {
         SequenceStateLayout::model_owned(self.model.text_model.layers.len())
     }
 
     fn prepare_sequence_state(&self, seq_id: SequenceId) {
         self.sequence_state
-            .prepare_sequence_state(seq_id, self.model.make_caches());
+            .prepare_sequence_state(seq_id, self.make_configured_caches());
     }
 
     fn reset_runtime_state(&self) {
@@ -6007,7 +6049,7 @@ impl LanguageModel for Gemma4Wrapper {
                 snapshot.family()
             ));
         }
-        let mut state = self.model.make_caches();
+        let mut state = self.make_configured_caches();
         for (idx, cache) in state.iter_mut().enumerate() {
             cache.restore_from(snapshot, &format!("layer{idx}"))?;
         }
@@ -6060,7 +6102,7 @@ impl LanguageModel for Gemma4Wrapper {
                 "Gemma 4 truncated restore: snapshot cannot be truncated to {target_len} tokens"
             ));
         }
-        let mut state = self.model.make_caches();
+        let mut state = self.make_configured_caches();
         for (idx, cache) in state.iter_mut().enumerate() {
             let prefix = format!("layer{idx}");
             cache.restore_from(snapshot, &prefix)?;

--- a/src/models/lfm2.rs
+++ b/src/models/lfm2.rs
@@ -39,6 +39,7 @@
 //! [`ModelOwnedSequenceState`] (like Jamba / NemotronH) and reports
 //! `supports_batching() == false`.
 
+use mlxcel_core::cache::KVCacheMode;
 use mlxcel_core::generate::LanguageModel;
 use mlxcel_core::layers::{KVCache, RMSNorm, UnifiedEmbedding, UnifiedLinear};
 use mlxcel_core::utils::{create_causal_mask, slice_axis, stack_arrays};
@@ -47,8 +48,10 @@ use mlxcel_core::{MlxArray, UniquePtr};
 use serde::Deserialize;
 use std::path::Path;
 
-use super::model_owned::ModelOwnedSequenceState;
-use super::recurrent_snapshot::{push_optional, restore_optional};
+use super::model_owned::{KvCacheLayerModes, ModelOwnedSequenceState};
+use super::recurrent_snapshot::{
+    push_kv_cache_mode, push_optional, restore_kv_cache_mode, restore_optional,
+};
 use super::switch_layers::{SwitchGLU, moe_weighted_sum};
 
 // The single-step short-conv decode fast path (issue #748) now lives in the
@@ -612,11 +615,15 @@ impl Lfm2DecoderLayer {
         matches!(self.mixer, Mixer::Attention(_))
     }
 
-    fn make_cache(&self) -> Lfm2LayerCache {
+    fn make_cache_with_mode(&self, mode: KVCacheMode) -> Lfm2LayerCache {
         match self.mixer {
-            Mixer::Attention(_) => Lfm2LayerCache::Attention(KVCache::new()),
+            Mixer::Attention(_) => Lfm2LayerCache::Attention(KVCache::new_with_mode(mode)),
             Mixer::Conv(_) => Lfm2LayerCache::Conv(None),
         }
+    }
+
+    fn make_cache(&self) -> Lfm2LayerCache {
+        self.make_cache_with_mode(KVCacheMode::Fp16)
     }
 
     fn forward(
@@ -715,27 +722,57 @@ impl Lfm2LayerCache {
         &self,
         snapshot: &mut mlxcel_core::generate::ModelStateSnapshot,
         prefix: &str,
-    ) {
+    ) -> Result<(), String> {
         match self {
             Lfm2LayerCache::Attention(kv) => {
+                if kv.mode != KVCacheMode::Fp16 {
+                    return Err(format!(
+                        "{prefix}.attention: model-state snapshots do not yet serialize {:?} KV sidecars",
+                        kv.mode
+                    ));
+                }
+                push_kv_cache_mode(snapshot, format!("{prefix}.attention.mode"), kv.mode);
                 push_optional(snapshot, format!("{prefix}.attention.keys"), &kv.keys);
                 push_optional(snapshot, format!("{prefix}.attention.values"), &kv.values);
+                Ok(())
             }
             Lfm2LayerCache::Conv(state) => {
                 push_optional(snapshot, format!("{prefix}.conv.state"), state);
+                Ok(())
             }
         }
     }
 
-    fn restore_from(&mut self, snapshot: &mlxcel_core::generate::ModelStateSnapshot, prefix: &str) {
+    fn restore_from(
+        &mut self,
+        snapshot: &mlxcel_core::generate::ModelStateSnapshot,
+        prefix: &str,
+    ) -> Result<(), String> {
         match self {
             Lfm2LayerCache::Attention(kv) => {
+                let snapshot_mode =
+                    restore_kv_cache_mode(snapshot, format!("{prefix}.attention.mode"))?
+                        .unwrap_or(KVCacheMode::Fp16);
+                if snapshot_mode != kv.mode {
+                    return Err(format!(
+                        "{prefix}.attention: snapshot KV mode {:?} does not match configured mode {:?}",
+                        snapshot_mode, kv.mode
+                    ));
+                }
+                if kv.mode != KVCacheMode::Fp16 {
+                    return Err(format!(
+                        "{prefix}.attention: model-state restores do not yet deserialize {:?} KV sidecars",
+                        kv.mode
+                    ));
+                }
                 kv.keys = restore_optional(snapshot, format!("{prefix}.attention.keys"));
                 kv.values = restore_optional(snapshot, format!("{prefix}.attention.values"));
                 kv.offset = snapshot.token_len() as i32;
+                Ok(())
             }
             Lfm2LayerCache::Conv(state) => {
                 *state = restore_optional(snapshot, format!("{prefix}.conv.state"));
+                Ok(())
             }
         }
     }
@@ -752,6 +789,7 @@ pub struct Lfm2Model {
     /// Model-owned mixed caches keyed by scheduler sequence id, plus a fallback
     /// slot for CLI / benchmark paths.
     sequence_state: ModelOwnedSequenceState<Lfm2LayerCache>,
+    kv_cache_layer_modes: KvCacheLayerModes,
 }
 
 impl Lfm2Model {
@@ -760,7 +798,11 @@ impl Lfm2Model {
     }
 
     pub fn make_caches(&self) -> Vec<Lfm2LayerCache> {
-        self.layers.iter().map(|l| l.make_cache()).collect()
+        self.layers
+            .iter()
+            .enumerate()
+            .map(|(idx, l)| l.make_cache_with_mode(self.kv_cache_layer_modes.mode_for_layer(idx)))
+            .collect()
     }
 
     fn forward_with_caches(
@@ -864,6 +906,7 @@ impl Lfm2Model {
             embedding_norm,
             eos_token_ids,
             sequence_state: ModelOwnedSequenceState::new(internal_caches),
+            kv_cache_layer_modes: KvCacheLayerModes::new(),
         })
     }
 }
@@ -1014,6 +1057,16 @@ impl LanguageModel for Lfm2Model {
             .prepare_sequence_state(seq_id, Lfm2Model::make_caches(self));
     }
 
+    fn set_kv_cache_layer_modes(&self, modes: Vec<KVCacheMode>) {
+        self.kv_cache_layer_modes.set(modes);
+        self.sequence_state
+            .replace_internal(Lfm2Model::make_caches(self));
+    }
+
+    fn kv_cache_layer_modes(&self) -> Option<Vec<KVCacheMode>> {
+        self.kv_cache_layer_modes.clone_modes()
+    }
+
     fn release_sequence_state_by_id(&self, seq_id: mlxcel_core::cache::SequenceId) {
         self.sequence_state.release_sequence_state(seq_id);
     }
@@ -1078,10 +1131,14 @@ impl LanguageModel for Lfm2Model {
                 let mut snapshot =
                     mlxcel_core::generate::ModelStateSnapshot::new("lfm2", token_len);
                 for (idx, cache) in state.iter().enumerate() {
-                    cache.snapshot_into(&mut snapshot, &format!("layer{idx}"));
+                    if let Err(err) = cache.snapshot_into(&mut snapshot, &format!("layer{idx}")) {
+                        tracing::warn!("LFM2 prompt-cache snapshot skipped: {err}");
+                        return None;
+                    }
                 }
-                snapshot
+                Some(snapshot)
             })
+            .flatten()
     }
 
     fn restore_sequence_state(
@@ -1097,7 +1154,7 @@ impl LanguageModel for Lfm2Model {
         }
         let mut state = Lfm2Model::make_caches(self);
         for (idx, cache) in state.iter_mut().enumerate() {
-            cache.restore_from(snapshot, &format!("layer{idx}"));
+            cache.restore_from(snapshot, &format!("layer{idx}"))?;
         }
         self.sequence_state.replace_sequence_state(seq_id, state);
         Ok(())

--- a/src/models/llama4.rs
+++ b/src/models/llama4.rs
@@ -21,16 +21,17 @@ use crate::models::llama4_helpers::{
     create_chunked_attention_mask, get_weight_copy, load_quantized_linear,
 };
 use crate::models::model_owned::{
-    ModelOwnedSequenceState, dispatch_paged_decode_from_backing_caches,
+    KvCacheLayerModes, ModelOwnedSequenceState, dispatch_paged_decode_from_backing_caches,
 };
 use crate::models::switch_layers::validate_expert_quantization_params;
-use mlxcel_core::cache::{CachePool, SequenceId, SequenceStateLayout};
+use mlxcel_core::cache::{CachePool, KVCacheMode, SequenceId, SequenceStateLayout};
 use mlxcel_core::generate::{DecodeBatchContext, LanguageModel};
 use mlxcel_core::layers::{ChunkedKVCache, KVCache, RMSNorm, UnifiedEmbedding, UnifiedLinear};
 use mlxcel_core::weights::WeightMap;
 use mlxcel_core::{MlxArray, UniquePtr};
 use serde::Deserialize;
 use std::path::Path;
+use std::sync::atomic::{AtomicBool, Ordering};
 
 // Llama4 Cache Types.
 /// Cache enum for Llama4's iGQA (Interleaved GQA) pattern
@@ -1396,20 +1397,44 @@ impl Llama4CxxModel {
     /// Create Llama4 caches for iGQA pattern
     /// MoE layers (non-4th) use ChunkedKVCache, dense layers (4th) use regular KVCache
     pub fn make_llama4_caches(&self) -> Vec<Llama4Cache> {
+        self.make_llama4_caches_with_modes(None)
+    }
+
+    pub(crate) fn make_llama4_caches_with_modes(
+        &self,
+        modes: Option<&KvCacheLayerModes>,
+    ) -> Vec<Llama4Cache> {
         let chunk_size = self.attention_chunk_size as i32;
         self.layers
             .iter()
             .enumerate()
             .map(|(idx, _)| {
+                let mode = modes
+                    .map(|modes| modes.mode_for_layer(idx))
+                    .unwrap_or(KVCacheMode::Fp16);
                 if (idx + 1) % 4 != 0 {
                     // MoE layer: use chunked cache
+                    warn_llama4_chunked_kv_mode_ignored(mode);
                     Llama4Cache::Chunked(ChunkedKVCache::new(chunk_size))
                 } else {
                     // Dense layer: use regular cache
-                    Llama4Cache::Regular(KVCache::new())
+                    Llama4Cache::Regular(KVCache::new_with_mode(mode))
                 }
             })
             .collect()
+    }
+}
+
+fn warn_llama4_chunked_kv_mode_ignored(mode: KVCacheMode) {
+    if mode == KVCacheMode::Fp16 {
+        return;
+    }
+    static WARNED: AtomicBool = AtomicBool::new(false);
+    if !WARNED.swap(true, Ordering::Relaxed) {
+        tracing::warn!(
+            requested_mode = %mode,
+            "Llama 4 ChunkedKVCache layers do not support quantized KV modes yet; keeping those layers at fp16"
+        );
     }
 }
 
@@ -1658,6 +1683,7 @@ impl LanguageModel for Llama4CxxModel {
 pub struct Llama4Wrapper {
     model: Llama4CxxModel,
     sequence_state: ModelOwnedSequenceState<Llama4Cache>,
+    kv_cache_layer_modes: KvCacheLayerModes,
 }
 
 impl Llama4Wrapper {
@@ -1666,12 +1692,18 @@ impl Llama4Wrapper {
         Self {
             model,
             sequence_state: ModelOwnedSequenceState::new(caches),
+            kv_cache_layer_modes: KvCacheLayerModes::new(),
         }
+    }
+
+    fn make_configured_caches(&self) -> Vec<Llama4Cache> {
+        self.model
+            .make_llama4_caches_with_modes(Some(&self.kv_cache_layer_modes))
     }
 
     pub fn reset_caches(&self) {
         self.sequence_state
-            .replace_internal(self.model.make_llama4_caches());
+            .replace_internal(self.make_configured_caches());
     }
 }
 
@@ -1714,6 +1746,15 @@ impl LanguageModel for Llama4Wrapper {
         Vec::new()
     }
 
+    fn set_kv_cache_layer_modes(&self, modes: Vec<KVCacheMode>) {
+        self.kv_cache_layer_modes.set(modes);
+        self.reset_caches();
+    }
+
+    fn kv_cache_layer_modes(&self) -> Option<Vec<KVCacheMode>> {
+        self.kv_cache_layer_modes.clone_modes()
+    }
+
     fn num_layers(&self) -> usize {
         self.model.layers.len()
     }
@@ -1732,7 +1773,7 @@ impl LanguageModel for Llama4Wrapper {
 
     fn prepare_sequence_state(&self, seq_id: SequenceId) {
         self.sequence_state
-            .prepare_sequence_state(seq_id, self.model.make_llama4_caches());
+            .prepare_sequence_state(seq_id, self.make_configured_caches());
     }
 
     fn reset_runtime_state(&self) {
@@ -1756,7 +1797,7 @@ impl LanguageModel for Llama4Wrapper {
     ) -> UniquePtr<MlxArray> {
         self.sequence_state.with_or_create_sequence_state(
             seq_id,
-            || self.model.make_llama4_caches(),
+            || self.make_configured_caches(),
             |sequence_caches| self.model.forward_igqa(input_ids, sequence_caches, None),
         )
     }
@@ -1771,7 +1812,7 @@ impl LanguageModel for Llama4Wrapper {
     ) -> UniquePtr<MlxArray> {
         self.sequence_state.with_or_create_sequence_state(
             seq_id,
-            || self.model.make_llama4_caches(),
+            || self.make_configured_caches(),
             |sequence_caches| {
                 self.model.forward_igqa_with_embeddings(
                     input_ids,

--- a/src/models/model_owned.rs
+++ b/src/models/model_owned.rs
@@ -15,13 +15,53 @@
 use std::cell::RefCell;
 use std::collections::HashMap;
 
-use mlxcel_core::cache::{PagedDecodeMetadata, SequenceId};
+use mlxcel_core::cache::{KVCacheMode, PagedDecodeMetadata, SequenceId};
 use mlxcel_core::generate::DecodeBatchContext;
 use mlxcel_core::{MlxArray, UniquePtr};
 
 pub(crate) struct ModelOwnedSequenceState<T> {
     internal: RefCell<Vec<T>>,
     sequences: RefCell<HashMap<SequenceId, Vec<T>>>,
+}
+
+/// Shared per-layer KV cache mode table for families whose attention caches
+/// live inside the model wrapper instead of the external generator cache slice.
+///
+/// The table is injected by the CLI generator or server scheduler after they
+/// resolve requested/effective KV mode and Boundary-V policy. Constructors use
+/// `mode_for_layer` so absent or short tables conservatively fall back to FP16.
+pub(crate) struct KvCacheLayerModes {
+    modes: RefCell<Option<Vec<KVCacheMode>>>,
+}
+
+impl KvCacheLayerModes {
+    pub(crate) fn new() -> Self {
+        Self {
+            modes: RefCell::new(None),
+        }
+    }
+
+    pub(crate) fn set(&self, modes: Vec<KVCacheMode>) {
+        *self.modes.borrow_mut() = Some(modes);
+    }
+
+    pub(crate) fn clone_modes(&self) -> Option<Vec<KVCacheMode>> {
+        self.modes.borrow().clone()
+    }
+
+    pub(crate) fn mode_for_layer(&self, layer_idx: usize) -> KVCacheMode {
+        self.modes
+            .borrow()
+            .as_ref()
+            .and_then(|modes| modes.get(layer_idx).copied())
+            .unwrap_or(KVCacheMode::Fp16)
+    }
+}
+
+impl Default for KvCacheLayerModes {
+    fn default() -> Self {
+        Self::new()
+    }
 }
 
 impl<T> ModelOwnedSequenceState<T> {

--- a/src/models/qwen3_5.rs
+++ b/src/models/qwen3_5.rs
@@ -32,7 +32,7 @@ use crate::models::gated_delta::{
     GatedDeltaCache, RMSNormGated, gated_delta_update, gated_delta_update_chain_parity,
     scaled_fast_rms_norm_no_weight,
 };
-use crate::models::model_owned::ModelOwnedSequenceState;
+use crate::models::model_owned::{KvCacheLayerModes, ModelOwnedSequenceState};
 use crate::models::qwen_mrope_state::MRopeState;
 use crate::models::qwen3_next::{
     MLP, Quantization, Qwen3NextAttention, Qwen3NextCache, Qwen3NextConfig, SparseMoeBlock,
@@ -40,7 +40,7 @@ use crate::models::qwen3_next::{
 use crate::models::speculative_exactness::{
     BlockChainExactness, ProbeKey, compare_block_against_chain, mtp_exactness_gate,
 };
-use mlxcel_core::cache::{CachePool, SequenceId, SequenceStateLayout};
+use mlxcel_core::cache::{CachePool, KVCacheMode, SequenceId, SequenceStateLayout};
 use mlxcel_core::dtype;
 use mlxcel_core::generate::LanguageModel;
 use mlxcel_core::layers::{KVCache, RMSNorm, UnifiedEmbedding, UnifiedLinear};
@@ -1365,6 +1365,7 @@ pub struct Qwen35Model {
     pub(crate) config: Qwen35Config,
     /// Internal and per-sequence mixed cache state.
     sequence_state: ModelOwnedSequenceState<Qwen3NextCache>,
+    kv_cache_layer_modes: KvCacheLayerModes,
     /// Per-sequence MRoPE state (mlx-vlm PR #1095). Each row
     /// in a server batch needs its own delta — the legacy fallback slot
     /// preserves CLI/single-row behavior when no `SequenceId` is plumbed.
@@ -1429,11 +1430,14 @@ impl Qwen35Model {
     fn make_internal_caches(&self) -> Vec<Qwen3NextCache> {
         self.layers
             .iter()
-            .map(|l| {
+            .enumerate()
+            .map(|(layer_idx, l)| {
                 if l.is_linear {
                     Qwen3NextCache::Linear(GatedDeltaCache::new())
                 } else {
-                    Qwen3NextCache::Attention(KVCache::new())
+                    Qwen3NextCache::Attention(KVCache::new_with_mode(
+                        self.kv_cache_layer_modes.mode_for_layer(layer_idx),
+                    ))
                 }
             })
             .collect()
@@ -1635,7 +1639,7 @@ impl Qwen35Model {
     fn split_batched_cache(cache: &Qwen3NextCache, batch_idx: usize) -> Qwen3NextCache {
         match cache {
             Qwen3NextCache::Attention(kv) => {
-                let mut split = KVCache::new();
+                let mut split = KVCache::new_with_mode(kv.mode);
                 split.offset = kv.offset;
                 split.keys = kv.keys.as_ref().map(|keys| {
                     mlxcel_core::slice(
@@ -1692,6 +1696,7 @@ impl Qwen35Model {
         input_ids: &MlxArray,
         seq_ids: &[SequenceId],
     ) -> UniquePtr<MlxArray> {
+        debug_assert!(self.configured_attention_kv_modes_all_fp16());
         let mut batched_caches = self.make_internal_caches();
         let logits = self.forward_internal(input_ids, None, &mut batched_caches, None);
         for (batch_idx, seq_id) in seq_ids.iter().copied().enumerate() {
@@ -1703,6 +1708,43 @@ impl Qwen35Model {
                 .replace_sequence_state(seq_id, split_caches);
         }
         logits
+    }
+
+    fn configured_attention_kv_modes_all_fp16(&self) -> bool {
+        let Some(modes) = self.kv_cache_layer_modes.clone_modes() else {
+            return true;
+        };
+        self.layers.iter().enumerate().all(|(layer_idx, layer)| {
+            layer.is_linear
+                || modes.get(layer_idx).copied().unwrap_or(KVCacheMode::Fp16) == KVCacheMode::Fp16
+        })
+    }
+
+    fn forward_batched_rows_sequential(
+        &self,
+        input_ids: &MlxArray,
+        seq_ids: Option<&[SequenceId]>,
+        batch_caches: &mut [&mut [KVCache]],
+    ) -> UniquePtr<MlxArray> {
+        let shape = mlxcel_core::array_shape(input_ids);
+        let input_0 = mlxcel_core::slice(input_ids, &[0, 0], &[1, shape[1]]);
+        let mut result = self.forward_with_sequence_id(
+            &input_0,
+            seq_ids.and_then(|ids| ids.first().copied()),
+            batch_caches[0],
+            None,
+        );
+        for (i, caches) in batch_caches.iter_mut().enumerate().skip(1) {
+            let input_i = mlxcel_core::slice(input_ids, &[i as i32, 0], &[i as i32 + 1, shape[1]]);
+            let logits_i = self.forward_with_sequence_id(
+                &input_i,
+                seq_ids.and_then(|ids| ids.get(i).copied()),
+                caches,
+                None,
+            );
+            result = mlxcel_core::concatenate(&result, &logits_i, 0);
+        }
+        result
     }
 
     fn forward_with_sequence_caches(
@@ -1879,6 +1921,7 @@ impl Qwen35Model {
             config: config_clone,
             sequence_state: ModelOwnedSequenceState::new(internal_caches),
             mrope_state: MRopeState::new(),
+            kv_cache_layer_modes: KvCacheLayerModes::new(),
         })
     }
 
@@ -3280,6 +3323,16 @@ impl LanguageModel for Qwen35Model {
             .prepare_sequence_state(seq_id, self.make_internal_caches());
     }
 
+    fn set_kv_cache_layer_modes(&self, modes: Vec<KVCacheMode>) {
+        self.kv_cache_layer_modes.set(modes);
+        self.sequence_state
+            .replace_internal(self.make_internal_caches());
+    }
+
+    fn kv_cache_layer_modes(&self) -> Option<Vec<KVCacheMode>> {
+        self.kv_cache_layer_modes.clone_modes()
+    }
+
     fn reset_runtime_state(&self) {
         // Used by: CxxGenerator single-row generation paths. Qwen 3.5 Next
         // owns mixed attention / GatedDelta cache state in
@@ -3308,10 +3361,14 @@ impl LanguageModel for Qwen35Model {
                 let mut snapshot =
                     mlxcel_core::generate::ModelStateSnapshot::new("qwen3_5", token_len);
                 for (idx, cache) in state.iter().enumerate() {
-                    cache.snapshot_into(&mut snapshot, &format!("layer{idx}"));
+                    if let Err(err) = cache.snapshot_into(&mut snapshot, &format!("layer{idx}")) {
+                        tracing::warn!("Qwen 3.5 prompt-cache snapshot skipped: {err}");
+                        return None;
+                    }
                 }
-                snapshot
+                Some(snapshot)
             })
+            .flatten()
     }
 
     fn restore_sequence_state(
@@ -3327,7 +3384,7 @@ impl LanguageModel for Qwen35Model {
         }
         let mut state = self.make_internal_caches();
         for (idx, cache) in state.iter_mut().enumerate() {
-            cache.restore_from(snapshot, &format!("layer{idx}"));
+            cache.restore_from(snapshot, &format!("layer{idx}"))?;
         }
         self.sequence_state.replace_sequence_state(seq_id, state);
         Ok(())
@@ -3386,8 +3443,8 @@ impl LanguageModel for Qwen35Model {
     ) -> UniquePtr<MlxArray> {
         let shape = mlxcel_core::array_shape(input_ids);
         if batch_caches.len() <= 1 || shape[1] <= 1 {
-            let token_0 = mlxcel_core::slice(input_ids, &[0, 0], &[1, shape[1]]);
             if batch_caches.len() == 1 {
+                let token_0 = mlxcel_core::slice(input_ids, &[0, 0], &[1, shape[1]]);
                 return self.forward_with_sequence_id(
                     &token_0,
                     seq_ids.and_then(|ids| ids.first().copied()),
@@ -3395,60 +3452,28 @@ impl LanguageModel for Qwen35Model {
                     None,
                 );
             }
-            let mut result = self.forward_with_sequence_id(
-                &token_0,
-                seq_ids.and_then(|ids| ids.first().copied()),
-                batch_caches[0],
-                None,
-            );
-            for (i, caches) in batch_caches.iter_mut().enumerate().skip(1) {
-                let input_i =
-                    mlxcel_core::slice(input_ids, &[i as i32, 0], &[i as i32 + 1, shape[1]]);
-                let logits_i = self.forward_with_sequence_id(
-                    &input_i,
-                    seq_ids.and_then(|ids| ids.get(i).copied()),
-                    caches,
-                    None,
-                );
-                result = mlxcel_core::concatenate(&result, &logits_i, 0);
-            }
-            return result;
+            return self.forward_batched_rows_sequential(input_ids, seq_ids, batch_caches);
         }
 
         if mask.is_some() {
-            let input_0 = mlxcel_core::slice(input_ids, &[0, 0], &[1, shape[1]]);
-            let mut result = self.forward_with_sequence_id(
-                &input_0,
-                seq_ids.and_then(|ids| ids.first().copied()),
-                batch_caches[0],
-                None,
-            );
-            for (i, caches) in batch_caches.iter_mut().enumerate().skip(1) {
-                let input_i =
-                    mlxcel_core::slice(input_ids, &[i as i32, 0], &[i as i32 + 1, shape[1]]);
-                let logits_i = self.forward_with_sequence_id(
-                    &input_i,
-                    seq_ids.and_then(|ids| ids.get(i).copied()),
-                    caches,
-                    None,
-                );
-                result = mlxcel_core::concatenate(&result, &logits_i, 0);
-            }
-            return result;
+            return self.forward_batched_rows_sequential(input_ids, seq_ids, batch_caches);
         }
 
         if let Some(seq_ids) = seq_ids {
+            if !self.configured_attention_kv_modes_all_fp16() {
+                tracing::debug!(
+                    "Qwen 3.5 batched prefill is disabled for non-FP16 model-owned KV modes until row-split sidecars are supported"
+                );
+                return self.forward_batched_rows_sequential(
+                    input_ids,
+                    Some(seq_ids),
+                    batch_caches,
+                );
+            }
             return self.forward_batched_prefill(input_ids, seq_ids);
         }
 
-        let input_0 = mlxcel_core::slice(input_ids, &[0, 0], &[1, shape[1]]);
-        let mut result = self.forward_with_sequence_id(&input_0, None, batch_caches[0], None);
-        for (i, caches) in batch_caches.iter_mut().enumerate().skip(1) {
-            let input_i = mlxcel_core::slice(input_ids, &[i as i32, 0], &[i as i32 + 1, shape[1]]);
-            let logits_i = self.forward_with_sequence_id(&input_i, None, caches, None);
-            result = mlxcel_core::concatenate(&result, &logits_i, 0);
-        }
-        result
+        self.forward_batched_rows_sequential(input_ids, None, batch_caches)
     }
 
     fn eos_token_ids(&self) -> Vec<i32> {

--- a/src/models/qwen3_next.rs
+++ b/src/models/qwen3_next.rs
@@ -38,9 +38,9 @@ use crate::distributed::pipeline::partial_loading::filter_weight_map;
 use crate::models::gated_delta::{
     GatedDeltaCache, RMSNormGated, gated_delta_update, scaled_fast_rms_norm_no_weight,
 };
-use crate::models::model_owned::ModelOwnedSequenceState;
+use crate::models::model_owned::{KvCacheLayerModes, ModelOwnedSequenceState};
 use crate::models::switch_layers::validate_expert_quantization_params;
-use mlxcel_core::cache::{SequenceId, SequenceStateLayout};
+use mlxcel_core::cache::{KVCacheMode, SequenceId, SequenceStateLayout};
 use mlxcel_core::dtype;
 use mlxcel_core::generate::LanguageModel;
 use mlxcel_core::layers::{KVCache, RMSNorm, UnifiedEmbedding, UnifiedLinear};
@@ -175,9 +175,20 @@ impl Qwen3NextCache {
         &self,
         snapshot: &mut mlxcel_core::generate::ModelStateSnapshot,
         prefix: &str,
-    ) {
+    ) -> Result<(), String> {
         match self {
             Qwen3NextCache::Attention(kv) => {
+                if kv.mode != KVCacheMode::Fp16 {
+                    return Err(format!(
+                        "{prefix}.attention: model-state snapshots do not yet serialize {:?} KV sidecars",
+                        kv.mode
+                    ));
+                }
+                super::recurrent_snapshot::push_kv_cache_mode(
+                    snapshot,
+                    format!("{prefix}.attention.mode"),
+                    kv.mode,
+                );
                 super::recurrent_snapshot::push_optional(
                     snapshot,
                     format!("{prefix}.attention.keys"),
@@ -188,8 +199,12 @@ impl Qwen3NextCache {
                     format!("{prefix}.attention.values"),
                     &kv.values,
                 );
+                Ok(())
             }
-            Qwen3NextCache::Linear(gd) => gd.snapshot_into(snapshot, &format!("{prefix}.linear")),
+            Qwen3NextCache::Linear(gd) => {
+                gd.snapshot_into(snapshot, &format!("{prefix}.linear"));
+                Ok(())
+            }
         }
     }
 
@@ -197,9 +212,26 @@ impl Qwen3NextCache {
         &mut self,
         snapshot: &mlxcel_core::generate::ModelStateSnapshot,
         prefix: &str,
-    ) {
+    ) -> Result<(), String> {
         match self {
             Qwen3NextCache::Attention(kv) => {
+                let snapshot_mode = super::recurrent_snapshot::restore_kv_cache_mode(
+                    snapshot,
+                    format!("{prefix}.attention.mode"),
+                )?
+                .unwrap_or(KVCacheMode::Fp16);
+                if snapshot_mode != kv.mode {
+                    return Err(format!(
+                        "{prefix}.attention: snapshot KV mode {:?} does not match configured mode {:?}",
+                        snapshot_mode, kv.mode
+                    ));
+                }
+                if kv.mode != KVCacheMode::Fp16 {
+                    return Err(format!(
+                        "{prefix}.attention: model-state restores do not yet deserialize {:?} KV sidecars",
+                        kv.mode
+                    ));
+                }
                 kv.keys = super::recurrent_snapshot::restore_optional(
                     snapshot,
                     format!("{prefix}.attention.keys"),
@@ -209,9 +241,11 @@ impl Qwen3NextCache {
                     format!("{prefix}.attention.values"),
                 );
                 kv.offset = snapshot.token_len() as i32;
+                Ok(())
             }
             Qwen3NextCache::Linear(gd) => {
                 gd.restore_from(snapshot, &format!("{prefix}.linear"));
+                Ok(())
             }
         }
     }
@@ -1416,6 +1450,7 @@ pub struct Qwen3NextModel {
     // model owns its heterogeneous cache here and persists it across forward
     // calls; recreating it per call would make decode stateless.
     sequence_state: ModelOwnedSequenceState<Qwen3NextCache>,
+    kv_cache_layer_modes: KvCacheLayerModes,
 }
 
 impl Qwen3NextModel {
@@ -1441,13 +1476,20 @@ impl Qwen3NextModel {
     }
 
     pub fn make_caches(&self) -> Vec<Qwen3NextCache> {
+        self.make_internal_caches()
+    }
+
+    fn make_internal_caches_with_modes(&self, modes: &KvCacheLayerModes) -> Vec<Qwen3NextCache> {
         self.layers
             .iter()
-            .map(|l| {
+            .enumerate()
+            .map(|(layer_idx, l)| {
                 if l.is_linear {
                     Qwen3NextCache::Linear(GatedDeltaCache::new())
                 } else {
-                    Qwen3NextCache::Attention(KVCache::new())
+                    Qwen3NextCache::Attention(KVCache::new_with_mode(
+                        modes.mode_for_layer(layer_idx),
+                    ))
                 }
             })
             .collect()
@@ -1597,20 +1639,12 @@ impl Qwen3NextModel {
             tie_word_embeddings: config.tie_word_embeddings,
             full_attention_interval: config.full_attention_interval,
             sequence_state: ModelOwnedSequenceState::new(internal_caches),
+            kv_cache_layer_modes: KvCacheLayerModes::new(),
         })
     }
 
     fn make_internal_caches(&self) -> Vec<Qwen3NextCache> {
-        self.layers
-            .iter()
-            .map(|l| {
-                if l.is_linear {
-                    Qwen3NextCache::Linear(GatedDeltaCache::new())
-                } else {
-                    Qwen3NextCache::Attention(KVCache::new())
-                }
-            })
-            .collect()
+        self.make_internal_caches_with_modes(&self.kv_cache_layer_modes)
     }
 
     /// Shared forward that routes through the model-owned heterogeneous cache.
@@ -1707,6 +1741,16 @@ impl LanguageModel for Qwen3NextModel {
             .prepare_sequence_state(seq_id, self.make_internal_caches());
     }
 
+    fn set_kv_cache_layer_modes(&self, modes: Vec<KVCacheMode>) {
+        self.kv_cache_layer_modes.set(modes);
+        self.sequence_state
+            .replace_internal(self.make_internal_caches());
+    }
+
+    fn kv_cache_layer_modes(&self) -> Option<Vec<KVCacheMode>> {
+        self.kv_cache_layer_modes.clone_modes()
+    }
+
     fn release_sequence_state_by_id(&self, seq_id: SequenceId) {
         self.sequence_state.release_sequence_state(seq_id);
     }
@@ -1725,10 +1769,14 @@ impl LanguageModel for Qwen3NextModel {
                 let mut snapshot =
                     mlxcel_core::generate::ModelStateSnapshot::new("qwen3_next", token_len);
                 for (idx, cache) in state.iter().enumerate() {
-                    cache.snapshot_into(&mut snapshot, &format!("layer{idx}"));
+                    if let Err(err) = cache.snapshot_into(&mut snapshot, &format!("layer{idx}")) {
+                        tracing::warn!("Qwen3-Next prompt-cache snapshot skipped: {err}");
+                        return None;
+                    }
                 }
-                snapshot
+                Some(snapshot)
             })
+            .flatten()
     }
 
     fn restore_sequence_state(
@@ -1744,7 +1792,7 @@ impl LanguageModel for Qwen3NextModel {
         }
         let mut state = self.make_internal_caches();
         for (idx, cache) in state.iter_mut().enumerate() {
-            cache.restore_from(snapshot, &format!("layer{idx}"));
+            cache.restore_from(snapshot, &format!("layer{idx}"))?;
         }
         self.sequence_state.replace_sequence_state(seq_id, state);
         Ok(())
@@ -2095,10 +2143,14 @@ mod cache_tests {
         let cache = Qwen3NextCache::Attention(kv);
 
         let mut snapshot = ModelStateSnapshot::new("qwen3_5", 23);
-        cache.snapshot_into(&mut snapshot, "layer0");
+        cache
+            .snapshot_into(&mut snapshot, "layer0")
+            .expect("fp16 attention snapshot should be supported");
 
         let mut restored = Qwen3NextCache::Attention(KVCache::new());
-        restored.restore_from(&snapshot, "layer0");
+        restored
+            .restore_from(&snapshot, "layer0")
+            .expect("fp16 attention snapshot should restore");
 
         match restored {
             Qwen3NextCache::Attention(kv) => {
@@ -2128,10 +2180,14 @@ mod cache_tests {
         let cache = Qwen3NextCache::Linear(gd);
 
         let mut snapshot = ModelStateSnapshot::new("qwen3_5", 29);
-        cache.snapshot_into(&mut snapshot, "layer1");
+        cache
+            .snapshot_into(&mut snapshot, "layer1")
+            .expect("linear snapshot should be supported");
 
         let mut restored = Qwen3NextCache::Linear(GatedDeltaCache::new());
-        restored.restore_from(&snapshot, "layer1");
+        restored
+            .restore_from(&snapshot, "layer1")
+            .expect("linear snapshot should restore");
 
         match restored {
             Qwen3NextCache::Linear(gd) => {
@@ -2151,6 +2207,35 @@ mod cache_tests {
             }
             Qwen3NextCache::Attention(_) => panic!("restored wrong cache variant"),
         }
+    }
+
+    #[test]
+    fn qwen3_next_attention_snapshot_refuses_non_fp16_modes() {
+        let cache = Qwen3NextCache::Attention(KVCache::new_with_mode(
+            mlxcel_core::cache::KVCacheMode::Int8,
+        ));
+        let mut snapshot = ModelStateSnapshot::new("qwen3_next", 1);
+        let err = cache
+            .snapshot_into(&mut snapshot, "layer0")
+            .expect_err("non-fp16 attention snapshot must be refused");
+        assert!(err.contains("Int8"));
+    }
+
+    #[test]
+    fn qwen3_next_attention_restore_refuses_mode_mismatch() {
+        let cache = Qwen3NextCache::Attention(KVCache::new());
+        let mut snapshot = ModelStateSnapshot::new("qwen3_next", 1);
+        cache
+            .snapshot_into(&mut snapshot, "layer0")
+            .expect("fp16 snapshot should be supported");
+
+        let mut restored = Qwen3NextCache::Attention(KVCache::new_with_mode(
+            mlxcel_core::cache::KVCacheMode::Int8,
+        ));
+        let err = restored
+            .restore_from(&snapshot, "layer0")
+            .expect_err("restoring fp16 snapshot into int8 cache must be refused");
+        assert!(err.contains("does not match configured mode"));
     }
 }
 

--- a/src/models/recurrent_snapshot.rs
+++ b/src/models/recurrent_snapshot.rs
@@ -18,6 +18,7 @@
 //! through the `LanguageModel` trait. These helpers keep the model files from
 //! repeating the same optional-tensor copy/restore boilerplate.
 
+use mlxcel_core::cache::KVCacheMode;
 use mlxcel_core::generate::ModelStateSnapshot;
 use mlxcel_core::{MlxArray, UniquePtr};
 
@@ -48,4 +49,45 @@ pub(crate) fn restore_optional(
 
 pub(crate) fn restore_i32(snapshot: &ModelStateSnapshot, name: impl AsRef<str>) -> Option<i32> {
     snapshot.tensor(name.as_ref()).map(mlxcel_core::item_i32)
+}
+
+pub(crate) fn push_kv_cache_mode(
+    snapshot: &mut ModelStateSnapshot,
+    name: impl Into<String>,
+    mode: KVCacheMode,
+) {
+    push_i32(snapshot, name, kv_cache_mode_to_i32(mode));
+}
+
+pub(crate) fn restore_kv_cache_mode(
+    snapshot: &ModelStateSnapshot,
+    name: impl AsRef<str>,
+) -> Result<Option<KVCacheMode>, String> {
+    let Some(tag) = restore_i32(snapshot, name.as_ref()) else {
+        return Ok(None);
+    };
+    kv_cache_mode_from_i32(tag).map(Some)
+}
+
+fn kv_cache_mode_to_i32(mode: KVCacheMode) -> i32 {
+    match mode {
+        KVCacheMode::Fp16 => 0,
+        KVCacheMode::Int8 => 1,
+        KVCacheMode::Turbo4Asym => 2,
+        KVCacheMode::Turbo3Asym => 3,
+        KVCacheMode::Turbo4 => 4,
+        KVCacheMode::Turbo4Delegated => 5,
+    }
+}
+
+fn kv_cache_mode_from_i32(tag: i32) -> Result<KVCacheMode, String> {
+    match tag {
+        0 => Ok(KVCacheMode::Fp16),
+        1 => Ok(KVCacheMode::Int8),
+        2 => Ok(KVCacheMode::Turbo4Asym),
+        3 => Ok(KVCacheMode::Turbo3Asym),
+        4 => Ok(KVCacheMode::Turbo4),
+        5 => Ok(KVCacheMode::Turbo4Delegated),
+        other => Err(format!("unknown serialized KV cache mode tag {other}")),
+    }
 }

--- a/src/server/batch/observability.rs
+++ b/src/server/batch/observability.rs
@@ -790,6 +790,9 @@ impl BatchObservability {
             prompt_cache_reject_mode_mismatch: self
                 .prompt_cache_reject_reasons
                 .count(PromptCacheRejectReason::ModeMismatch),
+            prompt_cache_reject_kv_mode_mismatch: self
+                .prompt_cache_reject_reasons
+                .count(PromptCacheRejectReason::KvModeMismatch),
             prompt_cache_reject_empty_set: self
                 .prompt_cache_reject_reasons
                 .count(PromptCacheRejectReason::EmptySet),
@@ -908,6 +911,7 @@ pub struct ObservabilitySnapshot {
     pub prompt_cache_reject_disabled: u64,
     pub prompt_cache_reject_prefix_too_short: u64,
     pub prompt_cache_reject_mode_mismatch: u64,
+    pub prompt_cache_reject_kv_mode_mismatch: u64,
     pub prompt_cache_reject_empty_set: u64,
     pub prompt_cache_reject_layout_constraints: u64,
     pub prompt_cache_reject_block_boundary_floor: u64,
@@ -1172,6 +1176,7 @@ mod tests {
         assert_eq!(snap.prompt_cache_reject_disabled, 0);
         assert_eq!(snap.prompt_cache_reject_prefix_too_short, 0);
         assert_eq!(snap.prompt_cache_reject_mode_mismatch, 0);
+        assert_eq!(snap.prompt_cache_reject_kv_mode_mismatch, 0);
         assert_eq!(snap.prompt_cache_reject_empty_set, 0);
         assert_eq!(snap.prompt_cache_reject_layout_constraints, 0);
         assert_eq!(snap.prompt_cache_reject_block_boundary_floor, 0);
@@ -1193,6 +1198,7 @@ mod tests {
         assert_eq!(snap.prompt_cache_reject_oversized, 0);
         assert_eq!(snap.prompt_cache_reject_disabled, 0);
         assert_eq!(snap.prompt_cache_reject_prefix_too_short, 0);
+        assert_eq!(snap.prompt_cache_reject_kv_mode_mismatch, 0);
         assert_eq!(snap.prompt_cache_reject_empty_set, 0);
         assert_eq!(snap.prompt_cache_reject_layout_constraints, 0);
         assert_eq!(snap.prompt_cache_reject_snapshot_diverged, 0);

--- a/src/server/batch/scheduler.rs
+++ b/src/server/batch/scheduler.rs
@@ -828,6 +828,33 @@ pub(crate) fn select_eviction_victim_from<'a>(
     }
 }
 
+fn validate_dense_detached_kv_modes_against_table(
+    dense: &mlxcel_core::cache::DetachedCacheSet,
+    expected: &[KVCacheMode],
+) -> Result<(), String> {
+    if expected.len() != dense.num_layers() {
+        return Err(format!(
+            "resolved {} KV cache layer modes for {} detached layers",
+            expected.len(),
+            dense.num_layers()
+        ));
+    }
+    for (idx, (detached, expected_mode)) in dense
+        .caches
+        .iter()
+        .zip(expected.iter().copied())
+        .enumerate()
+    {
+        let actual = detached.mode();
+        if actual != expected_mode {
+            return Err(format!(
+                "layer {idx} detached mode {actual} does not match resolved mode {expected_mode}"
+            ));
+        }
+    }
+    Ok(())
+}
+
 impl BatchScheduler {
     fn release_sequence_caches(&mut self, seq_id: SequenceId) {
         self.model.release_sequence_state_by_id(seq_id);
@@ -1517,6 +1544,7 @@ impl BatchScheduler {
     /// reserved, preserving the cross-tenant isolation contract.
     pub fn with_kv_cache_mode(mut self, mode: KVCacheMode) -> Self {
         self.kv_cache_mode = mode;
+        self.inject_model_owned_kv_cache_modes();
         self
     }
 
@@ -1536,6 +1564,8 @@ impl BatchScheduler {
     /// bit-exactly.
     pub fn with_batch_kv_quant(mut self, config: BatchKvQuantConfig) -> Self {
         self.batch_kv_quant = config;
+        self.inject_model_owned_kv_cache_modes();
+        self.log_effective_kv_cache_application();
         self
     }
 
@@ -2305,6 +2335,17 @@ impl BatchScheduler {
                         to = target,
                         "prompt-cache adopt: APC partial adoption truncated detached cache to block boundary"
                     );
+                }
+                if let Err(reason) = self.validate_dense_detached_kv_modes(&dense) {
+                    tracing::debug!(
+                        "prompt-cache adopt: dense KV mode mismatch ({reason}); falling back to cold prefill"
+                    );
+                    self.batch_observability.record_prompt_cache_reject(
+                        PromptCacheRejectReason::KvModeMismatch,
+                        None,
+                        matched_len,
+                    );
+                    return None;
                 }
                 self.cache_pool
                     .adopt(&self.model as &dyn LanguageModel, dense)
@@ -3449,6 +3490,9 @@ impl BatchScheduler {
     ///
     /// Used by: [`Self::allocate_sequence_state`].
     fn apply_kv_cache_mode_to(&mut self, seq_id: SequenceId) {
+        let batch_kv_quant = self.batch_kv_quant;
+        let kv_cache_mode = self.kv_cache_mode;
+        let requested_boundary_layers = mlxcel_core::cache::turbo::boundary_v_layers_from_env();
         let Some(caches) = self.cache_pool.get_caches_mut(seq_id) else {
             return;
         };
@@ -3458,32 +3502,59 @@ impl BatchScheduler {
             // is responsible for honoring the configured mode.
             return;
         }
-        let n_layers = caches.len();
-
-        // when the batched KV quant config is active, it
-        // takes precedence over the legacy `kv_cache_mode` path. The
-        // resolved table already encodes the per-layer mode (with the
-        // last-layer skip applied), so apply it directly.
-        if self.batch_kv_quant.is_enabled() {
-            let layer_modes = self.batch_kv_quant.resolve_layer_modes(n_layers);
-            for (cache, mode) in caches.iter_mut().zip(layer_modes) {
-                cache.mode = mode;
-            }
-            return;
-        }
-
-        // Legacy path: nominal mode + Boundary-V
-        // protection only.
-        let nominal = self.kv_cache_mode;
-        if nominal == KVCacheMode::Fp16 {
-            return;
-        }
-        let requested = mlxcel_core::cache::turbo::boundary_v_layers_from_env();
-        let layer_modes =
-            mlxcel_core::cache::turbo::resolve_layer_modes(nominal, n_layers, requested);
+        let layer_modes = if batch_kv_quant.is_enabled() {
+            batch_kv_quant.resolve_layer_modes(caches.len())
+        } else {
+            mlxcel_core::cache::turbo::resolve_layer_modes(
+                kv_cache_mode,
+                caches.len(),
+                requested_boundary_layers,
+            )
+        };
         for (cache, mode) in caches.iter_mut().zip(layer_modes) {
             cache.mode = mode;
         }
+    }
+
+    fn resolved_kv_cache_layer_modes(&self, n_layers: usize) -> Vec<KVCacheMode> {
+        if self.batch_kv_quant.is_enabled() {
+            return self.batch_kv_quant.resolve_layer_modes(n_layers);
+        }
+        let requested = mlxcel_core::cache::turbo::boundary_v_layers_from_env();
+        mlxcel_core::cache::turbo::resolve_layer_modes(self.kv_cache_mode, n_layers, requested)
+    }
+
+    fn configured_model_kv_cache_layer_modes(&self) -> Vec<KVCacheMode> {
+        self.resolved_kv_cache_layer_modes(self.model.num_layers())
+    }
+
+    fn inject_model_owned_kv_cache_modes(&self) {
+        self.model
+            .set_kv_cache_layer_modes(self.configured_model_kv_cache_layer_modes());
+    }
+
+    fn log_effective_kv_cache_application(&self) {
+        let modes = self.configured_model_kv_cache_layer_modes();
+        let effective_mode = if self.batch_kv_quant.is_enabled() {
+            self.batch_kv_quant.base_mode()
+        } else {
+            self.kv_cache_mode
+        };
+        let applied = modes.iter().filter(|mode| **mode == effective_mode).count();
+        tracing::info!(
+            kv_cache_mode_effective = %effective_mode,
+            kv_cache_mode_applied_layers = applied,
+            kv_cache_mode_total_layers = modes.len(),
+            "resolved KV cache mode applied to model caches"
+        );
+    }
+
+    fn validate_dense_detached_kv_modes(
+        &self,
+        dense: &mlxcel_core::cache::DetachedCacheSet,
+    ) -> Result<(), String> {
+        let expected = self.resolved_kv_cache_layer_modes(dense.num_layers());
+        validate_dense_detached_kv_modes_against_table(dense, &expected)
     }
 
     /// Prepare Turbo4Delegated cache state before a sequence enters decode.

--- a/src/server/batch/scheduler_tests.rs
+++ b/src/server/batch/scheduler_tests.rs
@@ -1594,6 +1594,53 @@ fn batch_kv_quant_per_layer_table_disabled_skip_keeps_uniform_modes() {
     }
 }
 
+fn detached_set_with_modes(
+    modes: &[mlxcel_core::cache::KVCacheMode],
+) -> mlxcel_core::cache::DetachedCacheSet {
+    let now = Instant::now();
+    let caches = modes
+        .iter()
+        .copied()
+        .map(|mode| {
+            let mut cache = mlxcel_core::cache::KVCache::new_with_mode(mode);
+            cache.clone_handle()
+        })
+        .collect();
+    mlxcel_core::cache::DetachedCacheSet {
+        caches,
+        backend: mlxcel_core::cache::SequenceStateBackend::DenseKvCache,
+        prompt_len: 0,
+        current_offset: 0,
+        created_at: now,
+        detached_at: now,
+        origin_seq_id: SequenceId::from_raw(123),
+    }
+}
+
+#[test]
+fn dense_detached_kv_mode_validation_accepts_the_resolved_table() {
+    use mlxcel_core::cache::KVCacheMode::{Fp16, Int8, Turbo4Asym};
+
+    let dense = detached_set_with_modes(&[Int8, Fp16, Turbo4Asym]);
+
+    super::validate_dense_detached_kv_modes_against_table(&dense, &[Int8, Fp16, Turbo4Asym])
+        .expect("matching detached KV modes must adopt");
+}
+
+#[test]
+fn dense_detached_kv_mode_validation_declines_named_mismatch() {
+    use mlxcel_core::cache::KVCacheMode::{Fp16, Int8};
+
+    let dense = detached_set_with_modes(&[Int8, Fp16]);
+    let err = super::validate_dense_detached_kv_modes_against_table(&dense, &[Fp16, Fp16])
+        .expect_err("a detached cache with a stale KV mode must not be adopted");
+
+    assert!(
+        err.contains("layer 0") && err.contains("int8") && err.contains("fp16"),
+        "mismatch error should name the layer and both modes: {err}"
+    );
+}
+
 // -------------------------------------------------------------------
 // Lookahead async_eval pipeline invalidation logic (issue #632)
 // -------------------------------------------------------------------

--- a/src/server/prompt_cache/apc_integration_tests.rs
+++ b/src/server/prompt_cache/apc_integration_tests.rs
@@ -358,6 +358,7 @@ fn apc_stats_reflect_block_chain_after_inserts() {
         crate::server::routes::cache::PagedBlockStats::default(),
         crate::server::routes::cache::RejectReasonStats::default(),
         crate::server::routes::cache::WarmupStats::default(),
+        "fp16".to_string(),
     );
     assert!(resp.enabled);
     assert!(resp.apc_enabled);
@@ -411,6 +412,7 @@ fn apc_disabled_flow_still_works_but_apc_active_entries_is_zero() {
         crate::server::routes::cache::PagedBlockStats::default(),
         crate::server::routes::cache::RejectReasonStats::default(),
         crate::server::routes::cache::WarmupStats::default(),
+        "fp16".to_string(),
     );
     assert!(resp.enabled);
     assert!(!resp.apc_enabled);

--- a/src/server/prompt_cache/metrics.rs
+++ b/src/server/prompt_cache/metrics.rs
@@ -50,6 +50,10 @@ pub enum PromptCacheRejectReason {
     /// backend (or vice versa), or a partial match declined under
     /// `require_whole_entry` (multimodal whole-entry policy).
     ModeMismatch,
+    /// Dense prompt-cache adoption declined because at least one detached
+    /// layer's KV cache mode differs from the scheduler's resolved per-layer
+    /// KV mode table.
+    KvModeMismatch,
     /// The detached, cloned, or snapshot KV set carried nothing to store or
     /// adopt (aborted before any prefill completed, or the model produced no
     /// capturable state).
@@ -94,11 +98,12 @@ pub enum PromptCacheRejectReason {
 impl PromptCacheRejectReason {
     /// All variants, in the stable order used by Prometheus/`/v1/cache/stats`
     /// exposition helpers.
-    pub const ALL: [Self; 9] = [
+    pub const ALL: [Self; 10] = [
         Self::Oversized,
         Self::Disabled,
         Self::PrefixTooShort,
         Self::ModeMismatch,
+        Self::KvModeMismatch,
         Self::EmptySet,
         Self::LayoutConstraints,
         Self::BlockBoundaryFloor,
@@ -114,6 +119,7 @@ impl PromptCacheRejectReason {
             Self::Disabled => "disabled",
             Self::PrefixTooShort => "prefix_too_short",
             Self::ModeMismatch => "mode_mismatch",
+            Self::KvModeMismatch => "kv_mode_mismatch",
             Self::EmptySet => "empty_set",
             Self::LayoutConstraints => "layout_constraints",
             Self::BlockBoundaryFloor => "block_boundary_floor",
@@ -172,6 +178,7 @@ pub struct PromptCacheRejectCounters {
     disabled: AtomicU64,
     prefix_too_short: AtomicU64,
     mode_mismatch: AtomicU64,
+    kv_mode_mismatch: AtomicU64,
     empty_set: AtomicU64,
     layout_constraints: AtomicU64,
     block_boundary_floor: AtomicU64,
@@ -191,6 +198,7 @@ impl PromptCacheRejectCounters {
             PromptCacheRejectReason::Disabled => &self.disabled,
             PromptCacheRejectReason::PrefixTooShort => &self.prefix_too_short,
             PromptCacheRejectReason::ModeMismatch => &self.mode_mismatch,
+            PromptCacheRejectReason::KvModeMismatch => &self.kv_mode_mismatch,
             PromptCacheRejectReason::EmptySet => &self.empty_set,
             PromptCacheRejectReason::LayoutConstraints => &self.layout_constraints,
             PromptCacheRejectReason::BlockBoundaryFloor => &self.block_boundary_floor,

--- a/src/server/routes/cache.rs
+++ b/src/server/routes/cache.rs
@@ -75,6 +75,7 @@ pub(crate) struct RejectReasonStats {
     pub disabled: u64,
     pub prefix_too_short: u64,
     pub mode_mismatch: u64,
+    pub kv_mode_mismatch: u64,
     pub empty_set: u64,
     pub layout_constraints: u64,
     pub block_boundary_floor: u64,
@@ -97,6 +98,7 @@ impl RejectReasonStats {
             disabled: snap.prompt_cache_reject_disabled,
             prefix_too_short: snap.prompt_cache_reject_prefix_too_short,
             mode_mismatch: snap.prompt_cache_reject_mode_mismatch,
+            kv_mode_mismatch: snap.prompt_cache_reject_kv_mode_mismatch,
             empty_set: snap.prompt_cache_reject_empty_set,
             layout_constraints: snap.prompt_cache_reject_layout_constraints,
             block_boundary_floor: snap.prompt_cache_reject_block_boundary_floor,
@@ -123,6 +125,8 @@ pub struct CacheStatsResponse {
     pub block_size: usize,
     /// APC hash algorithm string (`"sha256"` or `"blake3"`).
     pub hash: String,
+    /// Effective server KV cache mode after model allowlist/fallback resolution.
+    pub kv_cache_mode_effective: String,
     /// Live entries in the store.
     pub entries: usize,
     /// Total bytes consumed by live entries.
@@ -231,6 +235,8 @@ pub struct CacheStatsResponse {
     pub reject_prefix_too_short: u64,
     /// Cross-backend or whole-entry-policy declines (adopt path only).
     pub reject_mode_mismatch: u64,
+    /// Per-layer KV cache mode mismatch declines (dense adopt path only).
+    pub reject_kv_mode_mismatch: u64,
     /// Nothing-to-cache declines, from either path.
     pub reject_empty_set: u64,
     /// Pool-level operation failures (paged clone/trim, dense truncate,
@@ -316,6 +322,7 @@ pub async fn cache_stats(State(state): State<AppState>) -> Json<CacheStatsRespon
         paged,
         reject,
         warmups,
+        state.config.kv_cache_mode.to_string(),
     ))
 }
 
@@ -356,6 +363,7 @@ pub(crate) fn build_stats_response(
     paged: PagedBlockStats,
     reject: RejectReasonStats,
     warmups: WarmupStats,
+    kv_cache_mode_effective: String,
 ) -> CacheStatsResponse {
     let apc = &cfg.apc;
     match store {
@@ -377,6 +385,7 @@ pub(crate) fn build_stats_response(
                 apc_enabled: cfg.apc_enabled(),
                 block_size: apc.block_size,
                 hash: apc.hash.to_string(),
+                kv_cache_mode_effective: kv_cache_mode_effective.clone(),
                 entries: stats.entries,
                 bytes: stats.bytes,
                 capacity_bytes: cfg.capacity_bytes,
@@ -418,6 +427,7 @@ pub(crate) fn build_stats_response(
                 reject_disabled: reject.disabled,
                 reject_prefix_too_short: reject.prefix_too_short,
                 reject_mode_mismatch: reject.mode_mismatch,
+                reject_kv_mode_mismatch: reject.kv_mode_mismatch,
                 reject_empty_set: reject.empty_set,
                 reject_layout_constraints: reject.layout_constraints,
                 reject_block_boundary_floor: reject.block_boundary_floor,
@@ -435,6 +445,7 @@ pub(crate) fn build_stats_response(
             apc_enabled: false,
             block_size: apc.block_size,
             hash: apc.hash.to_string(),
+            kv_cache_mode_effective,
             entries: 0,
             bytes: 0,
             capacity_bytes: cfg.capacity_bytes,
@@ -479,6 +490,7 @@ pub(crate) fn build_stats_response(
             reject_disabled: reject.disabled,
             reject_prefix_too_short: reject.prefix_too_short,
             reject_mode_mismatch: reject.mode_mismatch,
+            reject_kv_mode_mismatch: reject.kv_mode_mismatch,
             reject_empty_set: reject.empty_set,
             reject_layout_constraints: reject.layout_constraints,
             reject_block_boundary_floor: reject.block_boundary_floor,

--- a/src/server/routes/cache.rs
+++ b/src/server/routes/cache.rs
@@ -322,8 +322,16 @@ pub async fn cache_stats(State(state): State<AppState>) -> Json<CacheStatsRespon
         paged,
         reject,
         warmups,
-        state.config.kv_cache_mode.to_string(),
+        cache_stats_effective_kv_mode(&state.config),
     ))
+}
+
+pub(crate) fn cache_stats_effective_kv_mode(config: &crate::server::ServerConfig) -> String {
+    if config.batch_kv_quant.is_enabled() {
+        config.batch_kv_quant.base_mode().to_string()
+    } else {
+        config.kv_cache_mode.to_string()
+    }
 }
 
 /// `POST /v1/cache/reset` — drop every live cache entry.

--- a/src/server/routes/cache_tests.rs
+++ b/src/server/routes/cache_tests.rs
@@ -33,6 +33,8 @@
 use std::sync::Arc;
 use std::time::Duration;
 
+use mlxcel_core::cache::{BatchKvQuantConfig, KVCacheMode, KvQuantScheme};
+
 use crate::server::prompt_cache::{
     ApcConfig, ApcHashAlgo, CacheEntry, MultimodalDigest, PromptCacheConfig, PromptCacheKey,
     PromptCacheStore,
@@ -520,6 +522,34 @@ fn build_stats_response_disabled_when_store_is_none() {
     assert_eq!(resp.lookups, 0);
     assert_eq!(resp.hit_rate, 0.0);
     assert_eq!(resp.block_size, cfg.apc.block_size);
+}
+
+#[test]
+fn cache_stats_effective_kv_mode_prefers_batch_kv_quant_when_enabled() {
+    let mut config = crate::server::ServerConfig {
+        kv_cache_mode: KVCacheMode::Fp16,
+        batch_kv_quant: BatchKvQuantConfig::new(KvQuantScheme::Uniform, 8, 64, true)
+            .expect("valid int8 batch KV config"),
+        ..crate::server::ServerConfig::default()
+    };
+    assert_eq!(
+        super::super::cache::cache_stats_effective_kv_mode(&config),
+        "int8"
+    );
+
+    config.batch_kv_quant = BatchKvQuantConfig::new(KvQuantScheme::TurboQuant, 4, 64, true)
+        .expect("valid turbo batch KV config");
+    assert_eq!(
+        super::super::cache::cache_stats_effective_kv_mode(&config),
+        "fp16+turbo4"
+    );
+
+    config.batch_kv_quant = BatchKvQuantConfig::default();
+    config.kv_cache_mode = KVCacheMode::Turbo4Delegated;
+    assert_eq!(
+        super::super::cache::cache_stats_effective_kv_mode(&config),
+        "turbo4-delegated"
+    );
 }
 
 #[test]

--- a/src/server/routes/cache_tests.rs
+++ b/src/server/routes/cache_tests.rs
@@ -86,6 +86,7 @@ fn cache_stats_response_serializes_with_expected_keys() {
         apc_enabled: true,
         block_size: 16,
         hash: "sha256".to_string(),
+        kv_cache_mode_effective: "int8".to_string(),
         entries: 3,
         bytes: 12345,
         capacity_bytes: 2 * 1024 * 1024 * 1024,
@@ -125,6 +126,7 @@ fn cache_stats_response_serializes_with_expected_keys() {
         reject_disabled: 0,
         reject_prefix_too_short: 2,
         reject_mode_mismatch: 3,
+        reject_kv_mode_mismatch: 12,
         reject_empty_set: 4,
         reject_layout_constraints: 5,
         reject_block_boundary_floor: 6,
@@ -142,6 +144,7 @@ fn cache_stats_response_serializes_with_expected_keys() {
         "\"apc_enabled\":true",
         "\"block_size\":16",
         "\"hash\":\"sha256\"",
+        "\"kv_cache_mode_effective\":\"int8\"",
         "\"entries\":3",
         "\"bytes\":12345",
         "\"capacity_bytes\":",
@@ -168,6 +171,7 @@ fn cache_stats_response_serializes_with_expected_keys() {
         "\"reject_disabled\":0",
         "\"reject_prefix_too_short\":2",
         "\"reject_mode_mismatch\":3",
+        "\"reject_kv_mode_mismatch\":12",
         "\"reject_empty_set\":4",
         "\"reject_layout_constraints\":5",
         "\"reject_block_boundary_floor\":6",
@@ -249,6 +253,7 @@ fn cache_stats_response_disabled_payload_uses_zero_counters() {
         apc_enabled: false,
         block_size: cfg.apc.block_size,
         hash: cfg.apc.hash.to_string(),
+        kv_cache_mode_effective: "fp16".to_string(),
         entries: 0,
         bytes: 0,
         capacity_bytes: cfg.capacity_bytes,
@@ -288,6 +293,7 @@ fn cache_stats_response_disabled_payload_uses_zero_counters() {
         reject_disabled: 0,
         reject_prefix_too_short: 0,
         reject_mode_mismatch: 0,
+        reject_kv_mode_mismatch: 0,
         reject_empty_set: 0,
         reject_layout_constraints: 0,
         reject_block_boundary_floor: 0,
@@ -334,6 +340,7 @@ fn build_stats_response_surfaces_paged_pool_independent_of_store() {
         paged,
         RejectReasonStats::default(),
         super::super::cache::WarmupStats::default(),
+        "fp16".to_string(),
     );
     assert!(!disabled.enabled);
     assert_eq!(disabled.paged_block_size, 32);
@@ -353,6 +360,7 @@ fn build_stats_response_surfaces_paged_pool_independent_of_store() {
         paged,
         RejectReasonStats::default(),
         super::super::cache::WarmupStats::default(),
+        "fp16".to_string(),
     );
     assert_eq!(enabled.paged_blocks_allocated, 200);
     assert_eq!(enabled.paged_bytes_in_use, 98304);
@@ -423,6 +431,7 @@ fn snapshot_divergence_reject_reaches_the_stats_body_with_its_geometry() {
         PagedBlockStats::default(),
         reject,
         super::super::cache::WarmupStats::default(),
+        "fp16".to_string(),
     );
     assert_eq!(resp.reject_snapshot_diverged, 1);
     let json = serde_json::to_string(&resp).expect("serialize");
@@ -462,6 +471,7 @@ fn other_reject_reasons_leave_the_stats_divergence_counter_at_zero() {
         PagedBlockStats::default(),
         reject,
         super::super::cache::WarmupStats::default(),
+        "fp16".to_string(),
     );
     assert_eq!(resp.reject_snapshot_diverged, 0);
     assert_eq!(resp.last_reject_entry_len, None);
@@ -501,6 +511,7 @@ fn build_stats_response_disabled_when_store_is_none() {
         PagedBlockStats::default(),
         RejectReasonStats::default(),
         super::super::cache::WarmupStats::default(),
+        "fp16".to_string(),
     );
     assert!(!resp.enabled);
     assert!(!resp.apc_enabled);
@@ -527,6 +538,7 @@ fn build_stats_response_reflects_live_store() {
         PagedBlockStats::default(),
         RejectReasonStats::default(),
         super::super::cache::WarmupStats::default(),
+        "fp16".to_string(),
     );
     assert!(resp.enabled);
     assert!(
@@ -573,6 +585,7 @@ fn build_stats_response_reflects_apc_blocks_when_enabled() {
         PagedBlockStats::default(),
         RejectReasonStats::default(),
         super::super::cache::WarmupStats::default(),
+        "fp16".to_string(),
     );
     assert!(resp.enabled);
     assert!(resp.apc_enabled, "APC must be enabled in this fixture");
@@ -610,6 +623,7 @@ fn build_stats_response_apc_zero_when_disabled_with_inserts() {
         PagedBlockStats::default(),
         RejectReasonStats::default(),
         super::super::cache::WarmupStats::default(),
+        "fp16".to_string(),
     );
     assert!(!resp.apc_enabled);
     assert_eq!(resp.entries, 3);
@@ -658,6 +672,7 @@ fn apc_unique_block_hashes_reflects_dedup_potential() {
         PagedBlockStats::default(),
         RejectReasonStats::default(),
         super::super::cache::WarmupStats::default(),
+        "fp16".to_string(),
     );
     assert_eq!(resp.entries, 2);
     assert_eq!(resp.apc_active_entries, 2);
@@ -736,6 +751,7 @@ async fn router_returns_stats_and_reset_with_correct_methods() {
             PagedBlockStats::default(),
             RejectReasonStats::default(),
             super::super::cache::WarmupStats::default(),
+            "fp16".to_string(),
         ))
     }
     async fn reset_handler(

--- a/src/vision/gemma4_unified.rs
+++ b/src/vision/gemma4_unified.rs
@@ -32,7 +32,7 @@ use super::gemma4_per_layer_inputs_state::Gemma4PerLayerInputsState;
 use super::processors::gemma4_unified::{Gemma4UnifiedImageInput, Gemma4UnifiedProcessor};
 use super::{encoders, merge};
 use crate::LanguageModel;
-use mlxcel_core::cache::{SequenceId, SequenceStateLayout};
+use mlxcel_core::cache::{KVCacheMode, SequenceId, SequenceStateLayout};
 use mlxcel_core::layers::KVCache;
 use mlxcel_core::{MlxArray, UniquePtr};
 
@@ -609,6 +609,14 @@ impl LanguageModel for Gemma4UnifiedModel {
 
     fn make_caches(&self) -> Vec<KVCache> {
         self.text_model.make_caches()
+    }
+
+    fn set_kv_cache_layer_modes(&self, modes: Vec<KVCacheMode>) {
+        self.text_model.set_kv_cache_layer_modes(modes)
+    }
+
+    fn kv_cache_layer_modes(&self) -> Option<Vec<KVCacheMode>> {
+        self.text_model.kv_cache_layer_modes()
     }
 
     fn sequence_state_layout(&self) -> SequenceStateLayout {

--- a/src/vision/gemma4_vl.rs
+++ b/src/vision/gemma4_vl.rs
@@ -23,7 +23,7 @@ use super::{encoders, merge, processors};
 use crate::LanguageModel;
 use crate::audio;
 use crate::multimodal::batched_dispatch::forward_batched_with_seq_ids_dispatch;
-use mlxcel_core::cache::{SequenceId, SequenceStateLayout};
+use mlxcel_core::cache::{KVCacheMode, SequenceId, SequenceStateLayout};
 use mlxcel_core::generate::DecodeBatchContext;
 use mlxcel_core::layers::KVCache;
 use mlxcel_core::{MlxArray, UniquePtr};
@@ -572,6 +572,14 @@ impl LanguageModel for Gemma4VLModel {
     /// [`Self::sequence_state_layout`].
     fn make_caches(&self) -> Vec<KVCache> {
         self.text_model.make_caches()
+    }
+
+    fn set_kv_cache_layer_modes(&self, modes: Vec<KVCacheMode>) {
+        self.text_model.set_kv_cache_layer_modes(modes)
+    }
+
+    fn kv_cache_layer_modes(&self) -> Option<Vec<KVCacheMode>> {
+        self.text_model.kv_cache_layer_modes()
     }
 
     fn sequence_state_layout(&self) -> SequenceStateLayout {

--- a/src/vision/lfm2_vl.rs
+++ b/src/vision/lfm2_vl.rs
@@ -32,7 +32,7 @@
 //!
 //! Used by: `loading::load_lfm2_vl`, `multimodal::vlm_runtime`.
 
-use mlxcel_core::cache::SequenceId;
+use mlxcel_core::cache::{KVCacheMode, SequenceId};
 use mlxcel_core::generate::{DecodeBatchContext, LanguageModel, ModelStateSnapshot};
 use mlxcel_core::layers::KVCache;
 use mlxcel_core::{MlxArray, UniquePtr};
@@ -176,6 +176,14 @@ impl LanguageModel for Lfm2VlModel {
 
     fn make_caches(&self) -> Vec<KVCache> {
         LanguageModel::make_caches(&self.text_model)
+    }
+
+    fn set_kv_cache_layer_modes(&self, modes: Vec<KVCacheMode>) {
+        self.text_model.set_kv_cache_layer_modes(modes)
+    }
+
+    fn kv_cache_layer_modes(&self) -> Option<Vec<KVCacheMode>> {
+        self.text_model.kv_cache_layer_modes()
     }
 
     fn num_layers(&self) -> usize {

--- a/src/vision/mod.rs
+++ b/src/vision/mod.rs
@@ -141,6 +141,7 @@ use crate::LanguageModel;
 use connectors::MultiModalConnector;
 use encoders::VisionEncoder;
 use merge::InputEmbeddings;
+use mlxcel_core::cache::KVCacheMode;
 use mlxcel_core::layers::KVCache;
 use mlxcel_core::{MlxArray, UniquePtr};
 use processors::ImageProcessor;
@@ -320,6 +321,14 @@ impl LanguageModel for VisionLanguageModel {
 
     fn make_caches(&self) -> Vec<KVCache> {
         self.text_model.make_caches()
+    }
+
+    fn set_kv_cache_layer_modes(&self, modes: Vec<KVCacheMode>) {
+        self.text_model.set_kv_cache_layer_modes(modes)
+    }
+
+    fn kv_cache_layer_modes(&self) -> Option<Vec<KVCacheMode>> {
+        self.text_model.kv_cache_layer_modes()
     }
 
     fn num_layers(&self) -> usize {

--- a/src/vision/qwen3_5_vl.rs
+++ b/src/vision/qwen3_5_vl.rs
@@ -21,7 +21,7 @@ use super::{encoders, merge, processors};
 use crate::LanguageModel;
 use crate::models::qwen3_5::{GdnRollbackSnapshot, VerifyOutput};
 use crate::models::qwen3_next::Qwen3NextCache;
-use mlxcel_core::cache::SequenceId;
+use mlxcel_core::cache::{KVCacheMode, SequenceId};
 use mlxcel_core::generate::DecodeBatchContext;
 use mlxcel_core::layers::KVCache;
 use mlxcel_core::{MlxArray, UniquePtr};
@@ -503,6 +503,14 @@ impl LanguageModel for Qwen35VLModel {
 
     fn make_caches(&self) -> Vec<KVCache> {
         self.text_model.make_caches()
+    }
+
+    fn set_kv_cache_layer_modes(&self, modes: Vec<KVCacheMode>) {
+        self.text_model.set_kv_cache_layer_modes(modes)
+    }
+
+    fn kv_cache_layer_modes(&self) -> Option<Vec<KVCacheMode>> {
+        self.text_model.kv_cache_layer_modes()
     }
 
     fn num_layers(&self) -> usize {


### PR DESCRIPTION
## Summary

Apply the resolved effective KV cache mode table to model-owned attention caches so `--kv-cache-mode` and `--kv-bits` no longer stop at dense external cache slices, while keeping observability and prompt-cache reuse aligned with the mode that is actually active.

## What changed

- Added `LanguageModel` KV-mode table hooks plus a shared `KvCacheLayerModes` helper and delegated the hooks through loaded-model and VLM wrappers.
- Injected resolved per-layer modes from the CLI generator and server scheduler, including Boundary-V and batch KV quantization policy, then reported the applied-layer count in the CLI and server surfaces.
- Updated Gemma 3, AFMoE, Gemma 4, Qwen 3.5, Qwen3-Next, Bailing MoE Linear, LFM2, and Llama 4 regular attention caches to use the injected mode while keeping recurrent, convolutional, gated-delta, and Llama 4 chunked caches unchanged.
- Made dense prompt-cache adoption reject stale per-layer KV modes with `kv_mode_mismatch`, and made model-owned snapshot restore refuse non-FP16 or mode-mismatched attention state instead of silently truncating quantization sidecars.
- Added `kv_cache_mode_effective` to cache statistics, preferring the batch KV quantization base mode when `--kv-bits` is active and otherwise using the legacy effective mode.
- Documented model-owned KV-mode behavior, snapshot conservatism, prompt-cache mismatch observability, and the Llama 4 `ChunkedKVCache` exception.

## Changes during review

- Fixed `/v1/cache/stats` to report the batch KV quantization mode instead of incorrectly falling back to `fp16` when `BatchKvQuantConfig` is enabled.

## Validation

- [x] `cargo test --workspace --profile test-fast --features metal,accelerate`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo fmt --all -- --check`
- [x] Focused generator forwarding, Qwen3-Next snapshot, dense prompt-cache mismatch, and cache-stats effective-mode tests
- [x] Gemma 3 real-checkpoint generation on Metal with both `fp16` and `int8`

Real checkpoint result: Gemma 3 FP16 and INT8 both completed on Metal, the banners reported `applied to 26 of 26 layers`, stderr was empty, and the greedy outputs differed, confirming that the model-owned cache consumed the configured mode.

Closes #1330
