### PR TITLE
feat(embeddings): EmbeddingGemma and Qwen3-Embedding forward passes

### DIFF
--- a/TECHNICAL_REPORTS/1413-embeddinggemma-qwen3-embedding-forward-20260826.en.md
+++ b/TECHNICAL_REPORTS/1413-embeddinggemma-qwen3-embedding-forward-20260826.en.md
@@ -1,0 +1,272 @@
+# Technical Report: PR #1413 - EmbeddingGemma and Qwen3-Embedding forward passes
+
+**Date**: 2026-08-26
+**Author**: mlxcel contributors
+**Status**: Completed; one layout covered by a synthetic checkpoint rather than a published one
+**Languages**: Rust, Markdown
+**Risk Level**: Medium
+
+---
+
+## Executive Summary
+
+PR #1413 implements the two decoder-backbone embedding families issue #1329 asks for, on top of the `/v1/embeddings` foundation that landed in #1408. EmbeddingGemma runs the existing Gemma 3 layers with bidirectional masks, mean pooling and two `Dense` projections; Qwen3-Embedding runs the existing Qwen3 layers causally and pools the last real token. Neither family adds a decoder: the whole change is masks, pooling, weight-key normalization, and one surgical split of `Qwen3Model::forward_impl`. Both load from their published checkpoints and reproduce their published reference numbers.
+
+---
+
+## 1. Problem Statement
+
+### 1.1 Background
+
+EmbeddingGemma (`model_type: gemma3_text`, `architectures: ["Gemma3TextModel"]`, `use_bidirectional_attention: true`) and Qwen3-Embedding (`model_type: qwen3`, `architectures: ["Qwen3ForCausalLM"]` plus a sentence-transformers `1_Pooling` module) are the two most downloaded small embedders, and both ship on decoder backbones mlxcel already implements. #1408 built the shared foundation: the `EmbeddingModel` trait, pooling, tokenization, micro-batching, the length limits, the mask builders in `mlxcel_core::utils`, detection into `ModelType::Gemma3Embedding` / `ModelType::Qwen3Embedding`, and a family dispatcher whose arms all returned "not yet supported". This PR fills in two of those arms.
+
+### 1.2 Existing obstacles
+
+- **Gemma3Model requires a head.** `Gemma3Model::from_weights` loads `lm_head` unconditionally and `forward_with_caches_and_embeddings` ends with `self.lm_head.forward(&h)`. An EmbeddingGemma checkpoint has no `lm_head` at all, so the generator constructor cannot be reused as is.
+- **Gemma3Model always builds causal masks.** The generator's prefill path constructs `create_causal_mask` and `create_sliding_window_prefill_mask`. A bidirectional embedder needs the opposite of both, and each layer additionally carries `Attention.window_size`, which the Metal 4 attention path applies as a causal window even when an explicit mask is supplied.
+- **Qwen3Model exposes only logits.** `forward_impl` ends with the head, so an embedder would have had to materialize a `[B, L, 151669]` tensor and discard it.
+- **Neither checkpoint is keyed like its generator.** The sentence-transformers exports save the inner `...Model`, so `embed_tokens.weight`, `layers.{i}....` and `norm.weight` arrive without the `model.` prefix the constructors expect. EmbeddingGemma additionally stores its projections in two different places depending on the publisher.
+
+### 1.3 Risk assessment
+
+| Risk | Impact | Likelihood |
+|------|--------|------------|
+| A causal mask reaches a bidirectional layer | High: embeddings are silently wrong, every gate except the numeric one still passes | Medium |
+| The sliding period is off by one | High: the wrong layers get the wrong mask, output stays fluent-looking | Medium |
+| `dense.0` and `dense.1` swapped | High: shapes still chain in one direction, output is wrong | Low |
+| Tests interfere through concurrent MLX execution | Medium: gate numbers become unreliable evidence | High on this host |
+
+---
+
+## 2. Technical Decisions
+
+### 2.1 Reuse the backbones; do not port two decoders
+
+Both families are the existing decoders with different masks and no head. The implementation therefore builds `gemma3::TransformerBlock` and `Qwen3Model` directly and adds only what differs. The cost of this choice is that the two obstacles in 1.2 have to be handled at the seam rather than inside a fresh module; the benefit is that every future fix to Gemma 3 or Qwen3 attention, quantization, or RoPE reaches the embedders for free.
+
+`src/models/gemma3.rs` needed no edit at all. `Attention.window_size` was already `pub`, so the embedding loader clears it after construction.
+
+### 2.2 The embedding path owns every mask
+
+`Gemma3EmbeddingModel::forward_hidden` builds both masks itself and passes `Some(mask)` to every layer:
+
+- full-attention layers get `create_bidirectional_padding_mask(attention_mask)`, shape `[B, 1, 1, L]`, blocking only padding keys;
+- sliding layers get `create_bidirectional_window_mask(attention_mask, sliding_window)`, shape `[B, 1, L, L]`, blocking a key when it is padding or when `|q - k| >= window`.
+
+That second form is exactly the bidirectional sliding overlay `transformers` composes for Gemma 3 (`kv_idx > q_idx - w` and `kv_idx < q_idx + w`). For inputs up to `sliding_window` tokens the two masks are equivalent, so the window only starts to matter past 512 tokens, which is why the real-checkpoint gate deliberately embeds a 1749-token document.
+
+Each layer's `self_attn.window_size` is set to `0` at load. This is not redundant with the mask: on the Metal 4 attention path `window_size` is applied by the kernel, so a layer given a bidirectional mask *and* a causal window would still be causal, and only on macOS. The rejected alternative, threading a per-call flag through `Attention::forward`, would have touched the generator's hot path for the benefit of a cold one.
+
+Per-call caches are `gemma3::Cache::Standard(KVCache::new())` at offset 0, created and dropped inside the forward. Rotating caches are pointless here: nothing is reused between calls, and offset 0 keeps RoPE positions and the mask key axis aligned with the input length.
+
+### 2.3 Derive the sliding period from `layer_types`, not from the scalar
+
+`gemma3::ModelArgs` parses `sliding_window_pattern`. transformers 4.57 renamed that key to `_sliding_window_pattern` and made `layer_types` authoritative, so the parsed value on a modern EmbeddingGemma config is the family default of 6, not a value read from the checkpoint. On `mlx-community/embeddinggemma-300m-4bit` the default happens to be right, which is precisely the argument for pinning it: a period that is off by one still loads, still runs, and only shows up as a quietly wrong vector.
+
+`resolve_sliding_window_pattern` reads `layer_types` when present, derives the period from the index of the first `full_attention` entry, then validates the entire list against that period rather than sampling it. An irregular list is a load error naming the offending layer. A config with no `full_attention` entry at all yields a period past the last layer, so no layer is treated as full attention. Falling back, it reads `sliding_window_pattern`, then `_sliding_window_pattern`, then the caller's default.
+
+This resolution happens before the layers are constructed, because `gemma3::layer_rope_params` uses the same period to choose between `rope_theta` and `rope_local_base_freq`. Getting the period right after construction would have left the RoPE bases wrong.
+
+### 2.4 Split `Qwen3Model::forward_impl` rather than exposing its internals
+
+`forward_hidden` covers embedding lookup, the layer loop and the final norm; `forward_impl` calls it and then applies the head. The generator's output is unchanged by construction, and a test proves it by reassembling the tied head on top of `forward_hidden` and demanding a token-exact match on a synthetic two-layer model. The alternatives, making `layers` and `norm` public or duplicating the loop in the embedder, would both have let the two paths drift.
+
+The same entry point is what a Qwen3 generative reranker (#1356) needs, so the doc comment names both consumers.
+
+### 2.5 One shared weight-key sanitizer
+
+A sentence-transformers export of a decoder backbone differs from the generator checkpoint in three mechanical ways, and every family that reuses a generator backbone has to undo all three. `src/models/embedding_sanitize.rs` does them in a fixed order: fold `{N}_Dense.linear.*` into `dense.{k}.*` by folder rank, drop `lm_head.*` and `head.*`, then prefix bare `embed_tokens.` / `layers.` / `norm.` with `model.`. The order matters: the `Dense` keys are not backbone roots and must be renamed before the prefix pass, or `2_Dense.linear.weight` would survive untouched while `layers.0...` moved.
+
+The folder numbers are sentence-transformers module positions (`2_Dense` comes after `1_Pooling`), not projection indices, so they are ranked rather than used directly. That is what makes both published EmbeddingGemma layouts converge on the same `dense.0` / `dense.1` keys. The function is a no-op on an mlx conversion and idempotent, so a family may call it unconditionally.
+
+### 2.6 Validate the `Dense` chain at load
+
+`load_dense_stack` walks `dense.0`, `dense.1`, ... and requires each projection's input width to equal the previous stage's output, starting from the backbone hidden size. A swapped pair is a load error naming the projection. Without this, `768 -> 3072 -> 768` and its reverse both load, the forward pass runs, and only the numbers are wrong, which is the hardest class of failure to notice.
+
+Reading the input width needs care on a quantized checkpoint: the weight is packed along the input axis (`dense.0.weight` is `[3072, 96]` at 4 bits), so `linear_features` reads the width from the `scales` grouping (`[3072, 12]` at group size 64, hence 768) and falls back to the weight's own second dimension when the tensor is dense.
+
+The stack is a `Vec`, not a fixed pair, so a bidirectional Gemma 3 export with no `Dense` module at all loads and reports `embedding_dim == hidden_size`.
+
+### 2.7 Force `tie_word_embeddings` in the Qwen3 embedding path
+
+The embedder stops at the final norm, so no head is ever applied. Setting the flag before `Qwen3Model::from_weights` drops an untied `lm_head` from memory (on the 0.6B checkpoint that tensor is 151669 by 1024) and prevents the constructor from failing on a head this path would never read.
+
+### 2.8 Cast back to the checkpoint dtype only when there is something to project
+
+`pool` returns f32 by design, so the reductions run at full precision whatever the activation dtype. The `Dense` projections carry the checkpoint's dtype, so the pooled vector is cast back before those matmuls. With no projections the f32 vector goes straight to the engine instead of taking a needless round trip through f16.
+
+### 2.9 Prompt prefixes stay caller-side, with one opt-in hook
+
+Nothing is injected server-side; an input embeds exactly as it is sent. `Qwen3EmbeddingModel::format_text` wraps a query as `Instruct: {task}\nQuery: {query}` only when the request supplies an `instruction`, and is the identity otherwise, which matches what the `EmbeddingModel` trait's doc comment already promised for this family. `instruction` applies to every input of a request, so a mixed query-and-document batch has to split into two requests or format its queries in the text; `docs/embeddings.md` says so. EmbeddingGemma keeps the identity and documents its seven `config_sentence_transformers.json` prefixes in a table.
+
+---
+
+## 3. Implementation Details
+
+### 3.1 EmbeddingGemma forward
+
+```
+h = embed_tokens[input_ids] * sqrt(hidden_size)
+full    = create_bidirectional_padding_mask(attention_mask)      # [B, 1, 1, L]
+sliding = create_bidirectional_window_mask(attention_mask, 512)  # [B, 1, L, L]
+for i, layer in layers:                                          # window_size cleared
+    h = layer.forward(h, fresh KVCache at offset 0,
+                      if (i + 1) % pattern == 0 { full } else { sliding })
+h      = norm(h)                                                 # GemmaRMSNorm
+pooled = pool(h, attention_mask, Mean)                           # f32
+pooled = dense.1(dense.0(astype(pooled, checkpoint dtype)))      # 768 -> 3072 -> 768
+```
+
+The engine L2-normalizes and applies `dimensions` truncation afterwards.
+
+### 3.2 Qwen3-Embedding forward
+
+```
+mask   = create_causal_padding_mask(attention_mask, 0)           # [B, 1, L, L]
+h      = model.forward_hidden(input_ids, None, fresh caches, Some(mask))
+pooled = pool(h, attention_mask, LastToken)
+```
+
+Right padding is what makes this correct without a second code path: the pooled position is the last real token, padding sits after it, and padding keys are blocked for every real query, so the padded row reproduces the solo run exactly.
+
+### 3.3 Weight-key mapping
+
+| Published form | After sanitization |
+|----------------|--------------------|
+| `embed_tokens.weight` (sentence-transformers) | `model.embed_tokens.weight` |
+| `model.embed_tokens.weight` (mlx) | unchanged |
+| `2_Dense/model.safetensors` `linear.weight` | `dense.0.weight` |
+| `3_Dense/model.safetensors` `linear.weight` | `dense.1.weight` |
+| `dense.0.*`, `dense.1.*` (mlx) | unchanged |
+| `lm_head.*`, `head.*` | dropped |
+
+### 3.4 Registration
+
+Only the `Gemma3Embedding` and `Qwen3Embedding` arms of `build_family_model` changed; every other family's "not yet supported" arm is untouched, which matters because sibling ports were landing in parallel. Detection, the `ModelType` variants and the `mlxcel arch` entries already existed from #1408, so `mlxcel arch` lists both under `Embedding` and `mlxcel list` shows both checkpoints with no further change.
+
+---
+
+## 4. Test Strategy
+
+### 4.1 Two properties that no shape check can catch
+
+The synthetic tests build a 16-wide Gemma 3 and a 16-wide Qwen3 from deterministic weights, so they need no checkpoint and no particular device.
+
+- `bidirectional_prefill_is_not_causal`: over 96 tokens, flipping the last token must move the first token's hidden state. A causal mask makes that difference exactly zero.
+- `causal_prefill_is_causal`: the mirror image for Qwen3. Flipping the last token must leave every earlier hidden state untouched within 1e-6, while the changed token itself moves.
+- `global_layers_use_padding_mask_and_sliding_layers_use_window`: two one-layer models built from the *same* weights, one with the layer full-attention and one sliding with window 4. A token 6 positions away moves the first token's state in the first model and not in the second.
+- `forward_hidden_then_head_matches_forward_impl`: the refactor guard, token-exact.
+- `padding_invariance` and `last_token_pool_uses_appended_eos`: a right-padded two-row batch reproduces the unpadded single-row result.
+
+### 4.2 Layout equivalence without the gated checkpoint
+
+Only the mlx conversion of EmbeddingGemma is downloadable without accepting the gated `google/embeddinggemma-300m` terms, so `sentence_transformers_subfolder_layout_loads_from_disk_and_matches_the_mlx_layout` materializes a checkpoint instead: it writes the same synthetic weights in the sentence-transformers spelling (bare backbone roots, an unused `lm_head`, the projections in `2_Dense/` and `3_Dense/` module folders), loads it through the real `Gemma3EmbeddingModel::load(dir)`, and asserts the embeddings are bit-identical to the mlx-style in-memory build. This exercises `load_weights_from_dir_with_subfolders`, the sanitizer and the constructor together, which a key-mapping unit test alone does not.
+
+### 4.3 Test-side MLX concurrency
+
+`EmbeddingModel` is documented as single-thread and the product honors that through the embedding worker, so this hazard is test-side only. Two concurrent MLX forward passes in one process interfere in two observed ways on this tree: a CUDA graph capture aborts the process (`cudaStreamEndCapture ... operation failed due to a previous error during capture`, reproduced at roughly three runs in four on a wide filter), and results drift, with a sibling unit measuring two byte-identical rows of one batch at cosine 0.999912 instead of 1.0.
+
+Every test here that builds a model or runs a forward pass takes a process-wide `mlx_test_guard()`, following the existing `llama4_helpers_tests::test_guard` pattern with poisoned-lock recovery so one panicking test fails alone. The guard cannot serialize against MLX work in *other* modules, which is why every gate this repository defines (`make verify-test`, `make verify-test-cuda`, `make test-fast`) already passes `--test-threads=1`; the Makefile documents that as load-bearing rather than tidiness. Every number below comes from that configuration, and the real-checkpoint gates print their values so a repeated run shows the spread instead of one pass/fail bit.
+
+---
+
+## 5. Real-Checkpoint Results
+
+Linux, GB10, CUDA. Three consecutive single-threaded runs produced bit-identical numbers.
+
+### `mlx-community/embeddinggemma-300m-4bit` (4-bit, 768 wide, `max_length` 2048)
+
+| Gate | Observed | Requirement |
+|------|----------|-------------|
+| Vector width and norm | 768, norms 1.0 | 768-dim unit vectors |
+| Query vs Mars | 0.642725 | highest by at least 0.1 |
+| Query vs Venus | 0.323360 | below the match |
+| Query vs Jupiter | 0.329467 | below the match |
+| Match margin | 0.313 | at least 0.1 |
+| `dimensions: 256` | width 256, norms 1.0, Mars 0.693574 > Venus 0.422158, Jupiter 0.412816 | unit vectors, ranking unchanged |
+| Identical inputs in one batch | cosine 1.000000000 | 1.0 within 1e-6 |
+| 1749-token document, solo vs padded batch | `max_abs_diff` 0.0 | within 1e-3 |
+| Unrelated sentence | 0.0271 | below 0.5 |
+
+### `Qwen/Qwen3-Embedding-0.6B` (bf16, 1024 wide, `max_length` 8192)
+
+| Gate | Observed | Requirement |
+|------|----------|-------------|
+| Query-document matrix | `[[0.766633, 0.143439], [0.136450, 0.600714]]` | model card `[[0.7646, 0.1414], [0.1355, 0.6000]]` within 2e-2 |
+| Largest deviation | 0.00204 | under 2e-2 |
+| Identical inputs in one batch | cosine 1.000000119 | 1.0 within 1e-6 |
+| Solo vs padded batch | `max_abs_diff` 0.0 | within 1e-3 |
+| Non-finite components | none | none |
+| Unrelated sentence | 0.1568 | below 0.5 |
+| `dimensions: 256`, `encoding_format: base64` | decodes to a 256-wide unit vector | valid |
+
+No PyTorch or `transformers` install exists on the validation host, so the Qwen3-Embedding reference is the checkpoint's published model card, as the issue prescribes. Nothing in this report is computed from a local reference implementation, and no number is estimated.
+
+Both families return the same values through `mlxcel embed` and through `mlxcel-server` plus `POST /v1/embeddings`, and `/v1/models` lists the served embedding model in each case.
+
+---
+
+## 6. Validation Summary
+
+| Command | Result |
+|---------|--------|
+| `cargo fmt --all -- --check` | exit 0 |
+| `cargo clippy --profile test-fast --features cuda --lib --bins --tests -- -D warnings` | exit 0 |
+| `cargo check --profile test-fast --features cuda --all-targets` | exit 0 |
+| `cargo test ... --lib -- --test-threads=1 models::gemma3_embedding models::qwen3_embedding models::embedding_sanitize` | 22 passed, 0 failed, three times, identical gate numbers |
+| `cargo test ... --lib embeddings:: -- --test-threads=1` | 62 passed, 0 failed |
+| `cargo test ... --lib models::gemma3 -- --test-threads=1` | 23 passed, 5 ignored, 0 failed |
+| `cargo test ... --lib models::qwen3 -- --test-threads=1` | 59 passed, 11 ignored, 0 failed |
+| `cargo build --profile test-fast --features cuda --bins` | exit 0 |
+
+The issue's acceptance criteria name the macOS `metal,accelerate` feature set. The CUDA gate is the equivalent on this host and is what ran; the macOS gate is CI's.
+
+No performance numbers are reported. The epic runs its performance pass separately, on a quiet machine.
+
+---
+
+## 7. Change Summary
+
+| File | Change |
+|------|--------|
+| `src/models/gemma3_embedding.rs` (new, 327) | `Gemma3EmbeddingModel`: bidirectional masks, mean pooling, `Dense` stack, period resolution |
+| `src/models/gemma3_embedding_tests.rs` (new, 635) | Synthetic mask and pooling gates, the on-disk subfolder layout test, the real-checkpoint gates |
+| `src/models/qwen3_embedding.rs` (new, 155) | `Qwen3EmbeddingModel`: causal-plus-padding mask, last-token pooling, instruction formatting |
+| `src/models/qwen3_embedding_tests.rs` (new, 381) | Refactor guard, causality gate, padding gate, the real-checkpoint gate |
+| `src/models/embedding_sanitize.rs` (new, 160) | Shared weight-key normalization plus `linear_features` |
+| `src/models/embedding_sanitize_tests.rs` (new, 140) | Both layouts, idempotence, the unknown-submodule case |
+| `src/models/embedding_test_support.rs` (new, 229) | Deterministic weights, shaped safetensors writer, checkpoint lookup, MLX guard |
+| `src/models/qwen3.rs` (+24/-4) | `forward_impl` split into `forward_hidden` plus the head |
+| `src/embeddings/loader.rs` (+6/-2) | Two family arms constructed |
+| `src/embeddings/real_checkpoint_tests.rs` (+5/-3) | Qwen3-Embedding leaves the unported list |
+| `src/models/mod.rs` (+5) | Three module declarations |
+| `docs/embeddings.md` (+64/-21) | Family notes, prompt prefixes, source map; the deletions are the SigLIP and ModernBERT family sections folded into one `Family notes` heading during the rebase, not removed content |
+| `docs/supported-models.md` (+2) | Two Embedding rows |
+
+13 files, 2133 insertions, 30 deletions, on top of the SigLIP (#1410) and ModernBERT (#1412) ports that merged while this one was in flight.
+
+---
+
+## 8. What Remains Unverified
+
+- **The published sentence-transformers EmbeddingGemma checkpoint.** `google/embeddinggemma-300m` is gated. The subfolder layout is proven against a synthetic checkpoint written in that spelling, not against the published artifact. A dense (non-quantized) EmbeddingGemma has therefore never been loaded end to end here either, though the same code path serves the dense Qwen3-Embedding checkpoint.
+- **macOS and Metal.** Everything here ran on Linux with CUDA. The `window_size = 0` clearing exists specifically for the Metal 4 attention path and is exercised only indirectly on this host; the CI macOS gate is what will confirm it.
+- **Larger Qwen3-Embedding variants.** 4B and 8B are the same code at a different size and are out of scope for the issue; neither was loaded.
+- **Matryoshka widths other than 256.** 512 and 128 are trained widths and go through the same `truncate_dimensions` path, but only 256 was measured against the ranking requirement.
+
+---
+
+## 9. Follow-up Actions
+
+- #1356 (Qwen3 generative reranker) can consume `Qwen3Model::forward_hidden` as is.
+- If `google/embeddinggemma-300m` becomes available on a validation host, add it to `local_embedding_checkpoints_detect_to_their_families` and to the EmbeddingGemma gate so the published subfolder layout is covered directly.
+- The epic's performance pass should include a long-input EmbeddingGemma case, since the sliding window only engages past 512 tokens and the two masks have different shapes (`[B, 1, 1, L]` against `[B, 1, L, L]`).
+
+---
+
+## References
+
+- Issue #1329, epic #1348
+- PR #1408 (embedding foundation), issue #1353
+- `docs/embeddings.md`, `docs/supported-models.md`
+- `mlx-community/embeddinggemma-300m-4bit`, `Qwen/Qwen3-Embedding-0.6B`

--- a/TECHNICAL_REPORTS/1413-embeddinggemma-qwen3-embedding-forward-20260826.ko.md
+++ b/TECHNICAL_REPORTS/1413-embeddinggemma-qwen3-embedding-forward-20260826.ko.md
@@ -1,0 +1,272 @@
+# 기술 보고서: PR #1413 - EmbeddingGemma와 Qwen3-Embedding forward pass
+
+**작성일**: 2026-08-26
+**작성자**: mlxcel contributors
+**상태**: 완료. 한 가지 레이아웃은 공개 체크포인트 대신 합성 체크포인트로 검증
+**언어**: Rust, Markdown
+**위험도**: Medium
+
+---
+
+## 요약
+
+PR #1413은 이슈 #1329가 요구한 두 decoder-backbone 임베딩 계열을 #1408에서 착지한 `/v1/embeddings` 기반 위에 구현한다. EmbeddingGemma는 기존 Gemma 3 레이어를 양방향 마스크로 돌리고 mean pooling 후 두 개의 `Dense` 투영을 적용한다. Qwen3-Embedding은 기존 Qwen3 레이어를 causal로 돌리고 마지막 실제 토큰을 pooling한다. 디코더를 새로 추가하지 않는다. 변경의 실체는 마스크, pooling, weight key 정규화, 그리고 `Qwen3Model::forward_impl`의 최소 분리뿐이다. 두 계열 모두 공개 체크포인트에서 로드되며 공개된 기준 수치를 재현한다.
+
+---
+
+## 1. 문제 정의
+
+### 1.1 배경
+
+EmbeddingGemma(`model_type: gemma3_text`, `architectures: ["Gemma3TextModel"]`, `use_bidirectional_attention: true`)와 Qwen3-Embedding(`model_type: qwen3`, `architectures: ["Qwen3ForCausalLM"]` + sentence-transformers `1_Pooling` 모듈)은 다운로드가 가장 많은 소형 임베더 두 종이고, 둘 다 mlxcel이 이미 구현한 디코더 백본 위에 올라간다. #1408은 공통 기반을 만들었다. `EmbeddingModel` 트레이트, pooling, 토크나이즈, 마이크로 배치, 길이 제한, `mlxcel_core::utils`의 마스크 빌더, `ModelType::Gemma3Embedding` / `ModelType::Qwen3Embedding` 탐지, 그리고 모든 arm이 "not yet supported"를 반환하던 계열 디스패처다. 이 PR은 그중 두 arm을 채운다.
+
+### 1.2 기존 장애물
+
+- **Gemma3Model은 head를 요구한다.** `Gemma3Model::from_weights`는 `lm_head`를 무조건 로드하고 `forward_with_caches_and_embeddings`는 `self.lm_head.forward(&h)`로 끝난다. EmbeddingGemma 체크포인트에는 `lm_head`가 아예 없으므로 생성용 생성자를 그대로 쓸 수 없다.
+- **Gemma3Model은 항상 causal 마스크를 만든다.** 생성 경로의 prefill은 `create_causal_mask`와 `create_sliding_window_prefill_mask`를 구성한다. 양방향 임베더는 둘 다의 반대가 필요하고, 각 레이어는 추가로 `Attention.window_size`를 들고 있는데 Metal 4 어텐션 경로는 명시적 마스크가 주어져도 이 값을 causal window로 적용한다.
+- **Qwen3Model은 logits만 노출한다.** `forward_impl`이 head로 끝나므로 임베더는 `[B, L, 151669]` 텐서를 만들었다가 버려야 했다.
+- **두 체크포인트 모두 생성용과 키 체계가 다르다.** sentence-transformers export는 내부 `...Model`을 저장하므로 `embed_tokens.weight`, `layers.{i}....`, `norm.weight`가 생성자가 기대하는 `model.` 접두사 없이 도착한다. EmbeddingGemma는 여기에 더해 배포처에 따라 투영을 서로 다른 위치에 저장한다.
+
+### 1.3 위험 평가
+
+| 위험 | 영향 | 가능성 |
+|------|------|--------|
+| 양방향 레이어에 causal 마스크가 들어감 | High. 임베딩이 조용히 틀리고 수치 게이트를 제외한 모든 게이트는 통과 | Medium |
+| sliding 주기가 1만큼 어긋남 | High. 잘못된 레이어에 잘못된 마스크가 들어가지만 출력은 그럴듯하게 유지 | Medium |
+| `dense.0`과 `dense.1`이 뒤바뀜 | High. 한 방향으로는 shape가 맞아떨어지고 값만 틀림 | Low |
+| 동시 MLX 실행으로 테스트가 서로 간섭 | Medium. 게이트 수치가 증거로서 신뢰할 수 없게 됨 | 이 호스트에서는 High |
+
+---
+
+## 2. 기술적 선택과 그 이유
+
+### 2.1 백본을 재사용하고 디코더를 새로 포팅하지 않는다
+
+두 계열은 마스크가 다르고 head가 없는 기존 디코더다. 따라서 구현은 `gemma3::TransformerBlock`과 `Qwen3Model`을 직접 만들고 다른 부분만 더한다. 이 선택의 비용은 1.2의 장애물 두 가지를 새 모듈 내부가 아니라 이음새에서 처리해야 한다는 점이고, 이득은 Gemma 3나 Qwen3의 어텐션, 양자화, RoPE에 가해지는 모든 후속 수정이 임베더에 자동으로 도달한다는 점이다.
+
+`src/models/gemma3.rs`는 전혀 수정하지 않았다. `Attention.window_size`가 이미 `pub`이라 임베딩 로더가 생성 후에 값을 지운다.
+
+### 2.2 임베딩 경로가 모든 마스크를 소유한다
+
+`Gemma3EmbeddingModel::forward_hidden`이 두 마스크를 직접 만들어 모든 레이어에 `Some(mask)`로 전달한다.
+
+- full-attention 레이어: `create_bidirectional_padding_mask(attention_mask)`, shape `[B, 1, 1, L]`, 패딩 key만 차단
+- sliding 레이어: `create_bidirectional_window_mask(attention_mask, sliding_window)`, shape `[B, 1, L, L]`, key가 패딩이거나 `|q - k| >= window`이면 차단
+
+두 번째 형태는 `transformers`가 Gemma 3용으로 합성하는 양방향 sliding overlay(`kv_idx > q_idx - w` 그리고 `kv_idx < q_idx + w`)와 정확히 같다. 입력이 `sliding_window` 토큰 이하이면 두 마스크는 동등하므로 window는 512 토큰을 넘어서야 의미를 갖기 시작한다. 실제 체크포인트 게이트가 일부러 1749 토큰 문서를 임베딩하는 이유가 이것이다.
+
+각 레이어의 `self_attn.window_size`는 로드 시 `0`으로 설정된다. 이는 마스크와 중복이 아니다. Metal 4 어텐션 경로에서는 `window_size`를 커널이 적용하므로, 양방향 마스크와 causal window를 함께 받은 레이어는 여전히 causal이 되고 그것도 macOS에서만 그렇게 된다. 기각한 대안은 `Attention::forward`에 호출별 플래그를 흘려보내는 것이었는데, 차가운 경로를 위해 생성의 뜨거운 경로를 건드리게 된다.
+
+호출별 캐시는 offset 0의 `gemma3::Cache::Standard(KVCache::new())`이고 forward 안에서 만들어져 소멸한다. 여기서 rotating 캐시는 무의미하다. 호출 간 재사용이 없고, offset 0이 RoPE 위치와 마스크 key 축을 입력 길이에 맞춰 준다.
+
+### 2.3 sliding 주기를 스칼라가 아니라 `layer_types`에서 도출한다
+
+`gemma3::ModelArgs`는 `sliding_window_pattern`을 파싱한다. transformers 4.57은 그 키를 `_sliding_window_pattern`으로 이름을 바꾸고 `layer_types`를 권위 있는 값으로 만들었으므로, 최신 EmbeddingGemma config에서 파싱되는 값은 체크포인트에서 읽은 값이 아니라 계열 기본값 6이다. `mlx-community/embeddinggemma-300m-4bit`에서는 기본값이 우연히 맞는데, 바로 그 점이 이 값을 못박아야 하는 근거다. 1만큼 어긋난 주기도 로드되고 실행되며 조용히 틀린 벡터로만 드러난다.
+
+`resolve_sliding_window_pattern`은 `layer_types`가 있으면 그것을 읽고 첫 `full_attention` 항목의 인덱스에서 주기를 도출한 뒤, 표본 검사가 아니라 목록 전체를 그 주기에 대해 검증한다. 불규칙한 목록은 문제 레이어를 이름으로 지목하는 로드 오류다. `full_attention` 항목이 하나도 없는 config는 마지막 레이어를 넘어서는 주기를 얻으므로 어떤 레이어도 full attention으로 취급되지 않는다. 폴백은 `sliding_window_pattern`, `_sliding_window_pattern`, 호출자 기본값 순이다.
+
+이 해석은 레이어 생성 전에 일어난다. `gemma3::layer_rope_params`가 같은 주기로 `rope_theta`와 `rope_local_base_freq` 중 하나를 고르기 때문이다. 생성 후에 주기를 바로잡았다면 RoPE base가 틀린 채로 남았을 것이다.
+
+### 2.4 내부를 노출하는 대신 `Qwen3Model::forward_impl`을 분리한다
+
+`forward_hidden`은 임베딩 조회, 레이어 루프, 최종 norm까지를 담당하고 `forward_impl`은 그것을 호출한 뒤 head를 적용한다. 생성 출력은 구조적으로 불변이며, 합성 2레이어 모델에서 `forward_hidden` 위에 tied head를 다시 얹어 토큰 단위로 정확히 일치하는지 요구하는 테스트가 이를 증명한다. 대안이던 `layers`와 `norm`의 공개, 또는 임베더에서 루프 복제는 두 경로가 갈라지도록 방치했을 것이다.
+
+같은 진입점을 Qwen3 생성형 리랭커(#1356)가 필요로 하므로 doc comment가 두 소비자를 함께 명시한다.
+
+### 2.5 공유 weight key 정규화 하나
+
+디코더 백본의 sentence-transformers export는 생성용 체크포인트와 기계적으로 세 가지가 다르고, 생성용 백본을 재사용하는 모든 계열이 그 셋을 모두 되돌려야 한다. `src/models/embedding_sanitize.rs`가 고정된 순서로 처리한다. `{N}_Dense.linear.*`를 폴더 순위에 따라 `dense.{k}.*`로 접고, `lm_head.*`와 `head.*`를 버리고, 벌거벗은 `embed_tokens.` / `layers.` / `norm.`에 `model.`을 붙인다. 순서가 중요하다. `Dense` 키는 백본 루트가 아니므로 접두사 단계 전에 이름을 바꿔야 하며, 그렇지 않으면 `layers.0...`이 옮겨가는 동안 `2_Dense.linear.weight`는 그대로 남는다.
+
+폴더 번호는 투영 인덱스가 아니라 sentence-transformers 모듈 위치(`2_Dense`는 `1_Pooling` 다음)이므로 직접 쓰지 않고 순위로 환산한다. 공개된 두 EmbeddingGemma 레이아웃이 동일한 `dense.0` / `dense.1` 키로 수렴하는 이유가 이것이다. 이 함수는 mlx 변환본에서는 no-op이고 멱등이므로 계열은 조건 없이 호출해도 된다.
+
+### 2.6 로드 시점에 `Dense` 사슬을 검증한다
+
+`load_dense_stack`은 `dense.0`, `dense.1`, ...를 순회하며 각 투영의 입력 폭이 이전 단계의 출력과 같은지를 백본 hidden size에서 출발해 요구한다. 뒤바뀐 쌍은 투영을 이름으로 지목하는 로드 오류다. 이 검사가 없으면 `768 -> 3072 -> 768`과 그 역방향이 모두 로드되고 forward도 돌아가며 값만 틀리는데, 이는 알아차리기 가장 어려운 부류의 실패다.
+
+양자화 체크포인트에서 입력 폭을 읽는 데는 주의가 필요하다. weight는 입력 축을 따라 패킹되므로(4비트에서 `dense.0.weight`는 `[3072, 96]`), `linear_features`는 폭을 `scales` 그룹화(group size 64에서 `[3072, 12]`, 따라서 768)에서 읽고 dense 텐서일 때만 weight의 두 번째 차원으로 폴백한다.
+
+스택은 고정 쌍이 아니라 `Vec`이므로 `Dense` 모듈이 전혀 없는 양방향 Gemma 3 export도 로드되고 `embedding_dim == hidden_size`를 보고한다.
+
+### 2.7 Qwen3 임베딩 경로에서 `tie_word_embeddings`를 강제한다
+
+임베더는 최종 norm에서 멈추므로 head는 결코 적용되지 않는다. `Qwen3Model::from_weights` 전에 플래그를 세우면 untied `lm_head`가 메모리에서 빠지고(0.6B 체크포인트에서 그 텐서는 151669 x 1024이다) 이 경로가 읽지도 않을 head 때문에 생성자가 실패하는 일도 막는다.
+
+### 2.8 투영할 대상이 있을 때만 체크포인트 dtype으로 되돌린다
+
+`pool`은 의도적으로 f32를 반환한다. 활성화 dtype이 무엇이든 축약을 전정밀도로 수행하기 위해서다. `Dense` 투영은 체크포인트 dtype을 들고 있으므로 그 matmul 전에 pooling 결과를 되돌린다. 투영이 없으면 f32 벡터가 f16을 불필요하게 왕복하지 않고 엔진으로 바로 간다.
+
+### 2.9 prompt 접두사는 호출자 쪽에 두되 opt-in 훅 하나를 제공한다
+
+서버 쪽에서 주입하는 것은 없다. 입력은 보낸 그대로 임베딩된다. `Qwen3EmbeddingModel::format_text`는 요청이 `instruction`을 줄 때만 질의를 `Instruct: {task}\nQuery: {query}`로 감싸고 그 외에는 항등이며, 이는 `EmbeddingModel` 트레이트의 doc comment가 이 계열에 대해 이미 약속한 동작이다. `instruction`은 요청의 모든 입력에 적용되므로 질의와 문서가 섞인 배치는 요청을 둘로 나누거나 질의를 본문에서 직접 포맷해야 하고, `docs/embeddings.md`가 그렇게 적는다. EmbeddingGemma는 항등을 유지하고 `config_sentence_transformers.json`의 일곱 가지 접두사를 표로 문서화한다.
+
+---
+
+## 3. 구현 세부
+
+### 3.1 EmbeddingGemma forward
+
+```
+h = embed_tokens[input_ids] * sqrt(hidden_size)
+full    = create_bidirectional_padding_mask(attention_mask)      # [B, 1, 1, L]
+sliding = create_bidirectional_window_mask(attention_mask, 512)  # [B, 1, L, L]
+for i, layer in layers:                                          # window_size는 0으로 지움
+    h = layer.forward(h, offset 0의 새 KVCache,
+                      if (i + 1) % pattern == 0 { full } else { sliding })
+h      = norm(h)                                                 # GemmaRMSNorm
+pooled = pool(h, attention_mask, Mean)                           # f32
+pooled = dense.1(dense.0(astype(pooled, 체크포인트 dtype)))       # 768 -> 3072 -> 768
+```
+
+L2 정규화와 `dimensions` 절단은 이후 엔진이 수행한다.
+
+### 3.2 Qwen3-Embedding forward
+
+```
+mask   = create_causal_padding_mask(attention_mask, 0)           # [B, 1, L, L]
+h      = model.forward_hidden(input_ids, None, 새 캐시, Some(mask))
+pooled = pool(h, attention_mask, LastToken)
+```
+
+두 번째 코드 경로 없이 이것이 옳게 동작하는 이유는 오른쪽 패딩이다. pooling 위치가 마지막 실제 토큰이고 패딩은 그 뒤에 놓이며 패딩 key는 모든 실제 query에 대해 차단되므로, 패딩된 행이 단독 실행을 그대로 재현한다.
+
+### 3.3 weight key 매핑
+
+| 공개된 형태 | 정규화 후 |
+|-------------|-----------|
+| `embed_tokens.weight` (sentence-transformers) | `model.embed_tokens.weight` |
+| `model.embed_tokens.weight` (mlx) | 그대로 |
+| `2_Dense/model.safetensors`의 `linear.weight` | `dense.0.weight` |
+| `3_Dense/model.safetensors`의 `linear.weight` | `dense.1.weight` |
+| `dense.0.*`, `dense.1.*` (mlx) | 그대로 |
+| `lm_head.*`, `head.*` | 삭제 |
+
+### 3.4 등록
+
+`build_family_model`에서 `Gemma3Embedding`과 `Qwen3Embedding` arm만 바뀌었고 다른 계열의 "not yet supported" arm은 손대지 않았다. 형제 포팅이 병렬로 착지하던 중이었기 때문에 이 점이 중요하다. 탐지, `ModelType` variant, `mlxcel arch` 항목은 #1408에서 이미 존재하므로 추가 변경 없이 `mlxcel arch`가 두 계열을 `Embedding` 아래에 나열하고 `mlxcel list`가 두 체크포인트를 보여준다.
+
+---
+
+## 4. 테스트 전략
+
+### 4.1 shape 검사로는 잡을 수 없는 두 성질
+
+합성 테스트는 결정론적 가중치로 16폭 Gemma 3와 16폭 Qwen3를 만들므로 체크포인트도 특정 장치도 필요 없다.
+
+- `bidirectional_prefill_is_not_causal`: 96 토큰에서 마지막 토큰을 바꾸면 첫 토큰의 hidden state가 움직여야 한다. causal 마스크에서는 그 차이가 정확히 0이 된다.
+- `causal_prefill_is_causal`: Qwen3용 거울상. 마지막 토큰을 바꿔도 이전 hidden state는 1e-6 이내로 변하지 않아야 하고, 바뀐 토큰 자신은 움직여야 한다.
+- `global_layers_use_padding_mask_and_sliding_layers_use_window`: 동일한 가중치로 만든 1레이어 모델 두 개, 하나는 full-attention, 다른 하나는 window 4의 sliding. 6칸 떨어진 토큰이 첫 모델에서는 첫 토큰 상태를 움직이고 둘째 모델에서는 움직이지 않는다.
+- `forward_hidden_then_head_matches_forward_impl`: 리팩터링 가드, 토큰 단위 일치.
+- `padding_invariance`와 `last_token_pool_uses_appended_eos`: 오른쪽 패딩된 2행 배치가 패딩 없는 단일 행 결과를 재현한다.
+
+### 4.2 gated 체크포인트 없이 레이아웃 동등성 확인
+
+EmbeddingGemma는 gated인 `google/embeddinggemma-300m` 약관에 동의하지 않으면 mlx 변환본만 내려받을 수 있으므로, `sentence_transformers_subfolder_layout_loads_from_disk_and_matches_the_mlx_layout`가 체크포인트를 직접 만들어낸다. 같은 합성 가중치를 sentence-transformers 표기(벌거벗은 백본 루트, 쓰이지 않는 `lm_head`, `2_Dense/`와 `3_Dense/` 모듈 폴더의 투영)로 기록하고 실제 `Gemma3EmbeddingModel::load(dir)` 경로로 로드한 뒤, mlx 방식 인메모리 빌드와 비트 단위로 같은 임베딩이 나오는지 확인한다. 이는 `load_weights_from_dir_with_subfolders`, 정규화기, 생성자를 함께 구동하며 키 매핑 단위 테스트만으로는 닿지 않는 영역이다.
+
+### 4.3 테스트 쪽 MLX 동시성
+
+`EmbeddingModel`은 단일 스레드로 문서화되어 있고 제품은 임베딩 워커를 통해 그것을 지키므로 이 위험은 테스트 쪽에만 있다. 한 프로세스 안의 동시 MLX forward pass는 이 트리에서 두 가지로 관찰되는 간섭을 일으킨다. CUDA graph capture가 프로세스를 중단시키고(`cudaStreamEndCapture ... operation failed due to a previous error during capture`, 넓은 필터에서 대략 4회 중 3회 재현), 결과가 흔들려 형제 유닛이 한 배치 안의 바이트 단위로 동일한 두 행에서 cosine 1.0 대신 0.999912를 측정했다.
+
+여기서 모델을 만들거나 forward pass를 돌리는 모든 테스트는 프로세스 전역 `mlx_test_guard()`를 잡는다. 기존 `llama4_helpers_tests::test_guard` 패턴을 따르고 poisoned lock을 복구해 패닉한 테스트 하나가 단독으로 실패하게 한다. 이 가드는 다른 모듈의 MLX 작업까지 직렬화할 수는 없으며, 그래서 이 저장소가 정의하는 모든 게이트(`make verify-test`, `make verify-test-cuda`, `make test-fast`)가 이미 `--test-threads=1`을 전달한다. Makefile은 그것을 정돈이 아니라 필수 조건으로 기록하고 있다. 아래 수치는 모두 그 구성에서 나왔고, 실제 체크포인트 게이트는 값을 출력하므로 반복 실행이 통과 여부 한 비트가 아니라 산포를 보여준다.
+
+---
+
+## 5. 실제 체크포인트 결과
+
+Linux, GB10, CUDA. 단일 스레드 연속 3회 실행이 비트 단위로 동일한 수치를 냈다.
+
+### `mlx-community/embeddinggemma-300m-4bit` (4-bit, 768폭, `max_length` 2048)
+
+| 게이트 | 관측값 | 요구 조건 |
+|--------|--------|-----------|
+| 벡터 폭과 norm | 768, norm 1.0 | 768차원 단위 벡터 |
+| 질의 vs Mars | 0.642725 | 최소 0.1 차이로 최고 |
+| 질의 vs Venus | 0.323360 | 매칭 문서보다 낮음 |
+| 질의 vs Jupiter | 0.329467 | 매칭 문서보다 낮음 |
+| 매칭 마진 | 0.313 | 최소 0.1 |
+| `dimensions: 256` | 폭 256, norm 1.0, Mars 0.693574 > Venus 0.422158, Jupiter 0.412816 | 단위 벡터, 순위 불변 |
+| 배치 내 동일 입력 | cosine 1.000000000 | 1e-6 이내 1.0 |
+| 1749토큰 문서, 단독 vs 패딩 배치 | `max_abs_diff` 0.0 | 1e-3 이내 |
+| 무관한 문장 | 0.0271 | 0.5 미만 |
+
+### `Qwen/Qwen3-Embedding-0.6B` (bf16, 1024폭, `max_length` 8192)
+
+| 게이트 | 관측값 | 요구 조건 |
+|--------|--------|-----------|
+| 질의-문서 행렬 | `[[0.766633, 0.143439], [0.136450, 0.600714]]` | model card `[[0.7646, 0.1414], [0.1355, 0.6000]]` 대비 2e-2 이내 |
+| 최대 편차 | 0.00204 | 2e-2 미만 |
+| 배치 내 동일 입력 | cosine 1.000000119 | 1e-6 이내 1.0 |
+| 단독 vs 패딩 배치 | `max_abs_diff` 0.0 | 1e-3 이내 |
+| 비유한 값 | 없음 | 없음 |
+| 무관한 문장 | 0.1568 | 0.5 미만 |
+| `dimensions: 256`, `encoding_format: base64` | 256폭 단위 벡터로 디코드 | 유효 |
+
+검증 호스트에는 PyTorch나 `transformers` 설치가 없으므로, 이슈가 지시한 대로 Qwen3-Embedding의 기준은 체크포인트의 공개 model card다. 이 보고서의 어떤 수치도 로컬 참조 구현에서 계산되지 않았고 추정된 값도 없다.
+
+두 계열 모두 `mlxcel embed`와 `mlxcel-server` + `POST /v1/embeddings`에서 같은 값을 반환하며, 각각 `/v1/models`가 서빙 중인 임베딩 모델을 나열한다.
+
+---
+
+## 6. 검증 요약
+
+| 명령 | 결과 |
+|------|------|
+| `cargo fmt --all -- --check` | exit 0 |
+| `cargo clippy --profile test-fast --features cuda --lib --bins --tests -- -D warnings` | exit 0 |
+| `cargo check --profile test-fast --features cuda --all-targets` | exit 0 |
+| `cargo test ... --lib -- --test-threads=1 models::gemma3_embedding models::qwen3_embedding models::embedding_sanitize` | 22 passed, 0 failed, 3회 반복, 동일 게이트 수치 |
+| `cargo test ... --lib embeddings:: -- --test-threads=1` | 62 passed, 0 failed |
+| `cargo test ... --lib models::gemma3 -- --test-threads=1` | 23 passed, 5 ignored, 0 failed |
+| `cargo test ... --lib models::qwen3 -- --test-threads=1` | 59 passed, 11 ignored, 0 failed |
+| `cargo build --profile test-fast --features cuda --bins` | exit 0 |
+
+이슈의 수용 기준은 macOS `metal,accelerate` feature set을 명시한다. 이 호스트에서는 CUDA 게이트가 그 등가물이며 실제로 실행된 것도 그것이다. macOS 게이트는 CI의 몫이다.
+
+성능 수치는 보고하지 않는다. 에픽이 조용한 머신에서 별도로 성능 패스를 돌린다.
+
+---
+
+## 7. 변경 요약
+
+| 파일 | 변경 |
+|------|------|
+| `src/models/gemma3_embedding.rs` (신규, 327) | `Gemma3EmbeddingModel`: 양방향 마스크, mean pooling, `Dense` 스택, 주기 해석 |
+| `src/models/gemma3_embedding_tests.rs` (신규, 635) | 합성 마스크 및 pooling 게이트, 디스크 subfolder 레이아웃 테스트, 실제 체크포인트 게이트 |
+| `src/models/qwen3_embedding.rs` (신규, 155) | `Qwen3EmbeddingModel`: causal + padding 마스크, last-token pooling, instruction 포맷 |
+| `src/models/qwen3_embedding_tests.rs` (신규, 381) | 리팩터링 가드, causality 게이트, 패딩 게이트, 실제 체크포인트 게이트 |
+| `src/models/embedding_sanitize.rs` (신규, 160) | 공유 weight key 정규화와 `linear_features` |
+| `src/models/embedding_sanitize_tests.rs` (신규, 140) | 두 레이아웃, 멱등성, 알 수 없는 서브모듈 처리 |
+| `src/models/embedding_test_support.rs` (신규, 229) | 결정론적 가중치, shaped safetensors writer, 체크포인트 탐색, MLX 가드 |
+| `src/models/qwen3.rs` (+24/-4) | `forward_impl`을 `forward_hidden` + head로 분리 |
+| `src/embeddings/loader.rs` (+6/-2) | 두 계열 arm 생성 |
+| `src/embeddings/real_checkpoint_tests.rs` (+5/-3) | Qwen3-Embedding이 미포팅 목록에서 빠짐 |
+| `src/models/mod.rs` (+5) | 모듈 선언 3개 |
+| `docs/embeddings.md` (+64/-21) | 계열 노트, prompt 접두사, 소스 맵. 삭제분은 rebase 중 SigLIP과 ModernBERT의 계열 절을 하나의 `Family notes` 제목 아래로 합친 결과이며 내용이 사라진 것은 아니다 |
+| `docs/supported-models.md` (+2) | Embedding 행 2개 |
+
+13개 파일, 2133 추가, 30 삭제. 이 작업이 진행되는 동안 머지된 SigLIP(#1410)과 ModernBERT(#1412) 포팅 위에 올려져 있다.
+
+---
+
+## 8. 검증되지 않은 부분
+
+- **공개된 sentence-transformers EmbeddingGemma 체크포인트.** `google/embeddinggemma-300m`은 gated다. subfolder 레이아웃은 그 표기로 기록한 합성 체크포인트로 증명했을 뿐 공개 산출물로 증명하지 않았다. 따라서 비양자화 EmbeddingGemma도 여기서 end-to-end로 로드된 적이 없다. 다만 같은 코드 경로가 dense인 Qwen3-Embedding 체크포인트를 서빙한다.
+- **macOS와 Metal.** 여기 모든 실행은 Linux와 CUDA에서 이루어졌다. `window_size = 0` 처리는 Metal 4 어텐션 경로를 위해 존재하며 이 호스트에서는 간접적으로만 구동된다. CI의 macOS 게이트가 확인해 줄 부분이다.
+- **더 큰 Qwen3-Embedding 변형.** 4B와 8B는 크기만 다른 같은 코드이고 이슈의 범위 밖이며 로드하지 않았다.
+- **256 외의 Matryoshka 폭.** 512와 128도 학습된 폭이고 같은 `truncate_dimensions` 경로를 지나지만, 순위 요구 조건에 대해 측정한 것은 256뿐이다.
+
+---
+
+## 9. 후속 과제
+
+- #1356(Qwen3 생성형 리랭커)은 `Qwen3Model::forward_hidden`을 그대로 사용할 수 있다.
+- 검증 호스트에서 `google/embeddinggemma-300m`을 사용할 수 있게 되면 `local_embedding_checkpoints_detect_to_their_families`와 EmbeddingGemma 게이트에 추가해 공개 subfolder 레이아웃을 직접 덮는다.
+- 에픽의 성능 패스에는 긴 입력 EmbeddingGemma 사례를 포함해야 한다. sliding window는 512 토큰을 넘어야 관여하고 두 마스크의 shape가 다르기 때문이다(`[B, 1, 1, L]` 대 `[B, 1, L, L]`).
+
+---
+
+## 참고
+
+- 이슈 #1329, 에픽 #1348
+- PR #1408(임베딩 기반), 이슈 #1353
+- `docs/embeddings.md`, `docs/supported-models.md`
+- `mlx-community/embeddinggemma-300m-4bit`, `Qwen/Qwen3-Embedding-0.6B`

--- a/docs/embeddings.md
+++ b/docs/embeddings.md
@@ -30,6 +30,9 @@ mlxcel serves embedding checkpoints through the OpenAI-compatible `POST /v1/embe
 | `src/server/routes/embeddings.rs` | HTTP handler, validation order, error mapping. |
 | `src/server/types/embeddings.rs` | Request and response types, base64 encoding. |
 | `src/commands/embed.rs` | `mlxcel embed`. |
+| `src/models/embedding_sanitize.rs` | Weight-key normalization shared by the decoder-backbone families: `{N}_Dense.linear.*` folding, head dropping, `model.` prefixing. |
+| `src/models/gemma3_embedding.rs` | EmbeddingGemma: bidirectional Gemma 3, mean pooling, two `Dense` projections. |
+| `src/models/qwen3_embedding.rs` | Qwen3-Embedding: causal Qwen3, last-token pooling. |
 
 ## Detection
 
@@ -95,6 +98,27 @@ Micro-batches are right-padded to their longest member (or to a fixed width when
 
 ## Family notes
 
+Prompt prefixes are caller-side everywhere: nothing is injected server-side, so an input embeds exactly as it is sent. The `instruction` request field (and `mlxcel embed --instruction`) reaches `EmbeddingModel::format_text`, and only a family that documents a format below does anything with it.
+
+### ModernBERT (`modernbert`)
+
+ModernBERT is an 8192-context bidirectional encoder with RoPE instead of an absolute position table, so `max_position_embeddings` does not cap the input length; `max_length` comes from `sentence_bert_config.json` and `tokenizer_config.json` and resolves to `8192` for both published checkpoints. Two out of every three layers use a sliding window of `local_attention / 2` keys on each side (64 with the published `local_attention: 128`) and rotate with `local_rope_theta` (10000); the remaining layers see the whole sequence and rotate with `global_rope_theta` (160000). Layer 0 legitimately ships no `attn_norm` (upstream makes it `nn.Identity()`); a missing `attn_norm` on any other layer is a load error. `Wqkv` and `Wi` are fused tensors and are split after the projection, never by slicing the weight, so a quantized export loads unchanged. `ModernBertModel` and `ModernBertForMaskedLM` both load as embedders, the MLM `head.*` / `decoder.*` tensors being dropped.
+
+`nomic-ai/modernbert-embed-base` is asymmetric and expects an explicit task prefix in the text: `search_query: ` before a query and `search_document: ` before a passage. The prefixes are part of the input string, not a server-side wrapper, so pass them yourself in `input` (or in `mlxcel embed -p`); omitting them costs retrieval quality. It also supports Matryoshka truncation, so `dimensions` down to 256 stays meaningful (the engine re-normalizes after truncating).
+
+```sh
+mlxcel embed -m nomic-ai/modernbert-embed-base \
+  -p "search_query: What is TSNE?" \
+  -p "search_document: t-SNE is a dimensionality reduction technique used for visualizing high-dimensional data." \
+  -p "search_document: The Eiffel Tower is a wrought-iron lattice tower in Paris."
+
+mlxcel-server -m nomic-ai/modernbert-embed-base --port 8080
+curl -s localhost:8080/v1/embeddings -H 'Content-Type: application/json' \
+  -d '{"input": ["search_query: What is TSNE?", "search_document: t-SNE is a dimensionality reduction technique used for visualizing high-dimensional data."]}'
+```
+
+`Alibaba-NLP/gte-reranker-modernbert-base` declares `ModernBertForSequenceClassification`, which detection deliberately refuses to route to any embedding variant (a reranker is not an embedder), so `-m` on that directory is a "not an embedding checkpoint" error today. Its head is implemented as `crate::models::modernbert_heads::ModernBertSequenceClassifier`, which loads by directory and returns `[B, num_labels]` logits from `classifier(norm(gelu(dense(pooled))))` with `classifier_pooling` (`cls` or `mean`) deciding the pooling; `/v1/rerank` wiring is #1356.
+
 ### SigLIP text (`siglip`, `SiglipModel` / `SiglipTextModel`)
 
 `src/models/siglip_text.rs` serves the text tower of a SigLIP checkpoint; the vision tower is not served on `/v1/embeddings` yet, so `image_url` items are rejected. The tower is the token plus learned-position embedding, the same pre-norm encoder block the VLM vision towers use (`src/vision/encoders/siglip.rs`), a final LayerNorm and a linear projection `head`.
@@ -108,6 +132,46 @@ Micro-batches are right-padded to their longest member (or to a fixed width when
 - `vision_model.*`, `logit_scale`, `logit_bias` and any `position_ids` buffer are dropped at load; the remaining keys are used as they are.
 
 One property to know before using these vectors for text-to-text retrieval: SigLIP's text tower is trained contrastively against images, never against other texts, so nothing in training pushes two unrelated captions apart and its text-only cosine similarities sit on a high anisotropic floor. Measured on `google/siglip-base-patch16-224` over six sentences spanning animals, machinery, finance, food and physics, the fourteen unrelated pairs scored between 0.519 and 0.725 (mean 0.653), while the one related pair (`a photo of a cat` against `a photo of a kitten`) reached 0.966. Rank candidates by margin rather than thresholding the absolute score, which is the opposite of what a sentence-transformers encoder invites.
+
+### EmbeddingGemma (`Gemma3Embedding`)
+
+The Gemma 3 text backbone run bidirectionally: the full-attention layers get a padding-only mask, the sliding layers get the same padding mask intersected with a symmetric `|q - k| < sliding_window` band. Up to `sliding_window` tokens (512 on the published checkpoints) the two masks are identical, so the window only starts to matter on longer inputs. The final norm output is mean pooled, then projected through two bias-free `Dense` modules (`768 -> 3072 -> 768`, no activation) before the engine's L2 normalization.
+
+Both published layouts load. The mlx conversions fold the projections into the main shards as `dense.0.*` and `dense.1.*` and keep the `model.` prefix; the sentence-transformers original stores them in `2_Dense/` and `3_Dense/` module folders, which arrive as `2_Dense.linear.weight` and `3_Dense.linear.weight` and are ranked into `dense.0` and `dense.1`. The `Dense` widths are checked to chain from the backbone hidden size, so a swapped pair is a load error instead of a quietly wrong vector.
+
+The alternation period comes from `config.json` `layer_types` when present: transformers 4.57 renamed the scalar to `_sliding_window_pattern`, which the Gemma 3 args type does not parse, and a period that is off by one still loads and still runs.
+
+Prompt prefixes (from `config_sentence_transformers.json`), applied by the caller:
+
+| Task | Prefix |
+|------|--------|
+| Retrieval query, reranking, bitext mining | `task: search result \| query: ` |
+| Retrieval document | `title: none \| text: ` |
+| Semantic similarity (STS) | `task: sentence similarity \| query: ` |
+| Classification | `task: classification \| query: ` |
+| Clustering | `task: clustering \| query: ` |
+| Code retrieval query | `task: code retrieval \| query: ` |
+| Summarization | `task: summarization \| query: ` |
+
+`max_length` is 2048 (`sentence_bert_config.json`). The trained Matryoshka widths are 768, 512, 256 and 128, so `dimensions` at those values keeps the ranking; any other value in `1..=768` is accepted and re-normalized but is not a trained width.
+
+```sh
+mlxcel embed -m mlx-community/embeddinggemma-300m-4bit \
+  -p "task: search result | query: Which planet is known as the Red Planet?" \
+  -p "title: none | text: Mars, known for its reddish appearance, is often referred to as the Red Planet."
+```
+
+### Qwen3-Embedding (`Qwen3Embedding`)
+
+The causal Qwen3 backbone with a causal-plus-padding mask and last-token pooling: the sentence embedding is the hidden state at the `<|endoftext|>` the tokenizer appends. Batches are right-padded, which leaves the causal mask over the real tokens identical to the unpadded single-row case. The tied `lm_head` is dropped at load, and the backbone stops at the final norm, so no `[B, L, vocab_size]` logit tensor is ever built.
+
+Queries use `Instruct: {task}\nQuery: {query}` and documents are raw text. Pass the task through `instruction` (or `--instruction`) and the family wraps the text; send the fully formatted string and leave `instruction` unset to do it yourself. `instruction` applies to every input of the request, so a mixed query-and-document batch either splits into two requests or formats its queries in the text itself. `max_length` is the hard cap of 8192. The checkpoint supports `dimensions` from 32 to 1024.
+
+```sh
+mlxcel embed -m Qwen/Qwen3-Embedding-0.6B \
+  --instruction "Given a web search query, retrieve relevant passages that answer the query" \
+  -p "What is the capital of China?"
+```
 
 ## Attention masks
 
@@ -188,27 +252,6 @@ mlxcel embed -m <path or repo-id> -p "text" [-p "text2" ...] [--image <file> ...
 ```
 
 Prints one vector per input (`[v1, v2, ...]`, one line each; a list of rows for multi-vector models) and, with two or more inputs, the cosine-similarity matrix (for multi-vector models the MaxSim score averaged over the query rows). `--json` prints one object with `embeddings`, `shapes`, `prompt_tokens` and `similarity` instead. This is the offline validation tool for every family: the same loader, pooling, normalization and batching as the server, without a listener.
-
-## Family notes
-
-### ModernBERT (`modernbert`)
-
-ModernBERT is an 8192-context bidirectional encoder with RoPE instead of an absolute position table, so `max_position_embeddings` does not cap the input length; `max_length` comes from `sentence_bert_config.json` and `tokenizer_config.json` and resolves to `8192` for both published checkpoints. Two out of every three layers use a sliding window of `local_attention / 2` keys on each side (64 with the published `local_attention: 128`) and rotate with `local_rope_theta` (10000); the remaining layers see the whole sequence and rotate with `global_rope_theta` (160000). Layer 0 legitimately ships no `attn_norm` (upstream makes it `nn.Identity()`); a missing `attn_norm` on any other layer is a load error. `Wqkv` and `Wi` are fused tensors and are split after the projection, never by slicing the weight, so a quantized export loads unchanged. `ModernBertModel` and `ModernBertForMaskedLM` both load as embedders, the MLM `head.*` / `decoder.*` tensors being dropped.
-
-`nomic-ai/modernbert-embed-base` is asymmetric and expects an explicit task prefix in the text: `search_query: ` before a query and `search_document: ` before a passage. The prefixes are part of the input string, not a server-side wrapper, so pass them yourself in `input` (or in `mlxcel embed -p`); omitting them costs retrieval quality. It also supports Matryoshka truncation, so `dimensions` down to 256 stays meaningful (the engine re-normalizes after truncating).
-
-```sh
-mlxcel embed -m nomic-ai/modernbert-embed-base \
-  -p "search_query: What is TSNE?" \
-  -p "search_document: t-SNE is a dimensionality reduction technique used for visualizing high-dimensional data." \
-  -p "search_document: The Eiffel Tower is a wrought-iron lattice tower in Paris."
-
-mlxcel-server -m nomic-ai/modernbert-embed-base --port 8080
-curl -s localhost:8080/v1/embeddings -H 'Content-Type: application/json' \
-  -d '{"input": ["search_query: What is TSNE?", "search_document: t-SNE is a dimensionality reduction technique used for visualizing high-dimensional data."]}'
-```
-
-`Alibaba-NLP/gte-reranker-modernbert-base` declares `ModernBertForSequenceClassification`, which detection deliberately refuses to route to any embedding variant (a reranker is not an embedder), so `-m` on that directory is a "not an embedding checkpoint" error today. Its head is implemented as `crate::models::modernbert_heads::ModernBertSequenceClassifier`, which loads by directory and returns `[B, num_labels]` logits from `classifier(norm(gelu(dense(pooled))))` with `classifier_pooling` (`cls` or `mean`) deciding the pooling; `/v1/rerank` wiring is #1356.
 
 ## Adding a family
 

--- a/docs/supported-models.md
+++ b/docs/supported-models.md
@@ -528,6 +528,8 @@ Embedding checkpoints are served through `POST /v1/embeddings` and the offline `
 |--------|--------------|-------------|---------|-----------------------|--------|
 | ModernBERT (alternating local/global attention, RoPE, GeGLU) | `modernbert` | `ModernBert` | `mean` (family default; `1_Pooling/config.json` wins) | [`nomic-ai/modernbert-embed-base`](https://huggingface.co/nomic-ai/modernbert-embed-base) | supported. `ModernBertModel` and `ModernBertForMaskedLM` load as embedders. nomic's checkpoint is asymmetric and needs the `search_query: ` / `search_document: ` prefixes in the input text; Matryoshka `dimensions` down to 256 is meaningful. `Alibaba-NLP/gte-reranker-modernbert-base` loads through the sequence-classification head, which `/v1/rerank` (#1356) consumes. |
 | SigLIP text tower | `siglip` | `SiglipText` | last position, fixed (no `1_Pooling`) | `google/siglip-base-patch16-224` | supported (text only) |
+| EmbeddingGemma (bidirectional Gemma 3) | `gemma3_text`, `gemma3` | `Gemma3Embedding` | mean, then two bias-free `Dense` projections (768 -> 3072 -> 768) | `mlx-community/embeddinggemma-300m-4bit` | supported |
+| Qwen3-Embedding | `qwen3` | `Qwen3Embedding` | last token (the appended `<|endoftext|>`) | `Qwen/Qwen3-Embedding-0.6B` | supported |
 
 SigLIP is the one family whose sequence width is fixed rather than derived: every input is truncated to 63 tokens plus the trailing `</s>` and right-padded to exactly the 64 learned positions, no attention mask is applied, and the vector is the projection `head` applied to the hidden state at position 63. The pad token and the EOS token are the same id (`</s>`, 1), which is what makes that slot meaningful for short inputs. Image embeddings through the SigLIP vision tower are not served yet.
 

--- a/src/embeddings/loader.rs
+++ b/src/embeddings/loader.rs
@@ -134,10 +134,14 @@ fn build_family_model(
         ModelType::ModernBert => Ok(Box::new(
             crate::models::modernbert_heads::ModernBertEmbeddingModel::load(model_dir, config)?,
         )),
+        ModelType::Gemma3Embedding => Ok(Box::new(
+            crate::models::gemma3_embedding::Gemma3EmbeddingModel::load(model_dir, config)?,
+        )),
+        ModelType::Qwen3Embedding => Ok(Box::new(
+            crate::models::qwen3_embedding::Qwen3EmbeddingModel::load(model_dir, config)?,
+        )),
         ModelType::Bert
         | ModelType::XlmRoberta
-        | ModelType::Gemma3Embedding
-        | ModelType::Qwen3Embedding
         | ModelType::Qwen3VLEmbedding
         | ModelType::Lfm2Embedding
         | ModelType::Ministral3Embedding

--- a/src/embeddings/real_checkpoint_tests.rs
+++ b/src/embeddings/real_checkpoint_tests.rs
@@ -265,9 +265,11 @@ fn generation_loader_rejects_real_embedding_checkpoints() {
 
 #[test]
 fn embedding_loader_reports_unported_families_on_real_checkpoints() {
-    // No family lands in this issue: the dispatcher must name the family and
-    // the route rather than fail on a missing tensor.
-    for (repo, family) in [(MINILM, "BERT"), (QWEN3_EMBEDDING, "Qwen3-Embedding")] {
+    // For a family whose forward pass has not landed yet, the dispatcher must
+    // name the family and the route rather than fail on a missing tensor.
+    // Ported families move out of this list; Gemma3Embedding and
+    // Qwen3Embedding did so in #1329.
+    for (repo, family) in [(MINILM, "BERT")] {
         let Some(dir) = local_checkpoint(repo) else {
             continue;
         };

--- a/src/models/embedding_sanitize.rs
+++ b/src/models/embedding_sanitize.rs
@@ -1,0 +1,160 @@
+// Copyright 2025-2026 Lablup Inc. and Jeongkyu Shin
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Weight-key normalization shared by the decoder-backbone embedding
+//! families served through `/v1/embeddings`.
+//!
+//! A sentence-transformers export of a decoder backbone differs from the
+//! generator checkpoint of the same architecture in three mechanical ways,
+//! and every family that reuses a generator backbone has to undo all three
+//! before the backbone constructor can find its tensors:
+//!
+//! 1. The backbone roots are stored bare (`embed_tokens.weight`,
+//!    `layers.0.…`, `norm.weight`) because the export saves the inner
+//!    `…Model` rather than the `…ForCausalLM` wrapper, while the mlx
+//!    conversions of the same checkpoints keep the `model.` prefix.
+//! 2. A generation head (`lm_head.*`, `head.*`) may still be present and is
+//!    never used by an embedder.
+//! 3. Post-pooling `Dense` modules live in numbered subfolders
+//!    (`2_Dense/model.safetensors` with a `linear.weight` inside), which
+//!    `load_weights_from_dir_with_subfolders` surfaces as
+//!    `2_Dense.linear.weight`, while an mlx conversion folds them into the
+//!    main shards as `dense.0.*`.
+//!
+//! Used by: `crate::models::gemma3_embedding`, `crate::models::qwen3_embedding`.
+
+use mlxcel_core::weights::WeightMap;
+
+/// Backbone roots a decoder `…Model` export stores without the `model.`
+/// prefix that the generator constructors expect.
+const BACKBONE_ROOTS: &[&str] = &["embed_tokens.", "layers.", "norm."];
+
+/// Generation-head roots an embedder never reads.
+const HEAD_ROOTS: &[&str] = &["lm_head.", "head."];
+
+/// Tensor suffixes a sentence-transformers `Dense` module can carry.
+const DENSE_SUFFIXES: &[&str] = &["weight", "bias", "scales", "biases"];
+
+/// Split `{N}_Dense.linear.{suffix}` into `(N, suffix)`.
+///
+/// Returns `None` for every other key, including a `{N}_Dense.` key whose
+/// inner module is not the `linear` sentence-transformers `Dense` uses, so
+/// an unknown module is left in place rather than silently renamed.
+fn dense_module_key(key: &str) -> Option<(u32, &str)> {
+    let (folder, rest) = key.split_once('.')?;
+    let index: u32 = folder.strip_suffix("_Dense")?.parse().ok()?;
+    let suffix = rest.strip_prefix("linear.")?;
+    DENSE_SUFFIXES.contains(&suffix).then_some((index, suffix))
+}
+
+/// Rename `{N}_Dense.linear.*` tensors to `dense.{k}.*`, where `k` numbers
+/// the folders by `N` ascending.
+///
+/// The folder numbers are sentence-transformers module positions (`2_Dense`
+/// after `1_Pooling`), not projection indices, so they are ranked rather
+/// than used directly. Returns the number of distinct `Dense` folders found;
+/// `0` means the checkpoint already stores the projections as `dense.{k}.*`
+/// (the mlx conversion layout) or has none.
+pub(crate) fn fold_dense_modules(weights: &mut WeightMap) -> usize {
+    let mut folders: Vec<u32> = weights
+        .keys()
+        .filter_map(|key| dense_module_key(key).map(|(index, _)| index))
+        .collect();
+    folders.sort_unstable();
+    folders.dedup();
+    if folders.is_empty() {
+        return 0;
+    }
+
+    let renames: Vec<(String, String)> = weights
+        .keys()
+        .filter_map(|key| {
+            let (index, suffix) = dense_module_key(key)?;
+            let rank = folders.iter().position(|&f| f == index)?;
+            Some((key.clone(), format!("dense.{rank}.{suffix}")))
+        })
+        .collect();
+    for (from, to) in renames {
+        if let Some(tensor) = weights.remove(&from) {
+            weights.insert(to, tensor);
+        }
+    }
+    folders.len()
+}
+
+/// Drop every generation-head tensor.
+pub(crate) fn drop_generation_head(weights: &mut WeightMap) {
+    weights.retain(|key, _| !HEAD_ROOTS.iter().any(|root| key.starts_with(root)));
+}
+
+/// Prefix bare backbone roots with `model.`.
+///
+/// A key that already starts with `model.` is left alone, so this is a no-op
+/// on an mlx conversion and idempotent when applied twice.
+pub(crate) fn prefix_backbone_roots(weights: &mut WeightMap) {
+    let renames: Vec<(String, String)> = weights
+        .keys()
+        .filter(|key| BACKBONE_ROOTS.iter().any(|root| key.starts_with(root)))
+        .map(|key| (key.clone(), format!("model.{key}")))
+        .collect();
+    for (from, to) in renames {
+        if let Some(tensor) = weights.remove(&from) {
+            weights.insert(to, tensor);
+        }
+    }
+}
+
+/// Apply all three normalizations in the order the layouts require: fold the
+/// `Dense` subfolders first (their keys are not backbone roots), then drop
+/// the head, then prefix the backbone.
+///
+/// Returns the number of `Dense` folders folded.
+pub(crate) fn sanitize_decoder_embedding_weights(weights: &mut WeightMap) -> usize {
+    let folded = fold_dense_modules(weights);
+    drop_generation_head(weights);
+    prefix_backbone_roots(weights);
+    folded
+}
+
+/// Logical `(out_features, in_features)` of a linear stored at `prefix`.
+///
+/// A quantized weight is packed along the input axis (`[out, in * bits /
+/// 32]`), so the input width is read from the `scales` grouping
+/// (`[out, in / group_size]`) instead of the packed row. `None` when the
+/// tensor is absent or is not rank 2.
+pub(crate) fn linear_features(
+    weights: &WeightMap,
+    prefix: &str,
+    group_size: i32,
+) -> Option<(i32, i32)> {
+    let shape = mlxcel_core::array_shape(weights.get(&format!("{prefix}.weight"))?);
+    if shape.len() != 2 {
+        return None;
+    }
+    let in_features = match weights.get(&format!("{prefix}.scales")) {
+        Some(scales) => {
+            let scales_shape = mlxcel_core::array_shape(scales);
+            if scales_shape.len() != 2 {
+                return None;
+            }
+            scales_shape[1].checked_mul(group_size)?
+        }
+        None => shape[1],
+    };
+    Some((shape[0], in_features))
+}
+
+#[cfg(test)]
+#[path = "embedding_sanitize_tests.rs"]
+mod embedding_sanitize_tests;

--- a/src/models/embedding_sanitize_tests.rs
+++ b/src/models/embedding_sanitize_tests.rs
@@ -1,0 +1,140 @@
+// Copyright 2025-2026 Lablup Inc. and Jeongkyu Shin
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Key-normalization gates for the decoder-backbone embedding families.
+
+use mlxcel_core::weights::WeightMap;
+
+use super::{linear_features, sanitize_decoder_embedding_weights};
+
+/// A zero tensor of the given shape, standing in for a real weight (only the
+/// key and the shape matter here).
+fn tensor(shape: &[i32]) -> mlxcel_core::UniquePtr<mlxcel_core::MlxArray> {
+    let count: i32 = shape.iter().product();
+    mlxcel_core::from_slice_f32(&vec![0.0; count as usize], shape)
+}
+
+fn map(entries: &[(&str, &[i32])]) -> WeightMap {
+    entries
+        .iter()
+        .map(|(key, shape)| ((*key).to_string(), tensor(shape)))
+        .collect()
+}
+
+fn sorted_keys(weights: &WeightMap) -> Vec<String> {
+    let mut keys: Vec<String> = weights.keys().cloned().collect();
+    keys.sort();
+    keys
+}
+
+#[test]
+fn dense_folder_keys_map_by_index() {
+    // sentence-transformers layout: 2_Dense is the up projection (out > in)
+    // and 3_Dense the down projection, ranked into dense.0 and dense.1.
+    let mut weights = map(&[
+        ("2_Dense.linear.weight", &[3072, 768]),
+        ("3_Dense.linear.weight", &[768, 3072]),
+        ("embed_tokens.weight", &[262144, 768]),
+        ("layers.0.input_layernorm.weight", &[768]),
+        ("norm.weight", &[768]),
+        ("lm_head.weight", &[262144, 768]),
+    ]);
+    assert_eq!(sanitize_decoder_embedding_weights(&mut weights), 2);
+    assert_eq!(
+        sorted_keys(&weights),
+        vec![
+            "dense.0.weight",
+            "dense.1.weight",
+            "model.embed_tokens.weight",
+            "model.layers.0.input_layernorm.weight",
+            "model.norm.weight",
+        ]
+    );
+    assert_eq!(
+        linear_features(&weights, "dense.0", 64),
+        Some((3072, 768)),
+        "dense.0 is the up projection"
+    );
+    assert_eq!(linear_features(&weights, "dense.1", 64), Some((768, 3072)));
+}
+
+#[test]
+fn mlx_conversion_layout_is_left_alone() {
+    // The mlx-community conversion already folds the projections into the
+    // main shards and keeps the `model.` prefix, so sanitization is a no-op
+    // on the key set.
+    let mut weights = map(&[
+        ("dense.0.weight", &[3072, 12]),
+        ("dense.0.scales", &[3072, 12]),
+        ("dense.1.weight", &[768, 48]),
+        ("dense.1.scales", &[768, 48]),
+        ("model.embed_tokens.weight", &[262144, 96]),
+        ("model.norm.weight", &[768]),
+    ]);
+    let before = sorted_keys(&weights);
+    assert_eq!(sanitize_decoder_embedding_weights(&mut weights), 0);
+    assert_eq!(sorted_keys(&weights), before);
+    // Packed 4-bit rows: the input width comes from the scales grouping.
+    assert_eq!(linear_features(&weights, "dense.0", 64), Some((3072, 768)));
+    assert_eq!(linear_features(&weights, "dense.1", 64), Some((768, 3072)));
+}
+
+#[test]
+fn both_layouts_produce_the_same_dense_shapes() {
+    let mut subfolder = map(&[
+        ("2_Dense.linear.weight", &[3072, 768]),
+        ("3_Dense.linear.weight", &[768, 3072]),
+    ]);
+    let mut folded = map(&[
+        ("dense.0.weight", &[3072, 768]),
+        ("dense.1.weight", &[768, 3072]),
+    ]);
+    sanitize_decoder_embedding_weights(&mut subfolder);
+    sanitize_decoder_embedding_weights(&mut folded);
+    assert_eq!(sorted_keys(&subfolder), sorted_keys(&folded));
+    for prefix in ["dense.0", "dense.1"] {
+        assert_eq!(
+            linear_features(&subfolder, prefix, 64),
+            linear_features(&folded, prefix, 64)
+        );
+    }
+}
+
+#[test]
+fn prefixing_is_idempotent_and_skips_non_backbone_roots() {
+    let mut weights = map(&[
+        ("embed_tokens.weight", &[8, 4]),
+        ("model.layers.0.mlp.up_proj.weight", &[8, 4]),
+        ("dense.0.weight", &[8, 4]),
+    ]);
+    sanitize_decoder_embedding_weights(&mut weights);
+    let once = sorted_keys(&weights);
+    sanitize_decoder_embedding_weights(&mut weights);
+    assert_eq!(sorted_keys(&weights), once);
+    assert_eq!(
+        once,
+        vec![
+            "dense.0.weight",
+            "model.embed_tokens.weight",
+            "model.layers.0.mlp.up_proj.weight",
+        ]
+    );
+}
+
+#[test]
+fn unknown_dense_submodule_is_not_renamed() {
+    let mut weights = map(&[("2_Dense.projection.weight", &[8, 4])]);
+    assert_eq!(sanitize_decoder_embedding_weights(&mut weights), 0);
+    assert_eq!(sorted_keys(&weights), vec!["2_Dense.projection.weight"]);
+}

--- a/src/models/embedding_test_support.rs
+++ b/src/models/embedding_test_support.rs
@@ -1,0 +1,229 @@
+// Copyright 2025-2026 Lablup Inc. and Jeongkyu Shin
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Test-only helpers shared by the decoder-backbone embedding family tests:
+//! a deterministic weight generator, small array utilities, and the
+//! soft-skipping checkpoint lookup the real-checkpoint gates use.
+
+use std::borrow::Cow;
+use std::collections::HashMap;
+use std::path::{Path, PathBuf};
+use std::sync::{Mutex, MutexGuard, OnceLock};
+
+use mlxcel_core::weights::WeightMap;
+use mlxcel_core::{MlxArray, UniquePtr};
+use safetensors::tensor::{Dtype as SafeTensorDtype, View};
+
+/// Serialize every test that builds an embedding model or runs a forward
+/// pass, across both decoder-backbone family test modules.
+///
+/// `EmbeddingModel` is documented as single-thread and the product honors
+/// that through the embedding worker, so this hazard is test-side only.
+/// libtest runs one thread per logical CPU, and two concurrent MLX forward
+/// passes in one process interfere in two observed ways on this tree: a CUDA
+/// graph capture aborts the process outright (`cudaStreamEndCapture ...
+/// operation failed due to a previous error during capture`), and results
+/// drift, with two byte-identical rows of one batch scoring cosine 0.999912
+/// instead of 1.0. A gate number read from an unguarded parallel run is not
+/// evidence of anything.
+///
+/// The lock is process-wide rather than per-module so the EmbeddingGemma and
+/// Qwen3-Embedding gates also serialize against each other. A poisoned lock
+/// is recovered rather than propagated: one panicking test must fail alone,
+/// not cascade into every later test in the module.
+///
+/// It cannot serialize against MLX work in *other* modules, which is why
+/// every gate this repository defines (`make verify-test`,
+/// `make verify-test-cuda`, `make test-fast`) passes `--test-threads=1`. A
+/// raw multi-threaded `cargo test` over a wide filter is not a supported way
+/// to run this suite on either backend.
+pub(crate) fn mlx_test_guard() -> MutexGuard<'static, ()> {
+    static GUARD: OnceLock<Mutex<()>> = OnceLock::new();
+    GUARD
+        .get_or_init(|| Mutex::new(()))
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner())
+}
+
+/// Deterministic xorshift64* generator.
+///
+/// Synthetic model weights must be reproducible across runs and across the
+/// two models a differential test compares, so nothing here draws from a
+/// seeded-by-time source.
+pub(crate) struct Rng(u64);
+
+impl Rng {
+    pub(crate) fn new(seed: u64) -> Self {
+        Self(seed | 1)
+    }
+
+    fn next_u64(&mut self) -> u64 {
+        let mut x = self.0;
+        x ^= x >> 12;
+        x ^= x << 25;
+        x ^= x >> 27;
+        self.0 = x;
+        x.wrapping_mul(0x2545_F491_4F6C_DD1D)
+    }
+
+    /// Uniform in `[-scale, scale)`.
+    pub(crate) fn next_f32(&mut self, scale: f32) -> f32 {
+        let unit = (self.next_u64() >> 40) as f32 / (1u32 << 24) as f32;
+        (unit * 2.0 - 1.0) * scale
+    }
+
+    /// `count` uniform values in `[-scale, scale)`.
+    pub(crate) fn values(&mut self, count: usize, scale: f32) -> Vec<f32> {
+        (0..count).map(|_| self.next_f32(scale)).collect()
+    }
+
+    /// A dense f32 tensor of the given shape.
+    pub(crate) fn tensor(&mut self, shape: &[i32], scale: f32) -> UniquePtr<MlxArray> {
+        let count: i32 = shape.iter().product();
+        mlxcel_core::from_slice_f32(&self.values(count as usize, scale), shape)
+    }
+
+    /// Insert a dense f32 tensor under `key`.
+    pub(crate) fn insert(&mut self, weights: &mut WeightMap, key: &str, shape: &[i32], scale: f32) {
+        weights.insert(key.to_string(), self.tensor(shape, scale));
+    }
+}
+
+/// `[B, L]` int32 token ids.
+pub(crate) fn ids_array(ids: &[i32], batch: i32, length: i32) -> UniquePtr<MlxArray> {
+    mlxcel_core::from_slice_i32(ids, &[batch, length])
+}
+
+/// Read an array back as a flat row-major `Vec<f32>`.
+pub(crate) fn to_vec(array: &MlxArray) -> Vec<f32> {
+    mlxcel_core::utils::array_to_vec_f32(array)
+}
+
+/// Largest absolute element-wise difference between two equally sized slices.
+pub(crate) fn max_abs_diff(a: &[f32], b: &[f32]) -> f32 {
+    assert_eq!(a.len(), b.len(), "compared slices must have equal length");
+    a.iter()
+        .zip(b)
+        .map(|(x, y)| (x - y).abs())
+        .fold(0.0_f32, f32::max)
+}
+
+/// Render an expected failure, including the anyhow context chain.
+///
+/// Neither the family models nor [`crate::embeddings::EmbeddingOutput`]
+/// implement `Debug` (they hold raw MLX handles), so `unwrap_err` is not
+/// available on their results.
+pub(crate) fn err_string<T>(result: anyhow::Result<T>) -> String {
+    match result {
+        Ok(_) => panic!("expected an error, got Ok"),
+        Err(error) => format!("{error:#}"),
+    }
+}
+
+/// Cosine similarity of two equally sized vectors.
+pub(crate) fn cosine(a: &[f32], b: &[f32]) -> f32 {
+    let dot: f32 = a.iter().zip(b).map(|(x, y)| x * y).sum();
+    let na: f32 = a.iter().map(|x| x * x).sum::<f32>().sqrt();
+    let nb: f32 = b.iter().map(|x| x * x).sum::<f32>().sqrt();
+    if na == 0.0 || nb == 0.0 {
+        return 0.0;
+    }
+    dot / (na * nb)
+}
+
+/// A shaped f32 tensor for the safetensors writer below.
+struct F32Tensor {
+    shape: Vec<usize>,
+    data: Vec<u8>,
+}
+
+impl View for &F32Tensor {
+    fn dtype(&self) -> SafeTensorDtype {
+        SafeTensorDtype::F32
+    }
+
+    fn shape(&self) -> &[usize] {
+        &self.shape
+    }
+
+    fn data(&self) -> Cow<'_, [u8]> {
+        self.data.as_slice().into()
+    }
+
+    fn data_len(&self) -> usize {
+        self.data.len()
+    }
+}
+
+/// A fresh empty directory under the system temp dir.
+pub(crate) fn temp_dir(name: &str) -> PathBuf {
+    let nanos = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap()
+        .as_nanos();
+    let dir = std::env::temp_dir().join(format!("mlxcel_embedding_test_{name}_{nanos}"));
+    std::fs::create_dir_all(&dir).unwrap();
+    dir
+}
+
+/// Write a shaped multi-tensor f32 safetensors file.
+///
+/// Used to materialize a synthetic checkpoint directory on disk so a family
+/// loader can be exercised through its real `load(dir)` path, subfolder
+/// module layout included, rather than only through an in-memory weight map.
+pub(crate) fn write_f32_safetensors(path: &Path, tensors: &[(String, Vec<i32>, Vec<f32>)]) {
+    let owned: Vec<(String, F32Tensor)> = tensors
+        .iter()
+        .map(|(name, shape, values)| {
+            (
+                name.clone(),
+                F32Tensor {
+                    shape: shape.iter().map(|&d| d as usize).collect(),
+                    data: values.iter().flat_map(|v| v.to_le_bytes()).collect(),
+                },
+            )
+        })
+        .collect();
+    let views: HashMap<&str, &F32Tensor> = owned
+        .iter()
+        .map(|(name, tensor)| (name.as_str(), tensor))
+        .collect();
+    safetensors::serialize_to_file(views, None, path).unwrap();
+}
+
+/// Locate a downloaded checkpoint: the mlxcel store, then the HuggingFace
+/// cache, then `<repo>/models/<name>`. `None` skips the calling gate, the
+/// same convention `src/embeddings/real_checkpoint_tests.rs` and
+/// `tests/*_parity.rs` follow.
+pub(crate) fn local_checkpoint(repo_id: &str) -> Option<PathBuf> {
+    let candidates = [
+        crate::downloader::model_dir(repo_id),
+        crate::downloader::hf_cache_snapshot(repo_id, None),
+        Some(
+            PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+                .join("models")
+                .join(crate::downloader::repo_basename(repo_id)),
+        ),
+    ];
+    let found = candidates
+        .into_iter()
+        .flatten()
+        .find(|dir| dir.join("config.json").is_file());
+    if found.is_none() {
+        eprintln!(
+            "skipping real-checkpoint gate: {repo_id} not present (mlxcel download {repo_id})"
+        );
+    }
+    found
+}

--- a/src/models/gemma3_embedding.rs
+++ b/src/models/gemma3_embedding.rs
@@ -1,0 +1,327 @@
+// Copyright 2025-2026 Lablup Inc. and Jeongkyu Shin
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! EmbeddingGemma: the Gemma 3 text backbone run bidirectionally, mean
+//! pooled, then projected through two bias-free `Dense` modules.
+//!
+//! The checkpoint is a Gemma 3 decoder (`model_type: gemma3_text`,
+//! `architectures: ["Gemma3TextModel"]`) exported with
+//! `use_bidirectional_attention: true`, so the layers, the norms and the RoPE
+//! schedule are exactly [`crate::models::gemma3`]'s. Only three things differ
+//! from the generator:
+//!
+//! - Every layer sees a bidirectional mask. The full-attention layers get a
+//!   padding-only mask; the sliding layers get the same padding mask
+//!   intersected with a symmetric `|q - k| < sliding_window` band, which is
+//!   how `transformers` builds the bidirectional sliding overlay. For inputs
+//!   up to `sliding_window` tokens the two masks are identical, so the window
+//!   only starts to matter past 512 tokens.
+//! - There is no `lm_head`. The final norm output is mask-weighted mean
+//!   pooled into one vector per row.
+//! - Two `Dense` projections (`768 -> 3072 -> 768`, no bias, no activation)
+//!   run after pooling, before the L2 normalization the engine applies.
+//!
+//! Because the masks are owned here, each layer's built-in causal window
+//! parameter is cleared after construction: an explicit mask plus a causal
+//! window would re-impose causality on the Metal 4 attention path.
+//!
+//! Prompt prefixes (`task: search result | query: `, `title: none | text: `)
+//! are caller-side and documented in `docs/embeddings.md`; the trained
+//! Matryoshka widths are 768, 512, 256 and 128.
+
+use std::path::Path;
+
+use anyhow::{Context, Result, bail};
+use mlxcel_core::layers::{GemmaRMSNorm, KVCache, UnifiedEmbedding, UnifiedLinear};
+use mlxcel_core::utils::{create_bidirectional_padding_mask, create_bidirectional_window_mask};
+use mlxcel_core::weights::WeightMap;
+use mlxcel_core::{MlxArray, UniquePtr};
+use serde_json::Value;
+
+use crate::embeddings::limits::config_normalize_flag;
+use crate::embeddings::loader::load_embedding_weights;
+use crate::embeddings::model::{EmbeddingBatch, EmbeddingModel, EmbeddingOutput};
+use crate::embeddings::pooling::{PoolingMode, pool, resolve_pooling_mode};
+use crate::models::embedding_sanitize::{linear_features, sanitize_decoder_embedding_weights};
+use crate::models::gemma3::{Cache, ModelArgs, TransformerBlock};
+
+/// `layer_types` entry marking a full-attention (global) layer.
+const FULL_ATTENTION: &str = "full_attention";
+
+/// EmbeddingGemma: bidirectional Gemma 3 layers, mean pooling, two `Dense`
+/// projections.
+pub struct Gemma3EmbeddingModel {
+    embed_tokens: UnifiedEmbedding,
+    layers: Vec<TransformerBlock>,
+    norm: GemmaRMSNorm,
+    /// Post-pooling projections in application order (`dense.0`, `dense.1`).
+    /// Empty for a bidirectional Gemma 3 export that ships no `Dense` module.
+    dense: Vec<UnifiedLinear>,
+    hidden_size: usize,
+    /// Symmetric half-width of the sliding-layer band, in tokens.
+    sliding_window: i32,
+    /// Layer `i` is a full-attention layer iff `(i + 1) % pattern == 0`.
+    sliding_window_pattern: usize,
+    pooling: PoolingMode,
+    normalize: bool,
+    embedding_dim: usize,
+}
+
+/// Resolve the sliding / full alternation period.
+///
+/// `layer_types` is authoritative when present: transformers 4.57 renamed the
+/// scalar to `_sliding_window_pattern` (which [`ModelArgs`] does not parse,
+/// so it would silently fall back to the family default of 6) and lists the
+/// per-layer kinds instead. The list is validated against the derived period
+/// rather than only sampled, because a period that is off by one still loads,
+/// still runs, and only shows up as a quietly wrong embedding.
+fn resolve_sliding_window_pattern(config: &Value, fallback: usize) -> Result<usize> {
+    let Some(layer_types) = config.get("layer_types").and_then(Value::as_array) else {
+        let scalar = config
+            .get("sliding_window_pattern")
+            .or_else(|| config.get("_sliding_window_pattern"))
+            .and_then(Value::as_u64)
+            .map(|v| v as usize)
+            .filter(|&v| v > 0);
+        return Ok(scalar.unwrap_or(fallback));
+    };
+    if layer_types.is_empty() {
+        return Ok(fallback);
+    }
+
+    let is_full: Vec<bool> = layer_types
+        .iter()
+        .map(|entry| entry.as_str() == Some(FULL_ATTENTION))
+        .collect();
+    // No full-attention layer at all: every layer is sliding, which
+    // `(i + 1) % pattern == 0` expresses with a period past the last index.
+    let pattern = match is_full.iter().position(|&full| full) {
+        Some(first) => first + 1,
+        None => return Ok(layer_types.len() + 1),
+    };
+    for (i, &full) in is_full.iter().enumerate() {
+        if full != (i + 1).is_multiple_of(pattern) {
+            bail!(
+                "config.json `layer_types` is not a repeating period-{pattern} pattern: layer {i} \
+                 is `{}` but the period derived from the first `{FULL_ATTENTION}` entry says \
+                 otherwise",
+                layer_types[i].as_str().unwrap_or("?")
+            );
+        }
+    }
+    Ok(pattern)
+}
+
+impl Gemma3EmbeddingModel {
+    /// Load an EmbeddingGemma checkpoint from `model_dir`.
+    ///
+    /// Accepts both published layouts: the mlx conversion, which folds the
+    /// projections into the main shards as `dense.{k}.*` and keeps the
+    /// `model.` prefix, and the sentence-transformers original, whose
+    /// `2_Dense/` and `3_Dense/` module folders reach us as
+    /// `{N}_Dense.linear.*` and whose backbone roots are bare.
+    pub fn load(model_dir: &Path, config: &Value) -> Result<Self> {
+        let mut args: ModelArgs = serde_json::from_value(config.clone())
+            .context("failed to parse the EmbeddingGemma config.json as a Gemma 3 config")?;
+        args.sliding_window_pattern =
+            resolve_sliding_window_pattern(config, args.sliding_window_pattern)?;
+
+        let mut weights = load_embedding_weights(model_dir, config)?;
+        sanitize_decoder_embedding_weights(&mut weights);
+
+        let pooling = resolve_pooling_mode(model_dir, PoolingMode::Mean)?;
+        Self::from_weights(&weights, &args, pooling, config_normalize_flag(config))
+    }
+
+    /// Build the model from an already sanitized weight map.
+    ///
+    /// Split from [`Self::load`] so the mask and pooling behaviour can be
+    /// exercised on a synthetic checkpoint-free model.
+    pub(crate) fn from_weights(
+        weights: &WeightMap,
+        args: &ModelArgs,
+        pooling: PoolingMode,
+        normalize: bool,
+    ) -> Result<Self> {
+        let group_size = args.group_size();
+        let bits = args.bits();
+        let embed_tokens =
+            UnifiedEmbedding::from_weights(weights, "model.embed_tokens", group_size, bits)
+                .map_err(|e| anyhow::anyhow!("EmbeddingGemma: {e}"))?;
+
+        let mut layers = Vec::with_capacity(args.num_hidden_layers);
+        for i in 0..args.num_hidden_layers {
+            let mut layer = TransformerBlock::from_weights(weights, args, i)
+                .map_err(|e| anyhow::anyhow!("EmbeddingGemma layer {i}: {e}"))?;
+            // The embedding path builds and owns every mask, so the layer must
+            // not also apply its causal sliding window.
+            layer.self_attn.window_size = 0;
+            layers.push(layer);
+        }
+
+        let norm_weight = weights
+            .get("model.norm.weight")
+            .map(|w| mlxcel_core::copy(w))
+            .ok_or_else(|| {
+                anyhow::anyhow!("EmbeddingGemma: weight not found: model.norm.weight")
+            })?;
+        let norm = GemmaRMSNorm::new(norm_weight, args.rms_norm_eps);
+
+        let dense = load_dense_stack(weights, group_size, bits, args.hidden_size)?;
+        let embedding_dim = match dense.len().checked_sub(1) {
+            Some(last) => linear_features(weights, &format!("dense.{last}"), group_size)
+                .map(|(out, _)| out as usize)
+                .unwrap_or(args.hidden_size),
+            None => args.hidden_size,
+        };
+
+        Ok(Self {
+            embed_tokens,
+            layers,
+            norm,
+            dense,
+            hidden_size: args.hidden_size,
+            sliding_window: args.sliding_window as i32,
+            sliding_window_pattern: args.sliding_window_pattern,
+            pooling,
+            normalize,
+            embedding_dim,
+        })
+    }
+
+    /// `true` when layer `i` is a full-attention layer.
+    fn is_full_attention(&self, i: usize) -> bool {
+        (i + 1).is_multiple_of(self.sliding_window_pattern)
+    }
+
+    /// `true` when at least one layer needs the windowed mask.
+    fn has_sliding_layers(&self) -> bool {
+        (0..self.layers.len()).any(|i| !self.is_full_attention(i))
+    }
+
+    /// Run the bidirectional backbone and the final norm, returning the
+    /// `[B, L, hidden_size]` hidden states before pooling.
+    ///
+    /// `attention_mask` is the `[B, L]` int32 padding mask (`1` = real token).
+    pub(crate) fn forward_hidden(
+        &self,
+        input_ids: &MlxArray,
+        attention_mask: &MlxArray,
+    ) -> UniquePtr<MlxArray> {
+        // Gemma scales the token embeddings by sqrt(hidden_size), exactly as
+        // `Gemma3Model::get_embed_tokens` does for the generator.
+        let mut h = self.embed_tokens.forward(input_ids);
+        h = mlxcel_core::multiply_scalar(&h, (self.hidden_size as f32).sqrt());
+
+        let full_mask = create_bidirectional_padding_mask(attention_mask);
+        let sliding_mask = (self.has_sliding_layers() && self.sliding_window >= 1)
+            .then(|| create_bidirectional_window_mask(attention_mask, self.sliding_window));
+
+        // Fresh per-call caches at offset 0: the embedder never reuses a KV
+        // cache, and offset 0 keeps RoPE and the mask key axis aligned with
+        // the input length.
+        let mut caches: Vec<Cache> = (0..self.layers.len())
+            .map(|_| Cache::Standard(KVCache::new()))
+            .collect();
+
+        for (i, layer) in self.layers.iter().enumerate() {
+            let mask: &MlxArray = if self.is_full_attention(i) {
+                &full_mask
+            } else {
+                sliding_mask.as_deref().unwrap_or(&full_mask)
+            };
+            h = layer.forward(&h, caches[i].as_interface(), Some(mask));
+        }
+        self.norm.forward(&h)
+    }
+}
+
+/// Load the post-pooling `Dense` stack (`dense.0`, `dense.1`, ...), verifying
+/// that the widths chain from the backbone hidden size.
+///
+/// A shape mismatch here is the failure mode a silent `dense.0` / `dense.1`
+/// swap produces: both projections load, the forward pass runs, and only the
+/// vectors are wrong. Checking the chain turns that into a load error.
+fn load_dense_stack(
+    weights: &WeightMap,
+    group_size: i32,
+    bits: i32,
+    hidden_size: usize,
+) -> Result<Vec<UnifiedLinear>> {
+    let mut stack = Vec::new();
+    let mut expected_in = hidden_size as i32;
+    for index in 0.. {
+        let prefix = format!("dense.{index}");
+        let Some((out_features, in_features)) = linear_features(weights, &prefix, group_size)
+        else {
+            break;
+        };
+        if in_features != expected_in {
+            bail!(
+                "EmbeddingGemma: {prefix} expects {in_features} input features but the previous \
+                 stage produces {expected_in}; the Dense modules are out of order or belong to a \
+                 different checkpoint"
+            );
+        }
+        stack.push(
+            UnifiedLinear::from_weights(weights, &prefix, group_size, bits)
+                .map_err(|e| anyhow::anyhow!("EmbeddingGemma {prefix}: {e}"))?,
+        );
+        expected_in = out_features;
+    }
+    Ok(stack)
+}
+
+impl EmbeddingModel for Gemma3EmbeddingModel {
+    fn embed(&self, batch: &EmbeddingBatch) -> Result<EmbeddingOutput> {
+        if batch.images.is_some_and(|images| !images.is_empty()) {
+            bail!("EmbeddingGemma is a text-only embedder and does not accept images");
+        }
+
+        let hidden = self.forward_hidden(batch.input_ids, batch.attention_mask);
+        let hidden_dtype = mlxcel_core::array_dtype(&hidden);
+        let mut pooled: UniquePtr<MlxArray> = pool(&hidden, batch.attention_mask, self.pooling);
+        if !self.dense.is_empty() {
+            // Pooling returns f32; the projections carry the checkpoint's own
+            // dtype, so cast back before the (possibly quantized) matmuls. With
+            // no projections the f32 pooled vector goes straight to the engine
+            // instead of taking a needless round trip through f16.
+            pooled = mlxcel_core::astype(&pooled, hidden_dtype);
+            for dense in &self.dense {
+                pooled = dense.forward(&pooled);
+            }
+        }
+
+        Ok(EmbeddingOutput {
+            embeddings: pooled,
+            last_hidden_state: None,
+        })
+    }
+
+    fn default_pooling(&self) -> PoolingMode {
+        PoolingMode::Mean
+    }
+
+    fn normalize(&self) -> bool {
+        self.normalize
+    }
+
+    fn embedding_dim(&self) -> usize {
+        self.embedding_dim
+    }
+}
+
+#[cfg(test)]
+#[path = "gemma3_embedding_tests.rs"]
+mod gemma3_embedding_tests;

--- a/src/models/gemma3_embedding_tests.rs
+++ b/src/models/gemma3_embedding_tests.rs
@@ -1,0 +1,635 @@
+// Copyright 2025-2026 Lablup Inc. and Jeongkyu Shin
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! EmbeddingGemma gates.
+//!
+//! The forward tests build a 16-wide synthetic Gemma 3 from deterministic
+//! weights, so they run on any device without a checkpoint. Two properties
+//! carry the port and neither is visible in a shape check: the layers must be
+//! bidirectional (a later token has to change an earlier token's state), and
+//! only the full-attention layers may see past the sliding band.
+//!
+//! The last test loads the real `mlx-community/embeddinggemma-300m-4bit`
+//! conversion and soft-skips when it is not downloaded.
+
+use anyhow::Result;
+use mlxcel_core::weights::WeightMap;
+use serde_json::json;
+
+use super::{Gemma3EmbeddingModel, resolve_sliding_window_pattern};
+use crate::embeddings::model::{EmbeddingBatch, EmbeddingModel};
+use crate::embeddings::pooling::PoolingMode;
+use crate::models::embedding_test_support::{
+    Rng, cosine, err_string, ids_array, local_checkpoint, max_abs_diff, mlx_test_guard, temp_dir,
+    to_vec, write_f32_safetensors,
+};
+use crate::models::gemma3::ModelArgs;
+
+const HIDDEN: usize = 16;
+const INTERMEDIATE: usize = 32;
+const HEAD_DIM: usize = 8;
+const VOCAB: usize = 32;
+const WINDOW: usize = 4;
+/// Output width of the second synthetic `Dense`; deliberately different from
+/// `HIDDEN` so a test can tell the projected width from the backbone width.
+const DENSE_OUT: usize = 24;
+
+const EMBEDDINGGEMMA: &str = "mlx-community/embeddinggemma-300m-4bit";
+
+fn tiny_args(num_layers: usize, sliding_window_pattern: usize) -> ModelArgs {
+    ModelArgs {
+        model_type: "gemma3_text".to_string(),
+        hidden_size: HIDDEN,
+        num_hidden_layers: num_layers,
+        intermediate_size: INTERMEDIATE,
+        num_attention_heads: 2,
+        head_dim: HEAD_DIM,
+        rms_norm_eps: 1e-6,
+        vocab_size: VOCAB,
+        num_key_value_heads: 1,
+        rope_theta: 1_000_000.0,
+        rope_local_base_freq: 10_000.0,
+        query_pre_attn_scalar: HEAD_DIM as f32,
+        sliding_window: WINDOW,
+        sliding_window_pattern,
+        max_position_embeddings: 128,
+        rope_scaling: None,
+        quantization: None,
+    }
+}
+
+/// One synthetic tensor: `(sanitized key, shape, values)`.
+type WeightSpec = (String, Vec<i32>, Vec<f32>);
+
+/// Deterministic weights for `args`, keyed the way the sanitizer leaves them.
+///
+/// Returned as raw values rather than MLX arrays so the same numbers can be
+/// loaded in memory and written to a synthetic checkpoint directory, which is
+/// what makes the two published layouts comparable bit for bit.
+fn tiny_weight_specs(args: &ModelArgs, dense: bool) -> Vec<WeightSpec> {
+    let mut rng = Rng::new(0x5EED_1329);
+    let mut specs: Vec<WeightSpec> = Vec::new();
+    let h = args.hidden_size as i32;
+    let hd = args.head_dim as i32;
+    let q_out = args.num_attention_heads as i32 * hd;
+    let kv_out = args.num_key_value_heads as i32 * hd;
+    let inter = args.intermediate_size as i32;
+
+    let mut push = |rng: &mut Rng, key: String, shape: Vec<i32>, scale: f32| {
+        let count: i32 = shape.iter().product();
+        let values = rng.values(count as usize, scale);
+        specs.push((key, shape, values));
+    };
+
+    push(
+        &mut rng,
+        "model.embed_tokens.weight".to_string(),
+        vec![args.vocab_size as i32, h],
+        0.5,
+    );
+    for i in 0..args.num_hidden_layers {
+        let p = format!("model.layers.{i}");
+        push(
+            &mut rng,
+            format!("{p}.self_attn.q_proj.weight"),
+            vec![q_out, h],
+            0.2,
+        );
+        push(
+            &mut rng,
+            format!("{p}.self_attn.k_proj.weight"),
+            vec![kv_out, h],
+            0.2,
+        );
+        push(
+            &mut rng,
+            format!("{p}.self_attn.v_proj.weight"),
+            vec![kv_out, h],
+            0.2,
+        );
+        push(
+            &mut rng,
+            format!("{p}.self_attn.o_proj.weight"),
+            vec![h, q_out],
+            0.2,
+        );
+        push(
+            &mut rng,
+            format!("{p}.self_attn.q_norm.weight"),
+            vec![hd],
+            0.1,
+        );
+        push(
+            &mut rng,
+            format!("{p}.self_attn.k_norm.weight"),
+            vec![hd],
+            0.1,
+        );
+        push(
+            &mut rng,
+            format!("{p}.mlp.gate_proj.weight"),
+            vec![inter, h],
+            0.2,
+        );
+        push(
+            &mut rng,
+            format!("{p}.mlp.up_proj.weight"),
+            vec![inter, h],
+            0.2,
+        );
+        push(
+            &mut rng,
+            format!("{p}.mlp.down_proj.weight"),
+            vec![h, inter],
+            0.2,
+        );
+        for norm in [
+            "input_layernorm",
+            "post_attention_layernorm",
+            "pre_feedforward_layernorm",
+            "post_feedforward_layernorm",
+        ] {
+            push(&mut rng, format!("{p}.{norm}.weight"), vec![h], 0.1);
+        }
+    }
+    push(&mut rng, "model.norm.weight".to_string(), vec![h], 0.1);
+    if dense {
+        push(&mut rng, "dense.0.weight".to_string(), vec![inter, h], 0.2);
+        push(
+            &mut rng,
+            "dense.1.weight".to_string(),
+            vec![DENSE_OUT as i32, inter],
+            0.2,
+        );
+    }
+    specs
+}
+
+/// The same weights as an in-memory map.
+fn tiny_weights(args: &ModelArgs, dense: bool) -> WeightMap {
+    tiny_weight_specs(args, dense)
+        .into_iter()
+        .map(|(key, shape, values)| (key, mlxcel_core::from_slice_f32(&values, &shape)))
+        .collect()
+}
+
+fn build(args: &ModelArgs, weights: &WeightMap) -> Result<Gemma3EmbeddingModel> {
+    Gemma3EmbeddingModel::from_weights(weights, args, PoolingMode::Mean, true)
+}
+
+/// `[L, HIDDEN]` hidden states of one unpadded row.
+fn hidden_states(model: &Gemma3EmbeddingModel, ids: &[i32]) -> Vec<f32> {
+    let length = ids.len() as i32;
+    let input = ids_array(ids, 1, length);
+    let mask = ids_array(&vec![1; ids.len()], 1, length);
+    to_vec(&model.forward_hidden(&input, &mask))
+}
+
+/// The first token's hidden state.
+fn first_token(states: &[f32]) -> &[f32] {
+    &states[..HIDDEN]
+}
+
+fn ramp(len: usize) -> Vec<i32> {
+    (0..len).map(|i| (i % VOCAB) as i32).collect()
+}
+
+// Config surface.
+
+#[test]
+fn layer_types_drives_the_sliding_pattern() {
+    // transformers 4.57 spells the scalar `_sliding_window_pattern`, which the
+    // Gemma 3 args type does not parse: without `layer_types` the family
+    // default would silently apply.
+    let config = json!({
+        "_sliding_window_pattern": 6,
+        "layer_types": [
+            "sliding_attention", "sliding_attention", "sliding_attention",
+            "sliding_attention", "sliding_attention", "full_attention",
+            "sliding_attention", "sliding_attention", "sliding_attention",
+            "sliding_attention", "sliding_attention", "full_attention"
+        ]
+    });
+    assert_eq!(resolve_sliding_window_pattern(&config, 99).unwrap(), 6);
+
+    // Underscore-prefixed scalar, no layer_types.
+    let scalar = json!({"_sliding_window_pattern": 4});
+    assert_eq!(resolve_sliding_window_pattern(&scalar, 99).unwrap(), 4);
+
+    // Neither: the caller's fallback (the ModelArgs default) stands.
+    assert_eq!(resolve_sliding_window_pattern(&json!({}), 6).unwrap(), 6);
+
+    // All sliding: the period is pushed past the last layer so no layer is
+    // ever treated as full attention.
+    let all_sliding = json!({"layer_types": ["sliding_attention", "sliding_attention"]});
+    assert_eq!(resolve_sliding_window_pattern(&all_sliding, 6).unwrap(), 3);
+}
+
+#[test]
+fn irregular_layer_types_are_a_load_error() {
+    let config = json!({
+        "layer_types": ["sliding_attention", "full_attention", "full_attention"]
+    });
+    let err = resolve_sliding_window_pattern(&config, 6)
+        .unwrap_err()
+        .to_string();
+    assert!(err.contains("layer_types"), "{err}");
+    assert!(err.contains("period-2"), "{err}");
+}
+
+// Forward pass.
+
+#[test]
+fn bidirectional_prefill_is_not_causal() {
+    let _guard = mlx_test_guard();
+    // One full-attention layer over 96 tokens: flipping the *last* token must
+    // move the *first* token's hidden state. A causal mask makes this exactly
+    // zero, which is the regression this guards.
+    let args = tiny_args(1, 1);
+    let weights = tiny_weights(&args, false);
+    let model = build(&args, &weights).unwrap();
+
+    let mut ids = ramp(96);
+    let baseline = hidden_states(&model, &ids);
+    ids[95] = (ids[95] + 7) % VOCAB as i32;
+    let perturbed = hidden_states(&model, &ids);
+
+    let moved = max_abs_diff(first_token(&baseline), first_token(&perturbed));
+    assert!(
+        moved > 1e-4,
+        "the first token did not react to the last token ({moved}); the mask is still causal"
+    );
+}
+
+#[test]
+fn global_layers_use_padding_mask_and_sliding_layers_use_window() {
+    let _guard = mlx_test_guard();
+    // Same weights, same input, one layer each: the only difference is whether
+    // layer 0 is full attention (pattern 1) or sliding (pattern 2). A token
+    // 6 positions away is outside the window of 4.
+    let global_args = tiny_args(1, 1);
+    let sliding_args = tiny_args(1, 2);
+    let weights = tiny_weights(&global_args, false);
+    let global = build(&global_args, &weights).unwrap();
+    let sliding = build(&sliding_args, &weights).unwrap();
+
+    let mut ids = ramp(12);
+    let global_before = hidden_states(&global, &ids);
+    let sliding_before = hidden_states(&sliding, &ids);
+    ids[6] = (ids[6] + 11) % VOCAB as i32;
+    let global_after = hidden_states(&global, &ids);
+    let sliding_after = hidden_states(&sliding, &ids);
+
+    let global_moved = max_abs_diff(first_token(&global_before), first_token(&global_after));
+    let sliding_moved = max_abs_diff(first_token(&sliding_before), first_token(&sliding_after));
+    assert!(
+        global_moved > 1e-4,
+        "the full-attention layer ignored a key 6 positions away ({global_moved})"
+    );
+    assert!(
+        sliding_moved < 1e-6,
+        "the sliding layer attended a key 6 positions away with window {WINDOW} ({sliding_moved})"
+    );
+}
+
+#[test]
+fn padding_invariance() {
+    let _guard = mlx_test_guard();
+    // Row 0 of a right-padded two-row batch must equal the same text embedded
+    // alone: padding keys are blocked, and mean pooling divides by the real
+    // token count.
+    let args = tiny_args(2, 2);
+    let weights = tiny_weights(&args, true);
+    let model = build(&args, &weights).unwrap();
+
+    let short = ramp(8);
+    let long: Vec<i32> = (0..12).map(|i| ((i * 5 + 3) % VOCAB) as i32).collect();
+
+    let alone = ids_array(&short, 1, short.len() as i32);
+    let alone_mask = ids_array(&vec![1; short.len()], 1, short.len() as i32);
+    let alone_out = model
+        .embed(&EmbeddingBatch {
+            input_ids: &alone,
+            attention_mask: &alone_mask,
+            token_type_ids: None,
+            images: None,
+        })
+        .unwrap();
+    let alone_values = to_vec(&alone_out.embeddings);
+
+    let mut padded_ids = short.clone();
+    padded_ids.resize(12, 0);
+    padded_ids.extend_from_slice(&long);
+    let mut padded_mask = vec![1; short.len()];
+    padded_mask.resize(12, 0);
+    padded_mask.extend(std::iter::repeat_n(1, 12));
+
+    let batch_ids = ids_array(&padded_ids, 2, 12);
+    let batch_mask = ids_array(&padded_mask, 2, 12);
+    let batch_out = model
+        .embed(&EmbeddingBatch {
+            input_ids: &batch_ids,
+            attention_mask: &batch_mask,
+            token_type_ids: None,
+            images: None,
+        })
+        .unwrap();
+    let batch_values = to_vec(&batch_out.embeddings);
+
+    assert_eq!(alone_values.len(), DENSE_OUT);
+    assert_eq!(batch_values.len(), 2 * DENSE_OUT);
+    let row0 = &batch_values[..DENSE_OUT];
+    assert!(
+        cosine(&alone_values, row0) > 1.0 - 1e-4,
+        "padded row 0 diverged from the unpadded run: cosine {}",
+        cosine(&alone_values, row0)
+    );
+    assert!(max_abs_diff(&alone_values, row0) < 1e-3);
+}
+
+#[test]
+fn dense_stack_sets_the_embedding_width() {
+    let _guard = mlx_test_guard();
+    let args = tiny_args(1, 1);
+    let with_dense = build(&args, &tiny_weights(&args, true)).unwrap();
+    let without_dense = build(&args, &tiny_weights(&args, false)).unwrap();
+    assert_eq!(with_dense.embedding_dim(), DENSE_OUT);
+    assert_eq!(without_dense.embedding_dim(), HIDDEN);
+    assert_eq!(with_dense.default_pooling(), PoolingMode::Mean);
+}
+
+#[test]
+fn sentence_transformers_subfolder_layout_loads_from_disk_and_matches_the_mlx_layout() {
+    let _guard = mlx_test_guard();
+    // The real `load(dir)` path over a synthetic checkpoint written in the
+    // sentence-transformers layout: bare backbone roots, an unused lm_head,
+    // and the two projections in `2_Dense/` and `3_Dense/` module folders.
+    // The mlx conversion of the same numbers must embed identically, which is
+    // the property `mlx-community/embeddinggemma-300m-4bit` alone cannot show
+    // (it only ships one of the two layouts).
+    let args = tiny_args(2, 2);
+    let specs = tiny_weight_specs(&args, true);
+
+    let dir = temp_dir("embeddinggemma_subfolders");
+    std::fs::write(
+        dir.join("config.json"),
+        serde_json::to_string(&json!({
+            "model_type": "gemma3_text",
+            "architectures": ["Gemma3TextModel"],
+            "use_bidirectional_attention": true,
+            "hidden_size": HIDDEN,
+            "num_hidden_layers": 2,
+            "intermediate_size": INTERMEDIATE,
+            "num_attention_heads": 2,
+            "num_key_value_heads": 1,
+            "head_dim": HEAD_DIM,
+            "rms_norm_eps": 1e-6,
+            "vocab_size": VOCAB,
+            "rope_theta": 1_000_000.0,
+            "rope_local_base_freq": 10_000.0,
+            "query_pre_attn_scalar": HEAD_DIM,
+            "sliding_window": WINDOW,
+            "layer_types": ["sliding_attention", "full_attention"],
+            "max_position_embeddings": 128,
+        }))
+        .unwrap(),
+    )
+    .unwrap();
+
+    let mut backbone: Vec<WeightSpec> = Vec::new();
+    let mut up: Vec<WeightSpec> = Vec::new();
+    let mut down: Vec<WeightSpec> = Vec::new();
+    for (key, shape, values) in specs {
+        match key.as_str() {
+            "dense.0.weight" => up.push(("linear.weight".to_string(), shape, values)),
+            "dense.1.weight" => down.push(("linear.weight".to_string(), shape, values)),
+            _ => backbone.push((
+                key.strip_prefix("model.").unwrap_or(&key).to_string(),
+                shape,
+                values,
+            )),
+        }
+    }
+    // An lm_head the embedder must drop rather than trip over.
+    backbone.push((
+        "lm_head.weight".to_string(),
+        vec![VOCAB as i32, HIDDEN as i32],
+        vec![0.0; VOCAB * HIDDEN],
+    ));
+    write_f32_safetensors(&dir.join("model.safetensors"), &backbone);
+    for (folder, tensors) in [("2_Dense", &up), ("3_Dense", &down)] {
+        std::fs::create_dir_all(dir.join(folder)).unwrap();
+        write_f32_safetensors(&dir.join(folder).join("model.safetensors"), tensors);
+    }
+
+    let config: serde_json::Value =
+        serde_json::from_str(&std::fs::read_to_string(dir.join("config.json")).unwrap()).unwrap();
+    let from_disk = Gemma3EmbeddingModel::load(&dir, &config).expect("subfolder layout loads");
+    assert_eq!(from_disk.embedding_dim(), DENSE_OUT);
+
+    let from_memory = build(&args, &tiny_weights(&args, true)).unwrap();
+    let ids = ramp(12);
+    let input = ids_array(&ids, 1, ids.len() as i32);
+    let mask = ids_array(&vec![1; ids.len()], 1, ids.len() as i32);
+    let batch = EmbeddingBatch {
+        input_ids: &input,
+        attention_mask: &mask,
+        token_type_ids: None,
+        images: None,
+    };
+    let disk_values = to_vec(&from_disk.embed(&batch).unwrap().embeddings);
+    let memory_values = to_vec(&from_memory.embed(&batch).unwrap().embeddings);
+    assert_eq!(
+        max_abs_diff(&disk_values, &memory_values),
+        0.0,
+        "the two published layouts produced different embeddings"
+    );
+
+    std::fs::remove_dir_all(&dir).unwrap();
+}
+
+#[test]
+fn swapped_dense_projections_are_a_load_error() {
+    let _guard = mlx_test_guard();
+    let args = tiny_args(1, 1);
+    let mut weights = tiny_weights(&args, true);
+    let up = weights.remove("dense.0.weight").unwrap();
+    let down = weights.remove("dense.1.weight").unwrap();
+    weights.insert("dense.0.weight".to_string(), down);
+    weights.insert("dense.1.weight".to_string(), up);
+
+    let err = err_string(build(&args, &weights));
+    assert!(err.contains("dense.0"), "{err}");
+    assert!(err.contains("out of order"), "{err}");
+}
+
+#[test]
+fn images_are_rejected() {
+    let _guard = mlx_test_guard();
+    let args = tiny_args(1, 1);
+    let model = build(&args, &tiny_weights(&args, false)).unwrap();
+    let ids = ids_array(&[1, 2, 3], 1, 3);
+    let mask = ids_array(&[1, 1, 1], 1, 3);
+    let image = crate::embeddings::model::ImageInput {
+        image: image::DynamicImage::new_rgb8(2, 2),
+    };
+    let images = [image];
+    let err = err_string(model.embed(&EmbeddingBatch {
+        input_ids: &ids,
+        attention_mask: &mask,
+        token_type_ids: None,
+        images: Some(&images),
+    }));
+    assert!(err.contains("text-only"), "{err}");
+}
+
+// Real checkpoint.
+
+#[test]
+fn embeddinggemma_checkpoint_loads_and_ranks_the_matching_document() {
+    let _guard = mlx_test_guard();
+    let Some(dir) = local_checkpoint(EMBEDDINGGEMMA) else {
+        return;
+    };
+    let _runtime = crate::initialize_runtime();
+    let loaded = crate::embeddings::load_embedding_model(&dir).expect("EmbeddingGemma loads");
+    assert_eq!(loaded.model_type, crate::models::ModelType::Gemma3Embedding);
+    assert_eq!(loaded.limits.dim, 768, "768-wide after the Dense stack");
+    assert_eq!(
+        loaded.limits.max_length, 2048,
+        "sentence_bert_config.json max_seq_length"
+    );
+
+    let engine = crate::embeddings::EmbeddingEngine::new(loaded, 16);
+    // Index 4 repeats index 0 verbatim: two byte-identical rows of one
+    // right-padded batch must produce cosine 1.0, which is the self-
+    // consistency gate and also the tell for cross-row interference.
+    let texts: Vec<String> = [
+        "task: search result | query: Which planet is known as the Red Planet?",
+        "title: none | text: Mars, known for its reddish appearance, is often referred to as the Red Planet.",
+        "title: none | text: Venus is the second planet from the Sun.",
+        "title: none | text: Jupiter is the largest planet in our solar system.",
+        "task: search result | query: Which planet is known as the Red Planet?",
+    ]
+    .iter()
+    .map(|s| (*s).to_string())
+    .collect();
+    let reply = engine
+        .embed_texts(&texts, &crate::embeddings::EmbedOptions::default())
+        .expect("EmbeddingGemma embeds");
+
+    assert_eq!(reply.vectors.len(), 5);
+    for vector in &reply.vectors {
+        assert_eq!(vector.shape, vec![768]);
+        let norm: f32 = vector.values.iter().map(|v| v * v).sum::<f32>().sqrt();
+        assert!((norm - 1.0).abs() < 1e-3, "unit vector, got {norm}");
+    }
+    let query = &reply.vectors[0].values;
+    let duplicate = cosine(query, &reply.vectors[4].values);
+    assert!(
+        (duplicate - 1.0).abs() < 1e-6,
+        "identical inputs scored {duplicate}, not 1.0"
+    );
+    let mars = cosine(query, &reply.vectors[1].values);
+    let venus = cosine(query, &reply.vectors[2].values);
+    let jupiter = cosine(query, &reply.vectors[3].values);
+    assert!(
+        mars > venus + 0.1 && mars > jupiter + 0.1,
+        "Mars {mars}, Venus {venus}, Jupiter {jupiter}"
+    );
+    assert!(
+        venus < 0.5 && jupiter < 0.5,
+        "Venus {venus}, Jupiter {jupiter}"
+    );
+
+    // Matryoshka truncation: 256 trained components, re-normalized, ranking
+    // unchanged.
+    let truncated = engine
+        .embed_texts(
+            &texts[..4],
+            &crate::embeddings::EmbedOptions {
+                instruction: None,
+                dimensions: Some(256),
+            },
+        )
+        .expect("EmbeddingGemma embeds at 256 dimensions");
+    for vector in &truncated.vectors {
+        assert_eq!(vector.shape, vec![256]);
+        let norm: f32 = vector.values.iter().map(|v| v * v).sum::<f32>().sqrt();
+        assert!((norm - 1.0).abs() < 1e-3, "unit vector, got {norm}");
+    }
+    let short_query = &truncated.vectors[0].values;
+    let short_mars = cosine(short_query, &truncated.vectors[1].values);
+    let short_venus = cosine(short_query, &truncated.vectors[2].values);
+    let short_jupiter = cosine(short_query, &truncated.vectors[3].values);
+    assert!(
+        short_mars > short_venus && short_mars > short_jupiter,
+        "ranking changed at 256 dimensions: Mars {short_mars}, Venus {short_venus}, Jupiter {short_jupiter}"
+    );
+
+    // Printed so a repeated run shows the spread rather than one pass/fail bit.
+    eprintln!(
+        "GATE embeddinggemma-300m-4bit duplicate={duplicate:.9} mars={mars:.6} venus={venus:.6} \
+         jupiter={jupiter:.6} mars@256={short_mars:.6} venus@256={short_venus:.6} \
+         jupiter@256={short_jupiter:.6}"
+    );
+}
+
+#[test]
+fn embeddinggemma_long_document_past_the_sliding_window_is_batch_invariant() {
+    let _guard = mlx_test_guard();
+    let Some(dir) = local_checkpoint(EMBEDDINGGEMMA) else {
+        return;
+    };
+    let _runtime = crate::initialize_runtime();
+    let loaded = crate::embeddings::load_embedding_model(&dir).expect("EmbeddingGemma loads");
+    let engine = crate::embeddings::EmbeddingEngine::new(loaded, 4);
+
+    // Well past the 512-token sliding window, so the windowed mask and the
+    // full mask genuinely disagree on this input.
+    let sentence = "Mars is the fourth planet from the Sun and the second smallest planet in the Solar System, with a thin carbon dioxide atmosphere and two small moons. ";
+    let long = format!("title: none | text: {}", sentence.repeat(60));
+    let short = "task: search result | query: Which planet is known as the Red Planet?".to_string();
+
+    let alone = engine
+        .embed_texts(
+            std::slice::from_ref(&long),
+            &crate::embeddings::EmbedOptions::default(),
+        )
+        .expect("long document embeds alone");
+    let batched = engine
+        .embed_texts(&[short, long], &crate::embeddings::EmbedOptions::default())
+        .expect("long document embeds in a padded batch");
+
+    assert!(
+        alone.prompt_tokens > 512,
+        "the long document is only {} tokens; it must exceed the sliding window",
+        alone.prompt_tokens
+    );
+    let solo = &alone.vectors[0].values;
+    let in_batch = &batched.vectors[1].values;
+    let drift = max_abs_diff(solo, in_batch);
+    assert!(
+        drift < 1e-3,
+        "the long document drifted by {drift} between the solo and the padded run"
+    );
+    assert!(
+        solo.iter().all(|v| v.is_finite()),
+        "the long document produced a non-finite component"
+    );
+    eprintln!(
+        "GATE embeddinggemma-300m-4bit long_document tokens={} batch_drift={drift:.3e}",
+        alone.prompt_tokens
+    );
+}

--- a/src/models/mod.rs
+++ b/src/models/mod.rs
@@ -17,6 +17,9 @@
 //! All implementations use mlxcel-core for direct MLX C++ bindings.
 
 mod detection;
+pub(crate) mod embedding_sanitize;
+#[cfg(test)]
+pub(crate) mod embedding_test_support;
 mod gemma3n_helpers;
 mod llama4_helpers;
 pub(crate) mod model_owned;
@@ -78,6 +81,7 @@ pub mod florence2;
 pub mod gemma;
 pub mod gemma2;
 pub mod gemma3;
+pub mod gemma3_embedding;
 pub mod gemma3n;
 pub mod gemma4;
 pub mod gemma4_mtp_target;
@@ -153,6 +157,7 @@ pub mod qwen2_vl;
 pub mod qwen3;
 pub mod qwen3_5;
 pub mod qwen3_5_mtp_target;
+pub mod qwen3_embedding;
 pub mod qwen3_moe;
 pub mod qwen3_next;
 pub mod qwen3_vl;

--- a/src/models/qwen3.rs
+++ b/src/models/qwen3.rs
@@ -850,9 +850,17 @@ impl Qwen3Model {
         self.forward_impl(input_ids, None, caches, mask)
     }
 
-    /// Forward with optional pre-computed embeddings (for VLM prefill).
-    /// Used by: MiniCPM-o VLM
-    pub fn forward_impl(
+    /// Everything up to and including the final norm: `[B, L, hidden_size]`
+    /// hidden states, with no head applied.
+    ///
+    /// Split out of [`Qwen3Model::forward_impl`] so an embedding wrapper can
+    /// reach the hidden states without materializing a `[B, L, vocab_size]`
+    /// logit tensor it would immediately discard. `forward_impl` calls this
+    /// and then applies the head, so the generation output is unchanged.
+    ///
+    /// Used by: Qwen3 generation, Qwen3Embedding, #1356 (Qwen3 generative
+    /// reranker).
+    pub(crate) fn forward_hidden(
         &self,
         input_ids: &MlxArray,
         input_embeddings: Option<&MlxArray>,
@@ -873,7 +881,19 @@ impl Qwen3Model {
         }
 
         // Final norm
-        let h = self.norm.forward(&h);
+        self.norm.forward(&h)
+    }
+
+    /// Forward with optional pre-computed embeddings (for VLM prefill).
+    /// Used by: MiniCPM-o VLM
+    pub fn forward_impl(
+        &self,
+        input_ids: &MlxArray,
+        input_embeddings: Option<&MlxArray>,
+        caches: &mut [KVCache],
+        mask: Option<&MlxArray>,
+    ) -> UniquePtr<MlxArray> {
+        let h = self.forward_hidden(input_ids, input_embeddings, caches, mask);
 
         // LM head
         if let Some(ref lm_head) = self.lm_head {

--- a/src/models/qwen3_embedding.rs
+++ b/src/models/qwen3_embedding.rs
@@ -1,0 +1,155 @@
+// Copyright 2025-2026 Lablup Inc. and Jeongkyu Shin
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Qwen3-Embedding: the causal Qwen3 backbone with last-token pooling.
+//!
+//! Unlike EmbeddingGemma this family keeps the decoder causal. The export is
+//! an ordinary `Qwen3ForCausalLM` (`model_type: qwen3`) with a
+//! sentence-transformers `1_Pooling` module declaring
+//! `pooling_mode_lasttoken: true`, and the sentence embedding is the hidden
+//! state at the `<|endoftext|>` token the tokenizer appends. Because the last
+//! real token attends every earlier token, a causal mask over a right-padded
+//! batch produces exactly the single-row result: padding sits after the
+//! pooled position and is blocked as a key everywhere.
+//!
+//! The only backbone work is reaching the hidden states without the head:
+//! [`Qwen3Model::forward_hidden`] stops after the final norm, so no
+//! `[B, L, vocab_size]` logit tensor is ever materialized. The tied `lm_head`
+//! is dropped at load for the same reason.
+//!
+//! The query format (`Instruct: {task}\nQuery: {query}`) is caller-side;
+//! passing `instruction` on the request or `--instruction` on the CLI applies
+//! it here, and documents embed as raw text.
+
+use std::path::Path;
+
+use anyhow::{Context, Result, bail};
+use mlxcel_core::utils::create_causal_padding_mask;
+use mlxcel_core::weights::WeightMap;
+use mlxcel_core::{MlxArray, UniquePtr};
+use serde_json::Value;
+
+use crate::embeddings::limits::config_normalize_flag;
+use crate::embeddings::loader::load_embedding_weights;
+use crate::embeddings::model::{EmbeddingBatch, EmbeddingModel, EmbeddingOutput};
+use crate::embeddings::pooling::{PoolingMode, pool, resolve_pooling_mode};
+use crate::models::embedding_sanitize::sanitize_decoder_embedding_weights;
+use crate::models::qwen3::{ModelArgs, Qwen3Model};
+
+/// Qwen3-Embedding: causal Qwen3 layers, last-token pooling.
+pub struct Qwen3EmbeddingModel {
+    model: Qwen3Model,
+    pooling: PoolingMode,
+    normalize: bool,
+    embedding_dim: usize,
+}
+
+impl Qwen3EmbeddingModel {
+    /// Load a Qwen3-Embedding checkpoint from `model_dir`.
+    ///
+    /// The published checkpoints save the inner `Qwen3Model`, so the backbone
+    /// roots arrive bare (`embed_tokens.weight`, `layers.0.…`, `norm.weight`)
+    /// and are prefixed with `model.` before the Qwen3 constructor runs.
+    pub fn load(model_dir: &Path, config: &Value) -> Result<Self> {
+        let mut args: ModelArgs = serde_json::from_value(config.clone())
+            .context("failed to parse the Qwen3-Embedding config.json as a Qwen3 config")?;
+        args.set_checkpoint_label(model_dir);
+        // The embedder stops at the final norm, so no head is ever applied.
+        // Forcing the tied flag both drops an untied `lm_head` from memory (on
+        // the 0.6B checkpoint that is a 151669 x 1024 tensor) and keeps the
+        // constructor from failing on a head this path would never read.
+        args.tie_word_embeddings = true;
+
+        let mut weights = load_embedding_weights(model_dir, config)?;
+        sanitize_decoder_embedding_weights(&mut weights);
+
+        let pooling = resolve_pooling_mode(model_dir, PoolingMode::LastToken)?;
+        Self::from_weights(&weights, &args, pooling, config_normalize_flag(config))
+    }
+
+    /// Build the model from an already sanitized weight map.
+    ///
+    /// Split from [`Self::load`] so the mask and pooling behaviour can be
+    /// exercised on a synthetic checkpoint-free model.
+    pub(crate) fn from_weights(
+        weights: &WeightMap,
+        args: &ModelArgs,
+        pooling: PoolingMode,
+        normalize: bool,
+    ) -> Result<Self> {
+        let model = Qwen3Model::from_weights(weights, args)
+            .map_err(|e| anyhow::anyhow!("Qwen3-Embedding: {e}"))?;
+        Ok(Self {
+            model,
+            pooling,
+            normalize,
+            embedding_dim: args.hidden_size,
+        })
+    }
+
+    /// Run the causal backbone and the final norm, returning the
+    /// `[B, L, hidden_size]` hidden states before pooling.
+    pub(crate) fn forward_hidden(
+        &self,
+        input_ids: &MlxArray,
+        attention_mask: &MlxArray,
+    ) -> UniquePtr<MlxArray> {
+        let mask = create_causal_padding_mask(attention_mask, 0);
+        let mut caches = self.model.make_caches();
+        self.model
+            .forward_hidden(input_ids, None, &mut caches, Some(&mask))
+    }
+}
+
+impl EmbeddingModel for Qwen3EmbeddingModel {
+    fn embed(&self, batch: &EmbeddingBatch) -> Result<EmbeddingOutput> {
+        if batch.images.is_some_and(|images| !images.is_empty()) {
+            bail!("Qwen3-Embedding is a text-only embedder and does not accept images");
+        }
+
+        let hidden = self.forward_hidden(batch.input_ids, batch.attention_mask);
+        let pooled = pool(&hidden, batch.attention_mask, self.pooling);
+
+        Ok(EmbeddingOutput {
+            embeddings: pooled,
+            last_hidden_state: None,
+        })
+    }
+
+    fn default_pooling(&self) -> PoolingMode {
+        PoolingMode::LastToken
+    }
+
+    fn normalize(&self) -> bool {
+        self.normalize
+    }
+
+    fn embedding_dim(&self) -> usize {
+        self.embedding_dim
+    }
+
+    /// Wrap a query in the checkpoint's instruction format when the caller
+    /// supplies one. Documents are embedded raw, which is what the model card
+    /// prescribes, so an absent or blank instruction is the identity.
+    fn format_text(&self, text: &str, instruction: Option<&str>) -> String {
+        match instruction.map(str::trim).filter(|task| !task.is_empty()) {
+            Some(task) => format!("Instruct: {task}\nQuery: {text}"),
+            None => text.to_string(),
+        }
+    }
+}
+
+#[cfg(test)]
+#[path = "qwen3_embedding_tests.rs"]
+mod qwen3_embedding_tests;

--- a/src/models/qwen3_embedding_tests.rs
+++ b/src/models/qwen3_embedding_tests.rs
@@ -1,0 +1,381 @@
+// Copyright 2025-2026 Lablup Inc. and Jeongkyu Shin
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Qwen3-Embedding gates.
+//!
+//! Three properties carry this port. The `forward_hidden` split must not
+//! change generation, so the first test reassembles the head on top of it and
+//! demands a token-exact match with `forward_impl`. The backbone must stay
+//! causal, unlike EmbeddingGemma's. And last-token pooling must pick the
+//! appended `<|endoftext|>` in a right-padded batch, which is the whole reason
+//! padding can sit after the pooled position.
+//!
+//! The last test loads the real `Qwen/Qwen3-Embedding-0.6B` checkpoint and
+//! soft-skips when it is not downloaded.
+
+use anyhow::Result;
+use mlxcel_core::weights::WeightMap;
+
+use super::Qwen3EmbeddingModel;
+use crate::embeddings::model::{EmbeddingBatch, EmbeddingModel};
+use crate::embeddings::pooling::PoolingMode;
+use crate::models::embedding_test_support::{
+    Rng, cosine, err_string, ids_array, local_checkpoint, max_abs_diff, mlx_test_guard, to_vec,
+};
+use crate::models::qwen3::{ModelArgs, Qwen3Model};
+
+const HIDDEN: usize = 16;
+const INTERMEDIATE: usize = 32;
+const HEAD_DIM: usize = 8;
+const VOCAB: usize = 32;
+
+const QWEN3_EMBEDDING: &str = "Qwen/Qwen3-Embedding-0.6B";
+
+/// The reference query-document cosine matrix from the checkpoint's model
+/// card, for the two queries and two documents below. The card publishes
+/// these for the bf16 original; no PyTorch or `transformers` install is
+/// available on the validation host, so this is the only reference the gate
+/// can compare against.
+const MODEL_CARD_SIMILARITY: [[f32; 2]; 2] = [[0.7646, 0.1414], [0.1355, 0.6000]];
+/// Tolerance the issue sets for the model-card matrix.
+const MODEL_CARD_TOLERANCE: f32 = 2e-2;
+
+fn tiny_args(num_layers: usize) -> ModelArgs {
+    ModelArgs {
+        model_type: "qwen3".to_string(),
+        hidden_size: HIDDEN,
+        num_hidden_layers: num_layers,
+        intermediate_size: INTERMEDIATE,
+        num_attention_heads: 2,
+        rms_norm_eps: 1e-6,
+        vocab_size: VOCAB,
+        num_key_value_heads: 1,
+        head_dim: HEAD_DIM,
+        max_position_embeddings: Some(128),
+        rope_theta: 1_000_000.0,
+        rope_scaling: None,
+        checkpoint_label: None,
+        tie_word_embeddings: true,
+        quantization: None,
+    }
+}
+
+/// Deterministic dense weights for `args`, in the sanitized key layout.
+fn tiny_weights(args: &ModelArgs) -> WeightMap {
+    let mut rng = Rng::new(0x00C0_FFEE_1329);
+    let mut w = WeightMap::new();
+    let h = args.hidden_size as i32;
+    let hd = args.head_dim as i32;
+    let q_out = args.num_attention_heads as i32 * hd;
+    let kv_out = args.num_key_value_heads as i32 * hd;
+    let inter = args.intermediate_size as i32;
+
+    rng.insert(
+        &mut w,
+        "model.embed_tokens.weight",
+        &[args.vocab_size as i32, h],
+        0.5,
+    );
+    for i in 0..args.num_hidden_layers {
+        let p = format!("model.layers.{i}");
+        rng.insert(
+            &mut w,
+            &format!("{p}.self_attn.q_proj.weight"),
+            &[q_out, h],
+            0.2,
+        );
+        rng.insert(
+            &mut w,
+            &format!("{p}.self_attn.k_proj.weight"),
+            &[kv_out, h],
+            0.2,
+        );
+        rng.insert(
+            &mut w,
+            &format!("{p}.self_attn.v_proj.weight"),
+            &[kv_out, h],
+            0.2,
+        );
+        rng.insert(
+            &mut w,
+            &format!("{p}.self_attn.o_proj.weight"),
+            &[h, q_out],
+            0.2,
+        );
+        rng.insert(&mut w, &format!("{p}.self_attn.q_norm.weight"), &[hd], 0.1);
+        rng.insert(&mut w, &format!("{p}.self_attn.k_norm.weight"), &[hd], 0.1);
+        rng.insert(
+            &mut w,
+            &format!("{p}.mlp.gate_proj.weight"),
+            &[inter, h],
+            0.2,
+        );
+        rng.insert(&mut w, &format!("{p}.mlp.up_proj.weight"), &[inter, h], 0.2);
+        rng.insert(
+            &mut w,
+            &format!("{p}.mlp.down_proj.weight"),
+            &[h, inter],
+            0.2,
+        );
+        rng.insert(&mut w, &format!("{p}.input_layernorm.weight"), &[h], 0.1);
+        rng.insert(
+            &mut w,
+            &format!("{p}.post_attention_layernorm.weight"),
+            &[h],
+            0.1,
+        );
+    }
+    rng.insert(&mut w, "model.norm.weight", &[h], 0.1);
+    w
+}
+
+fn build(args: &ModelArgs, weights: &WeightMap) -> Result<Qwen3EmbeddingModel> {
+    Qwen3EmbeddingModel::from_weights(weights, args, PoolingMode::LastToken, true)
+}
+
+fn ramp(len: usize) -> Vec<i32> {
+    (0..len).map(|i| (i % VOCAB) as i32).collect()
+}
+
+/// `[L, HIDDEN]` hidden states of one unpadded row.
+fn hidden_states(model: &Qwen3EmbeddingModel, ids: &[i32]) -> Vec<f32> {
+    let length = ids.len() as i32;
+    let input = ids_array(ids, 1, length);
+    let mask = ids_array(&vec![1; ids.len()], 1, length);
+    to_vec(&model.forward_hidden(&input, &mask))
+}
+
+// Backbone refactor.
+
+#[test]
+fn forward_hidden_then_head_matches_forward_impl() {
+    let _guard = mlx_test_guard();
+    // The split must be a pure refactor: applying the (tied) head to
+    // `forward_hidden` has to reproduce `forward_impl` bit for bit.
+    let args = tiny_args(2);
+    let weights = tiny_weights(&args);
+    let model = Qwen3Model::from_weights(&weights, &args).expect("synthetic Qwen3 loads");
+
+    let ids = ramp(12);
+    let input = ids_array(&ids, 1, ids.len() as i32);
+
+    let mut caches = model.make_caches();
+    let logits = to_vec(&model.forward_impl(&input, None, &mut caches, None));
+
+    let mut fresh = model.make_caches();
+    let hidden = model.forward_hidden(&input, None, &mut fresh, None);
+    let reassembled = to_vec(&model.embed_tokens.as_linear(&hidden));
+
+    assert_eq!(logits.len(), reassembled.len());
+    assert_eq!(
+        max_abs_diff(&logits, &reassembled),
+        0.0,
+        "forward_hidden plus the head is not token-exact with forward_impl"
+    );
+}
+
+// Forward pass.
+
+#[test]
+fn causal_prefill_is_causal() {
+    let _guard = mlx_test_guard();
+    // The mirror image of the EmbeddingGemma bidirectionality gate: flipping
+    // the last token must leave every earlier hidden state untouched.
+    let args = tiny_args(2);
+    let model = build(&args, &tiny_weights(&args)).unwrap();
+
+    let mut ids = ramp(96);
+    let baseline = hidden_states(&model, &ids);
+    ids[95] = (ids[95] + 7) % VOCAB as i32;
+    let perturbed = hidden_states(&model, &ids);
+
+    let earlier = 95 * HIDDEN;
+    let moved = max_abs_diff(&baseline[..earlier], &perturbed[..earlier]);
+    assert!(
+        moved < 1e-6,
+        "an earlier token reacted to the last token ({moved}); the mask is not causal"
+    );
+    let last = max_abs_diff(&baseline[earlier..], &perturbed[earlier..]);
+    assert!(
+        last > 1e-4,
+        "the changed token itself did not move ({last})"
+    );
+}
+
+#[test]
+fn last_token_pool_uses_appended_eos() {
+    let _guard = mlx_test_guard();
+    // Right padding after the pooled position must not change the vector: the
+    // padded row's last real token sees exactly the keys the unpadded row does.
+    let args = tiny_args(2);
+    let model = build(&args, &tiny_weights(&args)).unwrap();
+
+    let short = ramp(8);
+    let long: Vec<i32> = (0..12).map(|i| ((i * 5 + 3) % VOCAB) as i32).collect();
+
+    let alone = ids_array(&short, 1, short.len() as i32);
+    let alone_mask = ids_array(&vec![1; short.len()], 1, short.len() as i32);
+    let alone_values = to_vec(
+        &model
+            .embed(&EmbeddingBatch {
+                input_ids: &alone,
+                attention_mask: &alone_mask,
+                token_type_ids: None,
+                images: None,
+            })
+            .unwrap()
+            .embeddings,
+    );
+
+    let mut padded_ids = short.clone();
+    padded_ids.resize(12, 0);
+    padded_ids.extend_from_slice(&long);
+    let mut padded_mask = vec![1; short.len()];
+    padded_mask.resize(12, 0);
+    padded_mask.extend(std::iter::repeat_n(1, 12));
+
+    let batch_ids = ids_array(&padded_ids, 2, 12);
+    let batch_mask = ids_array(&padded_mask, 2, 12);
+    let batch_values = to_vec(
+        &model
+            .embed(&EmbeddingBatch {
+                input_ids: &batch_ids,
+                attention_mask: &batch_mask,
+                token_type_ids: None,
+                images: None,
+            })
+            .unwrap()
+            .embeddings,
+    );
+
+    assert_eq!(alone_values.len(), HIDDEN);
+    assert_eq!(batch_values.len(), 2 * HIDDEN);
+    assert!(max_abs_diff(&alone_values, &batch_values[..HIDDEN]) < 1e-4);
+}
+
+#[test]
+fn instruction_wraps_only_when_supplied() {
+    let _guard = mlx_test_guard();
+    let args = tiny_args(1);
+    let model = build(&args, &tiny_weights(&args)).unwrap();
+    assert_eq!(model.format_text("Paris", None), "Paris");
+    assert_eq!(model.format_text("Paris", Some("   ")), "Paris");
+    assert_eq!(
+        model.format_text(
+            "What is the capital of China?",
+            Some("Given a web search query, retrieve relevant passages that answer the query")
+        ),
+        "Instruct: Given a web search query, retrieve relevant passages that answer the query\nQuery: What is the capital of China?"
+    );
+    assert_eq!(model.default_pooling(), PoolingMode::LastToken);
+    assert_eq!(model.embedding_dim(), HIDDEN);
+}
+
+#[test]
+fn images_are_rejected() {
+    let _guard = mlx_test_guard();
+    let args = tiny_args(1);
+    let model = build(&args, &tiny_weights(&args)).unwrap();
+    let ids = ids_array(&[1, 2, 3], 1, 3);
+    let mask = ids_array(&[1, 1, 1], 1, 3);
+    let images = [crate::embeddings::model::ImageInput {
+        image: image::DynamicImage::new_rgb8(2, 2),
+    }];
+    let err = err_string(model.embed(&EmbeddingBatch {
+        input_ids: &ids,
+        attention_mask: &mask,
+        token_type_ids: None,
+        images: Some(&images),
+    }));
+    assert!(err.contains("text-only"), "{err}");
+}
+
+// Real checkpoint.
+
+#[test]
+fn qwen3_embedding_checkpoint_matches_the_model_card_similarity_matrix() {
+    let _guard = mlx_test_guard();
+    let Some(dir) = local_checkpoint(QWEN3_EMBEDDING) else {
+        return;
+    };
+    let _runtime = crate::initialize_runtime();
+    let loaded = crate::embeddings::load_embedding_model(&dir).expect("Qwen3-Embedding loads");
+    assert_eq!(loaded.model_type, crate::models::ModelType::Qwen3Embedding);
+    assert_eq!(loaded.limits.dim, 1024);
+
+    let engine = crate::embeddings::EmbeddingEngine::new(loaded, 16);
+    const TASK: &str = "Given a web search query, retrieve relevant passages that answer the query";
+    // Index 4 repeats index 0 verbatim: two byte-identical rows of one
+    // right-padded batch must produce cosine 1.0.
+    let texts: Vec<String> = [
+        format!("Instruct: {TASK}\nQuery: What is the capital of China?"),
+        format!("Instruct: {TASK}\nQuery: Explain gravity"),
+        "The capital of China is Beijing.".to_string(),
+        "Gravity is a force that attracts two bodies towards each other. It gives weight to physical objects and is responsible for the movement of planets around the sun.".to_string(),
+        format!("Instruct: {TASK}\nQuery: What is the capital of China?"),
+    ]
+    .to_vec();
+    let reply = engine
+        .embed_texts(&texts, &crate::embeddings::EmbedOptions::default())
+        .expect("Qwen3-Embedding embeds");
+
+    assert_eq!(reply.vectors.len(), 5);
+    for vector in &reply.vectors {
+        assert_eq!(vector.shape, vec![1024]);
+        assert!(
+            vector.values.iter().all(|v| v.is_finite()),
+            "a non-finite component reached the caller"
+        );
+        let norm: f32 = vector.values.iter().map(|v| v * v).sum::<f32>().sqrt();
+        assert!((norm - 1.0).abs() < 1e-3, "unit vector, got {norm}");
+    }
+    let duplicate = cosine(&reply.vectors[0].values, &reply.vectors[4].values);
+    assert!(
+        (duplicate - 1.0).abs() < 1e-6,
+        "identical inputs scored {duplicate}, not 1.0"
+    );
+    let mut observed = [[0.0_f32; 2]; 2];
+    for (q, expected_row) in MODEL_CARD_SIMILARITY.iter().enumerate() {
+        for (d, expected) in expected_row.iter().enumerate() {
+            let got = cosine(&reply.vectors[q].values, &reply.vectors[2 + d].values);
+            observed[q][d] = got;
+            assert!(
+                (got - expected).abs() < MODEL_CARD_TOLERANCE,
+                "query {q} vs document {d}: got {got}, model card says {expected}"
+            );
+        }
+    }
+
+    // Right padding sits after the pooled position, so the padded row must
+    // reproduce the solo run. This is the property the causal mask plus
+    // last-token pooling buys, on the real checkpoint rather than a synthetic.
+    let solo = engine
+        .embed_texts(
+            &[texts[2].clone()],
+            &crate::embeddings::EmbedOptions::default(),
+        )
+        .expect("Qwen3-Embedding embeds a single row");
+    let drift = max_abs_diff(&solo.vectors[0].values, &reply.vectors[2].values);
+    assert!(
+        drift < 1e-3,
+        "the document drifted by {drift} between the solo and the padded run"
+    );
+
+    // Printed so a repeated run shows the spread rather than one pass/fail bit.
+    eprintln!(
+        "GATE Qwen3-Embedding-0.6B duplicate={duplicate:.9} matrix=[[{:.6}, {:.6}], [{:.6}, {:.6}]] \
+         batch_drift={drift:.3e}",
+        observed[0][0], observed[0][1], observed[1][0], observed[1][1]
+    );
+}


### PR DESCRIPTION
## Summary

EmbeddingGemma and Qwen3-Embedding now run real forward passes behind the `EmbeddingModel` trait, reusing the Gemma 3 and Qwen3 backbones the tree already carries instead of adding two more decoders. Both load from their published checkpoints, serve through `mlxcel embed` and `POST /v1/embeddings`, and pass the epic's self-consistency gates plus the per-family numeric gate the issue names.

EmbeddingGemma runs the Gemma 3 layers bidirectionally: the full-attention layers get a padding-only mask, the sliding layers get the same padding mask intersected with a symmetric `|q - k| < sliding_window` band, which is how `transformers` builds the bidirectional sliding overlay. The final norm output is mean pooled and projected through the two bias-free `Dense` modules before the engine's L2 normalization. Qwen3-Embedding keeps the decoder causal, builds a causal-plus-padding mask over the right-padded batch, and pools the hidden state at the appended `<|endoftext|>`.

## What changed

### New

- `src/models/gemma3_embedding.rs` (+ tests): `Gemma3EmbeddingModel`. Loads a Gemma 3 config, resolves the sliding period, builds `gemma3::TransformerBlock` layers with `self_attn.window_size` cleared (the embedding path owns its masks, and an explicit mask plus a causal window would re-impose causality on the Metal 4 attention path), and applies the `Dense` stack after pooling. `default_pooling` is `Mean`, `embedding_dim` comes from the last `Dense`.
- `src/models/qwen3_embedding.rs` (+ tests): `Qwen3EmbeddingModel`. Wraps `Qwen3Model`, drops the tied `lm_head` at load (the embedder never applies a head, and on the 0.6B checkpoint that head is a 151669 x 1024 tensor), and pools with `LastToken`. `format_text` applies `Instruct: {task}\nQuery: {query}` when the request carries an `instruction`, and is the identity otherwise.
- `src/models/embedding_sanitize.rs` (+ tests): the weight-key normalization both families need. A sentence-transformers export of a decoder backbone stores the roots bare (`embed_tokens.weight`, `layers.0.…`, `norm.weight`) because it saves the inner `…Model` rather than the `…ForCausalLM` wrapper, may still carry an unused generation head, and puts post-pooling projections in numbered module subfolders. `sanitize_decoder_embedding_weights` folds `{N}_Dense.linear.*` into `dense.{k}.*` by folder rank, drops the head, and prefixes the backbone with `model.`. It is a no-op on an mlx conversion and idempotent.
- `src/models/embedding_test_support.rs`: test-only helpers shared by both family test modules (deterministic weight generator, a shaped safetensors writer, the soft-skipping checkpoint lookup, and the MLX serialization guard described under Concurrency below).

### Changed

- `src/models/qwen3.rs`: `forward_impl` split into `pub(crate) forward_hidden` (everything up to and including the final norm) plus the head application. `forward_impl` calls both, so generation output is unchanged; a test reassembles the head on top of `forward_hidden` and demands a token-exact match. This is what lets the embedder avoid materializing a `[B, L, vocab_size]` logit tensor it would discard, and #1356 needs the same entry point.
- `src/embeddings/loader.rs`: the `Gemma3Embedding` and `Qwen3Embedding` arms of `build_family_model` now construct their models. Every other family's `not yet supported` arm is untouched.
- `src/embeddings/real_checkpoint_tests.rs`: `Qwen3-Embedding` leaves the unported-families list, since its loader arm now exists.
- `src/models/mod.rs`: three module declarations.
- `docs/embeddings.md`: a `Family notes` section with the mask shapes, both `Dense` layouts, the prompt-prefix tables and the Matryoshka widths; the source map gains the three new modules; the status paragraph now points at the supported-models table instead of claiming no family has landed.
- `docs/supported-models.md`: the two Embedding rows.

### Not changed

No backbone behaviour. `gemma3.rs` needed no edit at all: `Attention.window_size` was already `pub`, so the embedder clears it after construction.

## Notes on two judgement calls

The sliding period comes from `config.json` `layer_types` when present, not from `sliding_window_pattern`. transformers 4.57 renamed the scalar to `_sliding_window_pattern`, which `gemma3::ModelArgs` does not parse, so the family default of 6 would have applied silently. It happens to be 6 on the published checkpoints, which is exactly why this is worth pinning: a period that is off by one still loads, still runs, and only shows up as a quietly wrong vector. The list is validated against the derived period rather than sampled, and an irregular list is a load error.

The `Dense` widths are checked to chain from the backbone hidden size. A swapped `dense.0` / `dense.1` pair loads and runs on both layouts and produces only wrong numbers; the chain check turns that into a load error naming the projection.

## Concurrency in the tests

`EmbeddingModel` is documented as single-thread and the product honors that through the embedding worker, so this is test-side only. Two concurrent MLX forward passes in one process interfere in two ways on this tree: a CUDA graph capture aborts the process (`cudaStreamEndCapture ... operation failed due to a previous error during capture`), and results drift, with two byte-identical rows of one batch scoring cosine 0.999912 instead of 1.0. Every test here that builds a model or runs a forward pass takes a process-wide `mlx_test_guard()`, following the existing `llama4_helpers_tests::test_guard` pattern with poisoned-lock recovery. The guard cannot serialize against MLX work in other modules, which is why every gate this repository defines (`make verify-test`, `make verify-test-cuda`, `make test-fast`) already passes `--test-threads=1`; all numbers below come from that configuration.

## Test plan

Run on Linux with GB10 and CUDA. The issue's acceptance criteria name the macOS `metal,accelerate` feature set; the CUDA gate is the equivalent on this host and is what ran.

- [x] `cargo fmt --all -- --check` (exit 0)
- [x] `cargo clippy --profile test-fast --features cuda --lib --bins --tests -- -D warnings` (exit 0)
- [x] `cargo check --profile test-fast --features cuda --all-targets` (exit 0)
- [x] `cargo test --profile test-fast --features cuda --lib -- --test-threads=1 models::gemma3_embedding models::qwen3_embedding models::embedding_sanitize`: 22 passed, 0 failed, repeated three times with bit-identical gate numbers
- [x] `cargo test --profile test-fast --features cuda --lib embeddings:: -- --test-threads=1`: 62 passed, 0 failed (the foundation suite is unchanged)
- [x] `cargo test --profile test-fast --features cuda --lib models::gemma3 -- --test-threads=1`: 23 passed, 5 ignored, 0 failed
- [x] `cargo test --profile test-fast --features cuda --lib models::qwen3 -- --test-threads=1`: 59 passed, 11 ignored, 0 failed
- [x] `cargo build --profile test-fast --features cuda --bins` (exit 0)
- [x] `mlxcel embed` and `mlxcel-server` + `POST /v1/embeddings` on both real checkpoints, numbers below
- [x] `mlxcel arch` lists both under `Embedding`; `mlxcel list` shows both checkpoints

### `mlx-community/embeddinggemma-300m-4bit` (4-bit, 768 wide, `max_length` 2048)

- Unit vectors at 768 and at `dimensions: 256`, every norm 1.0 within 1e-6.
- Query vs Mars 0.642725, vs Venus 0.323360, vs Jupiter 0.329467. The matching document wins by 0.313, well over the 0.1 the issue asks for, and both non-matching documents are under 0.5.
- At `dimensions: 256` the ranking is unchanged: Mars 0.693574, Venus 0.422158, Jupiter 0.412816.
- Two byte-identical rows inside one right-padded batch: cosine 1.000000000.
- A 1749-token document, well past the 512-token sliding window, embeds without error and is bit-identical between the solo run and the padded batch (`max_abs_diff` 0.0).
- An unrelated sentence scores 0.0271.
- The same numbers come back from `POST /v1/embeddings`, and `/v1/models` lists `embeddinggemma-300m-4bit`.

### `Qwen/Qwen3-Embedding-0.6B` (bf16, 1024 wide, `max_length` 8192)

- The query-document matrix is `[[0.766633, 0.143439], [0.136450, 0.600714]]` against the model card's `[[0.7646, 0.1414], [0.1355, 0.6000]]`. Largest deviation 0.00204, inside the 2e-2 the issue sets. No PyTorch or `transformers` install exists on this host, so the model card is the reference; nothing here is computed from a local reference implementation.
- Two byte-identical rows inside one batch: cosine 1.000000119, which is 1.0 to within one f32 ulp of the cosine itself.
- A document embedded alone and inside a right-padded batch is bit-identical (`max_abs_diff` 0.0), which is the property the causal mask plus last-token pooling buys.
- No non-finite component in any padded batch; an unrelated sentence scores 0.1568.
- The same numbers come back from `POST /v1/embeddings`, `dimensions: 256` with `encoding_format: base64` decodes to a 256-wide unit vector, and `/v1/models` lists `Qwen3-Embedding-0.6B`.

### Layout coverage

Only the mlx conversion of EmbeddingGemma is downloadable without accepting the gated `google/embeddinggemma-300m` terms, so the `2_Dense` / `3_Dense` subfolder layout is covered by a synthetic checkpoint written to disk instead: the test materializes the same weights in the sentence-transformers spelling (bare backbone roots, an unused `lm_head`, the two projections in module folders), loads it through the real `Gemma3EmbeddingModel::load(dir)`, and asserts the embeddings are bit-identical to the mlx-style in-memory build.

No performance numbers are reported here; the epic runs its performance pass separately.

## Rebase note

This branch is rebased on top of the SigLIP (#1410) and ModernBERT (#1412) ports, which merged while it was in flight. Both added a `## Family notes` section to `docs/embeddings.md`; the rebase folds all four family subsections under one heading in detection-table order, which is why that file shows deletions. `build_family_model` now carries four constructed arms and the remaining families keep their `not yet supported` arm untouched. The full verification below was re-run after the rebase, with the gate numbers bit-identical to the pre-rebase run, and `models::siglip` (10 passed) and `models::modernbert` (19 passed) still green.

Closes #1329
