### PR TITLE
feat(modernbert): port the ModernBERT encoder for /v1/embeddings

### DIFF
--- a/TECHNICAL_REPORTS/1412-modernbert-encoder-embeddings-20260826.en.md
+++ b/TECHNICAL_REPORTS/1412-modernbert-encoder-embeddings-20260826.en.md
@@ -1,0 +1,189 @@
+# Technical Report: PR #1412 - ModernBERT Encoder for /v1/embeddings
+
+**Date**: 2026-08-26
+**Author**: mlxcel contributors
+**Status**: Completed
+**Languages**: Rust, Markdown
+**Risk Level**: Medium
+
+---
+
+## Executive Summary
+
+PR #1412 ports the ModernBERT encoder (alternating local/global attention, RoPE, GeGLU) so `nomic-ai/modernbert-embed-base` serves through `POST /v1/embeddings` and `mlxcel embed`, and adds the `ModernBertForSequenceClassification` head that `/v1/rerank` (#1356) consumes. It is the first family forward pass to land on the embedding foundation from #1353, so it also establishes the pattern the remaining family ports follow: family module under `src/models/`, one arm in the embedding loader dispatcher, real-checkpoint gates that soft-skip.
+
+---
+
+## 1. Problem Statement
+
+### 1.1 Background
+
+Since #1353, mlxcel detected ModernBERT checkpoints and routed them to `/v1/embeddings`, but no forward pass existed. Loading `nomic-ai/modernbert-embed-base` reported `ModernBERT encoder is detected as an embedding checkpoint, but this embedding family is not yet supported`. The detection table, the `ModelType::ModernBert` variant, the `mlxcel arch` entry, and the `ModelKind::Embedding` registration were all already in place; only the model was missing.
+
+### 1.2 What the Architecture Demands
+
+ModernBERT is not a BERT variant with different hyperparameters. Five properties have no precedent in the existing encoder code:
+
+- **Alternating attention.** Two out of every three layers use a bidirectional sliding window; the third sees the whole sequence. The layer index alone decides which.
+- **Two RoPE bases.** A local layer rotates with `local_rope_theta` (10000), a global layer with `global_rope_theta` (160000). The bases differ by 16x.
+- **No position table.** RoPE replaces absolute positions, so `max_position_embeddings` does not cap input length the way it does for BERT, XLM-RoBERTa, and SigLIP.
+- **Fused projections.** `Wqkv` is one `[3 * hidden, hidden]` tensor and `Wi` one `[2 * intermediate, hidden]` tensor.
+- **An absent norm in layer 0.** Upstream makes `layers.0.attn_norm` an `nn.Identity()`, so the checkpoint ships no such tensor.
+
+### 1.3 Risk Assessment
+
+| Risk | Impact | Likelihood before this change |
+|------|--------|-------------------------------|
+| Local/global parity or RoPE base applied wrongly, producing plausible but degraded embeddings | High | High, because no shape assertion catches it |
+| Fused projections split by slicing the weight, silently breaking quantized exports | High | Medium |
+| `layers.0.attn_norm` treated as a load error, rejecting every valid checkpoint | High | High |
+| Reranker head advertising a label count that disagrees with its own logits | Medium | Medium, and invisible until #1356 consumes it |
+
+---
+
+## 2. Technical Decisions
+
+### 2.1 Alternate the RoPE Base With the Mask, Not Just the Mask
+
+`ModernBertArgs::is_local_layer` and `ModernBertArgs::rope_base` are a single source of truth consulted at layer construction. A reader who only ported the mask would produce a model that loads, runs, returns finite unit-norm vectors, and retrieves measurably worse. `layer_parity_selects_local_and_global_rope_base` pins both facets together across nine layer indices, and also covers the `local_rope_theta: null` fallback to the global base, which upstream expresses as `if config.local_rope_theta is not None`.
+
+### 2.2 Split the Fused Projections After the Matmul, Never the Weight
+
+`Wqkv` and `Wi` load through `UnifiedLinear` and are split with `slice_axis` on the projection output. Slicing the weight tensor instead would have been simpler to read and would have worked on the dense f32 checkpoints available here, but a quantized export packs each fused tensor as one unit with its own scales and biases; slicing the packed plane produces garbage. This decision costs nothing on the dense path and is the only reason a future quantized ModernBERT loads unchanged.
+
+### 2.3 Two Epsilon Fields Instead of a serde Alias
+
+The issue specified `#[serde(alias = "layer_norm_eps")]` on `norm_eps`. Both published checkpoints carry **both** keys in the same `config.json`, and serde reports a duplicate-field error when an aliased field is supplied under two of its names, so the alias would have failed to parse every real checkpoint. `norm_eps` and `layer_norm_eps` are independent `Option<f32>` fields resolved by a `norm_eps()` accessor. `norm_eps_accepts_either_spelling_and_both_together` locks all four combinations so a future simplification back to an alias fails loudly.
+
+### 2.4 Derive `num_labels` From the Tensor, Not the Config
+
+The first implementation took `num_labels` from `config.json` (`num_labels`, else `len(id2label)`, else 1). A synthetic test exposed the consequence: a config that understates the label count leaves `num_labels()` disagreeing with the real width of `logits`. Since #1356 will size its output on that accessor, the disagreement would surface as a downstream shape bug far from its cause. `classifier.weight`'s row count is now authoritative. Row counts are never packed by quantization, so this is correct on both paths; the column count is checked against `hidden_size` on the dense path only, and a config/tensor mismatch is logged rather than silently accepted.
+
+### 2.5 Reach the Reranker Head by Directory, Not by Detection
+
+`is_embedding_checkpoint` deliberately returns `Ok(None)` for any `architectures[0]` ending in `ForSequenceClassification`: a reranker is not an embedder, and #1353's tests assert that `Alibaba-NLP/gte-reranker-modernbert-base` does not detect as an embedding variant. Rather than weaken that rule, `ModernBertSequenceClassifier::load` reads and validates `config.json` itself and is reached by directory. `/v1/rerank` wiring in #1356 can therefore adopt the head without touching detection.
+
+---
+
+## 3. Implementation Details
+
+### 3.1 Forward Pass
+
+```
+h = LayerNorm(tok_embeddings[input_ids])                    # embeddings.norm, no bias
+global_mask  = create_bidirectional_padding_mask(mask)      # [B, 1, 1, L]
+sliding_mask = create_bidirectional_window_mask(mask, local_attention / 2 + 1)   # [B, 1, L, L]
+for i in 0..num_hidden_layers:
+    local = i % global_attn_every_n_layers != 0
+    x = h if i == 0 else LayerNorm(h)                       # layers.0 has no attn_norm
+    q, k, v = split(Wqkv(x))                                # each [B, heads, L, head_dim]
+    q, k = fast_rope(.., head_dim, traditional=false, base = local ? local : global)
+    h = h + Wo(sdpa(q, k, v, head_dim^-0.5, local ? sliding_mask : global_mask))
+    inp, gate = chunk(Wi(LayerNorm(h)))
+    h = h + Wo_mlp(gelu(inp) * gate)
+last_hidden_state = LayerNorm(h)                            # final_norm
+```
+
+The window argument is `local_attention / 2 + 1` because `create_bidirectional_window_mask` blocks at `|q - k| >= window`, while ModernBERT attends `|q - k| <= local_attention / 2`. With the published `local_attention: 128` the bound is 65, verified directly against the additive mask in `sliding_mask_attends_within_64_and_blocks_beyond`.
+
+### 3.2 Weight Layout and Sanitize
+
+`sanitize_modernbert_weights` strips an optional leading `model.` (present in the MLM and classifier exports, absent in `ModernBertModel`), always drops `decoder.*` and `pooler.*`, and drops `head.*` / `classifier.*` unless the caller is building the classification head. `ModernBertForMaskedLM` therefore loads as a plain embedder with its MLM head discarded.
+
+The `Wqkv` block order is Q, K, V, each holding all heads, which follows from upstream's `qkv.view(bs, -1, 3, num_heads, head_dim)`: the 2304-wide axis splits into three 768-wide blocks before the head split. `Wi`'s halves are (input, gate) in that order, so the activation lands on the first half and the gate multiplies the second.
+
+---
+
+## 4. Test-Harness Correctness Findings
+
+Three findings during validation were about the tests rather than the model, and each would have shipped a misleading gate.
+
+### 4.1 MLX Driven From Several Threads at Once
+
+`EmbeddingModel` is documented in `src/embeddings/model.rs` as used from exactly one thread, and the server backs that with a dedicated MLX-owning worker per model. `cargo test` runs tests in parallel by default, so the suite was the one component violating that contract. Two distinct symptoms appeared on this CUDA host:
+
+- **Silently wrong numbers.** One parallel run in three scored two byte-identical rows of a single batch at cosine 0.99991 instead of 1.0, and moved a reranker logit by 0.05, while the first row of every batch stayed bit-identical at 3.0652723. Non-associative float reduction cannot make two identical rows of one batch disagree by 9e-5.
+- **An abort.** `cudaStreamEndCapture ... operation failed due to a previous error during capture`, SIGABRT, inside MLX's CUDA graph capture.
+
+A shared module lock now serializes every MLX-touching test in both modules. An initial fix guarded only the five real-checkpoint gates and missed the nine synthetic tests that also build encoders, which is exactly what the abort then hit; the final audit confirms all fourteen MLX-touching tests take the lock and the five that do not are pure config-parsing or filesystem tests.
+
+### 4.2 A Tolerance Fitted to an Artifact
+
+The padding-invariance gate first failed with a worst per-component drift of 1.2e-3, which was rationalized as f32 reduction-order noise and given a 5e-3 bound. That explanation was wrong: the drift was the cross-talk above. Once serialized, the measured drift is 1.3e-7, and the bound is 1e-4. A tolerance sized around an artifact is worse than no tolerance, because it silently widens the gate while looking rigorous.
+
+### 4.3 A Gate That Assumed Its Own Premise
+
+The long-document gate was named for 4096 tokens but only repeated a sentence 220 times without checking the result. The document is actually 4187 tokens. The test now asserts both that the input exceeds 4096 tokens and that it stays under `max_length` so no truncation occurs, meaning an edit to the sentence cannot silently reduce it to a short-sequence test that still passes.
+
+---
+
+## 5. Real-Checkpoint Results
+
+Gate values were byte-identical across 15 consecutive runs after serialization.
+
+| Gate | Observed | Requirement |
+|------|----------|-------------|
+| Identical inputs, cosine | 0.999999583 | within 1e-6 of 1.0 |
+| Query vs relevant document | 0.625270 | must beat the unrelated one by 0.15 |
+| Query vs unrelated document | 0.144859 | below 0.5 |
+| Padded batch vs single input | cosine 0.999999642, worst component 1.3e-7 | within 1e-3 |
+| Document of 4187 tokens, batched vs solo | cosine 0.999999821 | within 1e-3 |
+| Vector L2 norms | 1.000000004 / 1.000000025 | within 1e-5 of 1.0 |
+| gte-reranker logits (relevant, irrelevant) | 3.0652723, -1.1471016 | finite `[B, 1]` |
+
+End to end, `mlxcel embed` returns a cosine matrix of 1.0000 on the diagonal, 0.6253 query vs the t-SNE document, and 0.1448 query vs the Eiffel document at dim 768 and max_length 8192. `mlxcel-server` serves `GET /v1/models` as `modernbert-embed-base` and `POST /v1/embeddings` as two unit-norm 768-dim vectors at cosine 0.62521, with `dimensions: 256` returning 256 re-normalized components.
+
+---
+
+## 6. Validation Summary
+
+| Command | Result |
+|---------|--------|
+| `cargo test --profile test-fast --features cuda --lib models::modernbert` | 19 passed, 0 failed |
+| `cargo test --profile test-fast --features cuda --lib embeddings::` | 62 passed, 0 failed |
+| `cargo clippy --profile test-fast --features cuda --lib --bins --tests -- -D warnings` | exit 0 |
+| `cargo fmt --all -- --check` | exit 0 |
+| `cargo build --profile test-fast --features cuda --bins` | exit 0 |
+| `mlxcel embed` / `mlxcel-server` + `POST /v1/embeddings` | verified against the real checkpoint |
+| `mlxcel arch` / `mlxcel list` | ModernBERT encoder listed under Embedding; both checkpoints listed |
+
+Clippy caught five real issues, all mechanical: two `manual_is_multiple_of` (which also removes a latent divide-by-zero shape, since `is_multiple_of(0)` returns cleanly where `%` panics), one `neg_multiply`, and two `excessive_precision` constants in the erf reference that f32 cannot represent.
+
+---
+
+## 7. Change Summary
+
+| File | Change |
+|------|--------|
+| `src/models/modernbert.rs` | New. Config parsing and validation, weight sanitize, GeGLU split, layer and encoder. |
+| `src/models/modernbert_heads.rs` | New. `EmbeddingModel` implementation and the sequence-classification head. |
+| `src/models/modernbert_tests.rs` | New. 14 unit tests covering parity, masks, GeGLU, sanitize, config, detection, and the classifier. |
+| `src/models/modernbert_real_checkpoint_tests.rs` | New. 5 soft-skipping real-checkpoint gates. |
+| `src/embeddings/loader.rs` | Only the `ModelType::ModernBert` arm split out of the `not yet supported` match. |
+| `src/models/mod.rs` | Module and test-module registration. |
+| `docs/supported-models.md` | Embedding table row. |
+| `docs/embeddings.md` | ModernBERT family section and status update. |
+
+Total: 8 files, +1866 / -2.
+
+---
+
+## 8. Follow-up Actions and Unverified Areas
+
+These are recorded because a future maintainer should not assume them covered.
+
+- **No quantized ModernBERT checkpoint exists to test.** The split-after-projection design in 2.2 is what makes the quantized path work, but no quantized export was available, so that path is reasoned rather than exercised.
+- **No element-wise parity against transformers.** PyTorch and transformers are not installed on this host, so numeric agreement with the reference implementation was not checked directly. Validation rests on the issue's published acceptance thresholds (relative ordering, the 0.15 margin, unit norms, padding invariance) rather than tensor-level parity. A parity harness would be the strongest remaining gate.
+- **The MLM path is covered synthetically only.** `sanitize_modernbert_weights` drops `head.*` and `decoder.*` and has a synthetic test, but no real `ModernBertForMaskedLM` checkpoint was loaded.
+- **Length coverage stops at 4187 tokens**, not the full 8192 the checkpoint allows.
+- **Reranker ordering is one pair.** The head ranks a relevant document above an irrelevant one, but full ordering validation belongs to #1356.
+- **Pre-existing teardown race, outside this PR.** The combined `models::modernbert` filter sometimes aborts at process exit with `Destroy(handle_) failed: driver shutting down` after `test result: ok`, turning a passing run into exit 101. Observed twice in 17 post-fix runs, with 0 in the most recent 10 consecutive runs and 0 in 9 isolated single-module runs, and both occurrences coincided with sibling units loading the same GPU. This is a load-dependent MLX CUDA context-teardown race already recorded from unmodified main and reproduced on the untouched `embeddings::` suite. The test command was deliberately not reshaped to hide it.
+
+---
+
+## References
+
+- Issue #1332 (this port), epic #1348 (embedding families)
+- PR #1408 / issue #1353 (embedding foundation: pooling, masks, `ModelKind::Embedding`, `/v1/embeddings`)
+- Issue #1356 (`/v1/rerank`, consumes `ModernBertSequenceClassifier`)
+- `docs/embeddings.md`, `docs/supported-models.md`

