### PR TITLE
update: audit shapeless MLX compile sites

### DIFF
--- a/.github/workflows/nightly-verify.yml
+++ b/.github/workflows/nightly-verify.yml
@@ -157,62 +157,12 @@ concurrency:
   cancel-in-progress: false
 
 jobs:
-  # Temporary branch-only qualification for issue #1392. Removed again after
-  # the final 20-site audit; no model weights are downloaded.
-  shapeless-compile-audit:
-    name: shapeless compile audit (macOS Apple Silicon)
-    if: >-
-      ${{ github.repository == 'lablup/mlxcel'
-          && github.event_name == 'workflow_dispatch' }}
-    runs-on: self-hosted-macos-26-arm64
-    timeout-minutes: 60
-    permissions:
-      contents: read
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v7
-        with:
-          persist-credentials: false
-      - name: Setup Metal build environment
-        run: |
-          set -euo pipefail
-          export PATH="/opt/homebrew/bin:/usr/local/bin:$PATH"
-          command -v cmake
-          if ! xcrun -f metal >/dev/null 2>&1; then
-            for candidate in /Applications/Xcode*.app/Contents/Developer; do
-              [ -d "$candidate" ] || continue
-              if DEVELOPER_DIR="$candidate" xcrun -f metal >/dev/null 2>&1; then
-                echo "DEVELOPER_DIR=$candidate" >> "$GITHUB_ENV"
-                break
-              fi
-            done
-          fi
-          xcrun -f metal
-          echo "/opt/homebrew/bin" >> "$GITHUB_PATH"
-          echo "/usr/local/bin" >> "$GITHUB_PATH"
-          CARGO_TARGET="$HOME/.cargo-target/mlxcel"
-          mkdir -p "$CARGO_TARGET"
-          echo "CARGO_TARGET_DIR=$CARGO_TARGET" >> "$GITHUB_ENV"
-      - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@stable
-        with:
-          components: rustfmt
-      - name: Audit every shapeless compile site
-        run: scripts/audit_shapeless_compile.sh
-      - name: Verify quiet-site regressions
-        run: >-
-          cargo test -p mlxcel-core --profile test-fast
-          --features metal,accelerate --lib eager_regression --
-          --nocapture --test-threads=1
-
   verify:
     name: fmt + clippy + test + video (macOS Apple Silicon)
     # Scheduled workflows run from the default branch of whatever repository
     # holds them. A fork that enables Actions would otherwise queue forever
     # against runner labels it does not own.
-    if: >-
-      ${{ github.repository == 'lablup/mlxcel'
-          && github.event_name == 'schedule' }}
+    if: github.repository == 'lablup/mlxcel'
     runs-on: self-hosted-macos-26-arm64 # Self-hosted Apple Silicon runner with macOS 26 SDK + Metal 4
     # Generous because a cold run is a full MLX C++ build plus a link of every
     # integration-test binary. Note that the FIRST run after the switch to

--- a/.github/workflows/nightly-verify.yml
+++ b/.github/workflows/nightly-verify.yml
@@ -157,12 +157,67 @@ concurrency:
   cancel-in-progress: false
 
 jobs:
+  # Temporary branch-only qualification for issue #1392. This job is removed
+  # before the implementation PR is opened; it never downloads model weights.
+  shapeless-compile-audit:
+    name: shapeless compile audit (macOS Apple Silicon)
+    if: >-
+      ${{ github.repository == 'lablup/mlxcel'
+          && github.event_name == 'workflow_dispatch' }}
+    runs-on: self-hosted-macos-26-arm64
+    timeout-minutes: 60
+    permissions:
+      contents: read
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v7
+        with:
+          persist-credentials: false
+
+      - name: Setup Metal build environment
+        run: |
+          set -euo pipefail
+          export PATH="/opt/homebrew/bin:/usr/local/bin:$PATH"
+          command -v cmake
+          if ! xcrun -f metal >/dev/null 2>&1; then
+            for candidate in /Applications/Xcode*.app/Contents/Developer; do
+              [ -d "$candidate" ] || continue
+              if DEVELOPER_DIR="$candidate" xcrun -f metal >/dev/null 2>&1; then
+                echo "DEVELOPER_DIR=$candidate" >> "$GITHUB_ENV"
+                break
+              fi
+            done
+          fi
+          xcrun -f metal
+          echo "/opt/homebrew/bin" >> "$GITHUB_PATH"
+          echo "/usr/local/bin" >> "$GITHUB_PATH"
+          CARGO_TARGET="$HOME/.cargo-target/mlxcel"
+          mkdir -p "$CARGO_TARGET"
+          echo "CARGO_TARGET_DIR=$CARGO_TARGET" >> "$GITHUB_ENV"
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          components: rustfmt
+
+      - name: Audit every remaining shapeless compile site
+        run: scripts/audit_shapeless_compile.sh
+
+      - name: Verify eager quiet-site regressions
+        run: >-
+          cargo test -p mlxcel-core --profile test-fast
+          --features metal,accelerate --lib eager_regression --
+          --nocapture --test-threads=1
+
   verify:
     name: fmt + clippy + test + video (macOS Apple Silicon)
     # Scheduled workflows run from the default branch of whatever repository
     # holds them. A fork that enables Actions would otherwise queue forever
     # against runner labels it does not own.
-    if: github.repository == 'lablup/mlxcel'
+    if: >-
+      ${{ github.repository == 'lablup/mlxcel'
+          && github.event_name == 'schedule' }}
     runs-on: self-hosted-macos-26-arm64 # Self-hosted Apple Silicon runner with macOS 26 SDK + Metal 4
     # Generous because a cold run is a full MLX C++ build plus a link of every
     # integration-test binary. Note that the FIRST run after the switch to

--- a/.github/workflows/nightly-verify.yml
+++ b/.github/workflows/nightly-verify.yml
@@ -157,12 +157,62 @@ concurrency:
   cancel-in-progress: false
 
 jobs:
+  # Temporary branch-only qualification for issue #1392. Removed after the
+  # final multi-dtype audit; no model weights are downloaded.
+  shapeless-compile-audit:
+    name: shapeless compile audit (macOS Apple Silicon)
+    if: >-
+      ${{ github.repository == 'lablup/mlxcel'
+          && github.event_name == 'workflow_dispatch' }}
+    runs-on: self-hosted-macos-26-arm64
+    timeout-minutes: 60
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v7
+        with:
+          persist-credentials: false
+      - name: Setup Metal build environment
+        run: |
+          set -euo pipefail
+          export PATH="/opt/homebrew/bin:/usr/local/bin:$PATH"
+          command -v cmake
+          if ! xcrun -f metal >/dev/null 2>&1; then
+            for candidate in /Applications/Xcode*.app/Contents/Developer; do
+              [ -d "$candidate" ] || continue
+              if DEVELOPER_DIR="$candidate" xcrun -f metal >/dev/null 2>&1; then
+                echo "DEVELOPER_DIR=$candidate" >> "$GITHUB_ENV"
+                break
+              fi
+            done
+          fi
+          xcrun -f metal
+          echo "/opt/homebrew/bin" >> "$GITHUB_PATH"
+          echo "/usr/local/bin" >> "$GITHUB_PATH"
+          CARGO_TARGET="$HOME/.cargo-target/mlxcel"
+          mkdir -p "$CARGO_TARGET"
+          echo "CARGO_TARGET_DIR=$CARGO_TARGET" >> "$GITHUB_ENV"
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          components: rustfmt
+      - name: Audit every shapeless compile site
+        run: scripts/audit_shapeless_compile.sh
+      - name: Verify quiet-site regressions
+        run: >-
+          cargo test -p mlxcel-core --profile test-fast
+          --features metal,accelerate --lib eager_regression --
+          --nocapture --test-threads=1
+
   verify:
     name: fmt + clippy + test + video (macOS Apple Silicon)
     # Scheduled workflows run from the default branch of whatever repository
     # holds them. A fork that enables Actions would otherwise queue forever
     # against runner labels it does not own.
-    if: github.repository == 'lablup/mlxcel'
+    if: >-
+      ${{ github.repository == 'lablup/mlxcel'
+          && github.event_name == 'schedule' }}
     runs-on: self-hosted-macos-26-arm64 # Self-hosted Apple Silicon runner with macOS 26 SDK + Metal 4
     # Generous because a cold run is a full MLX C++ build plus a link of every
     # integration-test binary. Note that the FIRST run after the switch to

--- a/.github/workflows/nightly-verify.yml
+++ b/.github/workflows/nightly-verify.yml
@@ -157,12 +157,62 @@ concurrency:
   cancel-in-progress: false
 
 jobs:
+  # Temporary branch-only qualification for issue #1392. Removed again after
+  # the final 20-site audit; no model weights are downloaded.
+  shapeless-compile-audit:
+    name: shapeless compile audit (macOS Apple Silicon)
+    if: >-
+      ${{ github.repository == 'lablup/mlxcel'
+          && github.event_name == 'workflow_dispatch' }}
+    runs-on: self-hosted-macos-26-arm64
+    timeout-minutes: 60
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v7
+        with:
+          persist-credentials: false
+      - name: Setup Metal build environment
+        run: |
+          set -euo pipefail
+          export PATH="/opt/homebrew/bin:/usr/local/bin:$PATH"
+          command -v cmake
+          if ! xcrun -f metal >/dev/null 2>&1; then
+            for candidate in /Applications/Xcode*.app/Contents/Developer; do
+              [ -d "$candidate" ] || continue
+              if DEVELOPER_DIR="$candidate" xcrun -f metal >/dev/null 2>&1; then
+                echo "DEVELOPER_DIR=$candidate" >> "$GITHUB_ENV"
+                break
+              fi
+            done
+          fi
+          xcrun -f metal
+          echo "/opt/homebrew/bin" >> "$GITHUB_PATH"
+          echo "/usr/local/bin" >> "$GITHUB_PATH"
+          CARGO_TARGET="$HOME/.cargo-target/mlxcel"
+          mkdir -p "$CARGO_TARGET"
+          echo "CARGO_TARGET_DIR=$CARGO_TARGET" >> "$GITHUB_ENV"
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          components: rustfmt
+      - name: Audit every shapeless compile site
+        run: scripts/audit_shapeless_compile.sh
+      - name: Verify quiet-site regressions
+        run: >-
+          cargo test -p mlxcel-core --profile test-fast
+          --features metal,accelerate --lib eager_regression --
+          --nocapture --test-threads=1
+
   verify:
     name: fmt + clippy + test + video (macOS Apple Silicon)
     # Scheduled workflows run from the default branch of whatever repository
     # holds them. A fork that enables Actions would otherwise queue forever
     # against runner labels it does not own.
-    if: github.repository == 'lablup/mlxcel'
+    if: >-
+      ${{ github.repository == 'lablup/mlxcel'
+          && github.event_name == 'schedule' }}
     runs-on: self-hosted-macos-26-arm64 # Self-hosted Apple Silicon runner with macOS 26 SDK + Metal 4
     # Generous because a cold run is a full MLX C++ build plus a link of every
     # integration-test binary. Note that the FIRST run after the switch to

--- a/.github/workflows/nightly-verify.yml
+++ b/.github/workflows/nightly-verify.yml
@@ -157,67 +157,12 @@ concurrency:
   cancel-in-progress: false
 
 jobs:
-  # Temporary branch-only qualification for issue #1392. This job is removed
-  # before the implementation PR is opened; it never downloads model weights.
-  shapeless-compile-audit:
-    name: shapeless compile audit (macOS Apple Silicon)
-    if: >-
-      ${{ github.repository == 'lablup/mlxcel'
-          && github.event_name == 'workflow_dispatch' }}
-    runs-on: self-hosted-macos-26-arm64
-    timeout-minutes: 60
-    permissions:
-      contents: read
-
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v7
-        with:
-          persist-credentials: false
-
-      - name: Setup Metal build environment
-        run: |
-          set -euo pipefail
-          export PATH="/opt/homebrew/bin:/usr/local/bin:$PATH"
-          command -v cmake
-          if ! xcrun -f metal >/dev/null 2>&1; then
-            for candidate in /Applications/Xcode*.app/Contents/Developer; do
-              [ -d "$candidate" ] || continue
-              if DEVELOPER_DIR="$candidate" xcrun -f metal >/dev/null 2>&1; then
-                echo "DEVELOPER_DIR=$candidate" >> "$GITHUB_ENV"
-                break
-              fi
-            done
-          fi
-          xcrun -f metal
-          echo "/opt/homebrew/bin" >> "$GITHUB_PATH"
-          echo "/usr/local/bin" >> "$GITHUB_PATH"
-          CARGO_TARGET="$HOME/.cargo-target/mlxcel"
-          mkdir -p "$CARGO_TARGET"
-          echo "CARGO_TARGET_DIR=$CARGO_TARGET" >> "$GITHUB_ENV"
-
-      - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@stable
-        with:
-          components: rustfmt
-
-      - name: Audit every remaining shapeless compile site
-        run: scripts/audit_shapeless_compile.sh
-
-      - name: Verify eager quiet-site regressions
-        run: >-
-          cargo test -p mlxcel-core --profile test-fast
-          --features metal,accelerate --lib eager_regression --
-          --nocapture --test-threads=1
-
   verify:
     name: fmt + clippy + test + video (macOS Apple Silicon)
     # Scheduled workflows run from the default branch of whatever repository
     # holds them. A fork that enables Actions would otherwise queue forever
     # against runner labels it does not own.
-    if: >-
-      ${{ github.repository == 'lablup/mlxcel'
-          && github.event_name == 'schedule' }}
+    if: github.repository == 'lablup/mlxcel'
     runs-on: self-hosted-macos-26-arm64 # Self-hosted Apple Silicon runner with macOS 26 SDK + Metal 4
     # Generous because a cold run is a full MLX C++ build plus a link of every
     # integration-test binary. Note that the FIRST run after the switch to

--- a/.github/workflows/nightly-verify.yml
+++ b/.github/workflows/nightly-verify.yml
@@ -157,62 +157,12 @@ concurrency:
   cancel-in-progress: false
 
 jobs:
-  # Temporary branch-only qualification for issue #1392. Removed after the
-  # final multi-dtype audit; no model weights are downloaded.
-  shapeless-compile-audit:
-    name: shapeless compile audit (macOS Apple Silicon)
-    if: >-
-      ${{ github.repository == 'lablup/mlxcel'
-          && github.event_name == 'workflow_dispatch' }}
-    runs-on: self-hosted-macos-26-arm64
-    timeout-minutes: 60
-    permissions:
-      contents: read
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v7
-        with:
-          persist-credentials: false
-      - name: Setup Metal build environment
-        run: |
-          set -euo pipefail
-          export PATH="/opt/homebrew/bin:/usr/local/bin:$PATH"
-          command -v cmake
-          if ! xcrun -f metal >/dev/null 2>&1; then
-            for candidate in /Applications/Xcode*.app/Contents/Developer; do
-              [ -d "$candidate" ] || continue
-              if DEVELOPER_DIR="$candidate" xcrun -f metal >/dev/null 2>&1; then
-                echo "DEVELOPER_DIR=$candidate" >> "$GITHUB_ENV"
-                break
-              fi
-            done
-          fi
-          xcrun -f metal
-          echo "/opt/homebrew/bin" >> "$GITHUB_PATH"
-          echo "/usr/local/bin" >> "$GITHUB_PATH"
-          CARGO_TARGET="$HOME/.cargo-target/mlxcel"
-          mkdir -p "$CARGO_TARGET"
-          echo "CARGO_TARGET_DIR=$CARGO_TARGET" >> "$GITHUB_ENV"
-      - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@stable
-        with:
-          components: rustfmt
-      - name: Audit every shapeless compile site
-        run: scripts/audit_shapeless_compile.sh
-      - name: Verify quiet-site regressions
-        run: >-
-          cargo test -p mlxcel-core --profile test-fast
-          --features metal,accelerate --lib eager_regression --
-          --nocapture --test-threads=1
-
   verify:
     name: fmt + clippy + test + video (macOS Apple Silicon)
     # Scheduled workflows run from the default branch of whatever repository
     # holds them. A fork that enables Actions would otherwise queue forever
     # against runner labels it does not own.
