### PR TITLE
fix(tests): pin the GPU default device in the shared embedding test guard

### DIFF
--- a/src/models/bert_tests.rs
+++ b/src/models/bert_tests.rs
@@ -16,7 +16,7 @@
 //! sanitization, position-id construction and the forward pass over a tiny
 //! deterministic random-weight checkpoint.
 
-use std::sync::{Mutex, MutexGuard, OnceLock};
+use std::sync::MutexGuard;
 
 use mlxcel_core::utils::array_to_vec_f32;
 use mlxcel_core::weights::WeightMap;
@@ -35,12 +35,13 @@ use super::{BertArgs, BertEncoder, BertVariant, sanitize, xlm_roberta_position_i
 /// measured under it is meaningless. A poisoned lock is recovered rather than
 /// propagated, so one failing test does not turn every later one into a
 /// confusing poisoning panic.
+///
+/// Delegates to the process-wide guard in
+/// [`crate::models::embedding_test_support`], which serializes every
+/// embedding and reranker family against each other and pins the default
+/// device back to the GPU.
 pub(crate) fn mlx_test_guard() -> MutexGuard<'static, ()> {
-    static GUARD: OnceLock<Mutex<()>> = OnceLock::new();
-    GUARD
-        .get_or_init(|| Mutex::new(()))
-        .lock()
-        .unwrap_or_else(|poisoned| poisoned.into_inner())
+    crate::models::embedding_test_support::mlx_test_guard()
 }
 
 // Geometry of the in-memory fixture. Small enough that a forward pass is

--- a/src/models/embedding_test_support.rs
+++ b/src/models/embedding_test_support.rs
@@ -48,12 +48,34 @@ use safetensors::tensor::{Dtype as SafeTensorDtype, View};
 /// `make verify-test-cuda`, `make test-fast`) passes `--test-threads=1`. A
 /// raw multi-threaded `cargo test` over a wide filter is not a supported way
 /// to run this suite on either backend.
+///
+/// The guard also pins MLX's process-wide default device back to the GPU
+/// when one is available. Other test modules move the default device to the
+/// CPU for their own reasons and never move it back
+/// (`multimodal::host_preprocessor_tests::ensure_cpu_device` does so inside a
+/// `Once`), and libtest runs modules in name order, so a gate that happens to
+/// sort after such a module silently measures the CPU backend instead: under
+/// `make verify-test-cuda` the `rerank::real_checkpoint_tests` gates scored a
+/// 4-bit Qwen3 reranker at 0.35 instead of 0.99 and produced NaN image
+/// scores from a bf16 Qwen3-VL reranker, while the same tests passed in
+/// isolation. Every real-checkpoint number this repository records is a GPU
+/// number, so the guard makes that explicit instead of depending on module
+/// order.
+///
+/// The pin is unconditional on purpose. `mlxcel_core::is_gpu_available()`
+/// reports whether the *current default* device is the GPU, so after another
+/// module has moved the default to the CPU it answers `false` and a guarded
+/// pin would never fire. `Device::gpu` is always constructible: on a CPU-only
+/// build MLX resolves it to the single default compute device (see
+/// `gpu_device_count`), so selecting it is safe on every backend.
 pub(crate) fn mlx_test_guard() -> MutexGuard<'static, ()> {
     static GUARD: OnceLock<Mutex<()>> = OnceLock::new();
-    GUARD
+    let guard = GUARD
         .get_or_init(|| Mutex::new(()))
         .lock()
-        .unwrap_or_else(|poisoned| poisoned.into_inner())
+        .unwrap_or_else(|poisoned| poisoned.into_inner());
+    mlxcel_core::set_default_device(true);
+    guard
 }
 
 /// Deterministic xorshift64* generator.

--- a/src/models/modernbert_tests.rs
+++ b/src/models/modernbert_tests.rs
@@ -20,7 +20,7 @@
 //! deterministic synthetic weights, so it needs no checkpoint. The
 //! real-checkpoint gates live in `modernbert_real_checkpoint_tests.rs`.
 