--- a/TECHNICAL_REPORTS/1412-modernbert-encoder-embeddings-20260826.ko.md
+++ b/TECHNICAL_REPORTS/1412-modernbert-encoder-embeddings-20260826.ko.md
@@ -1,0 +1,189 @@
+# 기술 보고서: PR #1412 - /v1/embeddings용 ModernBERT 인코더
+
+**작성일**: 2026-08-26
+**작성자**: mlxcel 기여자
+**상태**: 완료
+**언어**: Rust, Markdown
+**위험도**: Medium
+
+---
+
+## 요약
+
+PR #1412는 ModernBERT 인코더(local/global 어텐션 교대, RoPE, GeGLU)를 이식해 `nomic-ai/modernbert-embed-base`가 `POST /v1/embeddings`와 `mlxcel embed`로 서빙되게 한다. 아울러 #1356의 `/v1/rerank`가 사용할 `ModernBertForSequenceClassification` 헤드를 추가한다. #1353이 만든 임베딩 기반 위에 올라가는 첫 번째 패밀리 forward pass이므로, 남은 패밀리 이식이 따를 패턴(`src/models/` 아래 패밀리 모듈, 로더 디스패처의 arm 하나, 체크포인트가 없으면 조용히 건너뛰는 실제 체크포인트 게이트)도 함께 정한다.
+
+---
+
+## 1. 문제 정의
+
+### 1.1 배경
+
+#1353 이후 mlxcel은 ModernBERT 체크포인트를 탐지해 `/v1/embeddings`로 라우팅했지만 forward pass가 없었다. `nomic-ai/modernbert-embed-base`를 로드하면 `ModernBERT encoder is detected as an embedding checkpoint, but this embedding family is not yet supported`가 나왔다. 탐지 테이블, `ModelType::ModernBert` variant, `mlxcel arch` 항목, `ModelKind::Embedding` 등록은 모두 이미 있었고 모델만 없었다.
+
+### 1.2 아키텍처가 요구하는 것
+
+ModernBERT는 하이퍼파라미터만 다른 BERT 변형이 아니다. 기존 인코더 코드에 전례가 없는 성질이 다섯 가지다.
+
+- **어텐션 교대.** 세 층 중 두 층은 양방향 sliding window를, 나머지 한 층은 전체 시퀀스를 본다. 층 인덱스만으로 결정된다.
+- **RoPE base가 둘.** local 층은 `local_rope_theta`(10000), global 층은 `global_rope_theta`(160000)로 회전한다. 16배 차이다.
+- **위치 테이블 없음.** RoPE가 절대 위치를 대체하므로 BERT, XLM-RoBERTa, SigLIP과 달리 `max_position_embeddings`가 입력 길이를 제한하지 않는다.
+- **융합 projection.** `Wqkv`는 `[3 * hidden, hidden]` 텐서 하나, `Wi`는 `[2 * intermediate, hidden]` 텐서 하나다.
+- **0번 층의 norm 부재.** 상위 구현이 `layers.0.attn_norm`을 `nn.Identity()`로 두므로 체크포인트에 해당 텐서가 아예 없다.
+
+### 1.3 위험성
+
+| 위험 | 영향 | 변경 전 발생 가능성 |
+|------|------|---------------------|
+| local/global 패리티나 RoPE base를 잘못 적용해 그럴듯하지만 품질이 떨어진 임베딩 생성 | High | High. shape assertion으로는 잡히지 않음 |
+| 융합 projection을 weight 슬라이싱으로 분리해 양자화 export가 조용히 깨짐 | High | Medium |
+| `layers.0.attn_norm` 부재를 로드 오류로 처리해 모든 정상 체크포인트를 거부 | High | High |
+| reranker 헤드가 자기 logits와 어긋나는 label 수를 광고 | Medium | Medium. #1356이 사용하기 전까지 드러나지 않음 |
+
+---
+
+## 2. 기술적 선택과 그 이유
+
+### 2.1 마스크만이 아니라 RoPE base도 함께 교대
+
+`ModernBertArgs::is_local_layer`와 `ModernBertArgs::rope_base`를 층 생성 시점에 참조하는 단일 진실 공급원으로 두었다. 마스크만 이식한 사람은 로드되고 실행되며 유한한 단위 노름 벡터를 반환하지만 검색 품질이 눈에 띄게 나쁜 모델을 만들게 된다. `layer_parity_selects_local_and_global_rope_base`가 아홉 개 층 인덱스에서 두 측면을 함께 고정하고, 상위 구현의 `if config.local_rope_theta is not None`에 해당하는 `local_rope_theta: null` 시 global base 폴백도 함께 검증한다.
+
+### 2.2 융합 projection은 matmul 이후에 분리하고 weight는 건드리지 않음
+
+`Wqkv`와 `Wi`는 `UnifiedLinear`로 로드하고 projection 출력에 `slice_axis`를 적용해 나눈다. weight 텐서를 직접 자르는 편이 읽기 쉽고 여기 있는 dense f32 체크포인트에서는 동작하지만, 양자화 export는 각 융합 텐서를 자체 scales/biases와 함께 하나의 단위로 패킹하므로 패킹된 평면을 자르면 쓰레기 값이 나온다. dense 경로에서 비용이 없고, 향후 양자화 ModernBERT가 수정 없이 로드되는 유일한 근거다.
+
+### 2.3 serde alias 대신 epsilon 필드 두 개
+
+이슈는 `norm_eps`에 `#[serde(alias = "layer_norm_eps")]`를 지정했다. 그러나 공개된 두 체크포인트 모두 같은 `config.json`에 **두 키를 동시에** 담고 있고, serde는 alias가 있는 필드가 두 이름으로 동시에 제공되면 duplicate-field 오류를 낸다. 즉 alias 방식은 모든 실제 체크포인트에서 파싱에 실패했을 것이다. `norm_eps`와 `layer_norm_eps`를 독립적인 `Option<f32>`로 두고 `norm_eps()` 접근자로 해석한다. `norm_eps_accepts_either_spelling_and_both_together`가 네 가지 조합을 모두 고정하므로 나중에 alias로 되돌리면 즉시 실패한다.
+
+### 2.4 `num_labels`를 config가 아닌 텐서에서 유도
+
+최초 구현은 `num_labels`를 `config.json`에서 읽었다(`num_labels`, 없으면 `len(id2label)`, 없으면 1). 합성 테스트가 그 결과를 드러냈다. label 수를 실제보다 적게 적은 config는 `num_labels()`가 `logits`의 실제 폭과 어긋나게 만든다. #1356이 그 접근자로 출력 크기를 잡을 것이므로, 불일치는 원인에서 멀리 떨어진 하위 shape 버그로 나타났을 것이다. 이제 `classifier.weight`의 행 수가 기준이다. 행 수는 양자화로 패킹되지 않으므로 두 경로 모두에서 옳고, 열 수는 dense 경로에서만 `hidden_size`와 대조하며 config와 텐서가 어긋나면 조용히 받아들이지 않고 경고를 남긴다.
+
+### 2.5 reranker 헤드는 탐지가 아니라 디렉터리로 접근
+
+`is_embedding_checkpoint`는 `architectures[0]`이 `ForSequenceClassification`으로 끝나면 의도적으로 `Ok(None)`을 반환한다. reranker는 embedder가 아니며, #1353의 테스트가 `Alibaba-NLP/gte-reranker-modernbert-base`는 임베딩 variant로 탐지되지 않음을 단언한다. 이 규칙을 약화하는 대신 `ModernBertSequenceClassifier::load`가 `config.json`을 직접 읽고 검증하며 디렉터리로 접근된다. 따라서 #1356의 `/v1/rerank` 배선은 탐지를 건드리지 않고 헤드를 채택할 수 있다.
+
+---
+
+## 3. 구현 세부
+
+### 3.1 Forward Pass
+
+```
+h = LayerNorm(tok_embeddings[input_ids])                    # embeddings.norm, bias 없음
+global_mask  = create_bidirectional_padding_mask(mask)      # [B, 1, 1, L]
+sliding_mask = create_bidirectional_window_mask(mask, local_attention / 2 + 1)   # [B, 1, L, L]
+for i in 0..num_hidden_layers:
+    local = i % global_attn_every_n_layers != 0
+    x = h if i == 0 else LayerNorm(h)                       # layers.0에는 attn_norm 없음
+    q, k, v = split(Wqkv(x))                                # 각각 [B, heads, L, head_dim]
+    q, k = fast_rope(.., head_dim, traditional=false, base = local ? local : global)
+    h = h + Wo(sdpa(q, k, v, head_dim^-0.5, local ? sliding_mask : global_mask))
+    inp, gate = chunk(Wi(LayerNorm(h)))
+    h = h + Wo_mlp(gelu(inp) * gate)
+last_hidden_state = LayerNorm(h)                            # final_norm
+```
+
+window 인자가 `local_attention / 2 + 1`인 이유는 `create_bidirectional_window_mask`가 `|q - k| >= window`에서 차단하는 반면 ModernBERT는 `|q - k| <= local_attention / 2`를 어텐션하기 때문이다. 공개된 `local_attention: 128`에서 경계는 65이며, `sliding_mask_attends_within_64_and_blocks_beyond`가 additive 마스크 값을 직접 읽어 검증한다.
+
+### 3.2 가중치 레이아웃과 sanitize
+
+`sanitize_modernbert_weights`는 선택적 선행 `model.`(MLM/classifier export에는 있고 `ModernBertModel`에는 없음)을 제거하고, `decoder.*`와 `pooler.*`는 항상 버리며, 분류 헤드를 만드는 경우가 아니면 `head.*`와 `classifier.*`도 버린다. 따라서 `ModernBertForMaskedLM`은 MLM 헤드를 버린 순수 embedder로 로드된다.
+
+`Wqkv` 블록 순서가 Q, K, V이고 각 블록이 모든 head를 담는다는 사실은 상위 구현의 `qkv.view(bs, -1, 3, num_heads, head_dim)`에서 따라온다. 2304 폭 축이 head 분할 이전에 768 폭 블록 세 개로 나뉜다. `Wi`의 절반은 (input, gate) 순서이므로 활성화는 앞쪽 절반에, gate 곱은 뒤쪽 절반에 적용된다.
+
+---
+
+## 4. 테스트 하네스 정확성 문제
+
+검증 중 발견한 세 가지는 모델이 아니라 테스트의 문제였고, 각각 그대로 두었다면 오해를 부르는 게이트가 머지될 뻔했다.
+
+### 4.1 여러 스레드에서 동시에 구동된 MLX
+
+`EmbeddingModel`은 `src/embeddings/model.rs`에서 정확히 한 스레드에서만 쓰인다고 문서화돼 있고, 서버는 모델당 전용 MLX 소유 워커로 그 계약을 뒷받침한다. `cargo test`는 기본적으로 테스트를 병렬 실행하므로, 계약을 어긴 유일한 구성 요소가 테스트 스위트였다. 이 CUDA 호스트에서 두 가지 증상이 나타났다.
+
+- **조용히 틀린 값.** 병렬 실행 세 번 중 한 번에서, 한 배치 안의 바이트 단위로 동일한 두 행이 cosine 1.0이 아닌 0.99991을 기록했고 reranker logit이 0.05 움직였다. 반면 모든 배치의 첫 행은 3.0652723으로 비트 단위 동일했다. 부동소수점 reduction 순서로는 한 배치 내 동일한 두 행이 9e-5만큼 어긋날 수 없다.
+- **abort.** MLX의 CUDA graph capture 안에서 `cudaStreamEndCapture ... operation failed due to a previous error during capture`, SIGABRT.
+
+이제 두 모듈의 MLX를 건드리는 모든 테스트가 공유 모듈 락을 잡는다. 최초 수정은 실제 체크포인트 게이트 다섯 개만 보호하고 인코더를 만드는 합성 테스트 아홉 개를 놓쳤는데, 이후 abort가 정확히 그 지점을 때렸다. 최종 감사 결과 MLX를 건드리는 14개 테스트가 모두 락을 잡고, 잡지 않는 5개는 순수 config 파싱 또는 파일시스템 테스트다.
+
+### 4.2 아티팩트에 맞춘 허용 오차
+
+padding 불변성 게이트는 처음에 성분별 최대 편차 1.2e-3으로 실패했고, 이를 f32 reduction 순서 잡음으로 해석해 5e-3 경계를 부여했다. 그 해석은 틀렸다. 편차의 원인은 위의 교차 간섭이었다. 직렬화 이후 측정값은 1.3e-7이고 경계는 1e-4다. 아티팩트에 맞춰 잡은 허용 오차는 없느니만 못하다. 엄밀해 보이면서 게이트를 조용히 넓히기 때문이다.
+
+### 4.3 자기 전제를 가정한 게이트
+
+긴 문서 게이트는 이름이 4096 토큰이었지만 실제로는 문장을 220번 반복할 뿐 결과를 확인하지 않았다. 실제 길이는 4187 토큰이다. 이제 테스트가 입력이 4096 토큰을 넘는다는 것과 `max_length` 아래에 있어 절단되지 않는다는 것을 함께 단언하므로, 문장을 수정해도 통과하면서 짧은 시퀀스 테스트로 조용히 축소되는 일이 없다.
+
+---
+
+## 5. 실제 체크포인트 결과
+
+직렬화 이후 15회 연속 실행에서 게이트 값이 바이트 단위로 동일했다.
+
+| 게이트 | 관측값 | 요구 조건 |
+|--------|--------|-----------|
+| 동일 입력 cosine | 0.999999583 | 1.0에서 1e-6 이내 |
+| 질의 vs 관련 문서 | 0.625270 | 무관 문서를 0.15 이상 앞서야 함 |
+| 질의 vs 무관 문서 | 0.144859 | 0.5 미만 |
+| 패딩 배치 vs 단일 입력 | cosine 0.999999642, 최대 성분 편차 1.3e-7 | 1e-3 이내 |
+| 4187 토큰 문서, 배치 vs 단독 | cosine 0.999999821 | 1e-3 이내 |
+| 벡터 L2 노름 | 1.000000004 / 1.000000025 | 1.0에서 1e-5 이내 |
+| gte-reranker logits (관련, 무관) | 3.0652723, -1.1471016 | 유한한 `[B, 1]` |
+
+종단 확인으로 `mlxcel embed`는 대각선 1.0000, 질의 vs t-SNE 문서 0.6253, 질의 vs 에펠탑 문서 0.1448의 cosine 행렬을 dim 768, max_length 8192로 반환한다. `mlxcel-server`는 `GET /v1/models`에서 `modernbert-embed-base`를, `POST /v1/embeddings`에서 cosine 0.62521인 단위 노름 768차원 벡터 두 개를 반환하며, `dimensions: 256`은 재정규화된 256개 성분을 돌려준다.
+
+---
+
+## 6. 검증
+
+| 명령 | 결과 |
+|------|------|
+| `cargo test --profile test-fast --features cuda --lib models::modernbert` | 19 passed, 0 failed |
+| `cargo test --profile test-fast --features cuda --lib embeddings::` | 62 passed, 0 failed |
+| `cargo clippy --profile test-fast --features cuda --lib --bins --tests -- -D warnings` | exit 0 |
+| `cargo fmt --all -- --check` | exit 0 |
+| `cargo build --profile test-fast --features cuda --bins` | exit 0 |
+| `mlxcel embed` / `mlxcel-server` + `POST /v1/embeddings` | 실제 체크포인트로 확인 |
+| `mlxcel arch` / `mlxcel list` | Embedding 아래 ModernBERT encoder 표시, 두 체크포인트 모두 표시 |
+
+clippy가 잡은 다섯 건은 모두 기계적 수정이었다. `manual_is_multiple_of` 두 건(`is_multiple_of(0)`은 패닉 없이 반환하므로 `%`가 가진 잠재적 0 나눗셈 형태도 함께 제거된다), `neg_multiply` 한 건, f32가 표현할 수 없는 erf 참조 상수의 `excessive_precision` 두 건이다.
+
+---
+
+## 7. 변경 요약
+
+| 파일 | 변경 |
+|------|------|
+| `src/models/modernbert.rs` | 신규. config 파싱과 검증, 가중치 sanitize, GeGLU 분리, layer와 encoder. |
+| `src/models/modernbert_heads.rs` | 신규. `EmbeddingModel` 구현과 sequence-classification 헤드. |
+| `src/models/modernbert_tests.rs` | 신규. 패리티, 마스크, GeGLU, sanitize, config, 탐지, classifier를 다루는 단위 테스트 14개. |
+| `src/models/modernbert_real_checkpoint_tests.rs` | 신규. 조용히 건너뛰는 실제 체크포인트 게이트 5개. |
+| `src/embeddings/loader.rs` | `not yet supported` match에서 `ModelType::ModernBert` arm만 분리. |
+| `src/models/mod.rs` | 모듈 및 테스트 모듈 등록. |
+| `docs/supported-models.md` | Embedding 표 행 추가. |
+| `docs/embeddings.md` | ModernBERT 패밀리 절과 상태 갱신. |
+
+합계: 8개 파일, +1866 / -2.
+
+---
+
+## 8. 후속 조치와 미검증 영역
+
+향후 유지보수자가 이미 다뤄졌다고 가정하지 않도록 기록한다.
+
+- **양자화 ModernBERT 체크포인트가 없어 테스트하지 못했다.** 2.2의 projection 이후 분리 설계가 양자화 경로를 성립시키지만, 양자화 export가 없어 실제로 실행하지는 못하고 논증에 머물렀다.
+- **transformers와의 성분 단위 대조가 없다.** 이 호스트에 PyTorch와 transformers가 설치돼 있지 않아 참조 구현과의 수치 일치를 직접 확인하지 못했다. 검증은 이슈가 제시한 수용 기준(상대 순위, 0.15 마진, 단위 노름, 패딩 불변성)에 근거하며 텐서 단위 parity는 아니다. parity 하네스가 남은 가장 강력한 게이트다.
+- **MLM 경로는 합성 테스트만 있다.** `sanitize_modernbert_weights`가 `head.*`와 `decoder.*`를 버리고 합성 테스트도 있지만, 실제 `ModernBertForMaskedLM` 체크포인트를 로드하지는 않았다.
+- **길이 커버리지는 4187 토큰까지**이며 체크포인트가 허용하는 8192 전체는 아니다.
+- **reranker 순서 검증은 한 쌍뿐이다.** 헤드가 관련 문서를 무관 문서보다 위에 두는 것은 확인했으나 전체 순서 검증은 #1356의 몫이다.
+- **기존부터 있던 teardown race, 이 PR 범위 밖.** 통합 `models::modernbert` 필터가 `test result: ok` 이후 프로세스 종료 시점에 `Destroy(handle_) failed: driver shutting down`으로 abort하며 통과한 실행을 exit 101로 만드는 경우가 있다. 수정 이후 17회 중 2회 관측됐고, 가장 최근 10회 연속 실행과 단일 모듈 9회 실행에서는 0회였으며, 두 번 모두 형제 유닛이 같은 GPU를 점유하던 시점과 겹쳤다. 수정되지 않은 main에서 이미 기록됐고 손대지 않은 `embeddings::` 스위트에서도 재현된, 부하 의존적인 MLX CUDA 컨텍스트 teardown race다. 이를 감추기 위해 테스트 명령을 변형하지는 않았다.
+
+---
+
+## 참고
+
+- 이슈 #1332(본 이식), 에픽 #1348(임베딩 패밀리)
+- PR #1408 / 이슈 #1353(임베딩 기반: pooling, 마스크, `ModelKind::Embedding`, `/v1/embeddings`)
+- 이슈 #1356(`/v1/rerank`, `ModernBertSequenceClassifier` 사용)
+- `docs/embeddings.md`, `docs/supported-models.md`