-    if: >-
-      ${{ github.repository == 'lablup/mlxcel'
-          && github.event_name == 'schedule' }}
+    if: github.repository == 'lablup/mlxcel'
     runs-on: self-hosted-macos-26-arm64 # Self-hosted Apple Silicon runner with macOS 26 SDK + Metal 4
     # Generous because a cold run is a full MLX C++ build plus a link of every
     # integration-test binary. Note that the FIRST run after the switch to

--- a/TECHNICAL_REPORTS/1401-shapeless-compile-audit-20260825.en.md
+++ b/TECHNICAL_REPORTS/1401-shapeless-compile-audit-20260825.en.md
@@ -1,0 +1,138 @@
+# Technical Report: PR #1401 - Audit shapeless MLX compile sites
+
+**Date**: 2026-08-25
+**Status**: Completed
+**Languages**: Rust, C++, Bash
+**Risk Level**: Medium
+
+## Executive Summary
+
+PR #1401 turns the previously ad hoc investigation of `mlx::core::compile(..., shapeless=true)` into a repeatable hardware audit. Every production shapeless compile construction in `mlx_cxx_bridge.cpp` now passes through an opt-in eager oracle, while permanent regressions protect the quiet no-op shapes that could otherwise return plausible but wrong tensors.
+
+The final implementation preserves all compiled fusion. Local NVIDIA CUDA and Apple Silicon Metal both cleared all 20 current callables across f32, bf16, and f16 where supported, including first-use and warmed-cache calls; no model checkpoint was read or downloaded.
+
+## 1. Problem Statement
+
+PR #1391 removed a compiled min-p filter after it silently returned its input on Metal. The same C++ bridge contained many other shapeless compile constructions, and reasoning from output shape alone could not clear same-shape operations such as softcap and residual clipping.
+
+The issue's original line/function table had also drifted by the time implementation began: `softplus` was already eager, a cited QKV location had become the quantized MoE expert path, and masked versus unmasked softcap SDPA were two separate compiled callables. The current inventory is 20 callables.
+
+If left unaudited, a future MLX pin could silently disable an activation, attention transform, or state update while returning a shape- and dtype-valid tensor. The highest-risk cases are filters and bounded transforms whose no-op output remains numerically plausible.
+
+## 2. Technical Decisions
+
+### 2.1 Central opt-in eager oracle
+
+Every shapeless construction calls `compile_shapeless_audited(site, eager_fn)`. With `MLXCEL_SHAPELESS_COMPILE_AUDIT` unset, it returns the same compiled callable and adds no per-call comparison or registry work. When enabled before the first compiled function is initialized, it runs the compiled and eager graphs on identical inputs, checks output count, shape, dtype, and numeric closeness, and records calls by dtype/shape signature.
+
+This design avoids maintaining a second handwritten reference graph for the 20 production callables. The exact lambda passed to MLX compile is also the eager oracle, so later implementation changes cannot update one side and forget the other.
+
+### 2.2 Preserve fusion after measured clearance
+
+An intermediate implementation removed compile from softcap, clip-residual, and softcap SDPA proactively. Review rejected that approach because it would discard attention fusion without evidence of divergence. The final CUDA and Metal audits cleared those sites, so the optimized paths remain in production and permanent independent-reference tests guard their semantics.
+
+### 2.3 Hardware audit, not a model CI expansion
+
+`scripts/audit_shapeless_compile.sh` uses only small synthetic tensors. On Linux it requires `nvidia-smi`, reads the attached GPU's compute capability, and exports `MLX_CUDA_ARCHITECTURES`; on macOS it selects `metal,accelerate`. It rejects direct shapeless compile constructions outside the central wrapper and falls back to `grep` when a minimal Apple runner does not have `rg`.
+
+No permanent GitHub Actions job was added. The Apple audit ran through a temporary branch-only workflow that was removed before PR creation, leaving no Actions diff. This preserves the existing project boundary: hosted Actions may use the established approximately 0.6B fixtures, while larger checkpoint validation belongs on local hardware with existing weights.
+
+## 3. Implementation Details
+
+### 3.1 Audit flow
+
+```text
+Production (environment unset)
+call site -> compile_shapeless_audited -> original compiled callable
+
+On-demand audit (MLXCEL_SHAPELESS_COMPILE_AUDIT=1)
+call site -> compiled graph ----+
+             eager graph -------+-> shape/dtype/allclose -> per-site report
+                                      first call + warmed call per signature
+```
+
+### 3.2 Permanent quiet-site regressions
+
+- `compiled_softcap`: nonuniform logits above and below the cap, explicit `tanh(scores / cap) * cap` reference, and an assertion that the result is not the input.
+- `compiled_clip_residual`: f16 overflow-boundary values, explicit f32 widen/add/clip/f16 reference, and an assertion that the result is not the first input.
+- Masked and unmasked softcap SDPA: nonuniform Q/K/V values and an independent eager attention reference across f32, bf16, and f16.
+- GQA softcap SDPA: explicit repeated-K/V eager attention reference, preventing a shape-only test from accepting a plausible no-op.
+
+## 4. Hardware Audit Baseline
+
+The CUDA host was an NVIDIA GB10 with driver 580.173.02, CUDA 13 runtime visibility, and compute capability 12.1. The Metal result is GitHub Actions run [32746852051](https://github.com/lablup/mlxcel/actions/runs/32746852051) on `self-hosted-macos-26-arm64`.
+
+`6 / 3 / 3` means six calls, three distinct dtype/shape signatures, and all three signatures warmed by a second call. Clip-residual is intentionally f16-only and therefore reports `2 / 1 / 1`.
+
+| Site | Coverage (calls / signatures / warmed) | CUDA | Metal |
+|---|---:|---|---|
+| `compiled_swiglu_activation` | 6 / 3 / 3 | PASS | PASS |
+| `compiled_relu_squared` | 6 / 3 / 3 | PASS | PASS |
+| `compiled_silu` | 6 / 3 / 3 | PASS | PASS |
+| `compiled_gpt_oss_swiglu_activation` | 6 / 3 / 3 | PASS | PASS |
+| `compiled_gelu` | 6 / 3 / 3 | PASS | PASS |
+| `compiled_gelu_approx` | 6 / 3 / 3 | PASS | PASS |
+| `compiled_geglu_activation` | 6 / 3 / 3 | PASS | PASS |
+| `compiled_geglu_approx_activation` | 6 / 3 / 3 | PASS | PASS |
+| `compiled_gelu_topk` | 6 / 3 / 3 | PASS | PASS |
+| `compiled_softcap` | 6 / 3 / 3 | PASS | PASS |
+| `compiled_clip_residual` | 2 / 1 / 1 | PASS | PASS |
+| `compiled_softcap_sdpa_nomask` | 6 / 3 / 3 | PASS | PASS |
+| `compiled_softcap_sdpa_masked` | 6 / 3 / 3 | PASS | PASS |
+| `compiled_gelu_mlp_forward` | 6 / 3 / 3 | PASS | PASS |
+| `compiled_gelu_approx_mlp_forward` | 6 / 3 / 3 | PASS | PASS |
+| `compiled_gelu_approx_mlp_forward_global_scale` | 6 / 3 / 3 | PASS | PASS |
+| `compiled_per_layer_input_gate` | 6 / 3 / 3 | PASS | PASS |
+| `compiled_moe_expert_forward` | 6 / 3 / 3 | PASS | PASS |
+| `fused_gated_delta_decode_step_scalar_gate` | 6 / 3 / 3 | PASS | PASS |
+| `fused_gated_delta_decode_step_dim_gate` | 6 / 3 / 3 | PASS | PASS |
+
+## 5. Compatibility, Security, and Performance
+
+- **Breaking changes**: None. Existing bridge function names and production compiled behavior remain unchanged.
+- **New dependencies**: None. The audit script uses tools already expected on the selected backend and has an `rg`/`grep` inventory fallback.
+- **Security**: The audit is opt-in and synthetic. It reads no prompts, tokens, credentials, or model weights, and the report contains only site names and tensor signatures.
+- **Performance**: Audit-disabled calls return the original compiled function. The quiet-site fusion is retained after direct CUDA and Metal clearance.
+- **PR #1395**: Already included in the branch base, but unrelated; it fixes MLA KV-cache/Turbo4 safety rather than MLX compile behavior.
+
+## 6. Change Summary
+
+Implementation diff before adding this report:
+
+| Item | Value |
+|---|---:|
+| Files changed | 5 |
+| Lines added | 832 |
+| Lines deleted | 114 |
+| Permanent regression tests | 4 |
+| Audited shapeless callables | 20 |
+| New runtime dependencies | 0 |
+| Permanent workflow changes | 0 |
+
+Key files:
+
+- `src/lib/mlxcel-core/cpp/mlx_cxx_bridge.cpp`: central wrapper, registry, report, and complete production-site routing.
+- `src/lib/mlxcel-core/src/ffi_tests.rs`: multi-dtype hardware harness and quiet-site regressions.
+- `scripts/audit_shapeless_compile.sh`: backend selection, source inventory enforcement, and isolated ignored-test invocation.
+- `src/lib/mlxcel-core/cpp/mlx_cxx_bridge.h`, `src/lib/mlxcel-core/src/lib.rs`: audit report bridge.
+
+## 7. Validation
+
+- `scripts/audit_shapeless_compile.sh` on local CUDA: 20/20 PASS; 19 sites at `6/3/3`, clip-residual at `2/1/1`.
+- Apple Silicon Metal run 32746852051: the same 20/20 table; quiet-site regressions 4/4 PASS.
+- `cargo test -p mlxcel-core --profile test-fast --features cuda --lib eager_regression -- --nocapture --test-threads=1`: 4 passed.
+- `cargo test -p mlxcel-core --profile test-fast --features cuda --lib compiled_ -- --test-threads=1`: 30 passed.
+- `cargo clippy -p mlxcel-core --features cuda --all-targets -- -D warnings`: passed.
+- `cargo fmt --all -- --check`: passed.
+
+## 8. Follow-up Actions
+
+- Re-run `scripts/audit_shapeless_compile.sh` on CUDA and Apple Silicon after every MLX pin bump.
+- Treat a missing site, an unwarmed signature, or a `FAIL` row as a hard qualification failure; remove compile only from a measured divergent site or document the exact safe precondition.
+- Keep real-checkpoint validation separate: use existing local weights for checkpoints larger than the established hosted fixture boundary.
+
+## References
+
+- Issue #1392: shapeless compile audit request.
+- PR #1391: motivating compiled min-p no-op fix.
+- PR #1395: adjacent but unrelated MLA KV-cache/Turbo4 safety fix already present in the base.

--- a/TECHNICAL_REPORTS/1401-shapeless-compile-audit-20260825.en.md
+++ b/TECHNICAL_REPORTS/1401-shapeless-compile-audit-20260825.en.md
@@ -102,7 +102,7 @@ Implementation diff before adding this report:
 | Item | Value |
 |---|---:|
 | Files changed | 5 |
-| Lines added | 832 |
+| Lines added | 843 |
 | Lines deleted | 114 |
 | Permanent regression tests | 4 |
 | Audited shapeless callables | 20 |

--- a/TECHNICAL_REPORTS/1401-shapeless-compile-audit-20260825.ko.md
+++ b/TECHNICAL_REPORTS/1401-shapeless-compile-audit-20260825.ko.md
@@ -1,0 +1,138 @@
+# 기술 보고서: PR #1401 - Shapeless MLX compile 지점 감사
+
+**작성일**: 2026-08-25
+**상태**: 완료
+**언어**: Rust, C++, Bash
+**위험도**: Medium
+
+## 요약
+
+PR #1401은 `mlx::core::compile(..., shapeless=true)`에 대한 일회성 수동 조사를 반복 가능한 하드웨어 감사로 전환한다. `mlx_cxx_bridge.cpp`의 모든 production shapeless compile 생성 지점은 opt-in eager oracle을 통과하며, 조용한 no-op가 그럴듯한 텐서를 반환할 수 있는 경로는 영구 회귀 테스트로 보호한다.
+
+최종 구현은 모든 compiled fusion을 유지한다. 로컬 NVIDIA CUDA와 Apple Silicon Metal에서 현재 20개 callable을 f32, bf16, f16으로 가능한 범위까지 검사했고, 최초 호출과 warm-cache 재호출이 모두 통과했다. 모델 체크포인트는 읽거나 다운로드하지 않았다.
+
+## 1. 문제 정의
+
+PR #1391은 Metal에서 입력을 그대로 반환하던 compiled min-p filter를 제거했다. 같은 C++ bridge에는 여러 shapeless compile 생성 지점이 남아 있었고, 출력 shape만으로는 softcap이나 residual clipping처럼 입출력 shape가 같은 연산을 안전하다고 판단할 수 없었다.
+
+구현 시점에는 이슈의 원래 line/function 표도 실제 코드와 달라져 있었다. `softplus`는 이미 eager였고, QKV로 적힌 위치는 quantized MoE expert 경로였으며, masked/unmasked softcap SDPA는 서로 다른 두 compiled callable이었다. 현재 실제 inventory는 20개다.
+
+감사 없이 MLX pin을 올리면 activation, attention transform, state update가 조용히 비활성화되어도 shape와 dtype이 정상인 텐서를 반환할 수 있다. 특히 filter나 bounded transform은 no-op 결과도 수치적으로 그럴듯해 위험하다.
+
+## 2. 기술적 선택과 그 이유
+
+### 2.1 중앙 opt-in eager oracle
+
+모든 shapeless 생성 지점은 `compile_shapeless_audited(site, eager_fn)`을 호출한다. `MLXCEL_SHAPELESS_COMPILE_AUDIT`가 설정되지 않으면 기존 compiled callable을 그대로 반환하며 호출마다 비교하거나 registry를 갱신하지 않는다. 첫 compiled function 초기화 전에 audit를 활성화하면 동일 입력으로 compiled/eager graph를 실행해 output count, shape, dtype, numeric closeness를 비교하고 dtype/shape signature별 호출 수를 기록한다.
+
+이 방식은 20개 production callable에 대해 별도 handwritten reference graph를 중복 유지하지 않는다. MLX compile에 넘긴 정확히 같은 lambda가 eager oracle이므로, 나중에 한쪽 구현만 바뀌는 drift도 방지한다.
+
+### 2.2 실측 후 fusion 보존
+
+중간 구현은 softcap, clip-residual, softcap SDPA에서 compile을 선제적으로 제거했다. 하지만 실제 divergence 근거 없이 attention fusion을 버리면 성능 회귀가 될 수 있어 이 접근을 폐기했다. 최종 CUDA/Metal 감사에서 해당 지점이 모두 통과했으므로 production 최적화는 유지하고, 별도의 독립 reference 회귀 테스트로 의미론을 고정했다.
+
+### 2.3 모델 CI 확대가 아닌 하드웨어 감사
+
+`scripts/audit_shapeless_compile.sh`는 작은 synthetic tensor만 사용한다. Linux에서는 `nvidia-smi`가 보고하는 연결 GPU의 compute capability를 읽어 `MLX_CUDA_ARCHITECTURES`를 설정하고, macOS에서는 `metal,accelerate`를 선택한다. 중앙 wrapper를 우회하는 direct shapeless compile을 거부하며, 최소 Apple runner에 `rg`가 없으면 `grep`으로 inventory를 검사한다.
+
+영구 GitHub Actions job은 추가하지 않았다. Apple 감사용 branch-only workflow는 PR 생성 전에 제거되어 Actions diff가 없다. 기존 프로젝트 경계도 유지한다. Hosted Actions는 약 0.6B 수준의 기존 fixture를 사용할 수 있지만, 더 큰 체크포인트 검증은 로컬 하드웨어와 이미 존재하는 weights로 수행한다.
+
+## 3. 구현 상세
+
+### 3.1 감사 흐름
+
+```text
+Production (environment unset)
+call site -> compile_shapeless_audited -> original compiled callable
+
+On-demand audit (MLXCEL_SHAPELESS_COMPILE_AUDIT=1)
+call site -> compiled graph ----+
+             eager graph -------+-> shape/dtype/allclose -> per-site report
+                                      first call + warmed call per signature
+```
+
+### 3.2 영구 quiet-site 회귀 테스트
+
+- `compiled_softcap`: cap보다 큰 양수/음수 nonuniform logits, 명시적 `tanh(scores / cap) * cap` reference, 결과가 입력과 다르다는 assertion.
+- `compiled_clip_residual`: f16 overflow boundary 값, 명시적 f32 widen/add/clip/f16 reference, 결과가 첫 입력과 다르다는 assertion.
+- Masked/unmasked softcap SDPA: nonuniform Q/K/V와 독립 eager attention reference를 f32, bf16, f16으로 비교.
+- GQA softcap SDPA: explicit repeated-K/V eager attention reference로 shape-only 테스트가 그럴듯한 no-op를 허용하지 않도록 고정.
+
+## 4. 하드웨어 감사 기준선
+
+CUDA host는 NVIDIA GB10, driver 580.173.02, CUDA 13 runtime 가시성, compute capability 12.1 환경이다. Metal 결과는 `self-hosted-macos-26-arm64`에서 실행한 GitHub Actions [32746852051](https://github.com/lablup/mlxcel/actions/runs/32746852051)이다.
+
+`6 / 3 / 3`은 6회 호출, 3개 dtype/shape signature, 3개 signature 모두 2회차 warm 호출 완료를 뜻한다. Clip-residual은 의도적으로 f16 전용이므로 `2 / 1 / 1`이다.
+
+| Site | Coverage (calls / signatures / warmed) | CUDA | Metal |
+|---|---:|---|---|
+| `compiled_swiglu_activation` | 6 / 3 / 3 | PASS | PASS |
+| `compiled_relu_squared` | 6 / 3 / 3 | PASS | PASS |
+| `compiled_silu` | 6 / 3 / 3 | PASS | PASS |
+| `compiled_gpt_oss_swiglu_activation` | 6 / 3 / 3 | PASS | PASS |
+| `compiled_gelu` | 6 / 3 / 3 | PASS | PASS |
+| `compiled_gelu_approx` | 6 / 3 / 3 | PASS | PASS |
+| `compiled_geglu_activation` | 6 / 3 / 3 | PASS | PASS |
+| `compiled_geglu_approx_activation` | 6 / 3 / 3 | PASS | PASS |
+| `compiled_gelu_topk` | 6 / 3 / 3 | PASS | PASS |
+| `compiled_softcap` | 6 / 3 / 3 | PASS | PASS |
+| `compiled_clip_residual` | 2 / 1 / 1 | PASS | PASS |
+| `compiled_softcap_sdpa_nomask` | 6 / 3 / 3 | PASS | PASS |
+| `compiled_softcap_sdpa_masked` | 6 / 3 / 3 | PASS | PASS |
+| `compiled_gelu_mlp_forward` | 6 / 3 / 3 | PASS | PASS |
+| `compiled_gelu_approx_mlp_forward` | 6 / 3 / 3 | PASS | PASS |
+| `compiled_gelu_approx_mlp_forward_global_scale` | 6 / 3 / 3 | PASS | PASS |
+| `compiled_per_layer_input_gate` | 6 / 3 / 3 | PASS | PASS |
+| `compiled_moe_expert_forward` | 6 / 3 / 3 | PASS | PASS |
+| `fused_gated_delta_decode_step_scalar_gate` | 6 / 3 / 3 | PASS | PASS |
+| `fused_gated_delta_decode_step_dim_gate` | 6 / 3 / 3 | PASS | PASS |
+
+## 5. 호환성, 보안, 성능
+
+- **Breaking changes**: 없음. 기존 bridge function 이름과 production compiled 동작은 유지된다.
+- **새 의존성**: 없음. 감사 스크립트는 선택 backend의 기존 도구만 사용하고 `rg`/`grep` inventory fallback을 제공한다.
+- **보안**: 감사 기능은 opt-in이며 synthetic data만 사용한다. Prompt, token, credential, model weight를 읽지 않고 report에는 site 이름과 tensor signature만 남긴다.
+- **성능**: Audit-disabled 호출은 원래 compiled function을 반환한다. Quiet-site fusion은 CUDA/Metal 직접 검증 후 유지했다.
+- **PR #1395**: Branch base에 이미 포함되어 있지만 MLA KV-cache/Turbo4 안전성 수정으로, MLX compile 동작과는 무관하다.
+
+## 6. 변경 요약
+
+이 보고서 추가 전 implementation diff:
+
+| 항목 | 값 |
+|---|---:|
+| 변경 파일 | 5 |
+| 추가 라인 | 832 |
+| 삭제 라인 | 114 |
+| 영구 회귀 테스트 | 4 |
+| 감사한 shapeless callable | 20 |
+| 새 runtime 의존성 | 0 |
+| 영구 workflow 변경 | 0 |
+
+주요 파일:
+
+- `src/lib/mlxcel-core/cpp/mlx_cxx_bridge.cpp`: 중앙 wrapper, registry, report, 모든 production site routing.
+- `src/lib/mlxcel-core/src/ffi_tests.rs`: multi-dtype hardware harness와 quiet-site 회귀 테스트.
+- `scripts/audit_shapeless_compile.sh`: backend 선택, source inventory 강제, isolated ignored test 실행.
+- `src/lib/mlxcel-core/cpp/mlx_cxx_bridge.h`, `src/lib/mlxcel-core/src/lib.rs`: audit report bridge.
+
+## 7. 검증
+
+- 로컬 CUDA `scripts/audit_shapeless_compile.sh`: 20/20 PASS, 19개 site `6/3/3`, clip-residual `2/1/1`.
+- Apple Silicon Metal run 32746852051: 동일한 20/20 표, quiet-site 회귀 4/4 PASS.
+- `cargo test -p mlxcel-core --profile test-fast --features cuda --lib eager_regression -- --nocapture --test-threads=1`: 4 passed.
+- `cargo test -p mlxcel-core --profile test-fast --features cuda --lib compiled_ -- --test-threads=1`: 30 passed.
+- `cargo clippy -p mlxcel-core --features cuda --all-targets -- -D warnings`: 통과.
+- `cargo fmt --all -- --check`: 통과.
+
+## 8. 후속 조치
+
+- MLX pin을 올릴 때마다 CUDA와 Apple Silicon에서 `scripts/audit_shapeless_compile.sh`를 재실행한다.
+- 누락 site, warm되지 않은 signature, `FAIL` 행은 qualification 실패로 처리하고, 실측 divergence가 있는 site만 compile을 제거하거나 정확한 safe precondition을 문서화한다.
+- Real-checkpoint 검증은 별도로 유지하며, hosted fixture 경계보다 큰 체크포인트는 로컬의 기존 weights를 사용한다.
+
+## 참고 자료
+
+- Issue #1392: shapeless compile 감사 요청.
+- PR #1391: 동기를 제공한 compiled min-p no-op 수정.
+- PR #1395: base에 포함된 인접 변경이지만 MLA KV-cache/Turbo4 안전성 수정으로 본 감사와 무관.

--- a/TECHNICAL_REPORTS/1401-shapeless-compile-audit-20260825.ko.md
+++ b/TECHNICAL_REPORTS/1401-shapeless-compile-audit-20260825.ko.md
@@ -102,7 +102,7 @@ CUDA host는 NVIDIA GB10, driver 580.173.02, CUDA 13 runtime 가시성, compute 
 | 항목 | 값 |
 |---|---:|
 | 변경 파일 | 5 |
-| 추가 라인 | 832 |
+| 추가 라인 | 843 |
 | 삭제 라인 | 114 |
 | 영구 회귀 테스트 | 4 |
 | 감사한 shapeless callable | 20 |

--- a/scripts/audit_shapeless_compile.sh
+++ b/scripts/audit_shapeless_compile.sh
@@ -20,9 +20,17 @@ bridge="$repo_root/src/lib/mlxcel-core/cpp/mlx_cxx_bridge.cpp"
 
 # Every production shapeless=true construction must pass through the opt-in
 # eager-oracle wrapper. Comments do not match this literal call pattern.
-direct_shapeless="$(
-    rg -n 'mlx::core::compile\([^\n]*(true|shapeless=\*/true)' "$bridge"
-)"
+if command -v rg >/dev/null 2>&1; then
+    direct_shapeless="$(
+        rg -n 'mlx::core::compile\([^\n]*(true|shapeless=\*/true)' "$bridge"
+    )"
+else
+    # The self-hosted Apple runner intentionally carries only the build tools;
+    # keep the on-demand audit usable there without installing ripgrep.
+    direct_shapeless="$(
+        grep -En 'mlx::core::compile\([^)]*(true|shapeless=\*/true)' "$bridge"
+    )"
+fi
 direct_count="$(printf '%s\n' "$direct_shapeless" | sed '/^$/d' | wc -l | tr -d ' ')"
 if [[ $direct_count -ne 1 ]] \
     || [[ $direct_shapeless != *'mlx::core::compile(eager_fn, /*shapeless=*/true)'* ]]; then