-use std::sync::{Mutex, MutexGuard, OnceLock};
+use std::sync::MutexGuard;
 
 use mlxcel_core::utils::{array_to_vec_f32, create_bidirectional_window_mask};
 use mlxcel_core::weights::WeightMap;
@@ -52,11 +52,13 @@ use crate::models::{ModelType, get_model_type};
 ///
 /// A poisoned lock is recovered rather than propagated so one failing test does
 /// not cascade into false failures in the rest.
+///
+/// Delegates to the process-wide guard in
+/// [`crate::models::embedding_test_support`], which serializes every
+/// embedding and reranker family against each other and pins the default
+/// device back to the GPU.
 pub(super) fn mlx_guard() -> MutexGuard<'static, ()> {
-    static LOCK: OnceLock<Mutex<()>> = OnceLock::new();
-    LOCK.get_or_init(|| Mutex::new(()))
-        .lock()
-        .unwrap_or_else(|poisoned| poisoned.into_inner())
+    crate::models::embedding_test_support::mlx_test_guard()
 }
 
 // Synthetic checkpoint.


### PR DESCRIPTION
## Summary

The post-merge integration gate for epic #1348 (`make verify-test-cuda` on `ffca5659`, workspace, test-fast, `--test-threads=1`) failed two real-checkpoint reranker tests that pass in isolation: `rerank::real_checkpoint_tests::qwen3_generative_reranker_ranks_the_beijing_document_first` scored the Beijing document at 0.3486 instead of 0.9883, and `rerank::real_checkpoint_tests::qwen3_vl_reranker_scores_text_and_image_documents` returned `[NaN, NaN]` for image documents. A bisect over the modules that libtest runs before `rerank::` (name order under `--test-threads=1`) localized the poisoner to `multimodal::`: `multimodal::host_preprocessor_tests::ensure_cpu_device` moves MLX's process-wide default device to the CPU inside a `Once` and never moves it back. Every embedding family gate lives under `models::`, which sorts before `multimodal::`, so those gates measured the GPU; the reranker gates sort after it and silently measured the CPU backend, where the 4-bit Qwen3 reranker degrades and the bf16 Qwen3-VL image path produces NaN.

## Change

`crate::models::embedding_test_support::mlx_test_guard`, the process-wide lock every embedding and reranker gate already takes, now also pins the default device back to the GPU. Every real-checkpoint number this repository records is a GPU number, so the guard makes that explicit instead of depending on module order. The pin is unconditional: a first attempt guarded it with `mlxcel_core::is_gpu_available()`, and the reproduction kept failing with identical scores, because that function is implemented as `default_device() == Device::gpu` and therefore answers `false` precisely after another module has moved the default to the CPU. `Device::gpu` is always constructible (a CPU-only build resolves it to the single default compute device, which is why `gpu_device_count` clamps to at least 1), so selecting it is safe on every backend. The `is_gpu_available` naming is worth a follow-up of its own; `execution::runtime::initialize_runtime` reads it after possibly moving the default device to the CPU, which makes it report the requested device rather than hardware availability. The per-module guards in `models::bert_tests` and `models::modernbert_tests` now delegate to the shared guard, so there is one lock and one device policy for all embedding and reranker tests (this also closes the gap noted in the wave 1 reports that per-module locks could not serialize different families against each other). No production code changes.

## Verification

On GB10 (CUDA), all with `--profile test-fast --features cuda`: `cargo fmt --all -- --check` and `cargo clippy --lib --tests -- -D warnings` clean; the reproduction `cargo test -p mlxcel --lib -- --test-threads=1 multimodal:: rerank::real_checkpoint_tests`, which failed before the change with the scores above (and still failed with the `is_gpu_available` guarded variant), passes with 233 passed / 0 failed; `models::bert` and `models::modernbert` pass through the delegating guards. The full `make verify-test-cuda` is re-run on the merge commit as part of the epic's Phase 4 gate; the one remaining red test in that run, `mlxcel-core sampling::tests::temperature_one_support_unchanged`, is pre-existing and tracked in #1418.

Refs #1348
