### PR TITLE
fix: parse Python repr tool-call values (#1306)

### DIFF
--- a/TECHNICAL_REPORTS/1404-pythonic-tool-call-values-20260825.en.md
+++ b/TECHNICAL_REPORTS/1404-pythonic-tool-call-values-20260825.en.md
@@ -1,0 +1,134 @@
+# Technical Report: PR #1404 - Parse Python Repr Tool-Call Values
+
+**Date**: 2026-08-25
+**Author**: mlxcel contributors
+**Status**: Completed
+**Languages**: Rust, Markdown
+**Risk Level**: Medium
+
+---
+
+## Executive Summary
+
+PR #1404 makes the server's Pythonic tool-call parser accept the representation emitted by LFM2-family checkpoints: single-quoted strings, Python boolean/null literals, quoted commas, and nested list values. It also replaces an unsafe in-band comma sentinel with a direct quote- and bracket-aware scanner and adds parser and streaming regressions.
+
+---
+
+## 1. Problem Statement
+
+### 1.1 Background
+
+The Pythonic tool-call format encodes calls as `name(key=value, ...)`. Existing parsing assumed JSON-like double-quoted values even though some checkpoints emit Python `repr` syntax such as `name(query='hello', enabled=True, extra=None)`.
+
+### 1.2 Existing Issues
+
+- **Quote mismatch**: Single-quoted strings retained their surrounding quotes rather than becoming JSON strings.
+- **Literal mismatch**: `True`, `False`, and `None` were returned as strings rather than JSON boolean or null values.
+- **Incorrect comma boundaries**: Commas inside quoted strings or bracketed lists could split one argument into multiple fragments.
+- **Unsafe intermediate representation**: The initial fix masked list commas with a private-use character, which would have corrupted a legitimate occurrence of that character in model output.
+
+### 1.3 Risk Assessment
+
+| Risk | Impact | Likelihood before fix |
+|------|--------|-----------------------|
+| Tool arguments reach handlers with incorrect JSON types | High | High for affected checkpoints |
+| Quoted text or list values are truncated or rejected | High | Medium |
+| User-controlled private-use data is silently rewritten | Medium | Low |
+
+---
+
+## 2. Change Summary
+
+### 2.1 Python Repr Value Conversion
+
+The value parser now recognizes matching single or double delimiters, performs only the matching quote/backslash unescaping required by the protocol, and maps Python's boolean/null literals to JSON values. JSON-compatible legacy inputs keep their existing behavior.
+
+### 2.2 Structural Argument Splitting
+
+Arguments are scanned character by character while tracking the active quote, escape state, and bracket depth. A comma is a separator only outside quotes and at bracket depth zero, so quoted commas and nested list contents remain part of the same `key=value` segment.
+
+### 2.3 Streaming Coverage
+
+Regression tests exercise marker-wrapped calls through the stream filter, including input split across chunks. The Pythonic enter-only marker remains terminal tool-call framing, so ordinary text after the parsed call is not emitted as assistant content.
+
+---
+
+## 3. Technical Decisions
+
+### 3.1 Use a Direct Scanner Instead of an In-Band Sentinel
+
+**Decision:** Preserve original input bytes and detect separators structurally.
+
+**Rationale:** No Unicode scalar value is safe as an internal sentinel when the source text is model-controlled. Direct scanning eliminates collision-driven mutation while reusing the same quote and nesting concepts needed for list parsing.
+
+**Trade-off:** The scanner is longer than a regex substitution, but its state and separator rule are explicit and testable.
+
+### 3.2 Limit the Python Subset
+
+**Decision:** Support the repr constructs observed in the tool-call protocol without implementing a general Python parser.
+
+**Rationale:** Matching quote removal, limited escapes, scalar literals, and list nesting address the checkpoint output while keeping untrusted parsing deterministic and dependency-free.
+
+**Trade-off:** Full Python escape semantics, multiple calls in one response, call-level parentheses nesting, and quoted `)]` in the outer matcher remain unsupported.
+
+---
+
+## 4. Review and Quality Findings
+
+### 4.1 Implementation Review
+
+The correctness review found no unresolved issue after hardening. Focus covered conversion precedence, nesting and escape state, first-call-only compatibility, marker handling, and fragmented streams.
+
+### 4.2 Security and Performance Review
+
+No CRITICAL or HIGH finding remained. The review identified the private-use sentinel collision as a MEDIUM data-integrity issue; the final implementation removed the sentinel and added an exact preservation test. A pre-existing unmarked bare-Pythonic streaming limitation and the outer matcher's quoted `)]` limitation remain outside this issue. The scanner is linear in input length and introduces no new dependency or unbounded secondary allocation.
+
+### 4.3 Compatibility
+
+- **Breaking changes**: None to CLI or HTTP request schemas.
+- **New dependencies**: None.
+- **Behavior change**: LFM2-style Python repr values now reach tool handlers as correctly typed JSON values.
+
+---
+
+## 5. Validation
+
+- `cargo test --profile test-fast pythonic_ --lib` passed 31 focused tests.
+- `cargo test --workspace --profile test-fast --features metal,accelerate` passed the full workspace gate.
+- `cargo clippy --workspace --all-targets -- -D warnings` passed.
+- `cargo fmt --all -- --check` and `git diff --check` passed.
+- CI formatting, lint, dependency policy, crate-version, cross-repository reference, OpenXLA compile, and CLA checks passed before report generation.
+- Real-model validation was blocked because no local LFM2 checkpoint was available under `models/`; marker-wrapped parser and fragmented-stream regressions validate the affected protocol boundary synthetically.
+
+---
+
+## 6. Change Statistics
+
+| Item | Value |
+|------|-------|
+| Files changed | 3 |
+| Lines added | 243 |
+| Lines deleted | 57 |
+| Implementation commits | 2 |
+
+### Related Commits
+
+| Hash | Type | Message |
+|------|------|---------|
+| `fcf6dc1d5` | fix | Parse Python repr tool-call values |
+| `d0ef04b7b` | fix | Harden Pythonic tool arg splitting |
+
+---
+
+## 7. Follow-up Considerations
+
+- Validate a live `/v1/chat/completions` tool-call round trip when an LFM2 checkpoint becomes locally available.
+- Extend the outer call recognizer if real checkpoints emit quoted `)]`, nested call parentheses, or multiple Pythonic calls in one response.
+- Decide separately whether the stream filter should detect unmarked bare Pythonic calls without increasing false positives in normal assistant text.
+
+---
+
+## References
+
+- Issue #1306: Python repr syntax in Pythonic tool calls
+- PR #1404: parser conversion, structural splitting, and streaming regressions

--- a/TECHNICAL_REPORTS/1404-pythonic-tool-call-values-20260825.ko.md
+++ b/TECHNICAL_REPORTS/1404-pythonic-tool-call-values-20260825.ko.md
@@ -1,0 +1,134 @@
+# 기술 보고서: PR #1404 - Python Repr 도구 호출 값 파싱
+
+**작성일**: 2026-08-25
+**작성자**: mlxcel 기여자
+**상태**: 완료
+**언어**: Rust, Markdown
+**위험도**: Medium
+
+---
+
+## 요약
+
+PR #1404는 서버의 Pythonic tool-call parser가 LFM2 계열 체크포인트가 출력하는 single-quoted string, Python boolean/null literal, 인용된 comma, 중첩 list 값을 처리하도록 수정한다. 또한 안전하지 않은 in-band comma sentinel을 직접 quote·bracket-aware scanner로 교체하고 parser 및 streaming 회귀 테스트를 추가했다.
+
+---
+
+## 1. 문제 정의
+
+### 1.1 배경
+
+Pythonic tool-call 형식은 호출을 `name(key=value, ...)`로 인코딩한다. 기존 parser는 JSON 형태의 double-quoted value를 가정했지만 일부 체크포인트는 `name(query='hello', enabled=True, extra=None)` 같은 Python `repr` 문법을 출력한다.
+
+### 1.2 기존 문제점
+
+- **Quote 불일치**: Single-quoted string의 바깥 quote가 제거되지 않고 값에 남았다.
+- **Literal 불일치**: `True`, `False`, `None`이 JSON boolean 또는 null이 아니라 string으로 반환됐다.
+- **잘못된 comma 경계**: 인용된 string이나 bracket list 안의 comma가 하나의 인자를 여러 조각으로 나눌 수 있었다.
+- **안전하지 않은 중간 표현**: 초기 수정은 list comma를 private-use 문자로 치환했으며, 모델 출력에 해당 문자가 실제로 포함되면 데이터가 손상될 수 있었다.
+
+### 1.3 위험성
+
+| 위험 | 영향도 | 수정 전 가능성 |
+|------|--------|----------------|
+| Tool handler가 잘못된 JSON type의 인자를 수신 | High | 영향받는 체크포인트에서 High |
+| 인용 text 또는 list 값이 잘리거나 거부됨 | High | Medium |
+| 사용자 제어 private-use 데이터가 조용히 변조됨 | Medium | Low |
+
+---
+
+## 2. 변경 요약
+
+### 2.1 Python Repr 값 변환
+
+Value parser는 이제 짝이 맞는 single/double delimiter를 인식하고 프로토콜에 필요한 matching quote와 backslash만 제한적으로 unescape하며 Python boolean/null literal을 JSON 값으로 변환한다. 기존 JSON-compatible 입력 동작은 유지된다.
+
+### 2.2 구조 기반 인자 분리
+
+인자를 문자 단위로 scan하면서 현재 quote, escape 상태, bracket depth를 추적한다. Quote 밖이면서 bracket depth가 0일 때만 comma를 separator로 취급하므로 인용된 comma와 중첩 list 내용이 같은 `key=value` segment에 남는다.
+
+### 2.3 Streaming 검증
+
+Regression test는 chunk 사이에서 입력이 분리되는 경우를 포함해 marker-wrapped 호출을 stream filter 전체로 검증한다. Pythonic enter-only marker는 terminal tool-call framing이므로 파싱한 호출 뒤의 일반 text는 assistant content로 방출하지 않는다.
+
+---
+
+## 3. 기술적 선택과 그 이유
+
+### 3.1 In-Band Sentinel 대신 직접 Scanner 사용
+
+**결정:** 원본 입력 문자를 보존하고 separator를 구조적으로 탐지한다.
+
+**근거:** Source text를 모델이 제어하므로 어떤 Unicode scalar도 안전한 내부 sentinel이 될 수 없다. 직접 scan은 collision에 의한 변조를 없애면서 list parsing에도 필요한 quote와 nesting 개념을 재사용한다.
+
+**트레이드오프:** Scanner는 regex 치환보다 길지만 상태와 separator 규칙이 명시적이며 독립적으로 테스트할 수 있다.
+
+### 3.2 지원하는 Python Subset 제한
+
+**결정:** 범용 Python parser를 구현하지 않고 tool-call protocol에서 관찰된 repr 구성만 지원한다.
+
+**근거:** Matching quote 제거, 제한된 escape, scalar literal, list nesting으로 체크포인트 출력을 처리하면서 비신뢰 입력 parsing을 결정적이고 dependency-free하게 유지한다.
+
+**트레이드오프:** 전체 Python escape 의미론, 한 응답의 여러 호출, call-level parenthesis nesting, outer matcher 내부의 인용된 `)]`는 계속 지원하지 않는다.
+
+---
+
+## 4. 리뷰 및 품질 검토
+
+### 4.1 구현 리뷰
+
+Hardening 이후 correctness review에서 해결되지 않은 이슈는 없었다. 변환 우선순위, nesting·escape 상태, first-call-only 호환성, marker 처리, fragmented stream을 집중 검토했다.
+
+### 4.2 보안 및 성능 리뷰
+
+남은 CRITICAL 또는 HIGH finding은 없다. 리뷰에서 private-use sentinel collision을 MEDIUM data-integrity 이슈로 식별했으며, 최종 구현은 sentinel을 제거하고 정확한 보존 테스트를 추가했다. 기존 unmarked bare-Pythonic streaming 제한과 outer matcher의 인용된 `)]` 제한은 이 이슈 범위 밖에 남는다. Scanner는 입력 길이에 대해 선형이며 새 dependency나 무제한 secondary allocation을 추가하지 않는다.
+
+### 4.3 호환성
+
+- **Breaking change**: CLI 또는 HTTP request schema에는 없음.
+- **새 의존성**: 없음.
+- **동작 변경**: LFM2-style Python repr 값이 올바른 JSON type으로 tool handler에 전달된다.
+
+---
+
+## 5. 검증
+
+- `cargo test --profile test-fast pythonic_ --lib`의 집중 테스트 31개가 통과했다.
+- `cargo test --workspace --profile test-fast --features metal,accelerate` 전체 workspace gate가 통과했다.
+- `cargo clippy --workspace --all-targets -- -D warnings`가 통과했다.
+- `cargo fmt --all -- --check`와 `git diff --check`가 통과했다.
+- 보고서 생성 전 CI formatting, lint, dependency policy, crate-version, cross-repository reference, OpenXLA compile, CLA check가 통과했다.
+- `models/` 아래에 로컬 LFM2 체크포인트가 없어 실제 모델 검증은 차단됐다. 대신 marker-wrapped parser와 fragmented-stream 회귀 테스트로 영향받는 protocol boundary를 합성 검증했다.
+
+---
+
+## 6. 변경 통계
+
+| 항목 | 값 |
+|------|----|
+| 변경 파일 | 3 |
+| 추가 줄 | 243 |
+| 삭제 줄 | 57 |
+| 구현 커밋 | 2 |
+
+### 관련 커밋
+
+| 해시 | 유형 | 메시지 |
+|------|------|--------|
+| `fcf6dc1d5` | fix | Python repr tool-call 값 파싱 |
+| `d0ef04b7b` | fix | Pythonic tool 인자 분리 hardening |
+
+---
+
+## 7. 후속 고려 사항
+
+- LFM2 체크포인트를 로컬에서 사용할 수 있을 때 실제 `/v1/chat/completions` tool-call round trip을 검증한다.
+- 실제 체크포인트가 인용된 `)]`, 중첩 call parenthesis, 또는 한 응답의 여러 Pythonic call을 출력하면 outer call recognizer를 확장한다.
+- 일반 assistant text의 false positive를 늘리지 않으면서 stream filter가 unmarked bare Pythonic call을 탐지해야 하는지는 별도로 결정한다.
+
+---
+
+## 참고
+
+- 이슈 #1306: Pythonic tool call의 Python repr 문법
+- PR #1404: parser 변환, 구조 기반 분리, streaming 회귀 테스트

--- a/src/server/tool_calls/formats.rs
+++ b/src/server/tool_calls/formats.rs
@@ -1731,22 +1731,39 @@ const MASKED_COMMA: char = '\u{E000}';
 fn mask_bracketed_commas(raw: &str) -> String {
     let mut out = String::with_capacity(raw.len());
     let mut depth: i32 = 0;
-    let mut in_quotes = false;
+    let mut quote: Option<char> = None;
+    let mut escaped = false;
     for c in raw.chars() {
-        match c {
-            '"' => {
-                in_quotes = !in_quotes;
+        if let Some(active_quote) = quote {
+            if c == ',' && depth > 0 {
+                out.push(MASKED_COMMA);
+            } else {
                 out.push(c);
             }
-            '[' if !in_quotes => {
+            if escaped {
+                escaped = false;
+            } else if c == '\\' {
+                escaped = true;
+            } else if c == active_quote {
+                quote = None;
+            }
+            continue;
+        }
+
+        match c {
+            '"' | '\'' => {
+                quote = Some(c);
+                out.push(c);
+            }
+            '[' => {
                 depth += 1;
                 out.push(c);
             }
-            ']' if !in_quotes => {
+            ']' => {
                 depth = depth.saturating_sub(1);
                 out.push(c);
             }
-            ',' if !in_quotes && depth > 0 => out.push(MASKED_COMMA),
+            ',' if depth > 0 => out.push(MASKED_COMMA),
             _ => out.push(c),
         }
     }
@@ -1758,15 +1775,75 @@ fn unmask_bracketed_commas(masked: &str) -> String {
     masked.replace(MASKED_COMMA, ",")
 }
 
+/// Unescape only the repr-style escapes the pythonic format needs: the
+/// matching quote character and backslashes. Everything else stays literal.
+fn unescape_pythonic_quoted_body(body: &str, quote: char) -> String {
+    let mut out = String::with_capacity(body.len());
+    let mut chars = body.chars().peekable();
+    while let Some(c) = chars.next() {
+        if c == '\\'
+            && let Some(&next) = chars.peek()
+            && (next == quote || next == '\\')
+        {
+            out.push(next);
+            let _ = chars.next();
+            continue;
+        }
+        out.push(c);
+    }
+    out
+}
+
+/// Split a pythonic comma-separated sequence while respecting quoted strings
+/// and nested bracketed list literals.
+fn split_pythonic_commas(raw: &str) -> Vec<&str> {
+    let mut items = Vec::new();
+    let mut start = 0usize;
+    let mut depth: i32 = 0;
+    let mut quote: Option<char> = None;
+    let mut escaped = false;
+
+    for (idx, c) in raw.char_indices() {
+        if let Some(active_quote) = quote {
+            if escaped {
+                escaped = false;
+            } else if c == '\\' {
+                escaped = true;
+            } else if c == active_quote {
+                quote = None;
+            }
+            continue;
+        }
+
+        match c {
+            '"' | '\'' => quote = Some(c),
+            '[' => depth += 1,
+            ']' => depth = depth.saturating_sub(1),
+            ',' if depth == 0 => {
+                items.push(&raw[start..idx]);
+                start = idx + c.len_utf8();
+            }
+            _ => {}
+        }
+    }
+
+    items.push(&raw[start..]);
+    items
+}
+
 /// Build the JSON `arguments` object from a pythonic call's raw argument
 /// text (the `(.*?)` capture between the call's parentheses), using the
-/// per-argument regex `(\w+)=(?:"([^"]*)"|([^,]+))(?:,\s*|$)`: group 1 is
-/// the key; a matched quoted alternative (group 2) becomes a JSON string
-/// verbatim; a matched unquoted alternative (group 3) is coerced via
-/// [`coerce_pythonic_value`]. Returns `"{}"` for empty args (e.g. `ping()`).
+/// per-argument regex
+/// `(\w+)\s*=\s*(?:"((?:[^"\\]|\\.)*)"|'((?:[^'\\]|\\.)*)'|([^,]+))(?:,\s*|$)`:
+/// group 1 is the key; groups 2/3 are double-/single-quoted bodies and become
+/// JSON strings after repr-style unescaping; group 4 is the unquoted token and
+/// is coerced via [`coerce_pythonic_value`]. Returns `"{}"` for empty args
+/// (e.g. `ping()`).
 fn pythonic_arguments(args_raw: &str) -> String {
     let masked = mask_bracketed_commas(args_raw);
-    let Ok(args_re) = Regex::new(r#"(\w+)=(?:"([^"]*)"|([^,]+))(?:,\s*|$)"#) else {
+    let Ok(args_re) =
+        Regex::new(r#"(\w+)\s*=\s*(?:"((?:[^"\\]|\\.)*)"|'((?:[^'\\]|\\.)*)'|([^,]+))(?:,\s*|$)"#)
+    else {
         return "{}".to_string();
     };
 
@@ -1776,8 +1853,10 @@ fn pythonic_arguments(args_raw: &str) -> String {
         let Some(key) = caps.get(1) else { continue };
 
         let value = if let Some(quoted) = caps.get(2) {
-            serde_json::Value::String(quoted.as_str().to_string())
-        } else if let Some(unquoted) = caps.get(3) {
+            serde_json::Value::String(unescape_pythonic_quoted_body(quoted.as_str(), '"'))
+        } else if let Some(quoted) = caps.get(3) {
+            serde_json::Value::String(unescape_pythonic_quoted_body(quoted.as_str(), '\''))
+        } else if let Some(unquoted) = caps.get(4) {
             let restored = unmask_bracketed_commas(unquoted.as_str());
             coerce_pythonic_value(restored.trim())
         } else {
@@ -1800,11 +1879,13 @@ fn pythonic_arguments(args_raw: &str) -> String {
 const PYTHONIC_MAX_LIST_DEPTH: usize = 32;
 
 /// Coerce a trimmed unquoted pythonic argument value (or list item) in the
-/// order the format spec prescribes: integer, float, bool (`true`/`false`),
-/// a bracketed list `[...]` (each inner comma-separated item coerced the
-/// same way, recursively), else the raw string. A quoted list item (e.g.
-/// `"a"` inside `tags=["a", "b"]`) has its surrounding quotes stripped
-/// rather than falling through to the raw-string branch verbatim.
+/// order the format spec prescribes: integer, float, bool
+/// (`true`/`false`/`True`/`False`), `None`/`null`, a bracketed list `[...]`
+/// (each inner comma-separated item coerced the same way, recursively), a
+/// string wrapped in matching single or double quotes, else the raw string. A
+/// quoted list item (e.g. `"a"` inside `tags=["a", "b"]`) has its
+/// surrounding quotes stripped rather than falling through to the raw-string
+/// branch verbatim.
 fn coerce_pythonic_value(raw: &str) -> serde_json::Value {
     coerce_pythonic_value_inner(raw, 0)
 }
@@ -1821,8 +1902,11 @@ fn coerce_pythonic_value_inner(raw: &str, depth: usize) -> serde_json::Value {
     {
         return serde_json::Value::Number(n);
     }
-    if raw == "true" || raw == "false" {
-        return serde_json::Value::Bool(raw == "true");
+    if matches!(raw, "true" | "false" | "True" | "False") {
+        return serde_json::Value::Bool(matches!(raw, "true" | "True"));
+    }
+    if matches!(raw, "None" | "null") {
+        return serde_json::Value::Null;
     }
     // Only descend into a `[...]` list while under the depth cap. Past the cap
     // the value is left as a raw string, so adversarial deeply-nested brackets
@@ -1830,15 +1914,24 @@ fn coerce_pythonic_value_inner(raw: &str, depth: usize) -> serde_json::Value {
     if depth < PYTHONIC_MAX_LIST_DEPTH
         && let Some(inner) = raw.strip_prefix('[').and_then(|s| s.strip_suffix(']'))
     {
-        let items = inner
-            .split(',')
+        let items = split_pythonic_commas(inner)
+            .into_iter()
             .filter(|s| !s.trim().is_empty())
             .map(|item| coerce_pythonic_value_inner(item.trim(), depth + 1))
             .collect();
         return serde_json::Value::Array(items);
     }
     if raw.len() >= 2 && raw.starts_with('"') && raw.ends_with('"') {
-        return serde_json::Value::String(raw[1..raw.len() - 1].to_string());
+        return serde_json::Value::String(unescape_pythonic_quoted_body(
+            &raw[1..raw.len() - 1],
+            '"',
+        ));
+    }
+    if raw.len() >= 2 && raw.starts_with('\'') && raw.ends_with('\'') {
+        return serde_json::Value::String(unescape_pythonic_quoted_body(
+            &raw[1..raw.len() - 1],
+            '\'',
+        ));
     }
     serde_json::Value::String(raw.to_string())
 }
@@ -3827,6 +3920,18 @@ mod tests {
     }
 
     #[test]
+    fn pythonic_single_quoted_string_args() {
+        let text = "[get_weather(location='Warsaw', unit='celsius')]";
+        let result = try_pythonic(text).unwrap();
+        let args: serde_json::Value =
+            serde_json::from_str(&result.tool_calls[0].arguments).unwrap();
+        assert_eq!(
+            args,
+            serde_json::json!({"location": "Warsaw", "unit": "celsius"})
+        );
+    }
+
+    #[test]
     fn pythonic_unquoted_int_arg() {
         let text = "[set_count(count=42)]";
         let result = try_pythonic(text).unwrap();
@@ -3855,6 +3960,15 @@ mod tests {
     }
 
     #[test]
+    fn pythonic_python_bool_and_none_literals() {
+        let text = "[f(a=True, b=False, c=None)]";
+        let result = try_pythonic(text).unwrap();
+        let args: serde_json::Value =
+            serde_json::from_str(&result.tool_calls[0].arguments).unwrap();
+        assert_eq!(args, serde_json::json!({"a": true, "b": false, "c": null}));
+    }
+
+    #[test]
     fn pythonic_bracketed_list_arg() {
         // The unquoted alternative `[^,]+` in the per-argument regex cannot
         // itself cross a comma, so this exercises the comma-masking done in
@@ -3877,6 +3991,45 @@ mod tests {
         let args: serde_json::Value =
             serde_json::from_str(&result.tool_calls[0].arguments).unwrap();
         assert_eq!(args["tags"], serde_json::json!(["a", "b"]));
+    }
+
+    #[test]
+    fn pythonic_list_with_single_quoted_items() {
+        let text = "[f(tags=['x', 'y'])]";
+        let result = try_pythonic(text).unwrap();
+        let args: serde_json::Value =
+            serde_json::from_str(&result.tool_calls[0].arguments).unwrap();
+        assert_eq!(args, serde_json::json!({"tags": ["x", "y"]}));
+    }
+
+    #[test]
+    fn pythonic_list_with_quoted_item_containing_comma() {
+        let text = "[f(tags=['a,b', 'c'])]";
+        let result = try_pythonic(text).unwrap();
+        let args: serde_json::Value =
+            serde_json::from_str(&result.tool_calls[0].arguments).unwrap();
+        assert_eq!(args, serde_json::json!({"tags": ["a,b", "c"]}));
+    }
+
+    #[test]
+    fn pythonic_single_quoted_value_with_comma() {
+        let text = "[f(note='a, b', n=1)]";
+        let result = try_pythonic(text).unwrap();
+        let args: serde_json::Value =
+            serde_json::from_str(&result.tool_calls[0].arguments).unwrap();
+        assert_eq!(args, serde_json::json!({"note": "a, b", "n": 1}));
+    }
+
+    #[test]
+    fn pythonic_quoted_values_unescape_matching_quotes_and_backslashes() {
+        let text = r#"[f(single='It\'s \\ ok', double="say \"hi\" \\ now")]"#;
+        let result = try_pythonic(text).unwrap();
+        let args: serde_json::Value =
+            serde_json::from_str(&result.tool_calls[0].arguments).unwrap();
+        assert_eq!(
+            args,
+            serde_json::json!({"single": "It's \\ ok", "double": r#"say "hi" \ now"#})
+        );
     }
 
     #[test]
@@ -3915,6 +4068,21 @@ mod tests {
         let args: serde_json::Value =
             serde_json::from_str(&wrapped_result.tool_calls[0].arguments).unwrap();
         assert_eq!(args["x"], "y");
+    }
+
+    #[test]
+    fn pythonic_marker_wrapped_single_quotes() {
+        let wrapped = "<|tool_call_start|>[f(location='Warsaw', tags=['x', 'y'])]<|tool_call_end|>";
+        let bare = "[f(location='Warsaw', tags=['x', 'y'])]";
+        let wrapped_result = try_pythonic(wrapped).unwrap();
+        let bare_result = try_pythonic(bare).unwrap();
+        assert_eq!(wrapped_result.tool_calls, bare_result.tool_calls);
+        let args: serde_json::Value =
+            serde_json::from_str(&wrapped_result.tool_calls[0].arguments).unwrap();
+        assert_eq!(
+            args,
+            serde_json::json!({"location": "Warsaw", "tags": ["x", "y"]})
+        );
     }
 
     #[test]

--- a/src/server/tool_calls/formats.rs
+++ b/src/server/tool_calls/formats.rs
@@ -1716,65 +1716,6 @@ pub fn try_pythonic(text: &str) -> Option<ToolCallParseResult> {
     })
 }
 
-/// Placeholder used to temporarily hide commas that sit inside a `[...]`
-/// list literal from the per-argument regex in [`pythonic_arguments`]
-/// (whose unquoted alternative `[^,]+` would otherwise stop at the first
-/// comma, breaking multi-element lists such as `tags=[1, 2, 3]`). Restored
-/// by [`unmask_bracketed_commas`] once the surrounding key=value span has
-/// been captured. A Unicode Private Use Area codepoint is used so it cannot
-/// collide with a comma that legitimately appears in real argument text.
-const MASKED_COMMA: char = '\u{E000}';
-
-/// Hide commas that occur inside an unquoted `[...]` list literal (bracket
-/// depth > 0, outside a quoted string) behind [`MASKED_COMMA`] so the
-/// per-argument regex's unquoted alternative can span the whole list.
-fn mask_bracketed_commas(raw: &str) -> String {
-    let mut out = String::with_capacity(raw.len());
-    let mut depth: i32 = 0;
-    let mut quote: Option<char> = None;
-    let mut escaped = false;
-    for c in raw.chars() {
-        if let Some(active_quote) = quote {
-            if c == ',' && depth > 0 {
-                out.push(MASKED_COMMA);
-            } else {
-                out.push(c);
-            }
-            if escaped {
-                escaped = false;
-            } else if c == '\\' {
-                escaped = true;
-            } else if c == active_quote {
-                quote = None;
-            }
-            continue;
-        }
-
-        match c {
-            '"' | '\'' => {
-                quote = Some(c);
-                out.push(c);
-            }
-            '[' => {
-                depth += 1;
-                out.push(c);
-            }
-            ']' => {
-                depth = depth.saturating_sub(1);
-                out.push(c);
-            }
-            ',' if depth > 0 => out.push(MASKED_COMMA),
-            _ => out.push(c),
-        }
-    }
-    out
-}
-
-/// Restore commas hidden by [`mask_bracketed_commas`].
-fn unmask_bracketed_commas(masked: &str) -> String {
-    masked.replace(MASKED_COMMA, ",")
-}
-
 /// Unescape only the repr-style escapes the pythonic format needs: the
 /// matching quote character and backslashes. Everything else stays literal.
 fn unescape_pythonic_quoted_body(body: &str, quote: char) -> String {
@@ -1832,24 +1773,32 @@ fn split_pythonic_commas(raw: &str) -> Vec<&str> {
 }
 
 /// Build the JSON `arguments` object from a pythonic call's raw argument
-/// text (the `(.*?)` capture between the call's parentheses), using the
-/// per-argument regex
-/// `(\w+)\s*=\s*(?:"((?:[^"\\]|\\.)*)"|'((?:[^'\\]|\\.)*)'|([^,]+))(?:,\s*|$)`:
+/// text (the `(.*?)` capture between the call's parentheses). The raw string
+/// is first split on top-level commas with [`split_pythonic_commas`] so quoted
+/// strings and nested list literals stay intact, then each `key=value` segment
+/// is matched against
+/// `^(\w+)\s*=\s*(?:"((?:[^"\\]|\\.)*)"|'((?:[^'\\]|\\.)*)'|(.*))$`:
 /// group 1 is the key; groups 2/3 are double-/single-quoted bodies and become
 /// JSON strings after repr-style unescaping; group 4 is the unquoted token and
 /// is coerced via [`coerce_pythonic_value`]. Returns `"{}"` for empty args
 /// (e.g. `ping()`).
 fn pythonic_arguments(args_raw: &str) -> String {
-    let masked = mask_bracketed_commas(args_raw);
     let Ok(args_re) =
-        Regex::new(r#"(\w+)\s*=\s*(?:"((?:[^"\\]|\\.)*)"|'((?:[^'\\]|\\.)*)'|([^,]+))(?:,\s*|$)"#)
+        Regex::new(r#"^(\w+)\s*=\s*(?:"((?:[^"\\]|\\.)*)"|'((?:[^'\\]|\\.)*)'|(.*))$"#)
     else {
         return "{}".to_string();
     };
 
     let mut map = serde_json::Map::new();
-    for caps in args_re.captures_iter(&masked) {
-        let Ok(caps) = caps else { continue };
+    for segment in split_pythonic_commas(args_raw) {
+        let trimmed = segment.trim();
+        if trimmed.is_empty() {
+            continue;
+        }
+        let Ok(caps) = args_re.captures(trimmed) else {
+            continue;
+        };
+        let Some(caps) = caps else { continue };
         let Some(key) = caps.get(1) else { continue };
 
         let value = if let Some(quoted) = caps.get(2) {
@@ -1857,8 +1806,7 @@ fn pythonic_arguments(args_raw: &str) -> String {
         } else if let Some(quoted) = caps.get(3) {
             serde_json::Value::String(unescape_pythonic_quoted_body(quoted.as_str(), '\''))
         } else if let Some(unquoted) = caps.get(4) {
-            let restored = unmask_bracketed_commas(unquoted.as_str());
-            coerce_pythonic_value(restored.trim())
+            coerce_pythonic_value(unquoted.as_str().trim())
         } else {
             continue;
         };
@@ -4018,6 +3966,18 @@ mod tests {
         let args: serde_json::Value =
             serde_json::from_str(&result.tool_calls[0].arguments).unwrap();
         assert_eq!(args, serde_json::json!({"note": "a, b", "n": 1}));
+    }
+
+    #[test]
+    fn pythonic_preserves_private_use_chars_in_values() {
+        let text = "[f(note='prefix \u{E000} suffix', tags=['x', '\u{E000}'])]";
+        let result = try_pythonic(text).unwrap();
+        let args: serde_json::Value =
+            serde_json::from_str(&result.tool_calls[0].arguments).unwrap();
+        assert_eq!(
+            args,
+            serde_json::json!({"note": "prefix \u{E000} suffix", "tags": ["x", "\u{E000}"]})
+        );
     }
 
     #[test]

--- a/src/server/tool_calls/parser.rs
+++ b/src/server/tool_calls/parser.rs
@@ -453,6 +453,25 @@ mod tests {
     }
 
     #[test]
+    fn parse_pythonic_single_quoted_literals() {
+        let output = "<|tool_call_start|>[get_weather(location='Warsaw', verbose=True, fallback=None)]<|tool_call_end|>";
+        let tools = vec![make_tool("get_weather")];
+        let result = parse_tool_calls(output, Some(&tools));
+        assert!(result.has_tool_calls());
+        assert_eq!(result.tool_calls[0].name, "get_weather");
+        let args: serde_json::Value =
+            serde_json::from_str(&result.tool_calls[0].arguments).unwrap();
+        assert_eq!(
+            args,
+            serde_json::json!({"location": "Warsaw", "verbose": true, "fallback": null})
+        );
+        assert_eq!(
+            result.format,
+            Some(crate::server::tool_calls::ToolCallFormat::Pythonic)
+        );
+    }
+
+    #[test]
     fn parse_gemma4_format() {
         let output = "<|tool_call>call:get_weather{location:<|\"|>Tokyo<|\"|>}<tool_call|>";
         let tools = vec![make_tool("get_weather")];

--- a/src/server/tool_calls/stream_filter.rs
+++ b/src/server/tool_calls/stream_filter.rs
@@ -2123,6 +2123,17 @@ mod tests {
     }
 
     #[test]
+    fn pythonic_single_quoted_tool_call_suppressed() {
+        let mut f = StreamFilter::new();
+        let out = f.feed(
+            "<|tool_call_start|>[get_weather(location='Warsaw', note='a, b')]<|tool_call_end|>",
+        );
+        assert_eq!(out.content, None);
+        let flushed = f.flush();
+        assert_eq!(flushed.content, None);
+    }
+
+    #[test]
     fn pythonic_content_before_call_emitted() {
         let mut f = StreamFilter::new();
         let out = f.feed(

--- a/src/server/tool_calls/stream_filter.rs
+++ b/src/server/tool_calls/stream_filter.rs
@@ -2134,6 +2134,34 @@ mod tests {
     }
 
     #[test]
+    fn pythonic_single_quoted_tool_call_suppressed_across_fragments() {
+        let mut f = StreamFilter::new();
+        let fragments = [
+            "<|tool_call_sta",
+            "rt|>[get_weather(",
+            "location='Warsaw', ",
+            "note='a, b')]<|tool_",
+            "call_end|>",
+            "Done.",
+        ];
+
+        let mut total_content = String::new();
+        for frag in fragments {
+            if let Some(content) = f.feed(frag).content {
+                total_content.push_str(&content);
+            }
+        }
+        if let Some(content) = f.flush().content {
+            total_content.push_str(&content);
+        }
+
+        assert_eq!(
+            total_content, "",
+            "pythonic tool calls are terminal and intentionally keep the filter in ToolCall state",
+        );
+    }
+
+    #[test]
     fn pythonic_content_before_call_emitted() {
         let mut f = StreamFilter::new();
         let out = f.feed(


### PR DESCRIPTION
## Summary
- Accept Python repr-style tool-call values by unwrapping both single- and double-quoted arguments, applying limited matching-quote and backslash unescaping, and coercing `True`, `False`, and `None` to their JSON equivalents.
- Split `key=value` arguments directly with a quote- and bracket-aware scanner so quoted commas and nested list values remain intact without using an in-band private-use sentinel that could corrupt model-emitted data.
- Add focused regressions across the format parser, top-level tool-call parser, and stream filter for Python literals, quoted commas, nested lists, escaped quotes and backslashes, private-use characters, marker-wrapped parity, and fragmented streaming.

## Validation
- `cargo test --profile test-fast pythonic_ --lib` (31 passed)
- `cargo test --workspace --profile test-fast --features metal,accelerate`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo fmt --all -- --check`
- `git diff --check`

## Real-model validation
- Blocked because no local LFM2 checkpoint was present under `models/`; parser-level marker-wrapped and streaming-equivalence regressions cover the affected protocol boundary instead of a live `/v1/chat/completions` tool-call round trip.

## Residual risks
- The parser intentionally returns only the first Pythonic call, supports only the limited string unescaping required by the protocol, and does not parse call-level `)]` inside quoted values because the outer call matcher remains unchanged.
- The stream filter recognizes marker-wrapped Pythonic calls; support for unmarked bare Pythonic calls remains outside this issue.

Closes #1306