--- a/scripts/audit_shapeless_compile.sh
+++ b/scripts/audit_shapeless_compile.sh
@@ -1,0 +1,74 @@
+#!/usr/bin/env bash
+# Copyright 2025-2026 Lablup Inc. and Jeongkyu Shin
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -euo pipefail
+
+repo_root="$(git rev-parse --show-toplevel)"
+bridge="$repo_root/src/lib/mlxcel-core/cpp/mlx_cxx_bridge.cpp"
+
+# Every production shapeless=true construction must pass through the opt-in
+# eager-oracle wrapper. Comments do not match this literal call pattern.
+direct_shapeless="$(
+    rg -n 'mlx::core::compile\([^\n]*(true|shapeless=\*/true)' "$bridge"
+)"
+direct_count="$(printf '%s\n' "$direct_shapeless" | sed '/^$/d' | wc -l | tr -d ' ')"
+if [[ $direct_count -ne 1 ]] \
+    || [[ $direct_shapeless != *'mlx::core::compile(eager_fn, /*shapeless=*/true)'* ]]; then
+    printf 'unexpected direct shapeless compile site(s):\n' >&2
+    printf '%s\n' "$direct_shapeless" >&2
+    exit 1
+fi
+
+case "$(uname -s)" in
+    Darwin)
+        features="metal,accelerate"
+        ;;
+    Linux)
+        command -v nvidia-smi >/dev/null || {
+            printf 'nvidia-smi is required for the CUDA audit\n' >&2
+            exit 1
+        }
+        compute_capability="$(
+            nvidia-smi --query-gpu=compute_cap --format=csv,noheader \
+                | sed -n '1{s/\.//g;p;}'
+        )"
+        [[ -n $compute_capability ]] || {
+            printf 'could not determine the NVIDIA compute capability\n' >&2
+            exit 1
+        }
+        export MLX_CUDA_ARCHITECTURES="${MLX_CUDA_ARCHITECTURES:-$compute_capability}"
+        features="cuda"
+        ;;
+    *)
+        printf 'unsupported audit platform: %s\n' "$(uname -s)" >&2
+        exit 1
+        ;;
+esac
+
+export MLXCEL_SHAPELESS_COMPILE_AUDIT=1
+
+# Synthetic tensors only. This hardware qualification never downloads or opens
+# a model checkpoint, regardless of backend.
+exec cargo test \
+    -p mlxcel-core \
+    --profile test-fast \
+    --features "$features" \
+    --lib \
+    ffi_tests::shapeless_compile_audit_harness \
+    -- \
+    --ignored \
+    --exact \
+    --nocapture \
+    --test-threads=1

--- a/scripts/audit_shapeless_compile.sh
+++ b/scripts/audit_shapeless_compile.sh
@@ -19,23 +19,34 @@ repo_root="$(git rev-parse --show-toplevel)"
 bridge="$repo_root/src/lib/mlxcel-core/cpp/mlx_cxx_bridge.cpp"
 
 # Every production shapeless=true construction must pass through the opt-in
-# eager-oracle wrapper. Comments do not match this literal call pattern.
+# eager-oracle wrapper. Inventory the compile token itself so a future direct
+# call cannot evade this check merely by putting its arguments on another line.
 if command -v rg >/dev/null 2>&1; then
-    direct_shapeless="$(
-        rg -n 'mlx::core::compile\([^\n]*(true|shapeless=\*/true)' "$bridge"
-    )"
+    direct_compile="$(rg -nF 'mlx::core::compile(' "$bridge")"
 else
     # The self-hosted Apple runner intentionally carries only the build tools;
     # keep the on-demand audit usable there without installing ripgrep.
-    direct_shapeless="$(
-        grep -En 'mlx::core::compile\([^)]*(true|shapeless=\*/true)' "$bridge"
-    )"
+    direct_compile="$(grep -nF 'mlx::core::compile(' "$bridge")"
 fi
-direct_count="$(printf '%s\n' "$direct_shapeless" | sed '/^$/d' | wc -l | tr -d ' ')"
-if [[ $direct_count -ne 1 ]] \
-    || [[ $direct_shapeless != *'mlx::core::compile(eager_fn, /*shapeless=*/true)'* ]]; then
-    printf 'unexpected direct shapeless compile site(s):\n' >&2
-    printf '%s\n' "$direct_shapeless" >&2
+
+wrapper_count=0
+unexpected_compile=''
+while IFS= read -r line; do
+    case "$line" in
+        *'mlx::core::compile(eager_fn, /*shapeless=*/true)'*)
+            ((wrapper_count += 1))
+            ;;
+        *'mlx::core::compile('*false*)
+            [[ $line != *true* ]] || unexpected_compile+="$line"$'\n'
+            ;;
+        *)
+            unexpected_compile+="$line"$'\n'
+            ;;
+    esac
+done <<< "$direct_compile"
+if [[ $wrapper_count -ne 1 || -n $unexpected_compile ]]; then
+    printf 'unexpected direct compile site(s):\n' >&2
+    printf '%s' "$unexpected_compile" >&2
     exit 1
 fi
 

--- a/src/lib/mlxcel-core/cpp/mlx_cxx_bridge.cpp
+++ b/src/lib/mlxcel-core/cpp/mlx_cxx_bridge.cpp
@@ -1599,8 +1599,21 @@ std::unique_ptr<MlxArray> compiled_gelu_topk(
     return std::make_unique<MlxArray>(std::move(result[0]));
 }
 
-// Softcap: tanh(scores / cap) * cap
+// Compiled softcap: tanh(scores / cap) * cap
 // Used by: Gemma2 attention with logit softcapping