--- a/docs/embeddings.md
+++ b/docs/embeddings.md
@@ -189,6 +189,27 @@ mlxcel embed -m <path or repo-id> -p "text" [-p "text2" ...] [--image <file> ...
 
 Prints one vector per input (`[v1, v2, ...]`, one line each; a list of rows for multi-vector models) and, with two or more inputs, the cosine-similarity matrix (for multi-vector models the MaxSim score averaged over the query rows). `--json` prints one object with `embeddings`, `shapes`, `prompt_tokens` and `similarity` instead. This is the offline validation tool for every family: the same loader, pooling, normalization and batching as the server, without a listener.
 
+## Family notes
+
+### ModernBERT (`modernbert`)
+
+ModernBERT is an 8192-context bidirectional encoder with RoPE instead of an absolute position table, so `max_position_embeddings` does not cap the input length; `max_length` comes from `sentence_bert_config.json` and `tokenizer_config.json` and resolves to `8192` for both published checkpoints. Two out of every three layers use a sliding window of `local_attention / 2` keys on each side (64 with the published `local_attention: 128`) and rotate with `local_rope_theta` (10000); the remaining layers see the whole sequence and rotate with `global_rope_theta` (160000). Layer 0 legitimately ships no `attn_norm` (upstream makes it `nn.Identity()`); a missing `attn_norm` on any other layer is a load error. `Wqkv` and `Wi` are fused tensors and are split after the projection, never by slicing the weight, so a quantized export loads unchanged. `ModernBertModel` and `ModernBertForMaskedLM` both load as embedders, the MLM `head.*` / `decoder.*` tensors being dropped.
+
+`nomic-ai/modernbert-embed-base` is asymmetric and expects an explicit task prefix in the text: `search_query: ` before a query and `search_document: ` before a passage. The prefixes are part of the input string, not a server-side wrapper, so pass them yourself in `input` (or in `mlxcel embed -p`); omitting them costs retrieval quality. It also supports Matryoshka truncation, so `dimensions` down to 256 stays meaningful (the engine re-normalizes after truncating).
+
+```sh
+mlxcel embed -m nomic-ai/modernbert-embed-base \
+  -p "search_query: What is TSNE?" \
+  -p "search_document: t-SNE is a dimensionality reduction technique used for visualizing high-dimensional data." \
+  -p "search_document: The Eiffel Tower is a wrought-iron lattice tower in Paris."
+
+mlxcel-server -m nomic-ai/modernbert-embed-base --port 8080
+curl -s localhost:8080/v1/embeddings -H 'Content-Type: application/json' \
+  -d '{"input": ["search_query: What is TSNE?", "search_document: t-SNE is a dimensionality reduction technique used for visualizing high-dimensional data."]}'
+```
+
+`Alibaba-NLP/gte-reranker-modernbert-base` declares `ModernBertForSequenceClassification`, which detection deliberately refuses to route to any embedding variant (a reranker is not an embedder), so `-m` on that directory is a "not an embedding checkpoint" error today. Its head is implemented as `crate::models::modernbert_heads::ModernBertSequenceClassifier`, which loads by directory and returns `[B, num_labels]` logits from `classifier(norm(gelu(dense(pooled))))` with `classifier_pooling` (`cls` or `mean`) deciding the pooling; `/v1/rerank` wiring is #1356.
+
 ## Adding a family
 
 1. Add the family module under `src/models/` with an `EmbeddingModel` implementation. Read weights with `crate::embeddings::loader::load_embedding_weights` (module subfolders included, text bf16 rule applied) and resolve the pooling mode with `crate::embeddings::resolve_pooling_mode(model_dir, family_default)`. Build attention masks from `EmbeddingBatch::attention_mask` with the builders above. Return pooled `[B, D]` vectors (`[B, L, D]` with padding rows zeroed for multi-vector families); the engine normalizes and truncates.

--- a/docs/supported-models.md
+++ b/docs/supported-models.md
@@ -526,6 +526,7 @@ Embedding checkpoints are served through `POST /v1/embeddings` and the offline `
 
 | Family | `model_type` | `ModelType` | Pooling | Validation checkpoint | Status |
 |--------|--------------|-------------|---------|-----------------------|--------|
+| ModernBERT (alternating local/global attention, RoPE, GeGLU) | `modernbert` | `ModernBert` | `mean` (family default; `1_Pooling/config.json` wins) | [`nomic-ai/modernbert-embed-base`](https://huggingface.co/nomic-ai/modernbert-embed-base) | supported. `ModernBertModel` and `ModernBertForMaskedLM` load as embedders. nomic's checkpoint is asymmetric and needs the `search_query: ` / `search_document: ` prefixes in the input text; Matryoshka `dimensions` down to 256 is meaningful. `Alibaba-NLP/gte-reranker-modernbert-base` loads through the sequence-classification head, which `/v1/rerank` (#1356) consumes. |
 | SigLIP text tower | `siglip` | `SiglipText` | last position, fixed (no `1_Pooling`) | `google/siglip-base-patch16-224` | supported (text only) |
 
 SigLIP is the one family whose sequence width is fixed rather than derived: every input is truncated to 63 tokens plus the trailing `</s>` and right-padded to exactly the 64 learned positions, no attention mask is applied, and the vector is the projection `head` applied to the hidden state at position 63. The pad token and the EOS token are the same id (`</s>`, 1), which is what makes that slot meaningful for short inputs. Image embeddings through the SigLIP vision tower are not served yet.

--- a/src/embeddings/loader.rs
+++ b/src/embeddings/loader.rs
@@ -131,9 +131,11 @@ fn build_family_model(
 ) -> Result<Box<dyn EmbeddingModel>> {
     match model_type {
         ModelType::SiglipText => load_siglip_text_model(model_dir, config),
+        ModelType::ModernBert => Ok(Box::new(
+            crate::models::modernbert_heads::ModernBertEmbeddingModel::load(model_dir, config)?,
+        )),
         ModelType::Bert
         | ModelType::XlmRoberta
-        | ModelType::ModernBert
         | ModelType::Gemma3Embedding
         | ModelType::Qwen3Embedding
         | ModelType::Qwen3VLEmbedding

--- a/src/models/mod.rs
+++ b/src/models/mod.rs
@@ -120,6 +120,8 @@ pub mod ministral3;
 pub mod mistral4;
 pub mod mixtral;
 pub mod mllama;
+pub mod modernbert;
+pub mod modernbert_heads;
 pub mod molmo;
 pub mod molmo2;
 pub mod molmo_point;
@@ -1463,3 +1465,11 @@ mod granitemoehybrid_tests;
 #[cfg(test)]
 #[path = "minimax_tests.rs"]
 mod minimax_tests;
+
+#[cfg(test)]
+#[path = "modernbert_tests.rs"]
+mod modernbert_tests;
+
+#[cfg(test)]
+#[path = "modernbert_real_checkpoint_tests.rs"]
+mod modernbert_real_checkpoint_tests;

--- a/src/models/modernbert.rs
+++ b/src/models/modernbert.rs
@@ -1,0 +1,594 @@
+// Copyright 2025-2026 Lablup Inc. and Jeongkyu Shin
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! ModernBERT (`model_type: modernbert`) encoder, served through
+//! `/v1/embeddings` and `mlxcel embed`.
+//!
+//! ModernBERT is an 8192-context bidirectional encoder with pre-norm blocks,
+//! RoPE instead of an absolute position table, a fused `Wqkv` projection, a
+//! GeGLU MLP over a fused `Wi`, and an attention pattern that alternates two
+//! local (sliding-window) layers with one global layer. The two attention
+//! kinds differ in more than their mask: a local layer also rotates with
+//! `local_rope_theta` (10000) while a global layer rotates with
+//! `global_rope_theta` (160000), so getting the parity wrong is a silent
+//! quality regression that no shape assertion catches.
+//!
+//! # Layout notes that are easy to get wrong
+//!
+//! - **Layer 0 has no `attn_norm`.** Upstream makes it `nn.Identity()`, so the
+//!   checkpoint simply ships no `layers.0.attn_norm.weight`. Every other layer
+//!   must have one; a missing one there is a real error, not an identity.
+//! - **`Wqkv` is `[3 * hidden, hidden]` in Q, K, V order**, each block holding
+//!   all heads. Upstream reshapes to `[B, L, 3, heads, head_dim]`, which is
+//!   exactly `q = out[..., 0..D]`, `k = out[..., D..2D]`, `v = out[..., 2D..3D]`
+//!   followed by a per-block head split.
+//! - **`Wi` is `[2 * intermediate, hidden]` in (input, gate) order**: upstream
+//!   is `input, gate = Wi(x).chunk(2, -1)` then `Wo(act(input) * gate)`. The
+//!   activation lands on the *first* half.
+//! - Both fused projections load through [`UnifiedLinear`] and are split after
+//!   the matmul, never by slicing the weight, because a quantized export packs
+//!   each as one tensor.
+//! - `hidden_activation` is `gelu`, meaning the exact erf form
+//!   ([`mlxcel_core::gelu`]), not the tanh approximation.
+//!
+//! # Untrusted config
+//!
+//! `config.json` arrives from a third-party HuggingFace repo, so
+//! [`ModernBertArgs::validate`] rejects every scalar that could size an
+//! allocation, divide, or truncate through an `as i32` cast before it reaches
+//! an MLX entry point. An MLX C++ exception crossing the cxx bridge is an
+//! uncatchable `std::terminate`, not a Rust error.
+
+use mlxcel_core::layers::{LayerNorm, UnifiedEmbedding, UnifiedLinear};
+use mlxcel_core::utils::{
+    create_bidirectional_padding_mask, create_bidirectional_window_mask, slice_axis,
+};
+use mlxcel_core::weights::WeightMap;
+use mlxcel_core::{MlxArray, UniquePtr};
+use serde::Deserialize;
+use serde_json::Value;
+
+use crate::embeddings::loader::QuantizationParams;
+
+use super::gpt2::{layer_norm_from_weights, validate_embedding_table};
+
+/// `architectures[0]` of a ModernBERT reranker / classifier export.
+pub const MODERNBERT_SEQUENCE_CLASSIFICATION_ARCH: &str = "ModernBertForSequenceClassification";
+
+/// Largest `num_hidden_layers` accepted from an untrusted config.
+const MAX_HIDDEN_LAYERS: usize = 512;
+
+fn default_max_position_embeddings() -> usize {
+    8192
+}
+
+fn default_global_rope_theta() -> f32 {
+    160_000.0
+}
+
+fn default_global_attn_every_n_layers() -> usize {
+    3
+}
+
+fn default_local_attention() -> usize {
+    128
+}
+
+fn default_gelu() -> String {
+    "gelu".to_string()
+}
+
+fn default_classifier_pooling() -> String {
+    "cls".to_string()
+}
+
+/// ModernBERT `config.json`.
+///
+/// `norm_eps` and `layer_norm_eps` are two separate optional fields rather than
+/// one field with `#[serde(alias)]`: published checkpoints (both
+/// `nomic-ai/modernbert-embed-base` and `Alibaba-NLP/gte-reranker-modernbert-base`)
+/// carry **both** keys, and serde's `alias` reports a duplicate-field error when
+/// the input supplies the field under two of its names. [`Self::norm_eps`]
+/// resolves the pair.
+#[derive(Debug, Clone, Deserialize)]
+pub struct ModernBertArgs {
+    #[serde(default)]
+    pub architectures: Vec<String>,
+
+    pub vocab_size: usize,
+    pub hidden_size: usize,
+    pub num_hidden_layers: usize,
+    pub num_attention_heads: usize,
+    pub intermediate_size: usize,
+
+    #[serde(default = "default_max_position_embeddings")]
+    pub max_position_embeddings: usize,
+
+    /// Modern spelling of the LayerNorm epsilon.
+    #[serde(default)]
+    pub norm_eps: Option<f32>,
+    /// Legacy spelling; both are present in published checkpoints.
+    #[serde(default)]
+    pub layer_norm_eps: Option<f32>,
+    /// Every LayerNorm in the stack is bias-free in published checkpoints.
+    #[serde(default)]
+    pub norm_bias: bool,
+
+    #[serde(default = "default_global_rope_theta")]
+    pub global_rope_theta: f32,
+    /// `null` means "use `global_rope_theta` on local layers too".
+    #[serde(default)]
+    pub local_rope_theta: Option<f32>,
+
+    /// Layer `i` is global when `i % global_attn_every_n_layers == 0`.
+    #[serde(default = "default_global_attn_every_n_layers")]
+    pub global_attn_every_n_layers: usize,
+    /// Total sliding-window width; each side sees `local_attention / 2`.
+    #[serde(default = "default_local_attention")]
+    pub local_attention: usize,
+
+    #[serde(default)]
+    pub attention_bias: bool,
+    #[serde(default)]
+    pub mlp_bias: bool,
+
+    #[serde(default = "default_gelu")]
+    pub hidden_activation: String,
+
+    #[serde(default)]
+    pub pad_token_id: Option<i64>,
+
+    /// `cls` or `mean`; consulted only by the sequence-classification head.
+    #[serde(default = "default_classifier_pooling")]
+    pub classifier_pooling: String,
+    #[serde(default = "default_gelu")]
+    pub classifier_activation: String,
+    #[serde(default)]
+    pub classifier_bias: bool,
+    #[serde(default)]
+    pub num_labels: Option<usize>,
+    #[serde(default)]
+    pub id2label: Option<serde_json::Map<String, Value>>,
+}
+
+impl ModernBertArgs {
+    /// Parse and validate a sanitized `config.json` value.
+    pub fn from_config(config: &Value) -> Result<Self, String> {
+        let args: Self = serde_json::from_value(config.clone())
+            .map_err(|e| format!("failed to parse ModernBERT config.json: {e}"))?;
+        args.validate()?;
+        Ok(args)
+    }
+
+    /// Effective LayerNorm epsilon: `norm_eps`, then `layer_norm_eps`, then the
+    /// HuggingFace default.
+    pub fn norm_eps(&self) -> f32 {
+        self.norm_eps.or(self.layer_norm_eps).unwrap_or(1e-5)
+    }
+
+    /// `hidden_size / num_attention_heads`.
+    pub fn head_dim(&self) -> usize {
+        self.hidden_size / self.num_attention_heads
+    }
+
+    /// Layer `i` uses the sliding window instead of full bidirectional
+    /// attention. With `global_attn_every_n_layers = 3`, layers 0, 3, 6, ...
+    /// are global and the rest are local.
+    pub fn is_local_layer(&self, layer: usize) -> bool {
+        !layer.is_multiple_of(self.global_attn_every_n_layers)
+    }
+
+    /// RoPE base for layer `i`: `local_rope_theta` on a local layer when the
+    /// config sets it, `global_rope_theta` otherwise.
+    pub fn rope_base(&self, layer: usize) -> f32 {
+        if self.is_local_layer(layer) {
+            self.local_rope_theta.unwrap_or(self.global_rope_theta)
+        } else {
+            self.global_rope_theta
+        }
+    }
+
+    /// `window` argument for [`create_bidirectional_window_mask`], which blocks
+    /// at `|q - k| >= window`. ModernBERT attends `|q - k| <= local_attention / 2`,
+    /// so the window is one wider than the per-side reach.
+    pub fn local_window(&self) -> i32 {
+        (self.local_attention / 2 + 1) as i32
+    }
+
+    /// Head width of the classification head: `num_labels`, else the size of
+    /// `id2label`, else one.
+    pub fn num_labels(&self) -> usize {
+        self.num_labels
+            .or_else(|| self.id2label.as_ref().map(serde_json::Map::len))
+            .filter(|&n| n > 0)
+            .unwrap_or(1)
+    }
+
+    /// `true` when `architectures[0]` marks a sequence-classification export.
+    pub fn is_sequence_classifier(&self) -> bool {
+        self.architectures
+            .first()
+            .is_some_and(|arch| arch == MODERNBERT_SEQUENCE_CLASSIFICATION_ARCH)
+    }
+
+    /// Reject a config that would divide by zero, size an unbounded
+    /// allocation, or overflow an `as i32` cast inside MLX.
+    pub fn validate(&self) -> Result<(), String> {
+        let positive = |name: &str, value: usize| -> Result<(), String> {
+            if value == 0 || i32::try_from(value).is_err() {
+                return Err(format!(
+                    "ModernBERT config {name} must be in 1..={}, got {value}",
+                    i32::MAX
+                ));
+            }
+            Ok(())
+        };
+        positive("vocab_size", self.vocab_size)?;
+        positive("hidden_size", self.hidden_size)?;
+        positive("num_attention_heads", self.num_attention_heads)?;
+        positive("intermediate_size", self.intermediate_size)?;
+        positive("num_hidden_layers", self.num_hidden_layers)?;
+        positive(
+            "global_attn_every_n_layers",
+            self.global_attn_every_n_layers,
+        )?;
+        positive("max_position_embeddings", self.max_position_embeddings)?;
+
+        if self.num_hidden_layers > MAX_HIDDEN_LAYERS {
+            return Err(format!(
+                "ModernBERT config num_hidden_layers {} exceeds the {MAX_HIDDEN_LAYERS} layer cap",
+                self.num_hidden_layers
+            ));
+        }
+        if !self.hidden_size.is_multiple_of(self.num_attention_heads) {
+            return Err(format!(
+                "ModernBERT config hidden_size {} is not divisible by num_attention_heads {}",
+                self.hidden_size, self.num_attention_heads
+            ));
+        }
+        // `3 * hidden_size` and `2 * intermediate_size` are the fused
+        // projection widths that reach `reshape` as i32.
+        if i32::try_from(self.hidden_size.saturating_mul(3)).is_err()
+            || i32::try_from(self.intermediate_size.saturating_mul(2)).is_err()
+        {
+            return Err("ModernBERT config fused projection widths overflow i32".to_string());
+        }
+        if self.local_attention < 2 || i32::try_from(self.local_attention).is_err() {
+            return Err(format!(
+                "ModernBERT config local_attention must be >= 2, got {}",
+                self.local_attention
+            ));
+        }
+        for (name, theta) in [
+            ("global_rope_theta", Some(self.global_rope_theta)),
+            ("local_rope_theta", self.local_rope_theta),
+        ] {
+            if let Some(theta) = theta
+                && (!theta.is_finite() || theta <= 0.0)
+            {
+                return Err(format!(
+                    "ModernBERT config {name} must be finite and positive, got {theta}"
+                ));
+            }
+        }
+        let eps = self.norm_eps();
+        if !eps.is_finite() || eps <= 0.0 {
+            return Err(format!(
+                "ModernBERT config norm_eps must be finite and positive, got {eps}"
+            ));
+        }
+        if self.hidden_activation != "gelu" {
+            return Err(format!(
+                "ModernBERT hidden_activation `{}` is not supported; only `gelu` is",
+                self.hidden_activation
+            ));
+        }
+        if self.classifier_activation != "gelu" {
+            return Err(format!(
+                "ModernBERT classifier_activation `{}` is not supported; only `gelu` is",
+                self.classifier_activation
+            ));
+        }
+        if !matches!(self.classifier_pooling.as_str(), "cls" | "mean") {
+            return Err(format!(
+                "ModernBERT classifier_pooling `{}` is not supported; expected `cls` or `mean`",
+                self.classifier_pooling
+            ));
+        }
+        Ok(())
+    }
+}
+
+/// Strip the checkpoint's optional `model.` root and drop the tensors an
+/// encoder never runs.
+///
+/// `ModernBertModel` exports the backbone unprefixed; `ModernBertForMaskedLM`
+/// and `ModernBertForSequenceClassification` nest it under `model.` and add
+/// their own head at the top level. `decoder.*` (the MLM output projection) and
+/// `pooler.*` are always dropped; `head.*` and `classifier.*` survive only for
+/// the classification head (`keep_head`), so an MLM checkpoint loads as a plain
+/// embedder with its head discarded.
+pub fn sanitize_modernbert_weights(weights: WeightMap, keep_head: bool) -> WeightMap {
+    let mut out = WeightMap::with_capacity(weights.len());
+    for (key, value) in weights {
+        let key = key
+            .strip_prefix("model.")
+            .unwrap_or(key.as_str())
+            .to_string();
+        if key.starts_with("decoder.") || key.starts_with("pooler.") {
+            continue;
+        }
+        if !keep_head && (key.starts_with("head.") || key.starts_with("classifier.")) {
+            continue;
+        }
+        out.insert(key, value);
+    }
+    out
+}
+
+/// Per-forward shape constants shared by every block.
+#[derive(Debug, Clone, Copy)]
+struct Geometry {
+    hidden_size: i32,
+    num_heads: i32,
+    head_dim: i32,
+    intermediate_size: i32,
+    scale: f32,
+}
+
+/// Apply the GeGLU half-split of a fused `Wi` output.
+///
+/// `y` is `[.., 2 * intermediate]`; the first half is the activated input and
+/// the second half is the multiplicative gate, matching upstream's
+/// `input, gate = Wi(x).chunk(2, dim=-1)`.
+pub(crate) fn geglu(y: &MlxArray, intermediate: i32) -> UniquePtr<MlxArray> {
+    let input = slice_axis(y, -1, 0, intermediate);
+    let gate = slice_axis(y, -1, intermediate, 2 * intermediate);
+    mlxcel_core::multiply(&mlxcel_core::gelu(&input), &gate)
+}
+
+/// One pre-norm ModernBERT block.
+struct ModernBertLayer {
+    /// `None` for layer 0, where upstream uses `nn.Identity()`.
+    attn_norm: Option<LayerNorm>,
+    wqkv: UnifiedLinear,
+    wo: UnifiedLinear,
+    mlp_norm: LayerNorm,
+    wi: UnifiedLinear,
+    mlp_wo: UnifiedLinear,
+    /// Uses the sliding-window mask and `local_rope_theta`.
+    local: bool,
+    rope_base: f32,
+}
+
+impl ModernBertLayer {
+    fn from_weights(
+        weights: &WeightMap,
+        layer: usize,
+        args: &ModernBertArgs,
+        quant: Option<QuantizationParams>,
+    ) -> Result<Self, String> {
+        let prefix = format!("layers.{layer}");
+        let eps = args.norm_eps();
+        let (group_size, bits) = quant
+            .map(|q| (q.group_size, q.bits))
+            .unwrap_or((DEFAULT_GROUP_SIZE, DEFAULT_BITS));
+        let linear = |name: &str| -> Result<UnifiedLinear, String> {
+            UnifiedLinear::from_weights(weights, &format!("{prefix}.{name}"), group_size, bits)
+        };
+
+        // Layer 0 legitimately ships no attn_norm; any other layer missing one
+        // is a truncated or mismatched checkpoint, not an identity.
+        let attn_norm_prefix = format!("{prefix}.attn_norm");
+        let attn_norm = if weights.contains_key(&format!("{attn_norm_prefix}.weight")) {
+            Some(layer_norm_from_weights(
+                weights,
+                &attn_norm_prefix,
+                args.hidden_size,
+                eps,
+            )?)
+        } else if layer == 0 {
+            None
+        } else {
+            return Err(format!(
+                "Weight not found: {attn_norm_prefix}.weight (only layer 0 may omit attn_norm)"
+            ));
+        };
+
+        Ok(Self {
+            attn_norm,
+            wqkv: linear("attn.Wqkv")?,
+            wo: linear("attn.Wo")?,
+            mlp_norm: layer_norm_from_weights(
+                weights,
+                &format!("{prefix}.mlp_norm"),
+                args.hidden_size,
+                eps,
+            )?,
+            wi: linear("mlp.Wi")?,
+            mlp_wo: linear("mlp.Wo")?,
+            local: args.is_local_layer(layer),
+            rope_base: args.rope_base(layer),
+        })
+    }
+
+    /// Split one `[B, L, 3D]` fused projection block into `[B, heads, L, head_dim]`.
+    fn head_block(
+        qkv: &MlxArray,
+        index: i32,
+        b: i32,
+        l: i32,
+        geo: &Geometry,
+    ) -> UniquePtr<MlxArray> {
+        let block = slice_axis(
+            qkv,
+            -1,
+            index * geo.hidden_size,
+            (index + 1) * geo.hidden_size,
+        );
+        let block = mlxcel_core::reshape(&block, &[b, l, geo.num_heads, geo.head_dim]);
+        mlxcel_core::transpose_axes(&block, &[0, 2, 1, 3])
+    }
+
+    fn attention(&self, x: &MlxArray, mask: &MlxArray, geo: &Geometry) -> UniquePtr<MlxArray> {
+        let shape = mlxcel_core::array_shape(x);
+        let (b, l) = (shape[0], shape[1]);
+        let qkv = self.wqkv.forward(x);
+
+        let q = Self::head_block(&qkv, 0, b, l, geo);
+        let k = Self::head_block(&qkv, 1, b, l, geo);
+        let v = Self::head_block(&qkv, 2, b, l, geo);
+        // Full-head, non-traditional (split-half) RoPE over absolute positions
+        // 0..L; right padding keeps every real token at its own index.
+        let q = mlxcel_core::fast_rope(&q, geo.head_dim, false, self.rope_base, 1.0, 0);
+        let k = mlxcel_core::fast_rope(&k, geo.head_dim, false, self.rope_base, 1.0, 0);
+
+        let out = mlxcel_core::layers::attention(&q, &k, &v, geo.scale, Some(mask), 0.0, 0);
+        let out = mlxcel_core::transpose_axes(&out, &[0, 2, 1, 3]);
+        let out = mlxcel_core::reshape(&out, &[b, l, geo.hidden_size]);
+        self.wo.forward(&out)
+    }
+
+    fn forward(&self, h: &MlxArray, mask: &MlxArray, geo: &Geometry) -> UniquePtr<MlxArray> {
+        // Layer 0's `attn_norm` is the identity, so the pre-norm is skipped
+        // rather than materialized as a copy.
+        let normed = self.attn_norm.as_ref().map(|norm| norm.forward(h));
+        let normed: &MlxArray = normed.as_deref().unwrap_or(h);
+        let h = mlxcel_core::add(h, &self.attention(normed, mask, geo));
+
+        let projected = self.wi.forward(&self.mlp_norm.forward(&h));
+        let mlp = self
+            .mlp_wo
+            .forward(&geglu(&projected, geo.intermediate_size));
+        mlxcel_core::add(&h, &mlp)
+    }
+}
+
+/// Affine-quantization defaults used when `config.json` carries no
+/// `quantization` block; ignored on a dense checkpoint, where
+/// [`UnifiedLinear::from_weights`] takes the regular path.
+pub(crate) const DEFAULT_GROUP_SIZE: i32 = 64;
+pub(crate) const DEFAULT_BITS: i32 = 4;
+
+/// The ModernBERT encoder stack: embeddings, `num_hidden_layers` blocks, and
+/// the final LayerNorm.
+pub struct ModernBertEncoder {
+    tok_embeddings: UnifiedEmbedding,
+    embed_norm: LayerNorm,
+    layers: Vec<ModernBertLayer>,
+    final_norm: LayerNorm,
+    geometry: Geometry,
+    local_window: i32,
+    hidden_size: usize,
+    vocab_size: usize,
+}
+
+impl ModernBertEncoder {
+    /// Build the stack from an already-sanitized weight map.
+    pub fn from_weights(
+        weights: &WeightMap,
+        args: &ModernBertArgs,
+        quant: Option<QuantizationParams>,
+    ) -> Result<Self, String> {
+        let eps = args.norm_eps();
+        let (group_size, bits) = quant
+            .map(|q| (q.group_size, q.bits))
+            .unwrap_or((DEFAULT_GROUP_SIZE, DEFAULT_BITS));
+
+        let tok_embeddings =
+            UnifiedEmbedding::from_weights(weights, "embeddings.tok_embeddings", group_size, bits)?;
+        validate_embedding_table(
+            &tok_embeddings,
+            "embeddings.tok_embeddings",
+            args.vocab_size,
+            "vocab_size",
+            args.hidden_size,
+            "hidden_size",
+        )?;
+
+        let layers = (0..args.num_hidden_layers)
+            .map(|layer| ModernBertLayer::from_weights(weights, layer, args, quant))
+            .collect::<Result<Vec<_>, _>>()?;
+
+        let head_dim = args.head_dim();
+        Ok(Self {
+            tok_embeddings,
+            embed_norm: layer_norm_from_weights(weights, "embeddings.norm", args.hidden_size, eps)?,
+            layers,
+            final_norm: layer_norm_from_weights(weights, "final_norm", args.hidden_size, eps)?,
+            geometry: Geometry {
+                hidden_size: args.hidden_size as i32,
+                num_heads: args.num_attention_heads as i32,
+                head_dim: head_dim as i32,
+                intermediate_size: args.intermediate_size as i32,
+                scale: (head_dim as f32).powf(-0.5),
+            },
+            local_window: args.local_window(),
+            hidden_size: args.hidden_size,
+            vocab_size: args.vocab_size,
+        })
+    }
+
+    /// Width `D` of one hidden state.
+    pub fn hidden_size(&self) -> usize {
+        self.hidden_size
+    }
+
+    /// Vocabulary size the token ids are bounded by.
+    pub fn vocab_size(&self) -> usize {
+        self.vocab_size
+    }
+
+    /// Run the stack over one right-padded micro-batch.
+    ///
+    /// `input_ids` and `attention_mask` are both `[B, L]` int32; the result is
+    /// the `[B, L, D]` post-`final_norm` hidden state.
+    pub fn encode(
+        &self,
+        input_ids: &MlxArray,
+        attention_mask: &MlxArray,
+    ) -> Result<UniquePtr<MlxArray>, String> {
+        let ids_shape = mlxcel_core::array_shape(input_ids);
+        let mask_shape = mlxcel_core::array_shape(attention_mask);
+        if ids_shape.len() != 2 || ids_shape != mask_shape {
+            return Err(format!(
+                "ModernBERT expects [B, L] input_ids and a matching attention_mask, got \
+                 {ids_shape:?} and {mask_shape:?}"
+            ));
+        }
+
+        let mut hidden = self
+            .embed_norm
+            .forward(&self.tok_embeddings.forward(input_ids));
+        // Both masks are additive f32 `0 / -inf` and broadcast against
+        // `[B, heads, L, L]` scores: the global one is `[B, 1, 1, L]`, the
+        // sliding one `[B, 1, L, L]`.
+        let global_mask = create_bidirectional_padding_mask(attention_mask);
+        let sliding_mask = create_bidirectional_window_mask(attention_mask, self.local_window);
+        for layer in &self.layers {
+            let mask = if layer.local {
+                &sliding_mask
+            } else {
+                &global_mask
+            };
+            hidden = layer.forward(&hidden, mask, &self.geometry);
+        }
+        Ok(self.final_norm.forward(&hidden))
+    }
+
+    /// The sliding-window bound handed to [`create_bidirectional_window_mask`].
+    pub fn local_window_bound(&self) -> i32 {
+        self.local_window
+    }
+}

--- a/src/models/modernbert_heads.rs
+++ b/src/models/modernbert_heads.rs
@@ -1,0 +1,253 @@
+// Copyright 2025-2026 Lablup Inc. and Jeongkyu Shin
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! The two heads that sit on a [`ModernBertEncoder`]: the `/v1/embeddings`
+//! embedder and the `ModernBertForSequenceClassification` reranker head.
+//!
+//! - [`ModernBertEmbeddingModel`] pools the encoder's `[B, L, D]` hidden state
+//!   into `[B, D]`. The engine owns L2 normalization and `dimensions`
+//!   truncation, so this side only pools. The family default is `mean`, which
+//!   `1_Pooling/config.json` confirms for `nomic-ai/modernbert-embed-base`.
+//! - [`ModernBertSequenceClassifier`] applies upstream's
+//!   `classifier(norm(gelu(dense(pooled))))` and returns `[B, num_labels]`
+//!   logits. `/v1/rerank` wiring is #1356; this type is the loadable unit that
+//!   issue consumes, and it is reachable directly by directory because
+//!   `get_model_type` deliberately refuses to route a `ForSequenceClassification`
+//!   checkpoint to an embedding variant.
+
+use std::path::Path;
+
+use anyhow::{Result, anyhow, bail};
+use mlxcel_core::layers::{LayerNorm, UnifiedLinear};
+use mlxcel_core::weights::WeightMap;
+use mlxcel_core::{MlxArray, UniquePtr};
+use serde_json::Value;
+
+use crate::embeddings::loader::{
+    QuantizationParams, load_embedding_weights, quantization_params, read_embedding_config,
+};
+use crate::embeddings::model::{EmbeddingBatch, EmbeddingModel, EmbeddingOutput};
+use crate::embeddings::pooling::{PoolingMode, pool, resolve_pooling_mode};
+
+use super::gpt2::{dim_eq, layer_norm_from_weights};
+use super::modernbert::{
+    DEFAULT_BITS, DEFAULT_GROUP_SIZE, MODERNBERT_SEQUENCE_CLASSIFICATION_ARCH, ModernBertArgs,
+    ModernBertEncoder, sanitize_modernbert_weights,
+};
+
+/// Row count of `classifier.weight`, which is the real output width of
+/// [`ModernBertSequenceClassifier::logits`].
+///
+/// Quantization packs the input axis, never the output axis, so the row count
+/// is `num_labels` on both paths while the column count only equals
+/// `hidden_size` on the dense path. A `config.json` whose `num_labels` /
+/// `id2label` disagrees with the tensor is logged and overruled rather than
+/// silently trusted.
+fn classifier_rows(weights: &WeightMap, args: &ModernBertArgs) -> Result<usize, String> {
+    let weight = weights
+        .get("classifier.weight")
+        .ok_or_else(|| "Weight not found: classifier.weight".to_string())?;
+    let shape = mlxcel_core::array_shape(weight);
+    let [rows, cols] = shape.as_slice() else {
+        return Err(format!(
+            "classifier.weight must be a 2-D [num_labels, hidden_size] matrix, got shape {shape:?}"
+        ));
+    };
+    let rows = usize::try_from(*rows).unwrap_or(0);
+    if rows == 0 {
+        return Err("classifier.weight has no rows, so the head has no labels".to_string());
+    }
+    if !weights.contains_key("classifier.scales") && !dim_eq(*cols, args.hidden_size) {
+        return Err(format!(
+            "classifier.weight has shape {shape:?}, expected [num_labels, {}]",
+            args.hidden_size
+        ));
+    }
+    let declared = args.num_labels();
+    if declared != rows {
+        tracing::warn!(
+            target: "mlxcel::embeddings",
+            declared,
+            rows,
+            "ModernBERT config and classifier.weight disagree on the label count; using the tensor"
+        );
+    }
+    Ok(rows)
+}
+
+/// Load, sanitize and parse the pieces both heads need from a checkpoint
+/// directory. `keep_head` retains `head.*` / `classifier.*`.
+fn load_parts(
+    model_dir: &Path,
+    config: &Value,
+    keep_head: bool,
+) -> Result<(ModernBertArgs, WeightMap, Option<QuantizationParams>)> {
+    let args = ModernBertArgs::from_config(config).map_err(|e| anyhow!(e))?;
+    let weights = load_embedding_weights(model_dir, config)?;
+    let weights = sanitize_modernbert_weights(weights, keep_head);
+    Ok((args, weights, quantization_params(config)))
+}
+
+/// ModernBERT served through `/v1/embeddings` and `mlxcel embed`.
+pub struct ModernBertEmbeddingModel {
+    encoder: ModernBertEncoder,
+    pooling: PoolingMode,
+}
+
+impl ModernBertEmbeddingModel {
+    /// Load `ModernBertModel` (or `ModernBertForMaskedLM` with its MLM head
+    /// dropped) from a checkpoint directory.
+    pub fn load(model_dir: &Path, config: &Value) -> Result<Self> {
+        let (args, weights, quant) = load_parts(model_dir, config, false)?;
+        let encoder =
+            ModernBertEncoder::from_weights(&weights, &args, quant).map_err(|e| anyhow!(e))?;
+        let pooling = resolve_pooling_mode(model_dir, PoolingMode::Mean)?;
+        Ok(Self { encoder, pooling })
+    }
+
+    /// Borrow the encoder (the reranker head and the tests reuse it).
+    pub fn encoder(&self) -> &ModernBertEncoder {
+        &self.encoder
+    }
+}
+
+impl EmbeddingModel for ModernBertEmbeddingModel {
+    fn embed(&self, batch: &EmbeddingBatch) -> Result<EmbeddingOutput> {
+        if batch.images.is_some_and(|images| !images.is_empty()) {
+            bail!("ModernBERT is a text encoder and does not accept image inputs");
+        }
+        let hidden = self
+            .encoder
+            .encode(batch.input_ids, batch.attention_mask)
+            .map_err(|e| anyhow!(e))?;
+        let embeddings = pool(&hidden, batch.attention_mask, self.pooling);
+        Ok(EmbeddingOutput {
+            embeddings,
+            last_hidden_state: Some(hidden),
+        })
+    }
+
+    fn default_pooling(&self) -> PoolingMode {
+        PoolingMode::Mean
+    }
+
+    fn embedding_dim(&self) -> usize {
+        self.encoder.hidden_size()
+    }
+}
+
+/// `ModernBertForSequenceClassification`: the encoder plus upstream's
+/// prediction head and a `[num_labels, D]` classifier.
+pub struct ModernBertSequenceClassifier {
+    encoder: ModernBertEncoder,
+    head_dense: UnifiedLinear,
+    head_norm: LayerNorm,
+    classifier: UnifiedLinear,
+    pooling: PoolingMode,
+    num_labels: usize,
+}
+
+impl ModernBertSequenceClassifier {
+    /// Load a classifier checkpoint by directory.
+    ///
+    /// Detection routes `ForSequenceClassification` away from every embedding
+    /// variant on purpose (a reranker is not an embedder), so this constructor
+    /// reads and validates `config.json` itself rather than going through
+    /// `get_model_type`.
+    pub fn load(model_dir: &Path) -> Result<Self> {
+        let config = read_embedding_config(model_dir)?;
+        let (args, weights, quant) = load_parts(model_dir, &config, true)?;
+        if !args.is_sequence_classifier() {
+            bail!(
+                "{} declares architectures {:?}, not {MODERNBERT_SEQUENCE_CLASSIFICATION_ARCH}; \
+                 load it as an embedding model instead",
+                model_dir.display(),
+                args.architectures
+            );
+        }
+        Self::from_weights(&weights, &args, quant).map_err(|e| anyhow!(e))
+    }
+
+    /// Build the head from an already-sanitized weight map (`keep_head`).
+    pub fn from_weights(
+        weights: &WeightMap,
+        args: &ModernBertArgs,
+        quant: Option<QuantizationParams>,
+    ) -> Result<Self, String> {
+        let encoder = ModernBertEncoder::from_weights(weights, args, quant)?;
+        let (group_size, bits) = quant
+            .map(|q| (q.group_size, q.bits))
+            .unwrap_or((DEFAULT_GROUP_SIZE, DEFAULT_BITS));
+        let head_dense = UnifiedLinear::from_weights(weights, "head.dense", group_size, bits)?;
+        let head_norm =
+            layer_norm_from_weights(weights, "head.norm", args.hidden_size, args.norm_eps())?;
+        let classifier = UnifiedLinear::from_weights(weights, "classifier", group_size, bits)?;
+
+        // `num_labels` decides the advertised output width, so it must come
+        // from the tensor that actually produces it rather than from
+        // `config.json`. A config that disagrees would leave `num_labels()`
+        // lying about the `logits` shape. Row counts are never packed by
+        // quantization; the column count is, so it is only checked on the
+        // dense path.
+        let num_labels = classifier_rows(weights, args)?;
+        let pooling = match args.classifier_pooling.as_str() {
+            "cls" => PoolingMode::Cls,
+            // `validate` already rejects anything else.
+            _ => PoolingMode::Mean,
+        };
+        Ok(Self {
+            encoder,
+            head_dense,
+            head_norm,
+            classifier,
+            pooling,
+            num_labels,
+        })
+    }
+
+    /// Head width, i.e. the second axis of [`Self::logits`].
+    pub fn num_labels(&self) -> usize {
+        self.num_labels
+    }
+
+    /// Pooling the head applies before the dense projection.
+    pub fn classifier_pooling(&self) -> PoolingMode {
+        self.pooling
+    }
+
+    /// Borrow the encoder.
+    pub fn encoder(&self) -> &ModernBertEncoder {
+        &self.encoder
+    }
+
+    /// `[B, num_labels]` logits for one right-padded micro-batch.
+    ///
+    /// `input_ids` and `attention_mask` are `[B, L]` int32. Mean pooling is
+    /// mask-weighted, so padding columns never enter the score.
+    pub fn logits(
+        &self,
+        input_ids: &MlxArray,
+        attention_mask: &MlxArray,
+    ) -> Result<UniquePtr<MlxArray>> {
+        let hidden = self
+            .encoder
+            .encode(input_ids, attention_mask)
+            .map_err(|e| anyhow!(e))?;
+        let pooled = pool(&hidden, attention_mask, self.pooling);
+        let head = self
+            .head_norm
+            .forward(&mlxcel_core::gelu(&self.head_dense.forward(&pooled)));
+        Ok(self.classifier.forward(&head))
+    }
+}

--- a/src/models/modernbert_real_checkpoint_tests.rs
+++ b/src/models/modernbert_real_checkpoint_tests.rs
@@ -1,0 +1,298 @@
+// Copyright 2025-2026 Lablup Inc. and Jeongkyu Shin
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Real-checkpoint gates for the ModernBERT port.
+//!
+//! Each test soft-skips when its checkpoint is absent, the same convention
+//! `src/embeddings/real_checkpoint_tests.rs` and `tests/*_parity.rs` follow.
+//! Fetch with:
+//!
+//! ```sh
+//! mlxcel download nomic-ai/modernbert-embed-base
+//! mlxcel download Alibaba-NLP/gte-reranker-modernbert-base
+//! ```
+
+use std::path::{Path, PathBuf};
+
+use mlxcel_core::utils::array_to_vec_f32;
+
+use crate::embeddings::limits::resolve_pad_token_id;
+use crate::embeddings::tokenize::{EncodeOptions, encode_pairs, strip_padding_and_truncation};
+use crate::embeddings::{
+    DEFAULT_EMBEDDING_BATCH_SIZE, EmbedOptions, EmbeddingEngine, load_embedding_model,
+};
+use crate::models::modernbert_heads::ModernBertSequenceClassifier;
+use crate::models::modernbert_tests::mlx_guard;
+use crate::models::{ModelType, get_model_type};
+use crate::tokenizer::load_tokenizer;
+
+const EMBED: &str = "nomic-ai/modernbert-embed-base";
+const RERANKER: &str = "Alibaba-NLP/gte-reranker-modernbert-base";
+
+/// nomic's asymmetric prompt prefixes; both must be present verbatim.
+const QUERY_PREFIX: &str = "search_query: ";
+const DOCUMENT_PREFIX: &str = "search_document: ";
+
+/// Locate a downloaded checkpoint: the mlxcel store, then the HuggingFace
+/// cache, then `<repo>/models/<name>`. `None` skips the test.
+fn local_checkpoint(repo_id: &str) -> Option<PathBuf> {
+    let candidates = [
+        crate::downloader::model_dir(repo_id),
+        crate::downloader::hf_cache_snapshot(repo_id, None),
+        Some(
+            PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+                .join("models")
+                .join(crate::downloader::repo_basename(repo_id)),
+        ),
+    ];
+    let found = candidates
+        .into_iter()
+        .flatten()
+        .find(|dir| dir.join("config.json").is_file());
+    if found.is_none() {
+        eprintln!(
+            "skipping real-checkpoint gate: {repo_id} not present (mlxcel download {repo_id})"
+        );
+    }
+    found
+}
+
+/// Cosine similarity of two vectors the engine already L2-normalized, which
+/// reduces to the dot product. Every caller asserts unit norm first.
+fn cosine(a: &[f32], b: &[f32]) -> f32 {
+    a.iter().zip(b).map(|(x, y)| x * y).sum::<f32>()
+}
+
+fn l2_norm(v: &[f32]) -> f32 {
+    v.iter().map(|x| x * x).sum::<f32>().sqrt()
+}
+
+fn engine(dir: &Path) -> EmbeddingEngine {
+    let loaded = load_embedding_model(dir).expect("ModernBERT checkpoint loads");
+    assert_eq!(loaded.model_type, ModelType::ModernBert);
+    EmbeddingEngine::new(loaded, DEFAULT_EMBEDDING_BATCH_SIZE)
+}
+
+fn embed_all(engine: &EmbeddingEngine, texts: &[&str]) -> Vec<Vec<f32>> {
+    let owned: Vec<String> = texts.iter().map(|t| (*t).to_string()).collect();
+    engine
+        .embed_texts(&owned, &EmbedOptions::default())
+        .expect("forward pass succeeds")
+        .vectors
+        .into_iter()
+        .map(|v| v.values)
+        .collect()
+}
+
+#[test]
+fn modernbert_embed_base_detects_and_reports_its_limits() {
+    let Some(dir) = local_checkpoint(EMBED) else {
+        return;
+    };
+    let _mlx = mlx_guard();
+    assert_eq!(get_model_type(&dir).unwrap(), ModelType::ModernBert);
+    let engine = engine(&dir);
+    assert_eq!(engine.dim(), 768);
+    // sentence_bert_config max_seq_length 8192, tokenizer model_max_length
+    // 8192 and the hard cap all agree; RoPE means no positional table caps it.
+    assert_eq!(engine.max_length(), 8192);
+    assert_eq!(engine.vocab_size(), 50368);
+    assert!(!engine.multi_vector());
+    assert!(!engine.supports_images());
+}
+
+#[test]
+fn modernbert_embed_base_passes_the_self_consistency_gate() {
+    let Some(dir) = local_checkpoint(EMBED) else {
+        return;
+    };
+    let _mlx = mlx_guard();
+    let engine = engine(&dir);
+    let query = format!("{QUERY_PREFIX}What is TSNE?");
+    let tsne = format!(
+        "{DOCUMENT_PREFIX}t-SNE is a dimensionality reduction technique used for visualizing \
+         high-dimensional data."
+    );
+    let eiffel =
+        format!("{DOCUMENT_PREFIX}The Eiffel Tower is a wrought-iron lattice tower in Paris.");
+    let vectors = embed_all(&engine, &[&query, &tsne, &eiffel, &query]);
+
+    for (index, v) in vectors.iter().enumerate() {
+        assert_eq!(v.len(), 768, "vector {index} width");
+        assert!(v.iter().all(|x| x.is_finite()), "vector {index} is finite");
+        assert!(
+            (l2_norm(v) - 1.0).abs() <= 1e-5,
+            "vector {index} is not unit norm: {}",
+            l2_norm(v)
+        );
+    }
+
+    // Identical inputs must land on exactly the same vector.
+    let self_cosine = cosine(&vectors[0], &vectors[3]);
+    eprintln!(
+        "self-consistency: identical {self_cosine:.9}, relevant {:.6}, irrelevant {:.6}",
+        cosine(&vectors[0], &vectors[1]),
+        cosine(&vectors[0], &vectors[2])
+    );
+    assert!(
+        (self_cosine - 1.0).abs() <= 1e-6,
+        "identical texts scored {self_cosine}, expected 1.0 within 1e-6"
+    );
+
+    // The relevant document must win, and by a clear margin.
+    let relevant = cosine(&vectors[0], &vectors[1]);
+    let irrelevant = cosine(&vectors[0], &vectors[2]);
+    assert!(
+        relevant - irrelevant >= 0.15,
+        "cosine(query, t-SNE) {relevant} must beat cosine(query, Eiffel) {irrelevant} by 0.15"
+    );
+    assert!(
+        irrelevant < 0.5,
+        "unrelated sentences scored {irrelevant}, expected below 0.5"
+    );
+}
+
+#[test]
+fn modernbert_embed_base_is_padding_invariant_across_batches() {
+    let Some(dir) = local_checkpoint(EMBED) else {
+        return;
+    };
+    let _mlx = mlx_guard();
+    let engine = engine(&dir);
+    let short = format!("{QUERY_PREFIX}What is TSNE?");
+    let long = format!(
+        "{DOCUMENT_PREFIX}t-SNE is a dimensionality reduction technique used for visualizing \
+         high-dimensional data, and it is frequently contrasted with UMAP and with classical \
+         principal component analysis in the visualization literature."
+    );
+
+    let solo = embed_all(&engine, &[&short]).remove(0);
+    // The same text as the shorter member of a padded batch.
+    let batched = embed_all(&engine, &[&long, &short]).remove(1);
+    let drift = cosine(&solo, &batched);
+    let worst = solo
+        .iter()
+        .zip(&batched)
+        .map(|(a, b)| (a - b).abs())
+        .fold(0.0_f32, f32::max);
+    eprintln!("padding invariance: cosine {drift:.9}, worst component drift {worst:.9}");
+    assert!(
+        (drift - 1.0).abs() <= 1e-3,
+        "padded batch drifted from the single-input result: cosine {drift}"
+    );
+    // Padding cannot change the math: padding keys are blocked in both the
+    // global and the sliding-window mask, RoPE positions are unchanged, and
+    // LayerNorm and the MLP are per-position. All that is left is f32
+    // reduction-order noise from running the same rows at a different batch
+    // shape through 22 layers, measured at 1.3e-7 across repeated runs, so a
+    // bound three orders above that still catches any masking or RoPE bug.
+    assert!(
+        worst <= 1e-4,
+        "worst per-component drift {worst} exceeds the numerical-noise bound"
+    );
+}
+
+#[test]
+fn modernbert_embed_base_handles_a_4096_token_document() {
+    let Some(dir) = local_checkpoint(EMBED) else {
+        return;
+    };
+    let _mlx = mlx_guard();
+    let engine = engine(&dir);
+    // Well past the 128-token local window, so the alternating local layers
+    // are exercised over many windows rather than one.
+    let sentence = "t-SNE embeds high-dimensional points into two dimensions while preserving \
+                    local neighbourhood structure. ";
+    let long = format!("{DOCUMENT_PREFIX}{}", sentence.repeat(220));
+    let short = format!("{QUERY_PREFIX}What is TSNE?");
+
+    let solo = embed_all(&engine, &[&long]).remove(0);
+    assert!(solo.iter().all(|x| x.is_finite()));
+    assert!((l2_norm(&solo) - 1.0).abs() <= 1e-5);
+
+    let batched = embed_all(&engine, &[&long, &short]).remove(0);
+    let drift = cosine(&solo, &batched);
+    eprintln!("4096-token document: batched-vs-solo cosine {drift:.9}");
+    assert!(
+        (drift - 1.0).abs() <= 1e-3,
+        "a 4096-token document drifted inside a batch: cosine {drift}"
+    );
+}
+
+#[test]
+fn gte_reranker_modernbert_produces_finite_logits() {
+    let Some(dir) = local_checkpoint(RERANKER) else {
+        return;
+    };
+    let _mlx = mlx_guard();
+    // Detection must keep refusing to serve a reranker as an embedder; the
+    // head is reached by directory instead (#1356 wires /v1/rerank).
+    let err = get_model_type(&dir).expect_err("a reranker is not an embedding checkpoint");
+    assert!(err.to_string().contains("Unsupported model type"), "{err}");
+
+    let classifier = ModernBertSequenceClassifier::load(&dir).expect("the classifier head loads");
+    assert_eq!(classifier.num_labels(), 1, "id2label declares one label");
+    assert_eq!(classifier.encoder().hidden_size(), 768);
+
+    let tokenizer = strip_padding_and_truncation(load_tokenizer(&dir).unwrap());
+    let pad_id = resolve_pad_token_id(&dir, &tokenizer);
+    assert_eq!(pad_id, 50283, "[PAD] is id 50283 in the ModernBERT vocab");
+    // The `[CLS] query [SEP] document [SEP]` template the /v1/rerank path
+    // (#1356) will use.
+    let pairs: &[(&str, &str)] = &[
+        (
+            "what is the capital of France?",
+            "Paris is the capital and most populous city of France.",
+        ),
+        (
+            "what is the capital of France?",
+            "A tomato is a fruit that is commonly prepared as a vegetable.",
+        ),
+    ];
+    let batch = encode_pairs(
+        &tokenizer,
+        pairs,
+        EncodeOptions {
+            add_special_tokens: true,
+            max_length: 512,
+            with_token_type_ids: false,
+        },
+        pad_id,
+        None,
+    )
+    .expect("pair tokenization succeeds");
+    assert_eq!(batch.batch, 2);
+
+    let ids = batch.input_ids_array();
+    let mask = batch.attention_mask_array();
+    let logits = classifier.logits(&ids, &mask).expect("head runs");
+    assert_eq!(mlxcel_core::array_shape(&logits), vec![2, 1]);
+    let values = array_to_vec_f32(&logits);
+    eprintln!(
+        "gte-reranker logits: relevant {}, irrelevant {}",
+        values[0], values[1]
+    );
+    assert!(
+        values.iter().all(|v| v.is_finite()),
+        "reranker logits must be finite, got {values:?}"
+    );
+    // Ordering is #1356's acceptance gate, but a head wired to the wrong
+    // tensors would not rank the relevant document first either.
+    assert!(
+        values[0] > values[1],
+        "the relevant document scored {} and the irrelevant one {}",
+        values[0],
+        values[1]
+    );
+}

--- a/src/models/modernbert_real_checkpoint_tests.rs
+++ b/src/models/modernbert_real_checkpoint_tests.rs
@@ -204,29 +204,50 @@ fn modernbert_embed_base_is_padding_invariant_across_batches() {
 }
 
 #[test]
-fn modernbert_embed_base_handles_a_4096_token_document() {
+fn modernbert_embed_base_handles_a_document_beyond_4096_tokens() {
     let Some(dir) = local_checkpoint(EMBED) else {
         return;
     };
     let _mlx = mlx_guard();
     let engine = engine(&dir);
     // Well past the 128-token local window, so the alternating local layers
-    // are exercised over many windows rather than one.
+    // are exercised over dozens of windows rather than one.
     let sentence = "t-SNE embeds high-dimensional points into two dimensions while preserving \
                     local neighbourhood structure. ";
     let long = format!("{DOCUMENT_PREFIX}{}", sentence.repeat(220));
     let short = format!("{QUERY_PREFIX}What is TSNE?");
 
-    let solo = embed_all(&engine, &[&long]).remove(0);
+    // Assert the premise rather than assuming it: editing the sentence above
+    // must not silently shrink this into a short-sequence test that still
+    // passes while no longer covering long inputs.
+    let reply = engine
+        .embed_texts(std::slice::from_ref(&long), &EmbedOptions::default())
+        .expect("the long document embeds");
+    assert!(
+        reply.prompt_tokens > 4096,
+        "this gate must exceed 4096 tokens, got {}",
+        reply.prompt_tokens
+    );
+    assert!(
+        reply.prompt_tokens <= engine.max_length(),
+        "the document must fit under max_length {} without truncation, got {}",
+        engine.max_length(),
+        reply.prompt_tokens
+    );
+    let solo = reply.vectors[0].values.clone();
     assert!(solo.iter().all(|x| x.is_finite()));
     assert!((l2_norm(&solo) - 1.0).abs() <= 1e-5);
 
     let batched = embed_all(&engine, &[&long, &short]).remove(0);
     let drift = cosine(&solo, &batched);
-    eprintln!("4096-token document: batched-vs-solo cosine {drift:.9}");
+    eprintln!(
+        "long document ({} tokens): batched-vs-solo cosine {drift:.9}",
+        reply.prompt_tokens
+    );
     assert!(
         (drift - 1.0).abs() <= 1e-3,
-        "a 4096-token document drifted inside a batch: cosine {drift}"
+        "a {}-token document drifted inside a batch: cosine {drift}",
+        reply.prompt_tokens
     );
 }
 

--- a/src/models/modernbert_tests.rs
+++ b/src/models/modernbert_tests.rs
@@ -1,0 +1,685 @@
+// Copyright 2025-2026 Lablup Inc. and Jeongkyu Shin
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Unit tests for the ModernBERT port: config parsing, layer parity, the
+//! sliding-window mask, the first-layer `attn_norm` exception, the GeGLU
+//! half-split, padding invariance and the classifier head.
+//!
+//! Every forward-pass test runs a deliberately tiny encoder built from
+//! deterministic synthetic weights, so it needs no checkpoint. The
+//! real-checkpoint gates live in `modernbert_real_checkpoint_tests.rs`.
+
+use std::sync::{Mutex, MutexGuard, OnceLock};
+
+use mlxcel_core::utils::{array_to_vec_f32, create_bidirectional_window_mask};
+use mlxcel_core::weights::WeightMap;
+use mlxcel_core::{MlxArray, UniquePtr};
+use serde_json::{Value, json};
+
+use crate::embeddings::pooling::{PoolingMode, pool};
+use crate::models::modernbert::{
+    ModernBertArgs, ModernBertEncoder, geglu, sanitize_modernbert_weights,
+};
+use crate::models::modernbert_heads::ModernBertSequenceClassifier;
+use crate::models::{ModelType, get_model_type};
+
+/// Serializes every test that touches MLX, in this module and in
+/// [`super::modernbert_real_checkpoint_tests`], onto one thread at a time.
+///
+/// [`crate::embeddings::model::EmbeddingModel`] is documented as living on
+/// exactly one thread, and the server backs that with a dedicated MLX-owning
+/// worker per model. `cargo test` runs these in parallel by default, which
+/// breaks that contract in two observed ways on this CUDA host: silently wrong
+/// numbers (one parallel run in three scored two byte-identical rows of a single
+/// batch at cosine 0.99991 instead of 1.0 and moved a reranker logit by 0.05),
+/// and an outright abort inside MLX's CUDA graph capture
+/// (`cudaStreamEndCapture ... previous error during capture`, SIGABRT).
+/// Serializing makes the suite obey the same contract the product does.
+///
+/// Tests that only parse config or touch the filesystem do not need the guard;
+/// every test that builds an encoder, a classifier, or any `MlxArray` does.
+///
+/// A poisoned lock is recovered rather than propagated so one failing test does
+/// not cascade into false failures in the rest.
+pub(super) fn mlx_guard() -> MutexGuard<'static, ()> {
+    static LOCK: OnceLock<Mutex<()>> = OnceLock::new();
+    LOCK.get_or_init(|| Mutex::new(()))
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner())
+}
+
+// Synthetic checkpoint.
+
+const HIDDEN: usize = 8;
+const HEADS: usize = 2;
+const INTERMEDIATE: usize = 6;
+const LAYERS: usize = 4;
+const VOCAB: usize = 20;
+const LABELS: usize = 2;
+
+/// Deterministic pseudo-random values in `[-0.5, 0.5)` from a fixed seed, so
+/// every run of the suite sees byte-identical weights.
+fn pseudo_random(seed: u64, count: usize) -> Vec<f32> {
+    let mut state = seed.wrapping_mul(6_364_136_223_846_793_005).wrapping_add(1);
+    (0..count)
+        .map(|_| {
+            state ^= state << 13;
+            state ^= state >> 7;
+            state ^= state << 17;
+            ((state >> 40) as f32) / 16_777_216.0 - 0.5
+        })
+        .collect()
+}
+
+fn put(weights: &mut WeightMap, name: &str, shape: &[i32], seed: u64) {
+    let count: usize = shape.iter().map(|&d| d as usize).product();
+    weights.insert(
+        name.to_string(),
+        mlxcel_core::from_slice_f32(&pseudo_random(seed, count), shape),
+    );
+}
+
+/// `config.json` of the synthetic encoder. `local_attention` is 8, so the
+/// window bound is 5 and every token of a 3- or 5-token input is inside it.
+fn tiny_config() -> Value {
+    json!({
+        "model_type": "modernbert",
+        "architectures": ["ModernBertModel"],
+        "vocab_size": VOCAB,
+        "hidden_size": HIDDEN,
+        "num_hidden_layers": LAYERS,
+        "num_attention_heads": HEADS,
+        "intermediate_size": INTERMEDIATE,
+        "max_position_embeddings": 64,
+        "norm_eps": 1e-5,
+        "layer_norm_eps": 1e-5,
+        "norm_bias": false,
+        "global_rope_theta": 160000.0,
+        "local_rope_theta": 10000.0,
+        "global_attn_every_n_layers": 3,
+        "local_attention": 8,
+        "attention_bias": false,
+        "mlp_bias": false,
+        "hidden_activation": "gelu",
+        "classifier_pooling": "mean",
+        "classifier_activation": "gelu",
+        "classifier_bias": false,
+        "pad_token_id": 0
+    })
+}
+
+fn tiny_args() -> ModernBertArgs {
+    ModernBertArgs::from_config(&tiny_config()).expect("tiny config parses")
+}
+
+/// Backbone tensors of the synthetic checkpoint, in the published key layout.
+fn tiny_weights() -> WeightMap {
+    let mut weights = WeightMap::new();
+    put(
+        &mut weights,
+        "embeddings.tok_embeddings.weight",
+        &[VOCAB as i32, HIDDEN as i32],
+        1,
+    );
+    put(&mut weights, "embeddings.norm.weight", &[HIDDEN as i32], 2);
+    put(&mut weights, "final_norm.weight", &[HIDDEN as i32], 3);
+    for layer in 0..LAYERS {
+        let seed = 10 + layer as u64 * 7;
+        put(
+            &mut weights,
+            &format!("layers.{layer}.attn.Wqkv.weight"),
+            &[3 * HIDDEN as i32, HIDDEN as i32],
+            seed,
+        );
+        put(
+            &mut weights,
+            &format!("layers.{layer}.attn.Wo.weight"),
+            &[HIDDEN as i32, HIDDEN as i32],
+            seed + 1,
+        );
+        put(
+            &mut weights,
+            &format!("layers.{layer}.mlp.Wi.weight"),
+            &[2 * INTERMEDIATE as i32, HIDDEN as i32],
+            seed + 2,
+        );
+        put(
+            &mut weights,
+            &format!("layers.{layer}.mlp.Wo.weight"),
+            &[HIDDEN as i32, INTERMEDIATE as i32],
+            seed + 3,
+        );
+        put(
+            &mut weights,
+            &format!("layers.{layer}.mlp_norm.weight"),
+            &[HIDDEN as i32],
+            seed + 4,
+        );
+        // Layer 0 deliberately has none: upstream makes it nn.Identity().
+        if layer > 0 {
+            put(
+                &mut weights,
+                &format!("layers.{layer}.attn_norm.weight"),
+                &[HIDDEN as i32],
+                seed + 5,
+            );
+        }
+    }
+    weights
+}
+
+/// Backbone plus the sequence-classification head.
+fn tiny_classifier_weights() -> WeightMap {
+    let mut weights = tiny_weights();
+    put(
+        &mut weights,
+        "head.dense.weight",
+        &[HIDDEN as i32, HIDDEN as i32],
+        90,
+    );
+    put(&mut weights, "head.norm.weight", &[HIDDEN as i32], 91);
+    put(
+        &mut weights,
+        "classifier.weight",
+        &[LABELS as i32, HIDDEN as i32],
+        92,
+    );
+    put(&mut weights, "classifier.bias", &[LABELS as i32], 93);
+    weights
+}
+
+fn tiny_encoder() -> ModernBertEncoder {
+    ModernBertEncoder::from_weights(&tiny_weights(), &tiny_args(), None).expect("encoder builds")
+}
+
+/// `[B, L]` int32 ids and mask from per-row token lists, right-padded with 0.
+fn padded_batch(rows: &[&[i32]]) -> (UniquePtr<MlxArray>, UniquePtr<MlxArray>) {
+    let width = rows.iter().map(|r| r.len()).max().unwrap_or(0);
+    let mut ids: Vec<i32> = Vec::with_capacity(rows.len() * width);
+    let mut mask: Vec<i32> = Vec::with_capacity(rows.len() * width);
+    for row in rows {
+        let pad = width - row.len();
+        ids.extend_from_slice(row);
+        ids.extend(vec![0_i32; pad]);
+        mask.extend(vec![1_i32; row.len()]);
+        mask.extend(vec![0_i32; pad]);
+    }
+    let shape = [rows.len() as i32, width as i32];
+    (
+        mlxcel_core::from_slice_i32(&ids, &shape),
+        mlxcel_core::from_slice_i32(&mask, &shape),
+    )
+}
+
+fn assert_close(actual: &[f32], expected: &[f32], tolerance: f32, what: &str) {
+    assert_eq!(actual.len(), expected.len(), "{what}: length mismatch");
+    for (index, (a, e)) in actual.iter().zip(expected).enumerate() {
+        assert!(
+            (a - e).abs() <= tolerance,
+            "{what}: component {index} differs: {a} vs {e} (tolerance {tolerance})"
+        );
+    }
+}
+
+// Config and layer parity.
+
+#[test]
+fn layer_parity_selects_local_and_global_rope_base() {
+    let args = tiny_args();
+    assert_eq!(args.global_attn_every_n_layers, 3);
+    for layer in 0..9 {
+        let expect_global = layer % 3 == 0;
+        assert_eq!(
+            args.is_local_layer(layer),
+            !expect_global,
+            "layer {layer} parity"
+        );
+        let expected_base = if expect_global { 160_000.0 } else { 10_000.0 };
+        assert_eq!(args.rope_base(layer), expected_base, "layer {layer} base");
+    }
+    // A config without `local_rope_theta` falls back to the global base on
+    // every layer, matching upstream's `if config.local_rope_theta is not None`.
+    let mut config = tiny_config();
+    config["local_rope_theta"] = Value::Null;
+    let args = ModernBertArgs::from_config(&config).unwrap();
+    assert_eq!(args.rope_base(1), 160_000.0);
+    assert_eq!(args.rope_base(3), 160_000.0);
+}
+
+#[test]
+fn norm_eps_accepts_either_spelling_and_both_together() {
+    // Published checkpoints carry `norm_eps` and `layer_norm_eps` at once, so
+    // the two must be independent fields rather than one serde alias (an alias
+    // reports a duplicate-field error when both keys are present).
+    let both = ModernBertArgs::from_config(&tiny_config()).unwrap();
+    assert_eq!(both.norm_eps(), 1e-5);
+
+    let mut legacy_only = tiny_config();
+    legacy_only.as_object_mut().unwrap().remove("norm_eps");
+    legacy_only["layer_norm_eps"] = json!(1e-6);
+    assert_eq!(
+        ModernBertArgs::from_config(&legacy_only)
+            .unwrap()
+            .norm_eps(),
+        1e-6
+    );
+
+    let mut modern_only = tiny_config();
+    modern_only
+        .as_object_mut()
+        .unwrap()
+        .remove("layer_norm_eps");
+    modern_only["norm_eps"] = json!(1e-7);
+    assert_eq!(
+        ModernBertArgs::from_config(&modern_only)
+            .unwrap()
+            .norm_eps(),
+        1e-7
+    );
+
+    let mut neither = tiny_config();
+    neither.as_object_mut().unwrap().remove("norm_eps");
+    neither.as_object_mut().unwrap().remove("layer_norm_eps");
+    assert_eq!(
+        ModernBertArgs::from_config(&neither).unwrap().norm_eps(),
+        1e-5
+    );
+}
+
+#[test]
+fn config_validation_rejects_unsafe_scalars() {
+    let cases: &[(&str, Value, &str)] = &[
+        ("hidden_size", json!(0), "hidden_size"),
+        ("num_attention_heads", json!(3), "divisible"),
+        (
+            "global_attn_every_n_layers",
+            json!(0),
+            "global_attn_every_n",
+        ),
+        ("num_hidden_layers", json!(4096), "layer cap"),
+        ("local_attention", json!(1), "local_attention"),
+        ("global_rope_theta", json!(0.0), "global_rope_theta"),
+        ("hidden_activation", json!("silu"), "hidden_activation"),
+        ("classifier_pooling", json!("max"), "classifier_pooling"),
+    ];
+    for (key, value, fragment) in cases {
+        let mut config = tiny_config();
+        config[*key] = value.clone();
+        let err = ModernBertArgs::from_config(&config)
+            .expect_err(&format!("{key} = {value} must be rejected"))
+            .to_string();
+        assert!(err.contains(fragment), "{key}: {err}");
+    }
+}
+
+#[test]
+fn local_window_bound_attends_half_the_declared_window() {
+    // The published default: local_attention 128 means 64 keys on each side,
+    // so the exclusive bound handed to the mask builder is 65.
+    let mut config = tiny_config();
+    config["local_attention"] = json!(128);
+    let args = ModernBertArgs::from_config(&config).unwrap();
+    assert_eq!(args.local_window(), 65);
+    assert_eq!(tiny_args().local_window(), 5);
+}
+
+// Weight sanitize.
+
+#[test]
+fn sanitize_strips_model_prefix_and_drops_the_right_heads() {
+    let _mlx = mlx_guard();
+    let build = || {
+        let mut weights = WeightMap::new();
+        for key in [
+            "model.embeddings.tok_embeddings.weight",
+            "model.layers.0.attn.Wqkv.weight",
+            "model.final_norm.weight",
+            "head.dense.weight",
+            "head.norm.weight",
+            "classifier.weight",
+            "classifier.bias",
+            "decoder.weight",
+            "decoder.bias",
+            "pooler.dense.weight",
+        ] {
+            put(&mut weights, key, &[2, 2], 5);
+        }
+        weights
+    };
+
+    let embedder = sanitize_modernbert_weights(build(), false);
+    assert!(embedder.contains_key("embeddings.tok_embeddings.weight"));
+    assert!(embedder.contains_key("layers.0.attn.Wqkv.weight"));
+    assert!(embedder.contains_key("final_norm.weight"));
+    assert!(embedder.keys().all(|k| !k.starts_with("model.")));
+    for dropped in ["head.dense.weight", "classifier.weight", "decoder.weight"] {
+        assert!(!embedder.contains_key(dropped), "{dropped} must be dropped");
+    }
+    assert!(embedder.keys().all(|k| !k.starts_with("pooler.")));
+
+    let classifier = sanitize_modernbert_weights(build(), true);
+    assert!(classifier.contains_key("head.dense.weight"));
+    assert!(classifier.contains_key("head.norm.weight"));
+    assert!(classifier.contains_key("classifier.weight"));
+    assert!(classifier.contains_key("classifier.bias"));
+    // decoder.* is the MLM output projection and is never loaded.
+    assert!(classifier.keys().all(|k| !k.starts_with("decoder.")));
+}
+
+// Structure.
+
+#[test]
+fn first_layer_has_no_attn_norm() {
+    let _mlx = mlx_guard();
+    let args = tiny_args();
+    // The published layout: layers.0.attn_norm is absent and the stack loads.
+    let weights = tiny_weights();
+    assert!(!weights.contains_key("layers.0.attn_norm.weight"));
+    assert!(ModernBertEncoder::from_weights(&weights, &args, None).is_ok());
+
+    // Any other layer missing its attn_norm is a truncated checkpoint.
+    let mut broken = tiny_weights();
+    broken.remove("layers.1.attn_norm.weight");
+    // `expect_err` would need `ModernBertEncoder: Debug`, which no MLX-owning
+    // type implements, so match the error out instead.
+    let Err(err) = ModernBertEncoder::from_weights(&broken, &args, None) else {
+        panic!("a missing layers.1.attn_norm must fail the load");
+    };
+    assert!(err.contains("layers.1.attn_norm.weight"), "{err}");
+    assert!(err.contains("only layer 0"), "{err}");
+}
+
+#[test]
+fn sliding_mask_attends_within_64_and_blocks_beyond() {
+    let _mlx = mlx_guard();
+    // Real ModernBERT geometry: local_attention 128, so |q - k| <= 64 attends.
+    const LEN: usize = 200;
+    const REAL: usize = 150;
+    let mut config = tiny_config();
+    config["local_attention"] = json!(128);
+    let window = ModernBertArgs::from_config(&config).unwrap().local_window();
+    assert_eq!(window, 65);
+
+    // Row 0 is fully real; row 1 has REAL tokens followed by padding.
+    let mut mask = vec![1_i32; 2 * LEN];
+    mask[LEN + REAL..].fill(0);
+    let mask = mlxcel_core::from_slice_i32(&mask, &[2, LEN as i32]);
+
+    let additive = create_bidirectional_window_mask(&mask, window);
+    assert_eq!(
+        mlxcel_core::array_shape(&additive),
+        vec![2, 1, LEN as i32, LEN as i32]
+    );
+    let values = array_to_vec_f32(&additive);
+    let at = |b: usize, q: usize, k: usize| values[(b * LEN + q) * LEN + k];
+
+    // Fully real row: the window is the only constraint.
+    assert_eq!(at(0, 100, 100), 0.0, "self-attention is always allowed");
+    assert_eq!(at(0, 100, 36), 0.0, "|q - k| == 64 attends");
+    assert_eq!(at(0, 100, 164), 0.0, "|q - k| == 64 attends on the right");
+    assert!(at(0, 100, 35).is_infinite(), "|q - k| == 65 is blocked");
+    assert!(at(0, 100, 165).is_infinite(), "|q - k| == 65 is blocked");
+    assert!(at(0, 0, 65).is_infinite());
+    assert_eq!(at(0, 0, 64), 0.0);
+
+    // Padded row: padding keys are blocked even inside the window.
+    assert_eq!(at(1, 100, 149), 0.0, "last real key inside the window");
+    assert!(
+        at(1, 100, 150).is_infinite(),
+        "the first padding key is blocked although |q - k| == 50"
+    );
+    assert!(at(1, 10, 149).is_infinite(), "far real key still blocked");
+}
+
+#[test]
+fn geglu_splits_input_then_gate() {
+    let _mlx = mlx_guard();
+    // Direct: y = [inputs | gate], output = gelu(input) * gate.
+    let y = mlxcel_core::from_slice_f32(&[1.0, -2.0, 3.0, 0.5, 2.0, -1.0], &[1, 1, 6]);
+    let out = geglu(&y, 3);
+    assert_eq!(mlxcel_core::array_shape(&out), vec![1, 1, 3]);
+    let got = array_to_vec_f32(&out);
+    let gelu_exact = |x: f32| x * 0.5 * (1.0 + erf_approx(x / std::f32::consts::SQRT_2));
+    let expected = [
+        gelu_exact(1.0) * 0.5,
+        gelu_exact(-2.0) * 2.0,
+        -gelu_exact(3.0),
+    ];
+    assert_close(&got, &expected, 1e-5, "geglu");
+
+    // The gate is the SECOND half: zeroing it silences the MLP entirely, so
+    // the block output stops depending on mlp.Wo.
+    let args = tiny_args();
+    let zero_gate = |weights: &mut WeightMap| {
+        for layer in 0..LAYERS {
+            let key = format!("layers.{layer}.mlp.Wi.weight");
+            let mut rows = array_to_vec_f32(&weights[&key]);
+            rows[INTERMEDIATE * HIDDEN..].fill(0.0);
+            weights.insert(
+                key,
+                mlxcel_core::from_slice_f32(&rows, &[2 * INTERMEDIATE as i32, HIDDEN as i32]),
+            );
+        }
+    };
+    let (ids, mask) = padded_batch(&[&[3, 4, 5, 6, 7]]);
+
+    let mut a = tiny_weights();
+    zero_gate(&mut a);
+    let hidden_a = ModernBertEncoder::from_weights(&a, &args, None)
+        .unwrap()
+        .encode(&ids, &mask)
+        .unwrap();
+
+    let mut b = tiny_weights();
+    zero_gate(&mut b);
+    for layer in 0..LAYERS {
+        put(
+            &mut b,
+            &format!("layers.{layer}.mlp.Wo.weight"),
+            &[HIDDEN as i32, INTERMEDIATE as i32],
+            500 + layer as u64,
+        );
+    }
+    let hidden_b = ModernBertEncoder::from_weights(&b, &args, None)
+        .unwrap()
+        .encode(&ids, &mask)
+        .unwrap();
+
+    assert_close(
+        &array_to_vec_f32(&hidden_a),
+        &array_to_vec_f32(&hidden_b),
+        1e-6,
+        "a zero gate half makes mlp.Wo irrelevant",
+    );
+}
+
+/// `erf` for the reference GeGLU value, without pulling in a math crate.
+/// Abramowitz and Stegun 7.1.26; accurate to ~1.5e-7, well inside the 1e-5
+/// tolerance the assertion uses.
+fn erf_approx(x: f32) -> f32 {
+    let sign = if x < 0.0 { -1.0 } else { 1.0 };
+    let x = x.abs();
+    let t = 1.0 / (1.0 + 0.327_591_1 * x);
+    let y = 1.0
+        - (((((1.061_405_4 * t - 1.453_152) * t) + 1.421_413_7) * t - 0.284_496_74) * t
+            + 0.254_829_6)
+            * t
+            * (-x * x).exp();
+    sign * y
+}
+
+#[test]
+fn padding_invariance() {
+    let _mlx = mlx_guard();
+    let encoder = tiny_encoder();
+
+    let short: &[i32] = &[11, 4, 9];
+    let (solo_ids, solo_mask) = padded_batch(&[short]);
+    let solo = pool(
+        &encoder.encode(&solo_ids, &solo_mask).unwrap(),
+        &solo_mask,
+        PoolingMode::Mean,
+    );
+    let solo = array_to_vec_f32(&solo);
+
+    // The same text as the shorter member of a padded two-row batch.
+    let (batch_ids, batch_mask) = padded_batch(&[&[3, 4, 5, 6, 7, 8], short]);
+    let batched = pool(
+        &encoder.encode(&batch_ids, &batch_mask).unwrap(),
+        &batch_mask,
+        PoolingMode::Mean,
+    );
+    let batched = array_to_vec_f32(&batched);
+    assert_eq!(batched.len(), 2 * HIDDEN);
+
+    assert_close(
+        &batched[HIDDEN..],
+        &solo,
+        1e-4,
+        "padding must not change the pooled vector",
+    );
+}
+
+#[test]
+fn classifier_mean_pooling_ignores_padding() {
+    let _mlx = mlx_guard();
+    let mut config = tiny_config();
+    config["architectures"] = json!(["ModernBertForSequenceClassification"]);
+    config["id2label"] = json!({"0": "LABEL_0", "1": "LABEL_1"});
+    let args = ModernBertArgs::from_config(&config).unwrap();
+    assert!(args.is_sequence_classifier());
+    assert_eq!(args.num_labels(), LABELS);
+
+    let classifier =
+        ModernBertSequenceClassifier::from_weights(&tiny_classifier_weights(), &args, None)
+            .expect("classifier builds");
+    assert_eq!(classifier.num_labels(), LABELS);
+    assert_eq!(classifier.classifier_pooling(), PoolingMode::Mean);
+
+    let short: &[i32] = &[11, 4, 9];
+    let (solo_ids, solo_mask) = padded_batch(&[short]);
+    let solo = array_to_vec_f32(&classifier.logits(&solo_ids, &solo_mask).unwrap());
+    assert_eq!(solo.len(), LABELS);
+    assert!(solo.iter().all(|v| v.is_finite()), "logits are finite");
+
+    let (batch_ids, batch_mask) = padded_batch(&[&[3, 4, 5, 6, 7, 8], short]);
+    let batched = array_to_vec_f32(&classifier.logits(&batch_ids, &batch_mask).unwrap());
+    assert_eq!(batched.len(), 2 * LABELS);
+    assert_close(
+        &batched[LABELS..],
+        &solo,
+        1e-4,
+        "padding must not change the classifier logits",
+    );
+}
+
+#[test]
+fn classifier_cls_pooling_reads_the_first_real_token() {
+    let _mlx = mlx_guard();
+    let mut config = tiny_config();
+    config["architectures"] = json!(["ModernBertForSequenceClassification"]);
+    config["classifier_pooling"] = json!("cls");
+    let args = ModernBertArgs::from_config(&config).unwrap();
+    // The config declares no `num_labels` and no `id2label`, so its own
+    // default is one label ...
+    assert_eq!(
+        args.num_labels(),
+        1,
+        "no num_labels and no id2label means one"
+    );
+    // ... but classifier.weight is the tensor that actually produces the
+    // logits, so the head must advertise its row count instead.
+    let classifier =
+        ModernBertSequenceClassifier::from_weights(&tiny_classifier_weights(), &args, None)
+            .unwrap();
+    assert_eq!(classifier.classifier_pooling(), PoolingMode::Cls);
+    assert_eq!(
+        classifier.num_labels(),
+        LABELS,
+        "classifier.weight overrules a config that understates the label count"
+    );
+
+    let (ids, mask) = padded_batch(&[&[11, 4, 9]]);
+    let logits = array_to_vec_f32(&classifier.logits(&ids, &mask).unwrap());
+    assert_eq!(
+        logits.len(),
+        classifier.num_labels(),
+        "num_labels() must describe the real logits width"
+    );
+    assert!(logits.iter().all(|v| v.is_finite()));
+}
+
+#[test]
+fn classifier_rejects_a_weight_that_does_not_match_the_hidden_size() {
+    let _mlx = mlx_guard();
+    let mut config = tiny_config();
+    config["architectures"] = json!(["ModernBertForSequenceClassification"]);
+    let args = ModernBertArgs::from_config(&config).unwrap();
+
+    let mut weights = tiny_classifier_weights();
+    put(&mut weights, "classifier.weight", &[LABELS as i32, 3], 94);
+    let Err(err) = ModernBertSequenceClassifier::from_weights(&weights, &args, None) else {
+        panic!("a classifier.weight of the wrong width must fail the load");
+    };
+    assert!(err.contains("classifier.weight"), "{err}");
+    assert!(err.contains(&HIDDEN.to_string()), "{err}");
+}
+
+#[test]
+fn encoder_rejects_a_mask_that_does_not_match_the_ids() {
+    let _mlx = mlx_guard();
+    let encoder = tiny_encoder();
+    let (ids, _) = padded_batch(&[&[1, 2, 3]]);
+    let mask = mlxcel_core::from_slice_i32(&[1, 1], &[1, 2]);
+    let Err(err) = encoder.encode(&ids, &mask) else {
+        panic!("a mismatched mask must be rejected");
+    };
+    assert!(err.contains("attention_mask"), "{err}");
+}
+
+// Detection.
+
+#[test]
+fn modernbert_config_detects_as_the_embedding_family() {
+    let dir = std::env::temp_dir().join(format!(
+        "mlxcel_modernbert_detect_{}_{}",
+        std::process::id(),
+        std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_nanos()
+    ));
+    std::fs::create_dir_all(&dir).unwrap();
+
+    for arch in ["ModernBertModel", "ModernBertForMaskedLM"] {
+        let mut config = tiny_config();
+        config["architectures"] = json!([arch]);
+        std::fs::write(dir.join("config.json"), config.to_string()).unwrap();
+        assert_eq!(
+            get_model_type(&dir).unwrap(),
+            ModelType::ModernBert,
+            "{arch} must detect as the ModernBERT embedding family"
+        );
+    }
+
+    // A reranker is never an embedder: detection falls through to the
+    // generation dispatch, which has no `modernbert` arm.
+    let mut config = tiny_config();
+    config["architectures"] = json!(["ModernBertForSequenceClassification"]);
+    std::fs::write(dir.join("config.json"), config.to_string()).unwrap();
+    let err = get_model_type(&dir).expect_err("a classifier must not detect as an embedder");
+    assert!(err.to_string().contains("Unsupported model type"), "{err}");
+
+    std::fs::remove_dir_all(&dir).unwrap();
+}


