### PR TITLE
fix: harden side-model request boundaries

### DIFF
--- a/src/server/media.rs
+++ b/src/server/media.rs
@@ -333,6 +333,18 @@ pub(crate) fn current_image_input_limits() -> ImageInputLimits {
     }
 }
 
+/// Reject a request before resolution when it declares more images than the
+/// configured per-request limit.
+pub(crate) fn validate_image_count(count: usize, limits: ImageInputLimits) -> Result<()> {
+    if count > limits.max_images_per_request {
+        bail!(
+            "Too many image inputs: received at least {count}, maximum is {}",
+            limits.max_images_per_request
+        );
+    }
+    Ok(())
+}
+
 #[cfg(test)]
 pub(crate) async fn extract_chat_image_data(request: &ChatCompletionRequest) -> Vec<Vec<u8>> {
     match try_extract_chat_image_data(request).await {
@@ -1145,13 +1157,7 @@ where
     let mut images = Vec::new();
 
     for (index, url) in urls.into_iter().enumerate() {
-        if index >= limits.max_images_per_request {
-            bail!(
-                "Too many image inputs: received at least {}, maximum is {}",
-                index + 1,
-                limits.max_images_per_request
-            );
-        }
+        validate_image_count(index + 1, limits)?;
         match try_read_image_url_with_limits(url.as_ref(), limits).await {
             Ok(Some(bytes)) => images.push(bytes),
             Ok(None) => {}

--- a/src/server/model_provider.rs
+++ b/src/server/model_provider.rs
@@ -111,6 +111,10 @@ pub(crate) struct QueueFullError {
     pub(crate) max_queue_depth: usize,
 }
 
+#[derive(Debug, thiserror::Error)]
+#[error("the chat worker has exited; check the server log")]
+pub(crate) struct ChatWorkerGoneError;
+
 impl SingleStreamQueueReservation {
     fn try_new(batch_metrics: Arc<BatchMetrics>, max_queue_depth: usize) -> Result<Self> {
         if batch_metrics.try_reserve_queue_slot(max_queue_depth) {
@@ -188,6 +192,7 @@ pub struct ModelProvider {
     model_id: String,
     created_at: i64,
     loaded: Arc<AtomicBool>,
+    chat_unavailable: Arc<AtomicBool>,
     batch_metrics: Arc<BatchMetrics>,
     batch_observability: Arc<BatchObservability>,
     max_queue_depth: usize,
@@ -428,10 +433,10 @@ impl ModelProvider {
     /// Used when `-m` names the checkpoint `--reranker-model` already owns
     /// (#1356), so the reranker worker keeps the only copy of those weights.
     /// The worker thread starts, logs why chat is unavailable and exits, which
-    /// drops the request receiver; every generation request then fails at
-    /// enqueue time. That is the same observable state a failed chat load
-    /// leaves behind (`-m <embedding checkpoint>` reaches it too), including
-    /// `/health` reporting `loading model`, so no route needs a new case.
+    /// drops the request receiver and records a terminal no-chat state. Failed
+    /// chat loads record the same state (`-m <embedding checkpoint>` reaches
+    /// it too), so generation routes return a structured capability error while
+    /// `/health` keeps its existing `loading model` behavior.
     fn new_without_chat_model(
         model_path: PathBuf,
         batch_metrics: Arc<BatchMetrics>,
@@ -443,6 +448,7 @@ impl ModelProvider {
             .map(|s| s.to_string_lossy().to_string())
             .unwrap_or_else(|| "unknown".to_string());
         let (request_tx, request_rx) = mpsc::channel::<ModelRequest>();
+        let chat_unavailable = Arc::new(AtomicBool::new(true));
         let display_path = model_path.display().to_string();
         let worker_handle = thread::Builder::new()
             .name("model-worker-rerank-only".to_string())
@@ -458,6 +464,7 @@ impl ModelProvider {
             model_id,
             created_at: chrono::Utc::now().timestamp(),
             loaded: Arc::new(AtomicBool::new(false)),
+            chat_unavailable,
             batch_metrics,
             batch_observability,
             max_queue_depth: 1,
@@ -492,6 +499,8 @@ impl ModelProvider {
         let (request_tx, request_rx) = mpsc::channel::<ModelRequest>();
         let loaded = Arc::new(AtomicBool::new(false));
         let loaded_clone = loaded.clone();
+        let chat_unavailable = Arc::new(AtomicBool::new(false));
+        let chat_unavailable_clone = chat_unavailable.clone();
         let single_stream_queue_admission = Arc::new(AtomicBool::new(
             uses_single_stream_queue_admission(&model_path),
         ));
@@ -506,6 +515,7 @@ impl ModelProvider {
             reasoning_budget,
             request_rx,
             loaded_clone,
+            chat_unavailable_clone,
             worker_model_id,
             metrics_clone,
             obs_clone,
@@ -519,6 +529,7 @@ impl ModelProvider {
             loaded,
             batch_metrics,
             batch_observability,
+            chat_unavailable,
             max_queue_depth,
             single_stream_queue_admission,
             prompt_cache: None,
@@ -572,6 +583,7 @@ impl ModelProvider {
             loaded,
             batch_metrics,
             batch_observability,
+            chat_unavailable: Arc::new(AtomicBool::new(false)),
             max_queue_depth: usize::MAX,
             single_stream_queue_admission,
             prompt_cache: None,
@@ -809,6 +821,8 @@ impl ModelProvider {
         let single_stream_queue_admission = Arc::new(AtomicBool::new(
             uses_single_stream_queue_admission(&model_path),
         ));
+        let chat_unavailable = Arc::new(AtomicBool::new(false));
+        let chat_unavailable_clone = chat_unavailable.clone();
         let worker_model_id = model_id.clone();
         let metrics_clone = batch_metrics.clone();
         let obs_clone = batch_observability.clone();
@@ -866,6 +880,7 @@ impl ModelProvider {
             adapter_path,
             request_rx,
             loaded_clone,
+            chat_unavailable_clone,
             worker_model_id,
             sched_config,
             metrics_clone,
@@ -881,6 +896,7 @@ impl ModelProvider {
             batch_metrics,
             batch_observability,
             max_queue_depth,
+            chat_unavailable,
             single_stream_queue_admission,
             prompt_cache: prompt_cache_store,
             prompt_tokenizer: None,
@@ -913,6 +929,8 @@ impl ModelProvider {
         let single_stream_queue_admission = Arc::new(AtomicBool::new(
             uses_single_stream_queue_admission(&model_path),
         ));
+        let chat_unavailable = Arc::new(AtomicBool::new(false));
+        let chat_unavailable_clone = chat_unavailable.clone();
 
         // Clone model_id for the worker thread
         let worker_model_id = model_id.clone();
@@ -963,6 +981,7 @@ impl ModelProvider {
             adapter_path,
             request_rx,
             loaded_clone,
+            chat_unavailable_clone,
             worker_model_id,
             sched_config,
             metrics_clone,
@@ -978,6 +997,7 @@ impl ModelProvider {
             batch_metrics,
             batch_observability,
             max_queue_depth,
+            chat_unavailable,
             single_stream_queue_admission,
             prompt_cache: None,
             prompt_tokenizer: None,
@@ -1036,6 +1056,11 @@ impl ModelProvider {
     /// Check if model is loaded and ready for inference
     pub fn is_loaded(&self) -> bool {
         self.loaded.load(Ordering::Acquire)
+    }
+
+    /// Whether the generation worker reached a terminal no-chat state.
+    pub fn is_chat_unavailable(&self) -> bool {
+        self.chat_unavailable.load(Ordering::Acquire)
     }
 
     /// Generate text and return the full result
@@ -1433,19 +1458,23 @@ impl ModelProvider {
             QueueReservationMode::PreReserved(reservation) => reservation,
         };
 
-        if let Err(err) = self.request_tx.send(ModelRequest::Generate {
-            prompt,
-            prompt_token_ids,
-            options,
-            images,
-            audio,
-            videos,
-            media,
-            queue_reservation,
-            response_tx,
-            cancelled,
-        }) {
-            return Err(anyhow::anyhow!("Failed to send request: {err}"));
+        if self
+            .request_tx
+            .send(ModelRequest::Generate {
+                prompt,
+                prompt_token_ids,
+                options,
+                images,
+                audio,
+                videos,
+                media,
+                queue_reservation,
+                response_tx,
+                cancelled,
+            })
+            .is_err()
+        {
+            return Err(anyhow::Error::new(ChatWorkerGoneError));
         }
 
         Ok(response_rx)
@@ -1684,7 +1713,7 @@ where
                     ));
                 }
                 Err(mpsc::RecvTimeoutError::Disconnected) => {
-                    return Err(anyhow::anyhow!("Response channel closed"));
+                    return Err(anyhow::Error::new(ChatWorkerGoneError));
                 }
             }
         } else {
@@ -1692,7 +1721,7 @@ where
             // any timeout so we never spuriously abort a valid request.
             match response_rx.recv() {
                 Ok(ev) => ev,
-                Err(_) => return Err(anyhow::anyhow!("Response channel closed")),
+                Err(_) => return Err(anyhow::Error::new(ChatWorkerGoneError)),
             }
         };
 

--- a/src/server/model_provider_test_support.rs
+++ b/src/server/model_provider_test_support.rs
@@ -51,6 +51,7 @@ impl ModelProvider {
             model_id: "route-test-model".to_string(),
             created_at: 0,
             loaded,
+            chat_unavailable: Arc::new(AtomicBool::new(false)),
             batch_metrics,
             batch_observability,
             max_queue_depth,
@@ -61,4 +62,34 @@ impl ModelProvider {
             _worker_handle: worker_handle,
         }
     }
+
+    pub(crate) fn chat_unavailable_for_route_tests() -> Self {
+        Self::closed_worker_for_route_tests(true, false)
+    }
+
+    pub(crate) fn exited_chat_worker_for_route_tests() -> Self {
+        Self::closed_worker_for_route_tests(false, true)
+    }
+
+    fn closed_worker_for_route_tests(chat_unavailable: bool, loaded: bool) -> Self {
+        let (request_tx, request_rx) = mpsc::channel::<ModelRequest>();
+        drop(request_rx);
+        let batch_metrics = Arc::new(BatchMetrics::new());
+        Self {
+            request_tx,
+            model_id: "route-test-model".to_string(),
+            created_at: 0,
+            loaded: Arc::new(AtomicBool::new(loaded)),
+            chat_unavailable: Arc::new(AtomicBool::new(chat_unavailable)),
+            batch_metrics,
+            batch_observability: Arc::new(BatchObservability::new()),
+            max_queue_depth: usize::MAX,
+            single_stream_queue_admission: Arc::new(AtomicBool::new(false)),
+            prompt_cache: None,
+            prompt_tokenizer: None,
+            decode_hang_timeout: DECODE_HANG_TIMEOUT,
+            _worker_handle: thread::spawn(|| {}),
+        }
+    }
+
 }

--- a/src/server/model_provider_tests.rs
+++ b/src/server/model_provider_tests.rs
@@ -21,8 +21,8 @@ use mlxcel_core::generate::SamplingConfig;
 use mlxcel_core::sampling::{LogprobsConfig, TokenLogprobData};
 
 use super::{
-    DECODE_HANG_TIMEOUT, GenerateEvent, GenerationResult, ModelProvider, ModelRequest,
-    QueueReservationMode, SingleStreamQueueReservation, drain_generation_events,
+    ChatWorkerGoneError, DECODE_HANG_TIMEOUT, GenerateEvent, GenerationResult, ModelProvider,
+    ModelRequest, QueueReservationMode, SingleStreamQueueReservation, drain_generation_events,
     send_shutdown_signal, tokenize_prompt_for_generation,
     tokenize_prompt_for_generation_with_ordered_media, validated_decode_hang_timeout,
 };
@@ -93,7 +93,7 @@ fn drain_generation_events_reports_closed_channel() {
     let (tx, rx) = mpsc::channel::<GenerateEvent>();
     drop(tx);
     let err = drain_generation_events(rx, DECODE_HANG_TIMEOUT, |_| {}).unwrap_err();
-    assert!(err.to_string().contains("Response channel closed"));
+    assert!(err.downcast_ref::<ChatWorkerGoneError>().is_some());
 }
 
 #[test]
@@ -257,6 +257,7 @@ fn pre_reserved_single_stream_enqueue_does_not_double_reserve() {
         model_id: "test-model".to_string(),
         created_at: 0,
         loaded: Arc::new(AtomicBool::new(true)),
+        chat_unavailable: Arc::new(AtomicBool::new(false)),
         batch_metrics: metrics.clone(),
         batch_observability: Arc::new(BatchObservability::new()),
         max_queue_depth: 1,
@@ -302,6 +303,7 @@ fn scheduler_paths_do_not_create_single_stream_reservations() {
         model_id: "test-model".to_string(),
         created_at: 0,
         loaded: Arc::new(AtomicBool::new(true)),
+        chat_unavailable: Arc::new(AtomicBool::new(false)),
         batch_metrics: Arc::new(BatchMetrics::new()),
         batch_observability: Arc::new(BatchObservability::new()),
         max_queue_depth: 0,

--- a/src/server/model_worker.rs
+++ b/src/server/model_worker.rs
@@ -196,6 +196,7 @@ pub(crate) fn spawn_model_worker_with_batch_config(
     adapter_path: Option<PathBuf>,
     request_rx: mpsc::Receiver<ModelRequest>,
     loaded: Arc<AtomicBool>,
+    chat_unavailable: Arc<AtomicBool>,
     worker_model_id: String,
     sched_config: WorkerSchedulerConfig,
     batch_metrics: Arc<BatchMetrics>,
@@ -281,6 +282,7 @@ pub(crate) fn spawn_model_worker_with_batch_config(
                     (model, tokenizer)
                 }
                 Err(err) => {
+                    chat_unavailable.store(true, Ordering::Release);
                     tracing::error!("Failed to load model: {err}");
                     return;
                 }
@@ -898,6 +900,7 @@ pub(crate) fn spawn_legacy_model_worker(
     reasoning_budget: Option<crate::server::thinking_budget::ThinkingBudget>,
     request_rx: mpsc::Receiver<ModelRequest>,
     loaded: Arc<AtomicBool>,
+    chat_unavailable: Arc<AtomicBool>,
     worker_model_id: String,
     batch_metrics: Arc<BatchMetrics>,
     batch_observability: Arc<BatchObservability>,
@@ -966,6 +969,7 @@ pub(crate) fn spawn_legacy_model_worker(
                     (model, tokenizer)
                 }
                 Err(err) => {
+                    chat_unavailable.store(true, Ordering::Release);
                     tracing::error!("Failed to load model: {err}");
                     return;
                 }

--- a/src/server/routes/anthropic.rs
+++ b/src/server/routes/anthropic.rs
@@ -44,7 +44,7 @@ use crate::server::anthropic_translator::{
 };
 use crate::server::chat_request::{prepare_chat_request_with_cache, request_has_effective_input};
 use crate::server::config::ReasoningBudgetOverride;
-use crate::server::model_provider::QueueFullError;
+use crate::server::model_provider::{ChatWorkerGoneError, QueueFullError};
 use crate::server::streaming::sse_response;
 use crate::server::streaming_anthropic::{AnthropicBlockEmitter, anthropic_sse_channel};
 use crate::server::thinking_budget::{pick_budget_alias, resolve_request_budget};
@@ -67,6 +67,13 @@ fn generation_error_to_response(err: anyhow::Error) -> Response {
     if err.downcast_ref::<QueueFullError>().is_some() {
         AnthropicErrorResponse::overloaded("All slots are busy. Please try again later.")
             .into_response()
+    } else if err.downcast_ref::<ChatWorkerGoneError>().is_some() {
+        AnthropicErrorResponse::new(
+            StatusCode::SERVICE_UNAVAILABLE,
+            "The chat worker has exited; check the server log.",
+            "api_error",
+        )
+        .into_response()
     } else {
         AnthropicErrorResponse::api_error(format!("Generation failed: {err}")).into_response()
     }
@@ -79,6 +86,14 @@ pub async fn anthropic_messages(
     headers: HeaderMap,
     Json(request): Json<AnthropicRequest>,
 ) -> Response {
+    if let Some(message) = super::chat_unavailable_message(&state) {
+        return AnthropicErrorResponse::new(
+            StatusCode::NOT_IMPLEMENTED,
+            message,
+            "not_implemented",
+        )
+        .into_response();
+    }
     let translated = anthropic_request_to_chat(&request);
 
     // Reject requests with no effective input before any model dispatch

--- a/src/server/routes/availability_tests.rs
+++ b/src/server/routes/availability_tests.rs
@@ -1,0 +1,251 @@
+// Copyright 2025-2026 Lablup Inc. and Jeongkyu Shin
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::path::PathBuf;
+use std::sync::Arc;
+
+use axum::body::Body;
+use axum::http::{Method, Request, StatusCode};
+use serde_json::{Value, json};
+use tower::ServiceExt;
+
+use crate::embeddings::{EmbedOptions, EmbedReply, ImageInput};
+use crate::rerank::{RerankItem, RerankScores, RerankerKind};
+use crate::server::audio_model::{AudioModelKind, AudioModelProvider};
+use crate::server::embedding_model::{EmbeddingError, EmbeddingModelProvider};
+use crate::server::rerank_model::{RerankError, RerankModelProvider};
+use crate::server::{AppState, ChatTemplateProcessor, ModelProvider, ServerConfig, create_app};
+use crate::tokenizer::MlxcelTokenizer;
+
+struct SideEmbeddingProvider;
+
+impl EmbeddingModelProvider for SideEmbeddingProvider {
+    fn embed_texts(
+        &self,
+        _texts: Vec<String>,
+        _opts: EmbedOptions,
+    ) -> Result<EmbedReply, EmbeddingError> {
+        unreachable!("availability preflight must prevent embedding dispatch")
+    }
+
+    fn embed_tokens(
+        &self,
+        _token_rows: Vec<Vec<u32>>,
+        _opts: EmbedOptions,
+    ) -> Result<EmbedReply, EmbeddingError> {
+        unreachable!("availability preflight must prevent embedding dispatch")
+    }
+
+    fn embed_image(
+        &self,
+        _image: ImageInput,
+        _opts: EmbedOptions,
+    ) -> Result<EmbedReply, EmbeddingError> {
+        unreachable!("availability preflight must prevent embedding dispatch")
+    }
+
+    fn model_id(&self) -> &str {
+        "side-embedding"
+    }
+
+    fn created_at(&self) -> i64 {
+        0
+    }
+
+    fn dim(&self) -> usize {
+        1
+    }
+
+    fn multi_vector(&self) -> bool {
+        false
+    }
+
+    fn vocab_size(&self) -> usize {
+        1
+    }
+
+    fn max_length(&self) -> usize {
+        1
+    }
+}
+
+struct SideRerankProvider;
+
+impl RerankModelProvider for SideRerankProvider {
+    fn rerank(
+        &self,
+        _query: RerankItem,
+        _documents: Vec<RerankItem>,
+        _instruction: Option<String>,
+    ) -> Result<RerankScores, RerankError> {
+        unreachable!("availability preflight must prevent rerank dispatch")
+    }
+
+    fn model_id(&self) -> &str {
+        "side-reranker"
+    }
+
+    fn created_at(&self) -> i64 {
+        0
+    }
+
+    fn kind(&self) -> RerankerKind {
+        RerankerKind::GenerativeText
+    }
+
+    fn max_length(&self) -> usize {
+        1
+    }
+}
+
+struct SideAudioProvider;
+
+impl AudioModelProvider for SideAudioProvider {
+    fn supports(&self, kind: AudioModelKind) -> bool {
+        kind == AudioModelKind::Stt
+    }
+}
+
+fn state_with(provider: ModelProvider) -> AppState {
+    let provider = Arc::new(provider);
+    let batch_metrics = provider.batch_metrics().clone();
+    AppState::new(
+        provider,
+        ServerConfig::default(),
+        ChatTemplateProcessor::with_template("ok".to_string()),
+        MlxcelTokenizer::stub(),
+        PathBuf::from("route-test-model"),
+        batch_metrics,
+    )
+}
+
+async fn post(app: axum::Router, path: &str, body: Value) -> (StatusCode, Value) {
+    let response = app
+        .oneshot(
+            Request::builder()
+                .method(Method::POST)
+                .uri(path)
+                .header("content-type", "application/json")
+                .body(Body::from(body.to_string()))
+                .expect("request builds"),
+        )
+        .await
+        .expect("route responds");
+    let status = response.status();
+    let bytes = axum::body::to_bytes(response.into_body(), usize::MAX)
+        .await
+        .expect("body reads");
+    let body = if bytes.is_empty() {
+        Value::Null
+    } else {
+        serde_json::from_slice(&bytes).unwrap_or_else(|err| {
+            panic!(
+                "status {status}, invalid JSON body {body:?}: {err}",
+                body = String::from_utf8_lossy(&bytes)
+            )
+        })
+    };
+    (status, body)
+}
+
+#[tokio::test]
+async fn embedding_only_server_returns_501_on_all_generation_routes() {
+    let cases = [
+        (
+            "/v1/chat/completions",
+            json!({"model": "route-test-model", "messages": [{"role": "user", "content": "hello"}]}),
+        ),
+        (
+            "/v1/completions",
+            json!({"model": "route-test-model", "prompt": "hello"}),
+        ),
+        (
+            "/v1/responses",
+            json!({"model": "route-test-model", "input": "hello"}),
+        ),
+        (
+            "/v1/messages",
+            json!({
+                "model": "route-test-model",
+                "messages": [{"role": "user", "content": "hello"}],
+                "max_tokens": 1
+            }),
+        ),
+        ("/completion", json!({"prompt": "hello", "n_predict": 1})),
+    ];
+
+    for (path, body) in cases {
+        let state = state_with(ModelProvider::chat_unavailable_for_route_tests())
+            .with_embedding_model(Some(Arc::new(SideEmbeddingProvider)));
+        let (status, body) = post(create_app(state), path, body).await;
+        assert_eq!(status, StatusCode::NOT_IMPLEMENTED, "{path}: {body}");
+        assert_eq!(body["error"]["type"], "not_implemented", "{path}: {body}");
+        let message = body["error"]["message"].as_str().expect("message");
+        assert!(message.contains("/v1/embeddings"), "{path}: {body}");
+        assert!(message.contains("--embedding-model"), "{path}: {body}");
+    }
+}
+
+#[tokio::test]
+async fn rerank_only_server_names_the_served_route_and_flag() {
+    let state = state_with(ModelProvider::chat_unavailable_for_route_tests())
+        .with_rerank_model(Some(Arc::new(SideRerankProvider)));
+    let (status, body) = post(
+        create_app(state),
+        "/v1/chat/completions",
+        json!({"model": "route-test-model", "messages": [{"role": "user", "content": "hello"}]}),
+    )
+    .await;
+
+    assert_eq!(status, StatusCode::NOT_IMPLEMENTED, "{body}");
+    let message = body["error"]["message"].as_str().expect("message");
+    assert!(message.contains("/v1/rerank"), "{body}");
+    assert!(message.contains("--reranker-model"), "{body}");
+}
+
+#[tokio::test]
+async fn audio_only_server_names_the_served_routes() {
+    let state = state_with(ModelProvider::chat_unavailable_for_route_tests())
+        .with_audio_model(Some(Arc::new(SideAudioProvider)));
+    let (status, body) = post(
+        create_app(state),
+        "/v1/chat/completions",
+        json!({"model": "route-test-model", "messages": [{"role": "user", "content": "hello"}]}),
+    )
+    .await;
+
+    assert_eq!(status, StatusCode::NOT_IMPLEMENTED, "{body}");
+    let message = body["error"]["message"].as_str().expect("message");
+    assert!(message.contains("/v1/audio/transcriptions"), "{body}");
+    assert!(message.contains("/v1/audio/translations"), "{body}");
+}
+
+#[tokio::test]
+async fn exited_chat_worker_returns_503_without_channel_details() {
+    let state = state_with(ModelProvider::exited_chat_worker_for_route_tests());
+    let (status, body) = post(
+        create_app(state),
+        "/v1/chat/completions",
+        json!({"model": "route-test-model", "messages": [{"role": "user", "content": "hello"}]}),
+    )
+    .await;
+
+    assert_eq!(status, StatusCode::SERVICE_UNAVAILABLE, "{body}");
+    assert_eq!(body["error"]["type"], "server_error");
+    assert!(!body.to_string().contains("closed channel"), "{body}");
+    assert!(
+        body.to_string().contains("chat worker has exited"),
+        "{body}"
+    );
+}

--- a/src/server/routes/chat.rs
+++ b/src/server/routes/chat.rs
@@ -32,7 +32,6 @@ use crate::server::chat_request::{
     prepare_chat_request_with_cache, request_has_effective_input, resolve_effective_kwargs,
 };
 use crate::server::config::{PromptCacheRequestContext, ReasoningBudgetOverride};
-use crate::server::model_provider::QueueFullError;
 use crate::server::prompt_cache::key::{
     multimodal_digest_from_vecs, resolve_session_key, template_sig,
 };
@@ -76,11 +75,7 @@ pub(crate) fn structured_error_to_response(err: StructuredOutputError) -> ErrorR
 }
 
 fn generation_error_to_response(err: anyhow::Error) -> ErrorResponse {
-    if err.downcast_ref::<QueueFullError>().is_some() {
-        ErrorResponse::service_unavailable("All slots are busy. Please try again later.")
-    } else {
-        ErrorResponse::new(format!("Generation error: {err}"), "server_error")
-    }
+    super::generation_error_to_response(err)
 }
 
 /// Build the per-request prompt-cache context.
@@ -222,6 +217,10 @@ pub async fn chat_completions(
     headers: HeaderMap,
     Json(request): Json<ChatCompletionRequest>,
 ) -> Response {
+    if let Some(response) = super::chat_not_available(&state) {
+        return response.into_response();
+    }
+
     // Reject requests with no effective input before any other validation or
     // model dispatch (issue #773): an empty `messages` array, or messages
     // whose content is empty/whitespace-only with no media/tool/reasoning

--- a/src/server/routes/completions.rs
+++ b/src/server/routes/completions.rs
@@ -32,7 +32,6 @@ use crate::server::AppState;
 use crate::server::batch::RequestPriority;
 use crate::server::config::ReasoningBudgetOverride;
 use crate::server::media::MediaRequestMetadata;
-use crate::server::model_provider::QueueFullError;
 use crate::server::request_options::resolve_server_max_tokens;
 use crate::server::streaming::{sse_channel, sse_response};
 use crate::server::structured::build_constraint_from_response_format;
@@ -47,11 +46,7 @@ use super::chat::{
 };
 
 fn generation_error_to_response(err: anyhow::Error) -> ErrorResponse {
-    if err.downcast_ref::<QueueFullError>().is_some() {
-        ErrorResponse::service_unavailable("All slots are busy. Please try again later.")
-    } else {
-        ErrorResponse::new(format!("Generation error: {err}"), "server_error")
-    }
+    super::generation_error_to_response(err)
 }
 
 /// Build a `CompletionLogprobs` from a list of `TokenLogprobData` (legacy format).
@@ -143,6 +138,10 @@ pub async fn completions(
     headers: HeaderMap,
     Json(request): Json<CompletionRequest>,
 ) -> Response {
+    if let Some(response) = super::chat_not_available(&state) {
+        return response.into_response();
+    }
+
     // Reject whitespace-only-but-nonempty prompts before any model dispatch,
     // alongside the route's other pre-dispatch validations (issue #806).
     // See `prompt_is_whitespace_only` for why an empty prompt is allowed

--- a/src/server/routes/embeddings.rs
+++ b/src/server/routes/embeddings.rs
@@ -35,7 +35,10 @@ use serde_json::Value;
 use crate::embeddings::{EmbedOptions, EmbeddingVector, ImageInput};
 use crate::server::AppState;
 use crate::server::embedding_model::{EmbeddingError, EmbeddingModelProvider};
-use crate::server::media::{current_image_input_limits, try_read_image_url_with_limits};
+use crate::server::media::{
+    ImageInputLimits, current_image_input_limits, try_read_image_url_with_limits,
+    validate_image_count,
+};
 use crate::server::model_provider::model_worker::decode_request_images_with_limits;
 use crate::server::types::ErrorResponse;
 use crate::server::types::embeddings::{
@@ -77,10 +80,17 @@ pub(crate) fn embedding_error_response(err: EmbeddingError) -> ErrorResponse {
 fn validate_items(
     items: &[EmbedItem],
     provider: &dyn EmbeddingModelProvider,
+    limits: ImageInputLimits,
 ) -> Result<(), ErrorResponse> {
     if items.is_empty() {
         return Err(invalid_request("`input` must not be empty"));
     }
+    let image_count = items
+        .iter()
+        .filter(|item| matches!(item, EmbedItem::ImageUrl(_)))
+        .count();
+    validate_image_count(image_count, limits).map_err(|err| invalid_request(err.to_string()))?;
+
     let vocab_size = provider.vocab_size();
     for (index, item) in items.iter().enumerate() {
         match item {
@@ -116,8 +126,10 @@ fn validate_items(
 }
 
 /// Resolve every `image_url` item into a decoded image, in item order.
-async fn fetch_images(items: &[EmbedItem]) -> Result<Vec<(usize, ImageInput)>, ErrorResponse> {
-    let limits = current_image_input_limits();
+async fn fetch_images(
+    items: &[EmbedItem],
+    limits: ImageInputLimits,
+) -> Result<Vec<(usize, ImageInput)>, ErrorResponse> {
     let mut images = Vec::new();
     for (index, item) in items.iter().enumerate() {
         let EmbedItem::ImageUrl(url) = item else {
@@ -256,10 +268,11 @@ pub async fn create_embeddings(State(state): State<AppState>, Json(body): Json<V
     }
 
     let items = request.input.into_items();
-    if let Err(err) = validate_items(&items, provider.as_ref()) {
+    let image_limits = current_image_input_limits();
+    if let Err(err) = validate_items(&items, provider.as_ref(), image_limits) {
         return err.into_response();
     }
-    let images = match fetch_images(&items).await {
+    let images = match fetch_images(&items, image_limits).await {
         Ok(images) => images,
         Err(err) => return err.into_response(),
     };
@@ -286,6 +299,26 @@ pub async fn create_embeddings(State(state): State<AppState>, Json(body): Json<V
             return response.into_response();
         }
     };
+
+    if let Some((vector_index, value_index)) = vectors.iter().enumerate().find_map(|(i, vector)| {
+        vector
+            .values
+            .iter()
+            .position(|value| !value.is_finite())
+            .map(|j| (i, j))
+    }) {
+        tracing::error!(
+            vector_index,
+            value_index,
+            "embedding inference returned a non-finite value"
+        );
+        let mut response = ErrorResponse::new(
+            "embedding inference returned an invalid numeric result",
+            "server_error",
+        );
+        response.status = StatusCode::INTERNAL_SERVER_ERROR;
+        return response.into_response();
+    }
 
     state
         .metrics

--- a/src/server/routes/embeddings_tests.rs
+++ b/src/server/routes/embeddings_tests.rs
@@ -27,6 +27,7 @@ use tower::ServiceExt;
 
 use super::{NO_EMBEDDING_MODEL_MESSAGE, embedding_error_response};
 use crate::embeddings::stub::{STUB_DIM, STUB_VOCAB_SIZE, stub_loaded_model};
+use crate::embeddings::{EmbedOptions, EmbedReply, EmbeddingVector, ImageInput};
 use crate::server::embedding_model::{EmbeddingError, EmbeddingModelProvider};
 use crate::server::embedding_worker::EmbeddingWorkerProvider;
 use crate::server::types::embeddings::{
@@ -36,6 +37,70 @@ use crate::server::{AppState, ChatTemplateProcessor, ModelProvider, ServerConfig
 use crate::tokenizer::MlxcelTokenizer;
 
 const STUB_MODEL_ID: &str = "stub-embedding";
+
+struct NonFiniteEmbeddingProvider;
+
+impl NonFiniteEmbeddingProvider {
+    fn reply() -> EmbedReply {
+        EmbedReply {
+            vectors: vec![EmbeddingVector {
+                values: vec![f32::NAN],
+                shape: vec![1],
+            }],
+            prompt_tokens: 1,
+        }
+    }
+}
+
+impl EmbeddingModelProvider for NonFiniteEmbeddingProvider {
+    fn embed_texts(
+        &self,
+        _texts: Vec<String>,
+        _opts: EmbedOptions,
+    ) -> Result<EmbedReply, EmbeddingError> {
+        Ok(Self::reply())
+    }
+
+    fn embed_tokens(
+        &self,
+        _token_rows: Vec<Vec<u32>>,
+        _opts: EmbedOptions,
+    ) -> Result<EmbedReply, EmbeddingError> {
+        Ok(Self::reply())
+    }
+
+    fn embed_image(
+        &self,
+        _image: ImageInput,
+        _opts: EmbedOptions,
+    ) -> Result<EmbedReply, EmbeddingError> {
+        Ok(Self::reply())
+    }
+
+    fn model_id(&self) -> &str {
+        "non-finite-embedding"
+    }
+
+    fn created_at(&self) -> i64 {
+        0
+    }
+
+    fn dim(&self) -> usize {
+        1
+    }
+
+    fn multi_vector(&self) -> bool {
+        false
+    }
+
+    fn vocab_size(&self) -> usize {
+        128
+    }
+
+    fn max_length(&self) -> usize {
+        32
+    }
+}
 
 fn stub_provider(multi_vector: bool, batch_size: usize) -> Arc<dyn EmbeddingModelProvider> {
     Arc::new(
@@ -406,4 +471,43 @@ fn input_shapes_flatten_to_ordered_items() {
         Some(EmbeddingEncoding::Base64)
     );
     assert_eq!(EmbeddingEncoding::parse(Some("int8")), None);
+}
+
+#[tokio::test]
+async fn too_many_images_are_rejected_before_resolution() {
+    let input: Vec<Value> = (0..17)
+        .map(|_| {
+            json!({
+                "type": "image_url",
+                "image_url": {"url": "https://example.invalid/image.png"}
+            })
+        })
+        .collect();
+    let app = app_with(Some(stub_provider(false, 16)));
+    let (status, body) = post(app, "/v1/embeddings", json!({"input": input})).await;
+
+    assert_eq!(status, StatusCode::BAD_REQUEST, "{body}");
+    assert!(
+        body["error"]["message"]
+            .as_str()
+            .expect("message")
+            .contains("Too many image inputs"),
+        "{body}"
+    );
+}
+
+#[tokio::test]
+async fn non_finite_embeddings_return_500() {
+    let app = app_with(Some(Arc::new(NonFiniteEmbeddingProvider)));
+    let (status, body) = post(app, "/v1/embeddings", json!({"input": "hello"})).await;
+
+    assert_eq!(status, StatusCode::INTERNAL_SERVER_ERROR, "{body}");
+    assert_eq!(body["error"]["type"], "server_error");
+    assert!(
+        body["error"]["message"]
+            .as_str()
+            .expect("message")
+            .contains("invalid numeric result"),
+        "{body}"
+    );
 }

--- a/src/server/routes/mod.rs
+++ b/src/server/routes/mod.rs
@@ -17,6 +17,10 @@
 //! These files should stay focused on request/response translation. Shared
 //! policy belongs in `server/request_options.rs`, `server/chat_request.rs`,
 //! `server/media.rs`, `server/streaming.rs`, and `server/model_worker.rs`.
+use crate::server::AppState;
+use crate::server::audio_model::AudioModelKind;
+use crate::server::model_provider::{ChatWorkerGoneError, QueueFullError};
+use crate::server::types::ErrorResponse;
 
 pub mod anthropic;
 pub mod audio;
@@ -36,6 +40,10 @@ pub mod responses;
 pub mod slots;
 pub mod tokenize;
 
+#[cfg(test)]
+#[path = "availability_tests.rs"]
+mod availability_tests;
+
 pub use anthropic::{anthropic_count_tokens, anthropic_messages};
 pub use audio::{audio_speech, audio_transcriptions, audio_translations};
 pub use cache::{cache_reset, cache_stats};
@@ -53,3 +61,80 @@ pub use rerank::create_rerank;
 pub use responses::{cancel_response, create_response, delete_response, retrieve_response};
 pub use slots::slots;
 pub use tokenize::tokenize;
+
+/// Explain a terminal generation-unavailable state without exposing worker or
+/// channel implementation details.
+pub(crate) fn chat_unavailable_message(state: &AppState) -> Option<String> {
+    if !state.model_provider.is_chat_unavailable() {
+        return None;
+    }
+
+    let mut routes = Vec::new();
+    let mut side_model_flags = Vec::new();
+    if state.embedding_model.is_some() {
+        routes.push("/v1/embeddings");
+        side_model_flags.push("--embedding-model <path>");
+    }
+    if state.rerank_model.is_some() {
+        routes.push("/v1/rerank");
+        side_model_flags.push("--reranker-model <path>");
+    }
+    if let Some(audio) = state.audio_model.as_ref() {
+        if audio.supports(AudioModelKind::Stt) {
+            routes.push("/v1/audio/transcriptions");
+            routes.push("/v1/audio/translations");
+        }
+        if audio.supports(AudioModelKind::Tts) {
+            routes.push("/v1/audio/speech");
+        }
+    }
+
+    if routes.is_empty() {
+        return Some(
+            "This server has no loaded chat model; check the startup log for the load failure."
+                .to_string(),
+        );
+    }
+
+    let guidance = if side_model_flags.is_empty() {
+        "Start a separate server with -m <chat model> to serve generation.".to_string()
+    } else {
+        format!(
+            "Start with -m <chat model> {} to serve chat and these side-model routes.",
+            side_model_flags.join(" ")
+        )
+    };
+    Some(format!(
+        "This server has no loaded chat model; it serves {}. {guidance}",
+        routes.join(", ")
+    ))
+}
+
+/// Return the OpenAI-compatible capability response for a terminal no-chat
+/// provider state.
+pub(crate) fn chat_not_available(state: &AppState) -> Option<ErrorResponse> {
+    chat_unavailable_message(state).map(ErrorResponse::not_implemented)
+}
+
+/// Map generation dispatch failures consistently across OpenAI-compatible
+/// routes.
+pub(crate) fn generation_error_to_response(err: anyhow::Error) -> ErrorResponse {
+    if err.downcast_ref::<QueueFullError>().is_some() {
+        return ErrorResponse::service_unavailable("All slots are busy. Please try again later.");
+    }
+
+    let mut response = if err.downcast_ref::<ChatWorkerGoneError>().is_some() {
+        ErrorResponse::new(
+            "The chat worker has exited; check the server log.",
+            "server_error",
+        )
+    } else {
+        ErrorResponse::new(format!("Generation error: {err}"), "server_error")
+    };
+    response.status = if err.downcast_ref::<ChatWorkerGoneError>().is_some() {
+        axum::http::StatusCode::SERVICE_UNAVAILABLE
+    } else {
+        axum::http::StatusCode::INTERNAL_SERVER_ERROR
+    };
+    response
+}

--- a/src/server/routes/native_completion.rs
+++ b/src/server/routes/native_completion.rs
@@ -30,7 +30,6 @@ use axum::{
 use crate::server::batch::RequestPriority;
 use crate::server::config::ReasoningBudgetOverride;
 use crate::server::media::MediaRequestMetadata;
-use crate::server::model_provider::QueueFullError;
 use crate::server::request_options::{
     RequestOptionOverrides, build_server_generate_options, resolve_server_max_tokens,
 };
@@ -42,11 +41,7 @@ use crate::server::types::{
 use crate::server::{AppState, ServerConfig, ServerGenerateOptions};
 
 fn generation_error_to_response(err: anyhow::Error) -> ErrorResponse {
-    if err.downcast_ref::<QueueFullError>().is_some() {
-        ErrorResponse::service_unavailable("All slots are busy. Please try again later.")
-    } else {
-        ErrorResponse::new(format!("Generation error: {err}"), "server_error")
-    }
+    super::generation_error_to_response(err)
 }
 
 /// POST /completion
@@ -55,6 +50,10 @@ pub async fn native_completion(
     headers: HeaderMap,
     Json(request): Json<NativeCompletionRequest>,
 ) -> Response {
+    if let Some(response) = super::chat_not_available(&state) {
+        return response.into_response();
+    }
+
     // the native `/completion` endpoint does not support
     // `response_format`. Reject up front with a clear 400 so the client
     // does not assume their schema was honored — the chat-completions

--- a/src/server/routes/rerank.rs
+++ b/src/server/routes/rerank.rs
@@ -32,7 +32,10 @@ use serde_json::Value;
 
 use crate::rerank::{ImageInput, RerankItem};
 use crate::server::AppState;
-use crate::server::media::{current_image_input_limits, try_read_image_url_with_limits};
+use crate::server::media::{
+    ImageInputLimits, current_image_input_limits, try_read_image_url_with_limits,
+    validate_image_count,
+};
 use crate::server::model_provider::model_worker::decode_request_images_with_limits;
 use crate::server::rerank_model::{RerankError, RerankModelProvider};
 use crate::server::types::ErrorResponse;
@@ -75,10 +78,18 @@ fn validate_items(
     query: &RerankInput,
     documents: &[RerankInput],
     provider: &dyn RerankModelProvider,
+    limits: ImageInputLimits,
 ) -> Result<(), ErrorResponse> {
     if documents.is_empty() {
         return Err(invalid_request("`documents` must not be empty"));
     }
+    let image_count = usize::from(query.image_url().is_some())
+        + documents
+            .iter()
+            .filter(|document| document.image_url().is_some())
+            .count();
+    validate_image_count(image_count, limits).map_err(|err| invalid_request(err.to_string()))?;
+
     let supports_images = provider.supports_images();
     let check = |item: &RerankInput, label: String| -> Result<(), ErrorResponse> {
         if item.is_empty() {
@@ -101,11 +112,14 @@ fn validate_items(
 }
 
 /// Resolve an item's `image_url` into a decoded image.
-async fn fetch_image(item: &RerankInput, label: &str) -> Result<Option<ImageInput>, ErrorResponse> {
+async fn fetch_image(
+    item: &RerankInput,
+    label: &str,
+    limits: ImageInputLimits,
+) -> Result<Option<ImageInput>, ErrorResponse> {
     let Some(url) = item.image_url() else {
         return Ok(None);
     };
-    let limits = current_image_input_limits();
     let bytes = match try_read_image_url_with_limits(url, limits).await {
         Ok(Some(bytes)) => bytes,
         Ok(None) => {
@@ -130,10 +144,14 @@ async fn fetch_image(item: &RerankInput, label: &str) -> Result<Option<ImageInpu
 }
 
 /// Turn one request item into the worker's item type, fetching its image.
-async fn to_rerank_item(item: &RerankInput, label: &str) -> Result<RerankItem, ErrorResponse> {
+async fn to_rerank_item(
+    item: &RerankInput,
+    label: &str,
+    limits: ImageInputLimits,
+) -> Result<RerankItem, ErrorResponse> {
     Ok(RerankItem {
         text: item.text().map(str::to_string),
-        image: fetch_image(item, label).await?,
+        image: fetch_image(item, label, limits).await?,
     })
 }
 
@@ -176,17 +194,23 @@ pub async fn create_rerank(State(state): State<AppState>, Json(body): Json<Value
         .into_response();
     }
 
-    if let Err(err) = validate_items(&request.query, &request.documents, provider.as_ref()) {
+    let image_limits = current_image_input_limits();
+    if let Err(err) = validate_items(
+        &request.query,
+        &request.documents,
+        provider.as_ref(),
+        image_limits,
+    ) {
         return err.into_response();
     }
 
-    let query = match to_rerank_item(&request.query, "`query`").await {
+    let query = match to_rerank_item(&request.query, "`query`", image_limits).await {
         Ok(item) => item,
         Err(err) => return err.into_response(),
     };
     let mut documents = Vec::with_capacity(request.documents.len());
     for (index, document) in request.documents.iter().enumerate() {
-        match to_rerank_item(document, &format!("documents[{index}]")).await {
+        match to_rerank_item(document, &format!("documents[{index}]"), image_limits).await {
             Ok(item) => documents.push(item),
             Err(err) => return err.into_response(),
         }
@@ -222,6 +246,21 @@ pub async fn create_rerank(State(state): State<AppState>, Json(body): Json<Value
         return response.into_response();
     }
 
+    if let Some((index, score)) = scored
+        .scores
+        .iter()
+        .copied()
+        .enumerate()
+        .find(|(_, score)| !score.is_finite() || !(0.0..=1.0).contains(score))
+    {
+        tracing::error!(index, score, "reranker returned an invalid relevance score");
+        let mut response = ErrorResponse::new(
+            "rerank inference returned an invalid numeric result",
+            "server_error",
+        );
+        response.status = StatusCode::INTERNAL_SERVER_ERROR;
+        return response.into_response();
+    }
     state.metrics.record_request(
         scored.prompt_tokens,
         0,

--- a/src/server/routes/rerank_tests.rs
+++ b/src/server/routes/rerank_tests.rs
@@ -26,8 +26,8 @@ use serde_json::{Value, json};
 use tower::ServiceExt;
 
 use super::{NO_RERANKER_MODEL_MESSAGE, rerank_error_response};
-use crate::rerank::RerankerKind;
 use crate::rerank::stub::stub_loaded_reranker;
+use crate::rerank::{RerankItem, RerankScores, RerankerKind};
 use crate::server::rerank_model::{RerankError, RerankModelProvider};
 use crate::server::rerank_worker::RerankWorkerProvider;
 use crate::server::{AppState, ChatTemplateProcessor, ModelProvider, ServerConfig, create_app};
@@ -38,6 +38,38 @@ const STUB_MODEL_ID: &str = "stub-reranker";
 /// A 1x1 PNG as a data URI, so an image item can reach the route without a
 /// file or a network fetch.
 const TINY_PNG: &str = "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z8BQDwAEhQGAhKmMIQAAAABJRU5ErkJggg==";
+
+struct NonFiniteRerankProvider;
+
+impl RerankModelProvider for NonFiniteRerankProvider {
+    fn rerank(
+        &self,
+        _query: RerankItem,
+        documents: Vec<RerankItem>,
+        _instruction: Option<String>,
+    ) -> Result<RerankScores, RerankError> {
+        Ok(RerankScores {
+            scores: vec![f32::NAN; documents.len()],
+            prompt_tokens: 1,
+        })
+    }
+
+    fn model_id(&self) -> &str {
+        "non-finite-reranker"
+    }
+
+    fn created_at(&self) -> i64 {
+        0
+    }
+
+    fn kind(&self) -> RerankerKind {
+        RerankerKind::GenerativeText
+    }
+
+    fn max_length(&self) -> usize {
+        32
+    }
+}
 
 fn stub_provider(kind: RerankerKind, supports_images: bool) -> Arc<dyn RerankModelProvider> {
     Arc::new(
@@ -460,5 +492,47 @@ fn provider_errors_map_to_the_shared_status_codes() {
     assert_eq!(
         rerank_error_response(RerankError::Internal("boom".into())).status,
         StatusCode::INTERNAL_SERVER_ERROR
+    );
+}
+
+#[tokio::test]
+async fn too_many_images_are_rejected_before_resolution() {
+    let documents: Vec<Value> = (0..17).map(|_| json!({"image": TINY_PNG})).collect();
+    let app = app_with(Some(stub_provider(RerankerKind::GenerativeVl, true)));
+    let (status, body) = post(
+        app,
+        "/v1/rerank",
+        json!({"query": "alpha", "documents": documents}),
+    )
+    .await;
+
+    assert_eq!(status, StatusCode::BAD_REQUEST, "{body}");
+    assert!(
+        body["error"]["message"]
+            .as_str()
+            .expect("message")
+            .contains("Too many image inputs"),
+        "{body}"
+    );
+}
+
+#[tokio::test]
+async fn non_finite_scores_return_500() {
+    let app = app_with(Some(Arc::new(NonFiniteRerankProvider)));
+    let (status, body) = post(
+        app,
+        "/v1/rerank",
+        json!({"query": "alpha", "documents": ["alpha"]}),
+    )
+    .await;
+
+    assert_eq!(status, StatusCode::INTERNAL_SERVER_ERROR, "{body}");
+    assert_eq!(body["error"]["type"], "server_error");
+    assert!(
+        body["error"]["message"]
+            .as_str()
+            .expect("message")
+            .contains("invalid numeric result"),
+        "{body}"
     );
 }

--- a/src/server/routes/responses.rs
+++ b/src/server/routes/responses.rs
@@ -61,11 +61,7 @@ use crate::server::types::responses_response::{
 use crate::server::types::responses_stream::ResponseStreamEvent;
 
 fn generation_error_to_response(err: anyhow::Error) -> ErrorResponse {
-    if err.downcast_ref::<QueueFullError>().is_some() {
-        ErrorResponse::service_unavailable("All slots are busy. Please try again later.")
-    } else {
-        ErrorResponse::new(format!("Generation error: {err}"), "server_error")
-    }
+    super::generation_error_to_response(err)
 }
 
 use super::chat::{
@@ -80,6 +76,10 @@ pub async fn create_response(
     headers: HeaderMap,
     Json(request): Json<CreateResponseRequest>,
 ) -> Response {
+    if let Some(response) = super::chat_not_available(&state) {
+        return response.into_response();
+    }
+
     // -- Translate Responses request → ChatCompletionRequest ---------------
     let translated = match responses_request_to_chat(
         &request,

--- a/src/server/types/rerank.rs
+++ b/src/server/types/rerank.rs
@@ -164,8 +164,7 @@ pub fn sort_and_truncate(
 ) -> Vec<RerankResult> {
     results.sort_by(|a, b| {
         b.relevance_score
-            .partial_cmp(&a.relevance_score)
-            .unwrap_or(std::cmp::Ordering::Equal)
+            .total_cmp(&a.relevance_score)
             .then(a.index.cmp(&b.index))
     });
     if let Some(n) = top_n {


### PR DESCRIPTION
## Summary

- Enforce the configured aggregate image limit before embedding and rerank routes fetch, decode, or retain request images.
- Reject non-finite embedding values and non-finite or out-of-range rerank scores before API serialization, and use total ordering for validated rerank scores.
- Return explicit 501 capability responses for side-model-only servers and stable typed 503 responses when a chat worker exits, without exposing Rust channel internals.

## Post-merge audit findings

- HIGH: Embedding and rerank requests applied per-image byte, dimension, and decode limits but did not enforce `max_images_per_request` before resolving all declared images, allowing request memory and remote acquisition work to grow beyond the configured aggregate bound.
- MEDIUM: Embedding and rerank routes accepted invalid floating-point model output; embeddings could serialize invalid JSON or binary payloads, while rerank scores could violate the documented `[0, 1]` contract and make ordering unreliable.
- MEDIUM: Side-model-only servers and workers that exited after startup exposed channel implementation details through mismatched 400 responses; this also left the acceptance gap tracked in #1425.

## Corrections

- Add one shared image-count validator, reuse it in chat image collection, and validate embedding/rerank aggregate counts with a consistent limit snapshot before resolution.
- Fail invalid embedding and rerank numeric output with a logged 500 `server_error`, and sort validated relevance scores with `total_cmp`.
- Track terminal chat unavailability atomically, preflight all five live generation handlers, centralize OpenAI-compatible generation error mapping, and preserve Anthropic-native error envelopes.
- Add router-level coverage for embedding-only, rerank-only, audio-only, and exited-worker shapes, plus regressions for image-count and numeric-output guards.

## Verification

- `cargo fmt --all -- --check`
- `cargo clippy --fix --allow-dirty --lib --tests --profile test-fast --features cuda`
- `cargo clippy --lib --tests --profile test-fast --features cuda -- -D warnings`
- `cargo deny check`
- `cargo test --profile test-fast --features cuda --lib server::routes --no-fail-fast -- --test-threads=1` — 170 passed.
- `cargo test --profile test-fast --features cuda --lib server::model_provider --no-fail-fast -- --test-threads=1` — 51 passed.
- `cargo test --workspace --profile test-fast --features cuda --no-fail-fast -- --test-threads=1` — completed with only the pre-existing `sampling::tests::temperature_one_support_unchanged` bit-parity failure tracked in #1418; all corrected server targets passed.

## Residual follow-ups

- #1418 and the previously filed GPU/model follow-ups #1421, #1422, #1423, and #1424 remain independent of this server hardening.
- #1426 remains explicitly outside the epic's HTTP scoring scope.

Follow-up to #1348.

Closes #1425.