+namespace {
+    static CompiledArrayFn get_compiled_softcap() {
+        auto fn = [](const std::vector<array>& inputs) -> std::vector<array> {
+            const auto& scores = inputs[0];
+            const auto& cap = inputs[1];
+            auto result = mlx::core::multiply(
+                mlx::core::tanh(mlx::core::divide(scores, cap)), cap);
+            return {mlx::core::astype(result, scores.dtype())};
+        };
+        return compile_shapeless_audited("compiled_softcap", fn);
+    }
+}
+
 std::unique_ptr<MlxArray> compiled_softcap(
     const MlxArray& scores,
     float cap
@@ -1608,18 +1621,28 @@ std::unique_ptr<MlxArray> compiled_softcap(
     if (cap <= 0.0f) {
         return std::make_unique<MlxArray>(scores.inner);
     }
-    auto cap_arr = array(cap);
-    auto result = mlx::core::multiply(
-        mlx::core::tanh(mlx::core::divide(scores.inner, cap_arr)),
-        cap_arr);
-    return std::make_unique<MlxArray>(
-        mlx::core::astype(result, scores.inner.dtype()));
+    static auto compiled_fn = get_compiled_softcap();
+    auto result = compiled_fn({scores.inner, array(cap)});
+    return std::make_unique<MlxArray>(std::move(result[0]));
 }
 
-// Eager clip_residual for float16 overflow prevention. This deliberately stays
-// outside mlx::core::compile: the former shapeless callable could silently
-// return an input unchanged on Metal (#1391/#1392).
+// Compiled clip_residual for float16 overflow prevention.
 // Used by: Gemma3 residual connections
+namespace {
+    static CompiledArrayFn get_compiled_clip_residual_f16() {
+        auto fn = [](const std::vector<array>& inputs) -> std::vector<array> {
+            auto sum = mlx::core::add(
+                mlx::core::astype(inputs[0], mlx::core::float32),
+                mlx::core::astype(inputs[1], mlx::core::float32));
+            auto bound = array(65504.0f);
+            auto clipped = mlx::core::clip(
+                sum, mlx::core::negative(bound), bound);
+            return {mlx::core::astype(clipped, mlx::core::float16)};
+        };
+        return compile_shapeless_audited("compiled_clip_residual", fn);
+    }
+}
+
 std::unique_ptr<MlxArray> compiled_clip_residual(
     const MlxArray& x,
     const MlxArray& y
@@ -1628,40 +1651,53 @@ std::unique_ptr<MlxArray> compiled_clip_residual(
     if (x.inner.dtype() != mlx::core::float16) {
         return std::make_unique<MlxArray>(mlx::core::add(x.inner, y.inner));
     }
-    auto sum = mlx::core::add(
-        mlx::core::astype(x.inner, mlx::core::float32),
-        mlx::core::astype(y.inner, mlx::core::float32));
-    auto bound = array(65504.0f);
-    auto clipped = mlx::core::clip(sum, mlx::core::negative(bound), bound);
-    return std::make_unique<MlxArray>(
-        mlx::core::astype(clipped, mlx::core::float16));
+    static auto compiled_fn = get_compiled_clip_residual_f16();
+    auto result = compiled_fn({x.inner, y.inner});
+    return std::make_unique<MlxArray>(std::move(result[0]));
 }
 
-// Eager softcap SDPA: Q@K^T * scale -> softcap -> mask -> softmax -> @V.
-// The public name is retained for compatibility, but the implementation avoids
-// shapeless compile because a no-op here can be numerically plausible (#1392).
+// Compiled softcap SDPA: Q@K^T * scale -> softcap -> mask -> softmax -> @V.
 // Used by: Gemma2 attention with logit softcapping
 namespace {
-    static array softcap_sdpa_eager(
+    static array softcap_sdpa_graph(
         const array& q,
         const array& k,
         const array& v,
-        float scale,
-        float cap,
+        const array& scale,
+        const array& cap,
         const array* mask
     ) {
         auto scores = mlx::core::matmul(
             q, mlx::core::transpose(k, {0, 1, 3, 2}));
-        scores = mlx::core::multiply(scores, array(scale));
-        auto cap_arr = array(cap);
+        scores = mlx::core::multiply(scores, scale);
         scores = mlx::core::multiply(
-            mlx::core::tanh(mlx::core::divide(scores, cap_arr)), cap_arr);
+            mlx::core::tanh(mlx::core::divide(scores, cap)), cap);
         if (mask) {
             scores = mlx::core::add(scores, *mask);
         }
         auto result = mlx::core::matmul(
             mlx::core::softmax(scores, -1), v);
         return mlx::core::astype(result, v.dtype());
+    }
+
+    static CompiledArrayFn get_compiled_softcap_sdpa_nomask() {
+        auto fn = [](const std::vector<array>& inputs) -> std::vector<array> {
+            return {softcap_sdpa_graph(
+                inputs[0], inputs[1], inputs[2], inputs[3], inputs[4],
+                nullptr)};
+        };
+        return compile_shapeless_audited(
+            "compiled_softcap_sdpa_nomask", fn);
+    }
+
+    static CompiledArrayFn get_compiled_softcap_sdpa_masked() {
+        auto fn = [](const std::vector<array>& inputs) -> std::vector<array> {
+            return {softcap_sdpa_graph(
+                inputs[0], inputs[1], inputs[2], inputs[3], inputs[4],
+                &inputs[5])};
+        };
+        return compile_shapeless_audited(
+            "compiled_softcap_sdpa_masked", fn);
     }
 
     bool enable_softcap_gqa_decode_grouped_opt() {
@@ -1689,16 +1725,20 @@ std::unique_ptr<MlxArray> compiled_softcap_sdpa(
     float softcap,
     const MlxArray* mask
 ) {
-    std::optional<array> cast_mask;
     if (mask) {
-        cast_mask = mask->inner.dtype() == q.inner.dtype()
+        auto cast_mask = mask->inner.dtype() == q.inner.dtype()
             ? mask->inner
             : mlx::core::astype(mask->inner, q.inner.dtype());
+        static auto compiled_fn = get_compiled_softcap_sdpa_masked();
+        auto result = compiled_fn({
+            q.inner, k.inner, v.inner, array(scale), array(softcap),
+            std::move(cast_mask)});
+        return std::make_unique<MlxArray>(std::move(result[0]));
     }
-    auto result = softcap_sdpa_eager(
-        q.inner, k.inner, v.inner, scale, softcap,
-        cast_mask ? &*cast_mask : nullptr);
-    return std::make_unique<MlxArray>(std::move(result));
+    static auto compiled_fn = get_compiled_softcap_sdpa_nomask();
+    auto result = compiled_fn({
+        q.inner, k.inner, v.inner, array(scale), array(softcap)});
+    return std::make_unique<MlxArray>(std::move(result[0]));
 }
 
 // Softcap SDPA with GQA: do repeat_kv outside compiled graph, then call compiled SDPA
@@ -1760,16 +1800,20 @@ std::unique_ptr<MlxArray> compiled_softcap_sdpa_gqa(
     auto rk = do_repeat_kv(k.inner);
     auto rv = do_repeat_kv(v.inner);
 
-    std::optional<array> cast_mask;
     if (mask) {
-        cast_mask = mask->inner.dtype() == q.inner.dtype()
+        auto cast_mask = mask->inner.dtype() == q.inner.dtype()
             ? mask->inner
             : mlx::core::astype(mask->inner, q.inner.dtype());
+        static auto compiled_fn = get_compiled_softcap_sdpa_masked();
+        auto result = compiled_fn({
+            q.inner, rk, rv, array(scale), array(softcap),
+            std::move(cast_mask)});
+        return std::make_unique<MlxArray>(std::move(result[0]));
     }
-    auto result = softcap_sdpa_eager(
-        q.inner, rk, rv, scale, softcap,
-        cast_mask ? &*cast_mask : nullptr);
-    return std::make_unique<MlxArray>(std::move(result));
+    static auto compiled_fn = get_compiled_softcap_sdpa_nomask();
+    auto result = compiled_fn({
+        q.inner, rk, rv, array(scale), array(softcap)});
+    return std::make_unique<MlxArray>(std::move(result[0]));
 }
 
 // Compiled GELU MLP forward: down_proj(gelu(gate_proj(x)) * up_proj(x))

--- a/src/lib/mlxcel-core/cpp/mlx_cxx_bridge.cpp
+++ b/src/lib/mlxcel-core/cpp/mlx_cxx_bridge.cpp
@@ -10,12 +10,16 @@
 
 #include <cctype>
 #include <cstdint>
+#include <cstdlib>
+#include <functional>
 #include <map>
+#include <mutex>
 #include <sstream>
 #include <tuple>
-#include <vector>
+#include <unordered_map>
 #include <unordered_set>
 #include <utility>
+#include <vector>
 
 #ifdef MLXCEL_BRIDGE_METAL_BACKEND
 // Defined by the mlx/backend/metal/quantized.cpp overlay (issue #1187).
@@ -33,6 +37,149 @@ bool mlxcel_qmv_wide(void);
 namespace mlx_cxx {
 
 using namespace mlx::core;
+
+namespace {
+
+using CompiledArrayFn =
+    std::function<std::vector<array>(const std::vector<array>&)>;
+
+struct ShapelessAuditStats {
+    size_t calls = 0;
+    size_t failures = 0;
+    std::map<std::string, size_t> signatures;
+    std::string last_failure;
+};
+
+std::mutex& shapeless_audit_mutex() {
+    static auto* mutex = new std::mutex();
+    return *mutex;
+}
+
+std::map<std::string, ShapelessAuditStats>& shapeless_audit_stats() {
+    // Intentionally leaked: compiled functions may be destroyed after other
+    // function-local statics during process shutdown.
+    static auto* stats = new std::map<std::string, ShapelessAuditStats>();
+    return *stats;
+}
+
+bool shapeless_audit_enabled() {
+    const char* value = std::getenv("MLXCEL_SHAPELESS_COMPILE_AUDIT");
+    return value && std::string_view(value) != "0";
+}
+
+std::string shapeless_signature(const std::vector<array>& inputs) {
+    std::ostringstream out;
+    for (size_t input_index = 0; input_index < inputs.size(); ++input_index) {
+        if (input_index != 0) {
+            out << ';';
+        }
+        const auto& input = inputs[input_index];
+        out << from_dtype(input.dtype()) << ':';
+        const auto& shape = input.shape();
+        for (size_t dim_index = 0; dim_index < shape.size(); ++dim_index) {
+            if (dim_index != 0) {
+                out << 'x';
+            }
+            out << shape[dim_index];
+        }
+    }
+    return out.str();
+}
+
+bool shapeless_outputs_match(
+    const std::vector<array>& compiled,
+    const std::vector<array>& eager,
+    std::string& failure
+) {
+    if (compiled.size() != eager.size()) {
+        failure = "output-count mismatch";
+        return false;
+    }
+
+    for (size_t index = 0; index < compiled.size(); ++index) {
+        if (compiled[index].shape() != eager[index].shape()) {
+            failure = "output shape mismatch at index " + std::to_string(index);
+            return false;
+        }
+        if (compiled[index].dtype() != eager[index].dtype()) {
+            failure = "output dtype mismatch at index " + std::to_string(index);
+            return false;
+        }
+
+        const auto dtype = compiled[index].dtype();
+        const double tolerance =
+            (dtype == mlx::core::float16 || dtype == mlx::core::bfloat16)
+                ? 5e-3
+                : 1e-4;
+        auto close = mlx::core::allclose(
+            compiled[index], eager[index], tolerance, tolerance);
+        close.eval();
+        if (!close.item<bool>()) {
+            failure = "numeric mismatch at index " + std::to_string(index);
+            return false;
+        }
+    }
+    return true;
+}
+
+// Wrap every shapeless compile site with an opt-in eager oracle. Production
+// calls still receive the original compiled function with no comparison or
+// registry overhead. The one-shot hardware audit sets the environment variable
+// before any compiled function is initialized, invokes each site twice, and
+// reads the report below to prove both first-use and warmed-cache behavior.
+CompiledArrayFn compile_shapeless_audited(
+    const char* site,
+    CompiledArrayFn eager_fn
+) {
+    auto compiled_fn = mlx::core::compile(eager_fn, /*shapeless=*/true);
+    if (!shapeless_audit_enabled()) {
+        return compiled_fn;
+    }
+
+    return [site = std::string(site), eager_fn = std::move(eager_fn),
+            compiled_fn = std::move(compiled_fn)]
+        (const std::vector<array>& inputs) mutable -> std::vector<array> {
+        auto compiled = compiled_fn(inputs);
+        auto eager = eager_fn(inputs);
+        std::string failure;
+        const bool matches = shapeless_outputs_match(compiled, eager, failure);
+        const auto signature = shapeless_signature(inputs);
+
+        std::lock_guard<std::mutex> lock(shapeless_audit_mutex());
+        auto& stats = shapeless_audit_stats()[site];
+        ++stats.calls;
+        ++stats.signatures[signature];
+        if (!matches) {
+            ++stats.failures;
+            stats.last_failure = std::move(failure);
+        }
+        return compiled;
+    };
+}
+
+} // namespace
+
+rust::String shapeless_compile_audit_report() {
+    std::ostringstream out;
+    out << "site\tcalls\tsignatures\twarmed\tstatus\n";
+    std::lock_guard<std::mutex> lock(shapeless_audit_mutex());
+    for (const auto& [site, stats] : shapeless_audit_stats()) {
+        size_t warmed = 0;
+        for (const auto& [_, count] : stats.signatures) {
+            if (count >= 2) {
+                ++warmed;
+            }
+        }
+        out << site << '\t' << stats.calls << '\t' << stats.signatures.size()
+            << '\t' << warmed << '\t'
+            << (stats.failures == 0 ? "PASS" : "FAIL");
+        if (!stats.last_failure.empty()) {
+            out << " (" << stats.last_failure << ')';
+        }
+        out << '\n';
+    }
+    return rust::String(out.str());
+}
 
 // to_shape / to_dtype / from_dtype / gelu_tanh_approx live in
 // mlx_cxx_internal.h so the split-out TUs (kernels/nemotron/ext) share them.
@@ -1211,7 +1358,8 @@ namespace {
             return {mlx::core::multiply(silu_gate, x)};
         };
         // Compile with shapeless=true for kernel fusion
-        return mlx::core::compile(swiglu_fn, true);
+        return compile_shapeless_audited(
+            "compiled_swiglu_activation", swiglu_fn);
     }
 }
 
@@ -1223,7 +1371,7 @@ namespace {
             const auto& x = inputs[0];
             return {mlx::core::square(mlx::core::maximum(x, mlx::core::array(0)))};
         };
-        return mlx::core::compile(fn, true);
+        return compile_shapeless_audited("compiled_relu_squared", fn);
     }
 }
 
@@ -1241,7 +1389,7 @@ namespace {
             const auto& x = inputs[0];
             return {mlx::core::multiply(x, mlx::core::sigmoid(x))};
         };
-        return mlx::core::compile(fn, true);
+        return compile_shapeless_audited("compiled_silu", fn);
     }
 }
 
@@ -1286,7 +1434,8 @@ namespace {
             auto result = mlx::core::multiply(out_glu, mlx::core::add(x_linear, mlx::core::array(1.0f)));
             return {mlx::core::astype(result, x_linear_in.dtype())};
         };
-        return mlx::core::compile(fn, true);
+        return compile_shapeless_audited(
+            "compiled_gpt_oss_swiglu_activation", fn);
     }
 }
 
@@ -1313,7 +1462,7 @@ namespace {
             auto result = mlx::core::multiply(x, scale);
             return {mlx::core::astype(result, x.dtype())};
         };
-        return mlx::core::compile(fn, true);
+        return compile_shapeless_audited("compiled_gelu", fn);
     }
 }
 
@@ -1340,7 +1489,7 @@ namespace {
             auto result = mlx::core::multiply(x, scale);
             return {mlx::core::astype(result, x.dtype())};
         };
-        return mlx::core::compile(fn, true);
+        return compile_shapeless_audited("compiled_gelu_approx", fn);
     }
 }
 
@@ -1367,7 +1516,8 @@ namespace {
             auto result = mlx::core::multiply(gelu_gate, x);
             return {mlx::core::astype(result, x.dtype())};
         };
-        return mlx::core::compile(fn, true);
+        return compile_shapeless_audited(
+            "compiled_geglu_activation", fn);
     }
 }
 
@@ -1390,7 +1540,8 @@ namespace {
             auto result = mlx::core::multiply(gelu_tanh_approx(gate), x);
             return {mlx::core::astype(result, x.dtype())};
         };
-        return mlx::core::compile(fn, true);
+        return compile_shapeless_audited(
+            "compiled_geglu_approx_activation", fn);
     }
 }
 
@@ -1434,7 +1585,7 @@ namespace {
             auto result = mlx::core::multiply(zeroed, scale);
             return {mlx::core::astype(result, x.dtype())};
         };
-        return mlx::core::compile(fn, true);
+        return compile_shapeless_audited("compiled_gelu_topk", fn);
     }
 }
 
@@ -1448,22 +1599,8 @@ std::unique_ptr<MlxArray> compiled_gelu_topk(
     return std::make_unique<MlxArray>(std::move(result[0]));
 }
 
-// Compiled softcap: tanh(scores / cap) * cap
+// Softcap: tanh(scores / cap) * cap
 // Used by: Gemma2 attention with logit softcapping