### PR DESCRIPTION
## Summary

Ports the ModernBERT encoder (alternating local/global attention, RoPE, GeGLU) so `nomic-ai/modernbert-embed-base` serves through `POST /v1/embeddings` and `mlxcel embed`, and adds the `ModernBertForSequenceClassification` head that `/v1/rerank` (#1356) consumes for `Alibaba-NLP/gte-reranker-modernbert-base`. This is the first family forward pass to land on the embedding foundation from #1353.

The two attention kinds differ in more than their mask: a local layer attends `local_attention / 2` keys on each side and rotates with `local_rope_theta` (10000), while a global layer sees the whole sequence and rotates with `global_rope_theta` (160000). Getting that parity wrong is a silent quality regression rather than a shape error, so it is covered by an explicit test.

## What changed

- `src/models/modernbert.rs` (new): `ModernBertArgs` with full untrusted-config validation, `sanitize_modernbert_weights`, the GeGLU half-split, `ModernBertLayer` and `ModernBertEncoder`. Layer 0 legitimately ships no `attn_norm` (upstream `nn.Identity()`), while a missing `attn_norm` on any other layer is a load error. `Wqkv` and `Wi` load through `UnifiedLinear` and are split after the projection, never by slicing the weight, so a quantized export loads unchanged.
- `src/models/modernbert_heads.rs` (new): `ModernBertEmbeddingModel` implementing `EmbeddingModel` (default pooling `mean`, `embedding_dim` = `hidden_size`) and `ModernBertSequenceClassifier` producing `[B, num_labels]` logits from `classifier(norm(gelu(dense(pooled))))`.
- `src/embeddings/loader.rs`: only the `ModelType::ModernBert` arm is split out of the `not yet supported` match; every other family's arm is untouched.
- `src/models/mod.rs`: registers the two new modules and the two new test modules.
- `docs/supported-models.md` and `docs/embeddings.md`: the family row plus a ModernBERT section covering the `search_query: ` / `search_document: ` prefixes, Matryoshka `dimensions`, the window and RoPE-base alternation, and why the reranker is reached by directory rather than by detection.

## Two findings worth reviewer attention

`num_labels` now comes from the `classifier.weight` row count rather than from `config.json`. Reading it from `num_labels` / `id2label` meant a checkpoint whose config understated the label count would have had `num_labels()` disagree with the real `logits` width, which is exactly the contract #1356 depends on. Row counts are never packed by quantization, so this works on both the dense and quantized paths; the column count is validated against `hidden_size` on the dense path and a config/tensor disagreement is logged rather than silently trusted.

The real-checkpoint gates and every MLX-touching unit test take a shared module lock. `EmbeddingModel` is documented in `src/embeddings/model.rs` as living on exactly one thread and the server backs that with a dedicated MLX-owning worker, but `cargo test` runs them in parallel by default. That broke the contract in two ways on this host: silently wrong numbers (one parallel run in three scored two byte-identical rows of a single batch at cosine 0.99991 instead of 1.0 and moved a reranker logit by 0.05) and an abort inside MLX's CUDA graph capture. All 14 MLX-touching tests were audited; the 5 that do not take the lock are pure config-parsing or filesystem tests.

Separately, the long-document gate was named for 4096 tokens but only repeated a sentence 220 times without checking the result, so an edit to that sentence could have silently shrunk it into a short-sequence test that still passed. The document is actually 4187 tokens; the gate now asserts both that the input exceeds 4096 tokens and that it stays under `max_length` so no truncation occurs.

## Deviations from the issue body

- The issue asks for `#[serde(alias = "layer_norm_eps")]` on `norm_eps`. Both published checkpoints carry `norm_eps` **and** `layer_norm_eps` in the same `config.json`, and serde rejects an aliased field supplied under two names with a duplicate-field error, so the config would have failed to parse. They are two independent `Option<f32>` fields resolved by a `ModernBertArgs::norm_eps()` accessor instead, with a test locking all four combinations (both, legacy only, modern only, neither).
- `src/models/detection.rs` needed no change: #1353 already added `"modernbert" => ModelType::ModernBert` and the encoder-only `model_type` entry. The detection coverage the issue asks for is added as a test instead of a table edit.

## Known environment issue, outside this PR

On this GB10 CUDA host the combined `models::modernbert` filter sometimes aborts at process teardown with `Destroy(handle_) failed: driver shutting down` after `test result: ok`, turning a fully passing run into exit 101. Observed twice in 17 post-fix runs of the combined filter, with 0 in the most recent 10 consecutive runs and 0 in 9 isolated single-module runs; both occurrences happened while sibling units were loading the same GPU. This is a pre-existing, load-dependent MLX CUDA context-teardown race recorded from unmodified main and reproduced on the untouched `embeddings::` suite, not something this PR introduces, and the command was deliberately not reshaped to hide it.

## Test plan

- [x] `cargo test --profile test-fast --features cuda --lib models::modernbert` (19 passed, 0 failed; gate values byte-identical across 15 consecutive runs)
- [x] `cargo test --profile test-fast --features cuda --lib embeddings::` (62 passed, 0 failed)
- [x] `cargo clippy --profile test-fast --features cuda --lib --bins --tests -- -D warnings` (exit 0)
- [x] `cargo fmt --all -- --check` (exit 0)
- [x] `cargo build --profile test-fast --features cuda --bins` (exit 0)
- [x] `mlxcel embed -m nomic-ai/modernbert-embed-base` with the query and two documents: cosine 1.0000 on the diagonal, 0.6253 query vs the t-SNE document, 0.1448 query vs the Eiffel document, dim 768, max_length 8192
- [x] `mlxcel-server -m nomic-ai/modernbert-embed-base` plus `POST /v1/embeddings`: 2 vectors of dim 768 at unit norm, cosine 0.62521, and `dimensions: 256` returning 256 re-normalized components
- [x] A 4187-token document (asserted to exceed 4096 and to fit under `max_length`) embeds and matches its solo result inside a batch at cosine 0.999999821
- [x] `ModernBertSequenceClassifier::load` on `Alibaba-NLP/gte-reranker-modernbert-base`: finite `[2, 1]` logits, 3.065 for the relevant pair against -1.147 for the irrelevant one
- [x] `mlxcel arch` lists ModernBERT encoder under Embedding; `mlxcel list` shows both checkpoints

Closes #1332