-namespace {
-    static std::function<std::vector<array>(const std::vector<array>&)> get_compiled_softcap() {
-        auto fn = [](const std::vector<array>& inputs) -> std::vector<array> {
-            const auto& scores = inputs[0];
-            const auto& cap = inputs[1];
-            auto scaled = mlx::core::divide(scores, cap);
-            auto tanhed = mlx::core::tanh(scaled);
-            auto result = mlx::core::multiply(tanhed, cap);
-            return {mlx::core::astype(result, scores.dtype())};
-        };
-        return mlx::core::compile(fn, true);
-    }
-}
-
 std::unique_ptr<MlxArray> compiled_softcap(
     const MlxArray& scores,
     float cap
@@ -1471,31 +1608,18 @@ std::unique_ptr<MlxArray> compiled_softcap(
     if (cap <= 0.0f) {
         return std::make_unique<MlxArray>(scores.inner);
     }
-    static auto compiled_fn = get_compiled_softcap();
     auto cap_arr = array(cap);
-    auto result = compiled_fn({scores.inner, cap_arr});
-    return std::make_unique<MlxArray>(std::move(result[0]));
+    auto result = mlx::core::multiply(
+        mlx::core::tanh(mlx::core::divide(scores.inner, cap_arr)),
+        cap_arr);
+    return std::make_unique<MlxArray>(
+        mlx::core::astype(result, scores.inner.dtype()));
 }
 
-// Compiled clip_residual for float16 overflow prevention
+// Eager clip_residual for float16 overflow prevention. This deliberately stays
+// outside mlx::core::compile: the former shapeless callable could silently
+// return an input unchanged on Metal (#1391/#1392).
 // Used by: Gemma3 residual connections
-namespace {
-    static std::function<std::vector<array>(const std::vector<array>&)> get_compiled_clip_residual_f16() {
-        auto fn = [](const std::vector<array>& inputs) -> std::vector<array> {
-            const auto& x = inputs[0];
-            const auto& y = inputs[1];
-            auto x_f32 = mlx::core::astype(x, mlx::core::float32);
-            auto y_f32 = mlx::core::astype(y, mlx::core::float32);
-            auto sum = mlx::core::add(x_f32, y_f32);
-            auto bound = array(65504.0f);
-            auto neg_bound = mlx::core::negative(bound);
-            auto clipped = mlx::core::clip(sum, neg_bound, bound);
-            return {mlx::core::astype(clipped, mlx::core::float16)};
-        };
-        return mlx::core::compile(fn, true);
-    }
-}
-
 std::unique_ptr<MlxArray> compiled_clip_residual(
     const MlxArray& x,
     const MlxArray& y
@@ -1504,66 +1628,40 @@ std::unique_ptr<MlxArray> compiled_clip_residual(
     if (x.inner.dtype() != mlx::core::float16) {
         return std::make_unique<MlxArray>(mlx::core::add(x.inner, y.inner));
     }
-    static auto compiled_fn = get_compiled_clip_residual_f16();
-    auto result = compiled_fn({x.inner, y.inner});
-    return std::make_unique<MlxArray>(std::move(result[0]));
+    auto sum = mlx::core::add(
+        mlx::core::astype(x.inner, mlx::core::float32),
+        mlx::core::astype(y.inner, mlx::core::float32));
+    auto bound = array(65504.0f);
+    auto clipped = mlx::core::clip(sum, mlx::core::negative(bound), bound);
+    return std::make_unique<MlxArray>(
+        mlx::core::astype(clipped, mlx::core::float16));
 }
 
-// Compiled softcap SDPA: Q@K^T * scale -> softcap -> mask -> softmax -> @V
-// Fuses the entire attention score computation into a compiled graph
+// Eager softcap SDPA: Q@K^T * scale -> softcap -> mask -> softmax -> @V.
+// The public name is retained for compatibility, but the implementation avoids
+// shapeless compile because a no-op here can be numerically plausible (#1392).
 // Used by: Gemma2 attention with logit softcapping
 namespace {
-    // Compiled version without mask (single-token decode path)
-    static std::function<std::vector<array>(const std::vector<array>&)>
-    get_compiled_softcap_sdpa_nomask() {
-        auto fn = [](const std::vector<array>& inputs) -> std::vector<array> {
-            const auto& q = inputs[0];       // [B, H, 1, D]
-            const auto& k = inputs[1];       // [B, H, S, D]
-            const auto& v = inputs[2];       // [B, H, S, D]
-            const auto& scale_arr = inputs[3];
-            const auto& cap_arr = inputs[4];
-
-            // scores = Q @ K^T
-            auto k_t = mlx::core::transpose(k, {0, 1, 3, 2});
-            auto scores = mlx::core::matmul(q, k_t);
-
-            // scores = scores * scale
-            scores = mlx::core::multiply(scores, scale_arr);
-
-            // softcap: tanh(scores / cap) * cap
-            scores = mlx::core::multiply(mlx::core::tanh(mlx::core::divide(scores, cap_arr)), cap_arr);
-
-            // softmax
-            auto probs = mlx::core::softmax(scores, -1);
-
-            // probs @ V
-            auto result = mlx::core::matmul(probs, v);
-            return {mlx::core::astype(result, v.dtype())};
-        };
-        return mlx::core::compile(fn, true);  // shapeless=true
-    }
-
-    // Compiled version with mask (prefill path)
-    static std::function<std::vector<array>(const std::vector<array>&)>
-    get_compiled_softcap_sdpa_masked() {
-        auto fn = [](const std::vector<array>& inputs) -> std::vector<array> {
-            const auto& q = inputs[0];
-            const auto& k = inputs[1];
-            const auto& v = inputs[2];
-            const auto& scale_arr = inputs[3];
-            const auto& cap_arr = inputs[4];
-            const auto& mask = inputs[5];
-
-            auto k_t = mlx::core::transpose(k, {0, 1, 3, 2});
-            auto scores = mlx::core::matmul(q, k_t);
-            scores = mlx::core::multiply(scores, scale_arr);
-            scores = mlx::core::multiply(mlx::core::tanh(mlx::core::divide(scores, cap_arr)), cap_arr);
-            scores = mlx::core::add(scores, mask);
-            auto probs = mlx::core::softmax(scores, -1);
-            auto result = mlx::core::matmul(probs, v);
-            return {mlx::core::astype(result, v.dtype())};
-        };
-        return mlx::core::compile(fn, true);
+    static array softcap_sdpa_eager(
+        const array& q,
+        const array& k,
+        const array& v,
+        float scale,
+        float cap,
+        const array* mask
+    ) {
+        auto scores = mlx::core::matmul(
+            q, mlx::core::transpose(k, {0, 1, 3, 2}));
+        scores = mlx::core::multiply(scores, array(scale));
+        auto cap_arr = array(cap);
+        scores = mlx::core::multiply(
+            mlx::core::tanh(mlx::core::divide(scores, cap_arr)), cap_arr);
+        if (mask) {
+            scores = mlx::core::add(scores, *mask);
+        }
+        auto result = mlx::core::matmul(
+            mlx::core::softmax(scores, -1), v);
+        return mlx::core::astype(result, v.dtype());
     }
 
     bool enable_softcap_gqa_decode_grouped_opt() {
@@ -1591,23 +1689,16 @@ std::unique_ptr<MlxArray> compiled_softcap_sdpa(
     float softcap,
     const MlxArray* mask
 ) {
-    auto scale_arr = array(scale);
-    auto cap_arr = array(softcap);
-
+    std::optional<array> cast_mask;
     if (mask) {
-        static auto compiled_fn = get_compiled_softcap_sdpa_masked();
-        // Cast mask to Q's dtype if needed
-        auto m = mask->inner;
-        if (m.dtype() != q.inner.dtype()) {
-            m = mlx::core::astype(m, q.inner.dtype());
-        }
-        auto result = compiled_fn({q.inner, k.inner, v.inner, scale_arr, cap_arr, m});
-        return std::make_unique<MlxArray>(std::move(result[0]));
-    } else {
-        static auto compiled_fn = get_compiled_softcap_sdpa_nomask();
-        auto result = compiled_fn({q.inner, k.inner, v.inner, scale_arr, cap_arr});
-        return std::make_unique<MlxArray>(std::move(result[0]));
+        cast_mask = mask->inner.dtype() == q.inner.dtype()
+            ? mask->inner
+            : mlx::core::astype(mask->inner, q.inner.dtype());
     }
+    auto result = softcap_sdpa_eager(
+        q.inner, k.inner, v.inner, scale, softcap,
+        cast_mask ? &*cast_mask : nullptr);
+    return std::make_unique<MlxArray>(std::move(result));
 }
 
 // Softcap SDPA with GQA: do repeat_kv outside compiled graph, then call compiled SDPA
@@ -1669,20 +1760,16 @@ std::unique_ptr<MlxArray> compiled_softcap_sdpa_gqa(
     auto rk = do_repeat_kv(k.inner);
     auto rv = do_repeat_kv(v.inner);
 
-    auto scale_arr = array(scale);
-    auto cap_arr = array(softcap);
-
+    std::optional<array> cast_mask;
     if (mask) {
-        static auto compiled_fn = get_compiled_softcap_sdpa_masked();
-        auto m = mask->inner;
-        if (m.dtype() != q.inner.dtype()) m = mlx::core::astype(m, q.inner.dtype());
-        auto result = compiled_fn({q.inner, rk, rv, scale_arr, cap_arr, m});
-        return std::make_unique<MlxArray>(std::move(result[0]));
-    } else {
-        static auto compiled_fn = get_compiled_softcap_sdpa_nomask();
-        auto result = compiled_fn({q.inner, rk, rv, scale_arr, cap_arr});
-        return std::make_unique<MlxArray>(std::move(result[0]));
+        cast_mask = mask->inner.dtype() == q.inner.dtype()
+            ? mask->inner
+            : mlx::core::astype(mask->inner, q.inner.dtype());
     }
+    auto result = softcap_sdpa_eager(
+        q.inner, rk, rv, scale, softcap,
+        cast_mask ? &*cast_mask : nullptr);
+    return std::make_unique<MlxArray>(std::move(result));
 }
 
 // Compiled GELU MLP forward: down_proj(gelu(gate_proj(x)) * up_proj(x))
@@ -1728,7 +1815,8 @@ namespace {
 
             return {down};
         };
-        return mlx::core::compile(fn, true);  // shapeless=true
+        return compile_shapeless_audited(
+            "compiled_gelu_mlp_forward", fn);
     }
 }
 
@@ -1877,7 +1965,10 @@ namespace {
             return {down};
         };
 
-        auto [iter, _] = cache.emplace(key, mlx::core::compile(fn, /*shapeless=*/true));
+        auto [iter, _] = cache.emplace(
+            key,
+            compile_shapeless_audited(
+                "compiled_gelu_approx_mlp_forward", fn));
         return iter->second;
     }
 }
@@ -2097,7 +2188,11 @@ namespace {
             return {down};
         };
 
-        auto [iter, _] = cache.emplace(key, mlx::core::compile(fn, /*shapeless=*/shapeless));
+        auto compiled = shapeless
+            ? compile_shapeless_audited(
+                "compiled_gelu_approx_mlp_forward_global_scale", fn)
+            : mlx::core::compile(fn, /*shapeless=*/false);
+        auto [iter, _] = cache.emplace(key, std::move(compiled));
         return iter->second;
     }
 
@@ -3337,7 +3432,9 @@ namespace {
             return {combined};
         };
         auto [iter, _] = cache.emplace(
-            key, mlx::core::compile(fn, /*shapeless=*/true));
+            key,
+            compile_shapeless_audited(
+                "compiled_per_layer_input_gate", fn));
         return iter->second;
     }
 }
@@ -4205,7 +4302,8 @@ namespace {
 
             return {down};
         };
-        return mlx::core::compile(moe_expert_fn, true);  // shapeless=true
+        return compile_shapeless_audited(
+            "compiled_moe_expert_forward", moe_expert_fn);
     }
 }
 
@@ -5990,7 +6088,8 @@ namespace {
 
             return {y, ns};
         };
-        return mlx::core::compile(fn, true);
+        return compile_shapeless_audited(
+            "fused_gated_delta_decode_step_scalar_gate", fn);
     }
 
     // Compiled version for per-dim gate (g_ndim == 3): [B, H, Dk]
@@ -6021,7 +6120,8 @@ namespace {
 
             return {y, ns};
         };
-        return mlx::core::compile(fn, true);
+        return compile_shapeless_audited(
+            "fused_gated_delta_decode_step_dim_gate", fn);
     }
 }
 

--- a/src/lib/mlxcel-core/cpp/mlx_cxx_bridge.h
+++ b/src/lib/mlxcel-core/cpp/mlx_cxx_bridge.h
@@ -527,16 +527,14 @@ std::unique_ptr<MlxArray> compiled_geglu_approx_activation(
     const MlxArray& x
 );
 
-// Softcap attention scores: tanh(scores * inv_cap) * cap.
-// The compatibility name is retained; the implementation is eager so a
-// shapeless compile cannot silently return an input unchanged.
+// Compiled softcap attention scores: tanh(scores * inv_cap) * cap.
 // Used by: Gemma2 attention with logit softcapping
 std::unique_ptr<MlxArray> compiled_softcap(
     const MlxArray& scores,
     float cap
 );
 
-// Eager clip_residual for float16 overflow prevention
+// Compiled clip_residual for float16 overflow prevention
 // When float16: cast to f32, add, clip to f16 range, cast back
 // When other dtype: simple addition
 // Used by: Gemma3 residual connections
@@ -545,7 +543,7 @@ std::unique_ptr<MlxArray> compiled_clip_residual(
     const MlxArray& y
 );
 
-// Eager softcap SDPA: Q@K^T * scale -> softcap -> mask -> softmax -> @V
+// Compiled softcap SDPA: Q@K^T * scale -> softcap -> mask -> softmax -> @V
 // Used by: Gemma2 attention with logit softcapping
 std::unique_ptr<MlxArray> compiled_softcap_sdpa(
     const MlxArray& q,
@@ -556,7 +554,7 @@ std::unique_ptr<MlxArray> compiled_softcap_sdpa(
     const MlxArray* mask
 );
 
-// Eager softcap SDPA with GQA: handles repeat_kv + attention
+// Compiled softcap SDPA with GQA: handles repeat_kv + attention
 // Used by: Gemma2 attention (GQA + softcap)
 std::unique_ptr<MlxArray> compiled_softcap_sdpa_gqa(
     const MlxArray& q,

--- a/src/lib/mlxcel-core/cpp/mlx_cxx_bridge.h
+++ b/src/lib/mlxcel-core/cpp/mlx_cxx_bridge.h
@@ -468,6 +468,10 @@ std::unique_ptr<MlxArray> swiglu_mlp_forward(
     const MlxArray& down_proj
 );
 
+// One-shot report for MLXCEL_SHAPELESS_COMPILE_AUDIT=1. Each audited compile
+// site is compared against its eager graph on first-use and warmed calls.
+rust::String shapeless_compile_audit_report();
+
 // Compiled relu_squared: square(maximum(x, 0)) — single fused kernel
 std::unique_ptr<MlxArray> compiled_relu_squared(const MlxArray& x);
 
@@ -523,15 +527,16 @@ std::unique_ptr<MlxArray> compiled_geglu_approx_activation(
     const MlxArray& x
 );
 
-// Compiled softcap attention scores: tanh(scores * inv_cap) * cap
-// Fuses divide + tanh + multiply into single compiled kernel
+// Softcap attention scores: tanh(scores * inv_cap) * cap.
+// The compatibility name is retained; the implementation is eager so a
+// shapeless compile cannot silently return an input unchanged.
 // Used by: Gemma2 attention with logit softcapping
 std::unique_ptr<MlxArray> compiled_softcap(
     const MlxArray& scores,
     float cap
 );
 
-// Compiled clip_residual for float16 overflow prevention
+// Eager clip_residual for float16 overflow prevention
 // When float16: cast to f32, add, clip to f16 range, cast back
 // When other dtype: simple addition
 // Used by: Gemma3 residual connections
@@ -540,8 +545,7 @@ std::unique_ptr<MlxArray> compiled_clip_residual(
     const MlxArray& y
 );
 
-// Softcap SDPA: Q@K^T * scale -> softcap -> mask -> softmax -> @V
-// Combines the entire manual attention path into one compiled call
+// Eager softcap SDPA: Q@K^T * scale -> softcap -> mask -> softmax -> @V
 // Used by: Gemma2 attention with logit softcapping
 std::unique_ptr<MlxArray> compiled_softcap_sdpa(
     const MlxArray& q,
@@ -552,8 +556,7 @@ std::unique_ptr<MlxArray> compiled_softcap_sdpa(
     const MlxArray* mask
 );
 
-// Softcap SDPA with GQA: handles repeat_kv + attention in compiled graph
-// Avoids separate repeat_kv FFI calls by incorporating GQA internally
+// Eager softcap SDPA with GQA: handles repeat_kv + attention
 // Used by: Gemma2 attention (GQA + softcap)
 std::unique_ptr<MlxArray> compiled_softcap_sdpa_gqa(
     const MlxArray& q,

--- a/src/lib/mlxcel-core/src/ffi_tests.rs
+++ b/src/lib/mlxcel-core/src/ffi_tests.rs
@@ -2535,10 +2535,10 @@ fn shapeless_compile_audit_harness() {
     set_default_device(true);
     random_seed(1392);
 
-    let x = from_slice_f32(&[-3.0, -0.5, 0.25, 4.0], &[1, 4]);
-    let gate = from_slice_f32(&[1.5, -2.0, 0.75, 3.0], &[1, 4]);
-    let gpt_linear = from_slice_f32(&[-8.0, -1.0, 2.0, 8.0], &[1, 4]);
-    let gpt_glu = from_slice_f32(&[-2.0, 0.5, 2.0, 8.0], &[1, 4]);
+    let x_f32 = from_slice_f32(&[-3.0, -0.5, 0.25, 4.0], &[1, 4]);
+    let gate_f32 = from_slice_f32(&[1.5, -2.0, 0.75, 3.0], &[1, 4]);
+    let gpt_linear_f32 = from_slice_f32(&[-8.0, -1.0, 2.0, 8.0], &[1, 4]);
+    let gpt_glu_f32 = from_slice_f32(&[-2.0, 0.5, 2.0, 8.0], &[1, 4]);
     let clip_x = astype(
         &from_slice_f32(&[65504.0, -65504.0, 10.0, -10.0], &[1, 4]),
         dtype::FLOAT16,
@@ -2547,37 +2547,52 @@ fn shapeless_compile_audit_harness() {
         &from_slice_f32(&[4096.0, -4096.0, 2.0, -2.0], &[1, 4]),
         dtype::FLOAT16,
     );
-    let attn_q = from_slice_f32(&[8.0, -4.0, 2.0, 6.0], &[1, 1, 2, 2]);
-    let attn_k = from_slice_f32(&[4.0, -2.0, -6.0, 3.0, 2.0, 5.0], &[1, 1, 3, 2]);
-    let attn_v = from_slice_f32(&[1.0, 10.0, 2.0, 20.0, 4.0, 40.0], &[1, 1, 3, 2]);
-    let attn_mask = from_slice_f32(&[0.0, -1000.0, 0.0, 0.0, 0.0, -1000.0], &[1, 1, 2, 3]);
+    let attn_q_f32 = from_slice_f32(&[8.0, -4.0, 2.0, 6.0], &[1, 1, 2, 2]);
+    let attn_k_f32 = from_slice_f32(&[4.0, -2.0, -6.0, 3.0, 2.0, 5.0], &[1, 1, 3, 2]);
+    let attn_v_f32 = from_slice_f32(&[1.0, 10.0, 2.0, 20.0, 4.0, 40.0], &[1, 1, 3, 2]);
+    let attn_mask_f32 = from_slice_f32(&[0.0, -1000.0, 0.0, 0.0, 0.0, -1000.0], &[1, 1, 2, 3]);
+
+    for audit_dtype in [dtype::FLOAT32, dtype::BFLOAT16, dtype::FLOAT16] {
+        let x = astype(&x_f32, audit_dtype);
+        let gate = astype(&gate_f32, audit_dtype);
+        let gpt_linear = astype(&gpt_linear_f32, audit_dtype);
+        let gpt_glu = astype(&gpt_glu_f32, audit_dtype);
+        let attn_q = astype(&attn_q_f32, audit_dtype);
+        let attn_k = astype(&attn_k_f32, audit_dtype);
+        let attn_v = astype(&attn_v_f32, audit_dtype);
+        let attn_mask = astype(&attn_mask_f32, audit_dtype);
+
+        for _ in 0..2 {
+            eval(&compiled_swiglu_activation(&gate, &x));
+            eval(&compiled_relu_squared(&x));
+            eval(&compiled_silu(&x));
+            eval(&compiled_gpt_oss_swiglu_activation(&gpt_linear, &gpt_glu));
+            eval(&compiled_gelu(&x));
+            eval(&compiled_gelu_approx(&x));
+            eval(&compiled_geglu_activation(&gate, &x));
+            eval(&compiled_geglu_approx_activation(&gate, &x));
+            eval(&compiled_gelu_topk(&x, 0.75));
+            eval(&compiled_softcap(&x, 1.0));
+            let sdpa = unsafe {
+                compiled_softcap_sdpa(&attn_q, &attn_k, &attn_v, 4.0, 3.0, std::ptr::null())
+            };
+            eval(&sdpa);
+            let masked_sdpa = unsafe {
+                compiled_softcap_sdpa(
+                    &attn_q,
+                    &attn_k,
+                    &attn_v,
+                    4.0,
+                    3.0,
+                    attn_mask.as_ref().unwrap() as *const MlxArray,
+                )
+            };
+            eval(&masked_sdpa);
+        }
+    }
 
     for _ in 0..2 {
-        eval(&compiled_swiglu_activation(&gate, &x));
-        eval(&compiled_relu_squared(&x));
-        eval(&compiled_silu(&x));
-        eval(&compiled_gpt_oss_swiglu_activation(&gpt_linear, &gpt_glu));
-        eval(&compiled_gelu(&x));
-        eval(&compiled_gelu_approx(&x));
-        eval(&compiled_geglu_activation(&gate, &x));
-        eval(&compiled_geglu_approx_activation(&gate, &x));
-        eval(&compiled_gelu_topk(&x, 0.75));
-        eval(&compiled_softcap(&x, 1.0));
         eval(&compiled_clip_residual(&clip_x, &clip_y));
-        let sdpa =
-            unsafe { compiled_softcap_sdpa(&attn_q, &attn_k, &attn_v, 4.0, 3.0, std::ptr::null()) };
-        eval(&sdpa);
-        let masked_sdpa = unsafe {
-            compiled_softcap_sdpa(
-                &attn_q,
-                &attn_k,
-                &attn_v,
-                4.0,
-                3.0,
-                attn_mask.as_ref().unwrap() as *const MlxArray,
-            )
-        };
-        eval(&masked_sdpa);
     }
 
     let group_size = 64;
@@ -2587,63 +2602,66 @@ fn shapeless_compile_audit_harness() {
     let (gate_w, gate_s, gate_b) = random_quantized_weight(intermediate, hidden, group_size, bits);
     let (up_w, up_s, up_b) = random_quantized_weight(intermediate, hidden, group_size, bits);
     let (down_w, down_s, down_b) = random_quantized_weight(hidden, intermediate, group_size, bits);
-    let mlp_x = unsafe { random_normal(&[1, 1, hidden], dtype::FLOAT32, std::ptr::null()) };
+    let mlp_x_f32 = unsafe { random_normal(&[1, 1, hidden], dtype::FLOAT32, std::ptr::null()) };
 
-    for _ in 0..2 {
-        let precise = unsafe {
-            compiled_gelu_mlp_forward(
-                &mlp_x,
-                &gate_w,
-                &gate_s,
-                gate_b.as_ref().unwrap() as *const MlxArray,
-                &up_w,
-                &up_s,
-                up_b.as_ref().unwrap() as *const MlxArray,
-                &down_w,
-                &down_s,
-                down_b.as_ref().unwrap() as *const MlxArray,
-                group_size,
-                bits,
-                "affine",
-            )
-        };
-        eval(&precise);
-        let approximate = unsafe {
-            compiled_gelu_approx_mlp_forward(
-                &mlp_x,
-                &gate_w,
-                &gate_s,
-                gate_b.as_ref().unwrap() as *const MlxArray,
-                &up_w,
-                &up_s,
-                up_b.as_ref().unwrap() as *const MlxArray,
-                &down_w,
-                &down_s,
-                down_b.as_ref().unwrap() as *const MlxArray,
-                group_size,
-                bits,
-                "affine",
-            )
-        };
-        eval(&approximate);
-        let moe = unsafe {
-            compiled_moe_expert_forward(
-                &mlp_x,
-                &gate_w,
-                &gate_s,
-                gate_b.as_ref().unwrap() as *const MlxArray,
-                &up_w,
-                &up_s,
-                up_b.as_ref().unwrap() as *const MlxArray,
-                &down_w,
-                &down_s,
-                down_b.as_ref().unwrap() as *const MlxArray,
-                group_size,
-                bits,
-                "affine",
-            )
-        };
-        eval(&moe);
+    for audit_dtype in [dtype::FLOAT32, dtype::BFLOAT16, dtype::FLOAT16] {
+        let mlp_x = astype(&mlp_x_f32, audit_dtype);
+        for _ in 0..2 {
+            let precise = unsafe {
+                compiled_gelu_mlp_forward(
+                    &mlp_x,
+                    &gate_w,
+                    &gate_s,
+                    gate_b.as_ref().unwrap() as *const MlxArray,
+                    &up_w,
+                    &up_s,
+                    up_b.as_ref().unwrap() as *const MlxArray,
+                    &down_w,
+                    &down_s,
+                    down_b.as_ref().unwrap() as *const MlxArray,
+                    group_size,
+                    bits,
+                    "affine",
+                )
+            };
+            eval(&precise);
+            let approximate = unsafe {
+                compiled_gelu_approx_mlp_forward(
+                    &mlp_x,
+                    &gate_w,
+                    &gate_s,
+                    gate_b.as_ref().unwrap() as *const MlxArray,
+                    &up_w,
+                    &up_s,
+                    up_b.as_ref().unwrap() as *const MlxArray,
+                    &down_w,
+                    &down_s,
+                    down_b.as_ref().unwrap() as *const MlxArray,
+                    group_size,
+                    bits,
+                    "affine",
+                )
+            };
+            eval(&approximate);
+            let moe = unsafe {
+                compiled_moe_expert_forward(
+                    &mlp_x,
+                    &gate_w,
+                    &gate_s,
+                    gate_b.as_ref().unwrap() as *const MlxArray,
+                    &up_w,
+                    &up_s,
+                    up_b.as_ref().unwrap() as *const MlxArray,
+                    &down_w,
+                    &down_s,
+                    down_b.as_ref().unwrap() as *const MlxArray,
+                    group_size,
+                    bits,
+                    "affine",
+                )
+            };
+            eval(&moe);
+        }
     }
 
     let (scaled_gate_w, scaled_gate_s) =
@@ -2653,83 +2671,100 @@ fn shapeless_compile_audit_harness() {
     let (scaled_down_w, scaled_down_s) =
         random_block_float_weight(hidden, intermediate, 32, 4, "mxfp4");
     let global_scale = scale_scalar(1.25);
-    for _ in 0..2 {
-        let scaled = unsafe {
-            compiled_gelu_approx_mlp_forward_global_scale(
-                &mlp_x,
-                &scaled_gate_w,
-                &scaled_gate_s,
-                &scaled_up_w,
-                &scaled_up_s,
-                &scaled_down_w,
-                &scaled_down_s,
-                global_scale.as_ref().unwrap() as *const MlxArray,
-                global_scale.as_ref().unwrap() as *const MlxArray,
-                global_scale.as_ref().unwrap() as *const MlxArray,
-                32,
-                4,
-                "mxfp4",
-            )
-        };
-        eval(&scaled);
+    for audit_dtype in [dtype::FLOAT32, dtype::BFLOAT16, dtype::FLOAT16] {
+        let mlp_x = astype(&mlp_x_f32, audit_dtype);
+        for _ in 0..2 {
+            let scaled = unsafe {
+                compiled_gelu_approx_mlp_forward_global_scale(
+                    &mlp_x,
+                    &scaled_gate_w,
+                    &scaled_gate_s,
+                    &scaled_up_w,
+                    &scaled_up_s,
+                    &scaled_down_w,
+                    &scaled_down_s,
+                    global_scale.as_ref().unwrap() as *const MlxArray,
+                    global_scale.as_ref().unwrap() as *const MlxArray,
+                    global_scale.as_ref().unwrap() as *const MlxArray,
+                    32,
+                    4,
+                    "mxfp4",
+                )
+            };
+            eval(&scaled);
+        }
     }
 
     let (input_gate_w, input_gate_s, input_gate_b) =
         random_quantized_weight(hidden, hidden, group_size, bits);
     let (input_proj_w, input_proj_s, input_proj_b) =
         random_quantized_weight(hidden, hidden, group_size, bits);
-    let per_layer_input =
+    let per_layer_input_f32 =
         unsafe { random_normal(&[1, 1, hidden], dtype::FLOAT32, std::ptr::null()) };
-    let post_norm_w = ones(&[hidden], dtype::FLOAT32);
-    for _ in 0..2 {
-        let gated = unsafe {
-            compiled_per_layer_input_gate(
-                &mlp_x,
-                &per_layer_input,
-                &input_gate_w,
-                &input_gate_s,
-                input_gate_b.as_ref().unwrap() as *const MlxArray,
-                &input_proj_w,
-                &input_proj_s,
-                input_proj_b.as_ref().unwrap() as *const MlxArray,
-                &post_norm_w,
-                std::ptr::null(),
-                std::ptr::null(),
-                1e-6,
-                group_size,
-                bits,
-                "affine",
-            )
-        };
-        eval(&gated);
+    let post_norm_w_f32 = ones(&[hidden], dtype::FLOAT32);
+    for audit_dtype in [dtype::FLOAT32, dtype::BFLOAT16, dtype::FLOAT16] {
+        let mlp_x = astype(&mlp_x_f32, audit_dtype);
+        let per_layer_input = astype(&per_layer_input_f32, audit_dtype);
+        let post_norm_w = astype(&post_norm_w_f32, audit_dtype);
+        for _ in 0..2 {
+            let gated = unsafe {
+                compiled_per_layer_input_gate(
+                    &mlp_x,
+                    &per_layer_input,
+                    &input_gate_w,
+                    &input_gate_s,
+                    input_gate_b.as_ref().unwrap() as *const MlxArray,
+                    &input_proj_w,
+                    &input_proj_s,
+                    input_proj_b.as_ref().unwrap() as *const MlxArray,
+                    &post_norm_w,
+                    std::ptr::null(),
+                    std::ptr::null(),
+                    1e-6,
+                    group_size,
+                    bits,
+                    "affine",
+                )
+            };
+            eval(&gated);
+        }
     }
 
-    let q = from_slice_f32(&[0.1, 0.2, -0.3, 0.4, 0.5, -0.6, 0.7, 0.8], &[1, 2, 4]);
-    let k = from_slice_f32(&[-0.2, 0.3, 0.4, -0.5, 0.6, 0.7, -0.8, 0.9], &[1, 2, 4]);
-    let v = from_slice_f32(&[0.5, -0.4, 0.3, -0.2, 0.1, 0.8], &[1, 2, 3]);
-    let beta = from_slice_f32(&[0.25, 0.75], &[1, 2]);
-    let state = unsafe { random_normal(&[1, 2, 3, 4], dtype::FLOAT32, std::ptr::null()) };
-    let scalar_gate = from_slice_f32(&[0.8, 0.9], &[1, 2]);
-    let dim_gate = from_slice_f32(&[0.8, 0.9, 0.7, 0.6, 0.5, 0.75, 0.85, 0.95], &[1, 2, 4]);
-    for gate in [&scalar_gate, &dim_gate] {
-        for _ in 0..2 {
-            let mut output = UniquePtr::null();
-            let mut new_state = UniquePtr::null();
-            unsafe {
-                fused_gated_delta_decode_step(
-                    &q,
-                    &k,
-                    &v,
-                    gate,
-                    &beta,
-                    &state,
-                    dtype::FLOAT32,
-                    &mut output,
-                    &mut new_state,
-                );
+    let q_f32 = from_slice_f32(&[0.1, 0.2, -0.3, 0.4, 0.5, -0.6, 0.7, 0.8], &[1, 2, 4]);
+    let k_f32 = from_slice_f32(&[-0.2, 0.3, 0.4, -0.5, 0.6, 0.7, -0.8, 0.9], &[1, 2, 4]);
+    let v_f32 = from_slice_f32(&[0.5, -0.4, 0.3, -0.2, 0.1, 0.8], &[1, 2, 3]);
+    let beta_f32 = from_slice_f32(&[0.25, 0.75], &[1, 2]);
+    let state_f32 = unsafe { random_normal(&[1, 2, 3, 4], dtype::FLOAT32, std::ptr::null()) };
+    let scalar_gate_f32 = from_slice_f32(&[0.8, 0.9], &[1, 2]);
+    let dim_gate_f32 = from_slice_f32(&[0.8, 0.9, 0.7, 0.6, 0.5, 0.75, 0.85, 0.95], &[1, 2, 4]);
+    for audit_dtype in [dtype::FLOAT32, dtype::BFLOAT16, dtype::FLOAT16] {
+        let q = astype(&q_f32, audit_dtype);
+        let k = astype(&k_f32, audit_dtype);
+        let v = astype(&v_f32, audit_dtype);
+        let beta = astype(&beta_f32, audit_dtype);
+        let state = astype(&state_f32, audit_dtype);
+        let scalar_gate = astype(&scalar_gate_f32, audit_dtype);
+        let dim_gate = astype(&dim_gate_f32, audit_dtype);
+        for gate in [&scalar_gate, &dim_gate] {
+            for _ in 0..2 {
+                let mut output = UniquePtr::null();
+                let mut new_state = UniquePtr::null();
+                unsafe {
+                    fused_gated_delta_decode_step(
+                        &q,
+                        &k,
+                        &v,
+                        gate,
+                        &beta,
+                        &state,
+                        audit_dtype,
+                        &mut output,
+                        &mut new_state,
+                    );
+                }
+                eval(&output);
+                eval(&new_state);
             }
-            eval(&output);
-            eval(&new_state);
         }
     }
 
@@ -2772,8 +2807,19 @@ fn shapeless_compile_audit_harness() {
         let fields: Vec<_> = line.split('\t').collect();
         let calls: usize = fields[1].parse().unwrap();
         let warmed: usize = fields[3].parse().unwrap();
-        assert!(calls >= 2, "{site} must cover first-use and warm calls");
-        assert!(warmed >= 1, "{site} must warm at least one input signature");
+        let expected_signatures = if site == "compiled_clip_residual" {
+            1
+        } else {
+            3
+        };
+        assert!(
+            calls >= expected_signatures * 2,
+            "{site} must cover first-use and warm calls for every dtype"
+        );
+        assert!(
+            warmed >= expected_signatures,
+            "{site} must warm every audited dtype signature"
+        );
         assert_eq!(fields[4], "PASS", "{site} failed: {line}");
     }
 }

--- a/src/lib/mlxcel-core/src/ffi_tests.rs
+++ b/src/lib/mlxcel-core/src/ffi_tests.rs
@@ -2516,6 +2516,236 @@ fn scale_scalar(value: f32) -> UniquePtr<MlxArray> {
     full_f32(&[1], value, dtype::FLOAT32)
 }
 
+/// One-shot, backend-specific audit for every production
+/// `mlx::core::compile(..., shapeless=true)` site in the C++ bridge.
+///
+/// Run through `scripts/audit_shapeless_compile.sh`; the script sets the audit
+/// environment before this isolated test process starts, checks that no direct
+/// shapeless compile escaped the central wrapper, and selects Metal or CUDA.
+/// This is intentionally ignored by normal CI: it is a hardware qualification
+/// harness, not a reason for hosted runners to download model weights.
+#[test]
+#[ignore = "run with scripts/audit_shapeless_compile.sh on a reachable GPU"]
+fn shapeless_compile_audit_harness() {
+    assert_eq!(
+        std::env::var("MLXCEL_SHAPELESS_COMPILE_AUDIT").as_deref(),
+        Ok("1"),
+        "the audit environment must be set before any compiled function is initialized"
+    );
+    set_default_device(true);
+    random_seed(1392);
+
+    let x = from_slice_f32(&[-3.0, -0.5, 0.25, 4.0], &[1, 4]);
+    let gate = from_slice_f32(&[1.5, -2.0, 0.75, 3.0], &[1, 4]);
+    let gpt_linear = from_slice_f32(&[-8.0, -1.0, 2.0, 8.0], &[1, 4]);
+    let gpt_glu = from_slice_f32(&[-2.0, 0.5, 2.0, 8.0], &[1, 4]);
+
+    for _ in 0..2 {
+        eval(&compiled_swiglu_activation(&gate, &x));
+        eval(&compiled_relu_squared(&x));
+        eval(&compiled_silu(&x));
+        eval(&compiled_gpt_oss_swiglu_activation(&gpt_linear, &gpt_glu));
+        eval(&compiled_gelu(&x));
+        eval(&compiled_gelu_approx(&x));
+        eval(&compiled_geglu_activation(&gate, &x));
+        eval(&compiled_geglu_approx_activation(&gate, &x));
+        eval(&compiled_gelu_topk(&x, 0.75));
+    }
+
+    let group_size = 64;
+    let bits = 4;
+    let hidden = 128;
+    let intermediate = 256;
+    let (gate_w, gate_s, gate_b) = random_quantized_weight(intermediate, hidden, group_size, bits);
+    let (up_w, up_s, up_b) = random_quantized_weight(intermediate, hidden, group_size, bits);
+    let (down_w, down_s, down_b) = random_quantized_weight(hidden, intermediate, group_size, bits);
+    let mlp_x = unsafe { random_normal(&[1, 1, hidden], dtype::FLOAT32, std::ptr::null()) };
+
+    for _ in 0..2 {
+        let precise = unsafe {
+            compiled_gelu_mlp_forward(
+                &mlp_x,
+                &gate_w,
+                &gate_s,
+                gate_b.as_ref().unwrap() as *const MlxArray,
+                &up_w,
+                &up_s,
+                up_b.as_ref().unwrap() as *const MlxArray,
+                &down_w,
+                &down_s,
+                down_b.as_ref().unwrap() as *const MlxArray,
+                group_size,
+                bits,
+                "affine",
+            )
+        };
+        eval(&precise);
+        let approximate = unsafe {
+            compiled_gelu_approx_mlp_forward(
+                &mlp_x,
+                &gate_w,
+                &gate_s,
+                gate_b.as_ref().unwrap() as *const MlxArray,
+                &up_w,
+                &up_s,
+                up_b.as_ref().unwrap() as *const MlxArray,
+                &down_w,
+                &down_s,
+                down_b.as_ref().unwrap() as *const MlxArray,
+                group_size,
+                bits,
+                "affine",
+            )
+        };
+        eval(&approximate);
+        let moe = unsafe {
+            compiled_moe_expert_forward(
+                &mlp_x,
+                &gate_w,
+                &gate_s,
+                gate_b.as_ref().unwrap() as *const MlxArray,
+                &up_w,
+                &up_s,
+                up_b.as_ref().unwrap() as *const MlxArray,
+                &down_w,
+                &down_s,
+                down_b.as_ref().unwrap() as *const MlxArray,
+                group_size,
+                bits,
+                "affine",
+            )
+        };
+        eval(&moe);
+    }
+
+    let (scaled_gate_w, scaled_gate_s) =
+        random_block_float_weight(intermediate, hidden, 32, 4, "mxfp4");
+    let (scaled_up_w, scaled_up_s) =
+        random_block_float_weight(intermediate, hidden, 32, 4, "mxfp4");
+    let (scaled_down_w, scaled_down_s) =
+        random_block_float_weight(hidden, intermediate, 32, 4, "mxfp4");
+    let global_scale = scale_scalar(1.25);
+    for _ in 0..2 {
+        let scaled = unsafe {
+            compiled_gelu_approx_mlp_forward_global_scale(
+                &mlp_x,
+                &scaled_gate_w,
+                &scaled_gate_s,
+                &scaled_up_w,
+                &scaled_up_s,
+                &scaled_down_w,
+                &scaled_down_s,
+                global_scale.as_ref().unwrap() as *const MlxArray,
+                global_scale.as_ref().unwrap() as *const MlxArray,
+                global_scale.as_ref().unwrap() as *const MlxArray,
+                32,
+                4,
+                "mxfp4",
+            )
+        };
+        eval(&scaled);
+    }
+
+    let (input_gate_w, input_gate_s, input_gate_b) =
+        random_quantized_weight(hidden, hidden, group_size, bits);
+    let (input_proj_w, input_proj_s, input_proj_b) =
+        random_quantized_weight(hidden, hidden, group_size, bits);
+    let per_layer_input =
+        unsafe { random_normal(&[1, 1, hidden], dtype::FLOAT32, std::ptr::null()) };
+    let post_norm_w = ones(&[hidden], dtype::FLOAT32);
+    for _ in 0..2 {
+        let gated = unsafe {
+            compiled_per_layer_input_gate(
+                &mlp_x,
+                &per_layer_input,
+                &input_gate_w,
+                &input_gate_s,
+                input_gate_b.as_ref().unwrap() as *const MlxArray,
+                &input_proj_w,
+                &input_proj_s,
+                input_proj_b.as_ref().unwrap() as *const MlxArray,
+                &post_norm_w,
+                std::ptr::null(),
+                std::ptr::null(),
+                1e-6,
+                group_size,
+                bits,
+                "affine",
+            )
+        };
+        eval(&gated);
+    }
+
+    let q = from_slice_f32(&[0.1, 0.2, -0.3, 0.4, 0.5, -0.6, 0.7, 0.8], &[1, 2, 4]);
+    let k = from_slice_f32(&[-0.2, 0.3, 0.4, -0.5, 0.6, 0.7, -0.8, 0.9], &[1, 2, 4]);
+    let v = from_slice_f32(&[0.5, -0.4, 0.3, -0.2, 0.1, 0.8], &[1, 2, 3]);
+    let beta = from_slice_f32(&[0.25, 0.75], &[1, 2]);
+    let state = unsafe { random_normal(&[1, 2, 3, 4], dtype::FLOAT32, std::ptr::null()) };
+    let scalar_gate = from_slice_f32(&[0.8, 0.9], &[1, 2]);
+    let dim_gate = from_slice_f32(&[0.8, 0.9, 0.7, 0.6, 0.5, 0.75, 0.85, 0.95], &[1, 2, 4]);
+    for gate in [&scalar_gate, &dim_gate] {
+        for _ in 0..2 {
+            let mut output = UniquePtr::null();
+            let mut new_state = UniquePtr::null();
+            unsafe {
+                fused_gated_delta_decode_step(
+                    &q,
+                    &k,
+                    &v,
+                    gate,
+                    &beta,
+                    &state,
+                    dtype::FLOAT32,
+                    &mut output,
+                    &mut new_state,
+                );
+            }
+            eval(&output);
+            eval(&new_state);
+        }
+    }
+
+    let expected_sites = [
+        "compiled_swiglu_activation",
+        "compiled_relu_squared",
+        "compiled_silu",
+        "compiled_gpt_oss_swiglu_activation",
+        "compiled_gelu",
+        "compiled_gelu_approx",
+        "compiled_geglu_activation",
+        "compiled_geglu_approx_activation",
+        "compiled_gelu_topk",
+        "compiled_gelu_mlp_forward",
+        "compiled_gelu_approx_mlp_forward",
+        "compiled_gelu_approx_mlp_forward_global_scale",
+        "compiled_per_layer_input_gate",
+        "compiled_moe_expert_forward",
+        "fused_gated_delta_decode_step_scalar_gate",
+        "fused_gated_delta_decode_step_dim_gate",
+    ];
+    let report = shapeless_compile_audit_report();
+    eprintln!("{report}");
+    assert!(!report.contains("\tFAIL"), "audit failures:\n{report}");
+    assert_eq!(
+        report.lines().skip(1).count(),
+        expected_sites.len(),
+        "the report must contain every and only the audited production site"
+    );
+    for site in expected_sites {
+        let prefix = format!("{site}\t");
+        let line = report
+            .lines()
+            .find(|line| line.starts_with(&prefix))
+            .unwrap_or_else(|| panic!("missing audit row for {site}:\n{report}"));
+        let fields: Vec<_> = line.split('\t').collect();
+        let calls: usize = fields[1].parse().unwrap();
+        let warmed: usize = fields[3].parse().unwrap();
+        assert!(calls >= 2, "{site} must cover first-use and warm calls");
+        assert!(warmed >= 1, "{site} must warm at least one input signature");
+        assert_eq!(fields[4], "PASS", "{site} failed: {line}");
+    }
+}
+
 /// All three sidecars present, single-token input: the fused scaled kernel
 /// takes the compiled branch and must match the op-at-a-time reference.
 #[test]
@@ -2969,6 +3199,40 @@ fn test_compiled_softcap_preserves_bf16_and_f16_dtype() {
 }
 
 #[test]
+fn test_softcap_eager_regression_changes_large_logits_and_matches_reference() {
+    for dtype in [dtype::FLOAT32, dtype::BFLOAT16, dtype::FLOAT16] {
+        let scores = astype(
+            &from_slice_f32(&[-90.0, -30.0, 0.0, 30.0, 90.0], &[1, 5]),
+            dtype,
+        );
+        let cap = full_f32(&[1], 30.0, dtype::FLOAT32);
+        let reference = astype(&multiply(&tanh(&divide(&scores, &cap)), &cap), dtype);
+
+        // Exercise the compatibility entry point twice. Before #1392 the
+        // shapeless compiled callable could quietly return `scores` unchanged
+        // on Metal, especially after its first cached invocation.
+        let first = compiled_softcap(&scores, 30.0);
+        let warmed = compiled_softcap(&scores, 30.0);
+        eval(&first);
+        eval(&warmed);
+        eval(&reference);
+
+        let close = allclose(&warmed, &reference, 5e-3, 5e-3);
+        eval(&close);
+        assert!(
+            item_bool(&close),
+            "softcap must match the eager tanh reference for dtype {dtype}"
+        );
+        let unchanged = allclose(&warmed, &scores, 1e-4, 1e-4);
+        eval(&unchanged);
+        assert!(
+            !item_bool(&unchanged),
+            "large logits must be materially softcapped for dtype {dtype}"
+        );
+    }
+}
+
+#[test]
 fn test_compiled_clip_residual() {
     let x = from_slice_f32(&[1.0, 2.0, 3.0, 4.0], &[1, 4]);
     let y = from_slice_f32(&[0.5, 0.5, 0.5, 0.5], &[1, 4]);
@@ -2986,6 +3250,154 @@ fn test_compiled_clip_residual() {
         (item_f32(&total) - 12.0).abs() < 1e-3,
         "clip_residual([1,2,3,4], [0.5,0.5,0.5,0.5]) should sum to ~12.0, got {}",
         item_f32(&total)
+    );
+}
+
+#[test]
+fn test_clip_residual_f16_eager_regression_clips_overflow_and_matches_reference() {
+    let x = astype(
+        &from_slice_f32(&[65504.0, -65504.0, 10.0, -10.0], &[1, 4]),
+        dtype::FLOAT16,
+    );
+    let y = astype(
+        &from_slice_f32(&[4096.0, -4096.0, 2.0, -2.0], &[1, 4]),
+        dtype::FLOAT16,
+    );
+    let bound = full_f32(&[1], 65504.0, dtype::FLOAT32);
+    let reference = astype(
+        &clip(
+            &add(&astype(&x, dtype::FLOAT32), &astype(&y, dtype::FLOAT32)),
+            &negative(&bound),
+            &bound,
+        ),
+        dtype::FLOAT16,
+    );
+
+    let first = compiled_clip_residual(&x, &y);
+    let warmed = compiled_clip_residual(&x, &y);
+    eval(&first);
+    eval(&warmed);
+    eval(&reference);
+    let close = allclose(&warmed, &reference, 0.0, 0.0);
+    eval(&close);
+    assert!(
+        item_bool(&close),
+        "float16 residual must widen, add, clip, and cast back exactly"
+    );
+    let unchanged = allclose(&warmed, &x, 0.0, 0.0);
+    eval(&unchanged);
+    assert!(
+        !item_bool(&unchanged),
+        "clip_residual must not silently return its first input"
+    );
+}
+
+fn softcap_sdpa_reference(
+    q: &MlxArray,
+    k: &MlxArray,
+    v: &MlxArray,
+    scale: f32,
+    cap: f32,
+    mask: Option<&MlxArray>,
+) -> UniquePtr<MlxArray> {
+    let k_t = transpose_axes(k, &[0, 1, 3, 2]);
+    let scale_arr = full_f32(&[1], scale, dtype::FLOAT32);
+    let cap_arr = full_f32(&[1], cap, dtype::FLOAT32);
+    let mut scores = multiply(&matmul(q, &k_t), &scale_arr);
+    scores = multiply(&tanh(&divide(&scores, &cap_arr)), &cap_arr);
+    if let Some(mask) = mask {
+        scores = add(&scores, &astype(mask, array_dtype(q)));
+    }
+    astype(&matmul(&softmax(&scores, -1), v), array_dtype(v))
+}
+
+#[test]
+fn test_softcap_sdpa_eager_regression_matches_nonuniform_reference() {
+    for dtype in [dtype::FLOAT32, dtype::BFLOAT16, dtype::FLOAT16] {
+        let q = astype(
+            &from_slice_f32(&[8.0, -4.0, 2.0, 6.0, -3.0, 7.0, 5.0, 1.0], &[1, 2, 2, 2]),
+            dtype,
+        );
+        let k = astype(
+            &from_slice_f32(
+                &[
+                    4.0, -2.0, -6.0, 3.0, 2.0, 5.0, 7.0, 1.0, -3.0, 8.0, 6.0, -5.0,
+                ],
+                &[1, 2, 3, 2],
+            ),
+            dtype,
+        );
+        let v = astype(
+            &from_slice_f32(
+                &[
+                    1.0, 10.0, 2.0, 20.0, 4.0, 40.0, -1.0, -10.0, -2.0, -20.0, -4.0, -40.0,
+                ],
+                &[1, 2, 3, 2],
+            ),
+            dtype,
+        );
+        let mask = astype(
+            &from_slice_f32(
+                &[
+                    0.0, -1000.0, 0.0, 0.0, 0.0, -1000.0, 0.0, -1000.0, 0.0, 0.0, 0.0, -1000.0,
+                ],
+                &[1, 2, 2, 3],
+            ),
+            dtype,
+        );
+
+        for mask in [None, Some(mask.as_ref().unwrap())] {
+            let reference = softcap_sdpa_reference(&q, &k, &v, 4.0, 3.0, mask);
+            let mask_ptr = mask.map_or(std::ptr::null(), |m| m as *const MlxArray);
+            let first = unsafe { compiled_softcap_sdpa(&q, &k, &v, 4.0, 3.0, mask_ptr) };
+            let warmed = unsafe { compiled_softcap_sdpa(&q, &k, &v, 4.0, 3.0, mask_ptr) };
+            eval(&first);
+            eval(&warmed);
+            eval(&reference);
+            let close = allclose(&warmed, &reference, 5e-3, 5e-3);
+            eval(&close);
+            assert!(
+                item_bool(&close),
+                "softcap SDPA must match its eager reference for dtype {dtype}"
+            );
+        }
+    }
+}
+
+#[test]
+fn test_softcap_sdpa_gqa_eager_regression_matches_repeated_kv_reference() {
+    let q = from_slice_f32(
+        &[
+            8.0, -4.0, 2.0, 6.0, -3.0, 7.0, 5.0, 1.0, 4.0, 3.0, -2.0, 9.0, 7.0, -1.0, 6.0, 2.0,
+        ],
+        &[1, 4, 2, 2],
+    );
+    let k = from_slice_f32(
+        &[
+            4.0, -2.0, -6.0, 3.0, 2.0, 5.0, 7.0, 1.0, -3.0, 8.0, 6.0, -5.0,
+        ],
+        &[1, 2, 3, 2],
+    );
+    let v = from_slice_f32(
+        &[
+            1.0, 10.0, 2.0, 20.0, 4.0, 40.0, -1.0, -10.0, -2.0, -20.0, -4.0, -40.0,
+        ],
+        &[1, 2, 3, 2],
+    );
+    let repeated_k = repeat(&k, 2, 1);
+    let repeated_v = repeat(&v, 2, 1);
+    let reference = softcap_sdpa_reference(&q, &repeated_k, &repeated_v, 4.0, 3.0, None);
+
+    let first = unsafe { compiled_softcap_sdpa_gqa(&q, &k, &v, 4.0, 3.0, 2, std::ptr::null()) };
+    let warmed = unsafe { compiled_softcap_sdpa_gqa(&q, &k, &v, 4.0, 3.0, 2, std::ptr::null()) };
+    eval(&first);
+    eval(&warmed);
+    eval(&reference);
+    let close = allclose(&warmed, &reference, 1e-4, 1e-4);
+    eval(&close);
+    assert!(
+        item_bool(&close),
+        "GQA softcap SDPA must match explicit repeated-K/V eager attention"
     );
 }
 

--- a/src/lib/mlxcel-core/src/ffi_tests.rs
+++ b/src/lib/mlxcel-core/src/ffi_tests.rs
@@ -2539,6 +2539,18 @@ fn shapeless_compile_audit_harness() {
     let gate = from_slice_f32(&[1.5, -2.0, 0.75, 3.0], &[1, 4]);
     let gpt_linear = from_slice_f32(&[-8.0, -1.0, 2.0, 8.0], &[1, 4]);
     let gpt_glu = from_slice_f32(&[-2.0, 0.5, 2.0, 8.0], &[1, 4]);
+    let clip_x = astype(
+        &from_slice_f32(&[65504.0, -65504.0, 10.0, -10.0], &[1, 4]),
+        dtype::FLOAT16,
+    );
+    let clip_y = astype(
+        &from_slice_f32(&[4096.0, -4096.0, 2.0, -2.0], &[1, 4]),
+        dtype::FLOAT16,
+    );
+    let attn_q = from_slice_f32(&[8.0, -4.0, 2.0, 6.0], &[1, 1, 2, 2]);
+    let attn_k = from_slice_f32(&[4.0, -2.0, -6.0, 3.0, 2.0, 5.0], &[1, 1, 3, 2]);
+    let attn_v = from_slice_f32(&[1.0, 10.0, 2.0, 20.0, 4.0, 40.0], &[1, 1, 3, 2]);
+    let attn_mask = from_slice_f32(&[0.0, -1000.0, 0.0, 0.0, 0.0, -1000.0], &[1, 1, 2, 3]);
 
     for _ in 0..2 {
         eval(&compiled_swiglu_activation(&gate, &x));
@@ -2550,6 +2562,22 @@ fn shapeless_compile_audit_harness() {
         eval(&compiled_geglu_activation(&gate, &x));
         eval(&compiled_geglu_approx_activation(&gate, &x));
         eval(&compiled_gelu_topk(&x, 0.75));
+        eval(&compiled_softcap(&x, 1.0));
+        eval(&compiled_clip_residual(&clip_x, &clip_y));
+        let sdpa =
+            unsafe { compiled_softcap_sdpa(&attn_q, &attn_k, &attn_v, 4.0, 3.0, std::ptr::null()) };
+        eval(&sdpa);
+        let masked_sdpa = unsafe {
+            compiled_softcap_sdpa(
+                &attn_q,
+                &attn_k,
+                &attn_v,
+                4.0,
+                3.0,
+                attn_mask.as_ref().unwrap() as *const MlxArray,
+            )
+        };
+        eval(&masked_sdpa);
     }
 
     let group_size = 64;
@@ -2715,6 +2743,10 @@ fn shapeless_compile_audit_harness() {
         "compiled_geglu_activation",
         "compiled_geglu_approx_activation",
         "compiled_gelu_topk",
+        "compiled_softcap",
+        "compiled_clip_residual",
+        "compiled_softcap_sdpa_nomask",
+        "compiled_softcap_sdpa_masked",
         "compiled_gelu_mlp_forward",
         "compiled_gelu_approx_mlp_forward",
         "compiled_gelu_approx_mlp_forward_global_scale",

--- a/src/lib/mlxcel-core/src/lib.rs
+++ b/src/lib/mlxcel-core/src/lib.rs
@@ -657,16 +657,15 @@ mod ffi {
         /// Used by: Gemma3n MLP layers with activation_sparsity > 0
         fn compiled_gelu_topk(x: &MlxArray, std_multiplier: f32) -> UniquePtr<MlxArray>;
 
-        /// Eager softcap: tanh(scores / cap) * cap.
-        /// The compatibility name is retained to avoid an API break.
+        /// Compiled softcap: tanh(scores / cap) * cap.
         /// Used by: Gemma2 attention with logit softcapping
         fn compiled_softcap(scores: &MlxArray, cap: f32) -> UniquePtr<MlxArray>;
 
-        /// Eager clip_residual for float16 overflow prevention
+        /// Compiled clip_residual for float16 overflow prevention
         /// Used by: Gemma3 residual connections
         fn compiled_clip_residual(x: &MlxArray, y: &MlxArray) -> UniquePtr<MlxArray>;
 
-        /// Eager softcap SDPA: Q@K^T * scale -> softcap -> mask -> softmax -> @V
+        /// Compiled softcap SDPA: Q@K^T * scale -> softcap -> mask -> softmax -> @V
         /// Used by: Gemma2 attention with logit softcapping
         unsafe fn compiled_softcap_sdpa(
             q: &MlxArray,
@@ -677,7 +676,7 @@ mod ffi {
             mask: *const MlxArray,
         ) -> UniquePtr<MlxArray>;
 
-        /// Eager softcap SDPA with GQA: repeat_kv + attention
+        /// Compiled softcap SDPA with GQA: repeat_kv + attention
         /// Used by: Gemma2 attention (GQA + softcap)
         unsafe fn compiled_softcap_sdpa_gqa(
             q: &MlxArray,

--- a/src/lib/mlxcel-core/src/lib.rs
+++ b/src/lib/mlxcel-core/src/lib.rs
@@ -613,6 +613,9 @@ mod ffi {
             down_proj: &MlxArray,
         ) -> UniquePtr<MlxArray>;
 
+        /// Report collected by the opt-in shapeless compile hardware audit.
+        fn shapeless_compile_audit_report() -> String;
+
         /// Compiled SwiGLU activation with kernel fusion
         /// Uses mlx::core::compile(shapeless=true) like Python's @mx.compile
         /// output = silu(gate) * x
@@ -654,16 +657,16 @@ mod ffi {
         /// Used by: Gemma3n MLP layers with activation_sparsity > 0
         fn compiled_gelu_topk(x: &MlxArray, std_multiplier: f32) -> UniquePtr<MlxArray>;
 
-        /// Compiled softcap: tanh(scores / cap) * cap — single fused kernel
+        /// Eager softcap: tanh(scores / cap) * cap.
+        /// The compatibility name is retained to avoid an API break.
         /// Used by: Gemma2 attention with logit softcapping
         fn compiled_softcap(scores: &MlxArray, cap: f32) -> UniquePtr<MlxArray>;
 
-        /// Compiled clip_residual for float16 overflow prevention
+        /// Eager clip_residual for float16 overflow prevention
         /// Used by: Gemma3 residual connections
         fn compiled_clip_residual(x: &MlxArray, y: &MlxArray) -> UniquePtr<MlxArray>;
 
-        /// Compiled softcap SDPA: Q@K^T * scale -> softcap -> mask -> softmax -> @V
-        /// Fuses the entire manual attention path into one compiled call
+        /// Eager softcap SDPA: Q@K^T * scale -> softcap -> mask -> softmax -> @V
         /// Used by: Gemma2 attention with logit softcapping
         unsafe fn compiled_softcap_sdpa(
             q: &MlxArray,
@@ -674,8 +677,7 @@ mod ffi {
             mask: *const MlxArray,
         ) -> UniquePtr<MlxArray>;
 
-        /// Compiled softcap SDPA with GQA: fuses repeat_kv + attention
-        /// Avoids separate repeat_kv FFI calls by incorporating GQA internally
+        /// Eager softcap SDPA with GQA: repeat_kv + attention
         /// Used by: Gemma2 attention (GQA + softcap)
         unsafe fn compiled_softcap_sdpa_gqa(
             q: &MlxArray,


### PR DESCRIPTION
## Summary

- Route every production `mlx::core::compile(..., shapeless=true)` construction in `mlx_cxx_bridge.cpp` through one opt-in audit wrapper that compares compiled outputs with the identical eager graph, records input signatures and warm calls, and adds no comparison or registry work unless `MLXCEL_SHAPELESS_COMPILE_AUDIT=1` is set before initialization.
- Add `scripts/audit_shapeless_compile.sh`, which rejects any shapeless construction that bypasses the wrapper, selects Metal or CUDA from the host, derives the CUDA architecture directly from `nvidia-smi`, and runs an isolated synthetic-tensor hardware audit without reading or downloading model weights.
- Add permanent no-op regressions for `compiled_softcap`, `compiled_clip_residual`, masked/unmasked softcap SDPA, and GQA softcap SDPA using nonuniform values and independent eager references.

## Findings

- The issue's line/function table had drifted: current `softplus` is eager, the cited QKV line is the quantized MoE expert path, and the bridge currently has 20 actual shapeless callables after separating masked and unmasked softcap SDPA.
- On the local NVIDIA GB10 (CUDA compute capability 12.1), all 20 sites matched their eager graphs. Nineteen sites covered f32, bf16, and f16 with first-use plus warmed calls (`calls=6`, `signatures=3`, `warmed=3`, `PASS`); the f16-only clip-residual path reported `2/1/1/PASS`.
- The final Apple Silicon Metal run produced the same table and passed all four quiet-site regressions: https://github.com/lablup/mlxcel/actions/runs/32746852051
- Since the quiet sites did not diverge on either reachable backend, their compiled fusion remains intact; converting softcap SDPA to unconditional eager operations would have introduced an unsupported performance regression.
- PR #1395 is already present in this branch's base and addresses MLA KV-cache/Turbo4 safety, not shapeless compile behavior, so it does not supersede this audit.

## Validation

- [x] `scripts/audit_shapeless_compile.sh` on local NVIDIA GB10: 20/20 PASS across f32/bf16/f16 where supported; no model weights used
- [x] Apple Silicon Metal on-demand audit: 20/20 PASS, quiet-site regressions 4/4 PASS; no model weights used
- [x] `cargo test -p mlxcel-core --profile test-fast --features cuda --lib eager_regression -- --nocapture --test-threads=1`: 4 passed
- [x] `cargo test -p mlxcel-core --profile test-fast --features cuda --lib compiled_ -- --test-threads=1`: 30 passed
- [x] `cargo clippy -p mlxcel-core --features cuda --all-targets -- -D warnings`
- [x] `cargo fmt --all -- --check`
- [x] Final diff contains no GitHub Actions workflow change

## Model-test boundary

This audit uses only small synthetic tensors. It adds no GitHub Actions model download. The existing project boundary remains unchanged: hosted Actions may use the established approximately 0.6B fixtures, while tests requiring larger checkpoints run locally against already-present weights and reachable hardware.

Closes #1392
