### PR TITLE
fix(server): accept space-separated negative values on server flags

### DIFF
--- a/compat/llama-server/b10621/chat-templates.json
+++ b/compat/llama-server/b10621/chat-templates.json
@@ -206,13 +206,11 @@
       "default": "-1",
       "description": "token budget for thinking: -1 for unrestricted, 0 for immediate end, N>0 for token budget (default: -1) (env: LLAMA_ARG_THINK_BUDGET)",
       "discovery": "help-entry-head",
-      "state": "deferred",
+      "state": "supported",
       "issue": 1447,
       "test": "tests/llama_compat_manifest.rs",
       "notes": "Same -1/0/N semantics; canonical LLAMA_ARG_THINK_BUDGET honored at runtime (clap binds the flag, the env bridge is code, covered by tests/thinking_budget.rs).",
-      "divergence": [
-        "A negative value must be written as --reasoning-budget=-1; the space-separated --reasoning-budget -1 that llama-server accepts is rejected by mlxcel's argv parser (#1447)."
-      ],
+      "divergence": [],
       "mlxcel": {
         "accepted_spellings": [
           "--reasoning-budget"

--- a/compat/llama-server/b10621/runtime-and-context.json
+++ b/compat/llama-server/b10621/runtime-and-context.json
@@ -431,13 +431,11 @@
       "default": "-1, -1 = infinity",
       "description": "number of tokens to predict (default: -1, -1 = infinity) (env: LLAMA_ARG_N_PREDICT)",
       "discovery": "help-entry-head",
-      "state": "deferred",
+      "state": "supported",
       "issue": 1450,
       "test": "tests/llama_compat_manifest.rs",
       "notes": "Both spellings (--predict, --n-predict) accepted; default -1 = until EOS/context, matching llama-server per request.",
-      "divergence": [
-        "A negative value must be written as --predict=-1 or --n-predict=-1; the space-separated --predict -1 that llama-server accepts is rejected by mlxcel's argv parser (#1450)."
-      ],
+      "divergence": [],
       "mlxcel": {
         "accepted_spellings": [
           "--predict",

--- a/compat/llama-server/b10621/sampling-and-grammar.json
+++ b/compat/llama-server/b10621/sampling-and-grammar.json
@@ -670,7 +670,6 @@
       "test": "tests/llama_compat_manifest.rs",
       "notes": "seed -1 = nondeterministic accepted exactly. The below-minus-one rejection added by #1430 lives on the HTTP field (see field:seed), not on this flag: the flag maps every negative value to the random sentinel.",
       "divergence": [
-        "A negative value must be written as --seed=-1; the space-separated --seed -1 that llama-server accepts is rejected by mlxcel's argv parser (#1436).",
         "Every negative value is treated as the random-seed sentinel; b10621 parses the value with std::stoul, so a value below -1 becomes one specific uint32 seed (#1436)."
       ],
       "mlxcel": {

--- a/src/bin/mlx_server.rs
+++ b/src/bin/mlx_server.rs
@@ -68,6 +68,21 @@ use mlxcel::server::{
     about = "llama-server compatible HTTP server for MLX inference on Apple Silicon and CUDA GPUs",
     args_conflicts_with_subcommands = true,
     flatten_help = true,
+    // b10621 accepts a space-separated negative value on every option whose
+    // domain admits one (`llama-server --seed -1`), and mlxcel rejected all
+    // 122 of its value-taking long options with "unexpected argument '-1'"
+    // until this setting was added (#1459). `ServerArgs` is flattened into
+    // this command, so the setting reaches every server flag from here.
+    //
+    // `allow_negative_numbers`, not `allow_hyphen_values`: the latter takes
+    // ANY `-`-leading token as the pending option's value, so a mistyped
+    // `--seed --moldel foo` would silently bind `--moldel` as the seed and
+    // never report the typo. This one admits only tokens that lex as a
+    // number, which is exactly the domain b10621 documents. Options whose
+    // own domain excludes negatives (`--port: u16`, `--ctx-size: usize`,
+    // `parse_unit_interval` on `--diffusion-threshold`) still reject `-1` in
+    // their own value parser, which is asserted in this file's test module.
+    allow_negative_numbers = true,
     verbatim_doc_comment,
     after_help = "\
 Model and Runtime Support:
@@ -2193,5 +2208,257 @@ mod tests {
             primary.dry_sequence_breakers,
             vec!["a".to_string(), "b".to_string()]
         );
+    }
+    // ── Space-separated negative values (issue #1459) ───────────────────
+    //
+    // b10621 accepts `llama-server --seed -1`, and mlxcel rejected the space
+    // form on all 122 of its value-taking long options with "unexpected
+    // argument '-1' found" until `allow_negative_numbers` landed on the root
+    // command. These tests pin the fix on the command the shipped binary
+    // actually parses with, and pin the two properties that separate
+    // `allow_negative_numbers` from `allow_hyphen_values`: a mistyped flag
+    // after an option is still reported rather than swallowed as its value,
+    // and an option whose domain excludes negatives still fails in its value
+    // parser instead of silently accepting `-1`.
+
+    /// Long options that decline a space-separated value of ANY sign because
+    /// they declare `require_equals`, so `--opt -1` failing on them is not a
+    /// negative-number defect. Both are mlxcel-only cache knobs with no
+    /// b10621 counterpart, so no llama-server command line reaches them.
+    const REQUIRE_EQUALS_LONGS: [&str; 2] = ["--apc-enabled", "--prompt-cache-enabled"];
+
+    /// True when clap rejects `argv` with the `unexpected argument` error that
+    /// every value-taking option produced for a space-separated `-1` before
+    /// #1459.
+    fn rejected_as_unexpected_argument(argv: &[&str]) -> bool {
+        match Cli::try_parse_from(argv) {
+            Ok(_) => false,
+            Err(err) => err.kind() == clap::error::ErrorKind::UnknownArgument,
+        }
+    }
+
+    #[test]
+    fn every_value_taking_long_option_accepts_a_space_separated_negative_number() {
+        use clap::CommandFactory;
+
+        let mut command = Cli::command();
+        command.build();
+        let options: Vec<(String, bool)> = command
+            .get_arguments()
+            .filter(|arg| arg.get_num_args().is_some_and(|r| r.takes_values()))
+            .filter_map(|arg| {
+                arg.get_long()
+                    .map(|long| (format!("--{long}"), arg.is_require_equals_set()))
+            })
+            .collect();
+
+        let mut swept = 0usize;
+        let mut exempt: Vec<String> = Vec::new();
+        let mut rejected: Vec<String> = Vec::new();
+        for (long, require_equals) in &options {
+            if *require_equals {
+                // Prove the exemption rather than assume it: an option that
+                // requires `=` must decline a space-separated positive value
+                // too, otherwise it is a real negative-number rejection
+                // hiding behind this branch.
+                assert!(
+                    Cli::try_parse_from(["mlxcel-server", long, "1"]).is_err(),
+                    "{long} declares require_equals but bound a space-separated positive \
+                     value; the #1459 sweep exemption no longer describes it"
+                );
+                exempt.push(long.clone());
+                continue;
+            }
+            swept += 1;
+            if rejected_as_unexpected_argument(&["mlxcel-server", long, "-1"]) {
+                rejected.push(long.clone());
+            }
+        }
+
+        assert!(
+            rejected.is_empty(),
+            "these mlxcel-server options still reject a space-separated negative value that \
+             b10621 accepts: {rejected:?}"
+        );
+        exempt.sort();
+        assert_eq!(
+            exempt, REQUIRE_EQUALS_LONGS,
+            "the set of options that take no space-separated value has changed. If a b10621 \
+             option gained require_equals, that is a compatibility regression; if a new \
+             mlxcel-only knob gained it, extend REQUIRE_EQUALS_LONGS deliberately"
+        );
+        // 122 value-taking long options at the time of the fix, minus the two
+        // require_equals knobs. The floor guards against a sweep that silently
+        // stops enumerating.
+        assert!(
+            swept >= 100,
+            "only {swept} value-taking long options were swept; the enumeration has collapsed"
+        );
+    }
+
+    #[test]
+    fn negative_seed_predict_and_reasoning_budget_parse_in_space_form() {
+        for argv in [
+            &["mlxcel-server", "--seed", "-1"][..],
+            &["mlxcel-server", "-s", "-1"][..],
+        ] {
+            assert_eq!(
+                parse_server_args(argv).seed,
+                -1,
+                "{argv:?} must bind -1 to the seed"
+            );
+        }
+        for argv in [
+            &["mlxcel-server", "--predict", "-1"][..],
+            &["mlxcel-server", "-n", "-1"][..],
+            &["mlxcel-server", "--n-predict", "-1"][..],
+        ] {
+            assert_eq!(
+                parse_server_args(argv).predict,
+                -1,
+                "{argv:?} must bind -1 to the predict budget"
+            );
+        }
+        assert_eq!(
+            parse_server_args(&["mlxcel-server", "--reasoning-budget", "-1"]).reasoning_budget,
+            -1
+        );
+
+        // -1 is also the default for all three, so a distinct negative is what
+        // proves the token was consumed as the value rather than dropped.
+        assert_eq!(
+            parse_server_args(&["mlxcel-server", "--seed", "-7"]).seed,
+            -7
+        );
+        assert_eq!(
+            parse_server_args(&["mlxcel-server", "--predict", "-7"]).predict,
+            -7
+        );
+        assert_eq!(
+            parse_server_args(&["mlxcel-server", "--reasoning-budget", "-7"]).reasoning_budget,
+            -7
+        );
+    }
+
+    #[test]
+    fn a_negative_float_parses_in_space_form() {
+        let args = parse_server_args(&["mlxcel-server", "--presence-penalty", "-1.5"]);
+        assert!(
+            (args.presence_penalty - (-1.5)).abs() < f32::EPSILON,
+            "--presence-penalty -1.5 must bind -1.5, got {}",
+            args.presence_penalty
+        );
+    }
+
+    #[test]
+    fn equals_form_negative_values_still_parse() {
+        assert_eq!(parse_server_args(&["mlxcel-server", "--seed=-7"]).seed, -7);
+        assert_eq!(
+            parse_server_args(&["mlxcel-server", "--predict=-7"]).predict,
+            -7
+        );
+        assert_eq!(
+            parse_server_args(&["mlxcel-server", "--n-predict=-7"]).predict,
+            -7
+        );
+        assert_eq!(
+            parse_server_args(&["mlxcel-server", "--reasoning-budget=-7"]).reasoning_budget,
+            -7
+        );
+    }
+
+    #[test]
+    fn a_negative_value_for_a_non_negative_option_fails_in_the_value_parser() {
+        for (long, argv) in [
+            ("--port", &["mlxcel-server", "--port", "-1"][..]),
+            ("--ctx-size", &["mlxcel-server", "--ctx-size", "-1"][..]),
+            // Custom `parse_unit_interval` parser rather than a clap numeric
+            // range, so it exercises the other rejection path.
+            (
+                "--diffusion-threshold",
+                &["mlxcel-server", "--diffusion-threshold", "-1"][..],
+            ),
+        ] {
+            let err = Cli::try_parse_from(argv)
+                .expect_err("a negative value outside the option's domain must be rejected");
+            assert_eq!(
+                err.kind(),
+                clap::error::ErrorKind::ValueValidation,
+                "{long} must fail in its value parser, not as an unknown argument"
+            );
+            let text = err.to_string();
+            assert!(
+                text.contains(long) && text.contains("-1"),
+                "the {long} rejection must name the option and the offending value, got: {text}"
+            );
+            assert!(
+                !text.contains("unexpected argument"),
+                "{long} must no longer report the value as an unexpected argument, got: {text}"
+            );
+        }
+    }
+
+    #[test]
+    fn a_negative_parallel_reaches_the_value_parser_not_the_argv_parser() {
+        // b10621 documents a negative in `--parallel`'s help text while
+        // mlxcel's field is `usize`. Command-wide `allow_negative_numbers`
+        // makes `-1` a candidate value here, so the type parser is what must
+        // reject it, with a message that names the option and the value.
+        let err = Cli::try_parse_from(["mlxcel-server", "--parallel", "-1"])
+            .expect_err("--parallel is usize and must reject a negative slot count");
+        assert_eq!(err.kind(), clap::error::ErrorKind::ValueValidation);
+        let text = err.to_string();
+        assert!(
+            text.contains("--parallel") && text.contains("-1"),
+            "the --parallel rejection must name the option and the value, got: {text}"
+        );
+        assert!(
+            !text.contains("unexpected argument"),
+            "--parallel -1 must no longer be an argv-parser error, got: {text}"
+        );
+    }
+
+    #[test]
+    fn a_negative_number_with_no_option_awaiting_a_value_is_still_an_error() {
+        for argv in [
+            &["mlxcel-server", "-1"][..],
+            // The seed consumes the first negative; the second has nothing
+            // pending and must not be silently absorbed.
+            &["mlxcel-server", "--seed", "-1", "-2"][..],
+        ] {
+            let err = Cli::try_parse_from(argv)
+                .expect_err("a stray negative number must not be silently consumed");
+            assert_eq!(
+                err.kind(),
+                clap::error::ErrorKind::UnknownArgument,
+                "{argv:?} must report the stray negative number"
+            );
+        }
+    }
+
+    #[test]
+    fn a_mistyped_flag_after_an_option_is_reported_not_swallowed() {
+        // This is the whole reason the fix is `allow_negative_numbers` and not
+        // `allow_hyphen_values`: the latter takes any `-`-leading token as the
+        // pending option's value, so this typo would bind `--moldel` to the
+        // seed and never be reported.
+        let err = Cli::try_parse_from(["mlxcel-server", "--seed", "--moldel", "foo"])
+            .expect_err("a mistyped flag must not be swallowed as the seed value");
+        assert_eq!(err.kind(), clap::error::ErrorKind::UnknownArgument);
+        assert!(
+            err.to_string().contains("--moldel"),
+            "the diagnostic must name the mistyped flag, got: {err}"
+        );
+    }
+
+    #[test]
+    fn the_download_subcommand_does_not_take_negative_numbers() {
+        // `allow_negative_numbers` is a per-command setting that does not
+        // propagate into subcommands, and `download` deliberately keeps the
+        // default: it has one positional repo-id and no numeric option, so a
+        // leading `-1` there is a typo rather than a value (#1459).
+        let err = Cli::try_parse_from(["mlxcel-server", "download", "-1"])
+            .expect_err("`download -1` has no numeric option to bind to");
+        assert_eq!(err.kind(), clap::error::ErrorKind::UnknownArgument);
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -863,6 +863,12 @@ fn parse_kv_cache_budget(s: &str) -> Result<mlxcel::memory_estimate::PagedBudget
 
 /// Server options
 #[derive(Args, Debug)]
+// `allow_negative_numbers` lands on the generated `serve` subcommand the same
+// way the `after_help` below does, so `mlxcel serve --seed -1` parses like the
+// b10621 `llama-server --seed -1` it is copied from (#1459). See the matching
+// comment on the `mlxcel-server` root command in `src/bin/mlx_server.rs` for
+// why this is not `allow_hyphen_values`.
+#[command(allow_negative_numbers = true)]
 #[command(after_help = "\
 Remote Pipeline Parallel Example (TCP):
   1. Generate a shared cluster config:

--- a/src/main_tests.rs
+++ b/src/main_tests.rs
@@ -988,3 +988,262 @@ fn arch_supported_alias_parses_to_arch() {
         "`supported` alias must map to the Arch command"
     );
 }
+
+// ── Space-separated negative values on `mlxcel serve` (issue #1459) ───
+//
+// b10621 accepts `llama-server --seed -1`, and `mlxcel serve` rejected the
+// space form on all 122 of its value-taking long options with "unexpected
+// argument '-1' found" until `allow_negative_numbers` landed on the
+// `ServeArgs` command attributes. The `mlxcel-server` half of this lives in
+// the test module of `src/bin/mlx_server.rs`; both binaries need their own
+// coverage because they are separate clap commands built from separate
+// structs.
+
+/// Long options that decline a space-separated value of ANY sign because they
+/// declare `require_equals`, so `--opt -1` failing on them is not a
+/// negative-number defect. Both are mlxcel-only cache knobs with no b10621
+/// counterpart, so no llama-server command line reaches them.
+const SERVE_REQUIRE_EQUALS_LONGS: [&str; 2] = ["--apc-enabled", "--prompt-cache-enabled"];
+
+/// `mlxcel serve -m models/foo <rest...>`. `serve` requires `--model`, so
+/// every case carries it; the helper keeps the argv under test readable.
+fn serve_argv(rest: &[&str]) -> Vec<String> {
+    ["mlxcel", "serve", "-m", "models/foo"]
+        .iter()
+        .chain(rest.iter())
+        .map(|token| (*token).to_owned())
+        .collect()
+}
+
+/// The `ServeArgs` produced by `mlxcel serve -m models/foo <rest...>`.
+fn parse_serve_args(rest: &[&str]) -> super::ServeArgs {
+    let cli = Cli::try_parse_from(serve_argv(rest)).expect("`mlxcel serve` args should parse");
+    match cli.command {
+        Commands::Serve(args) => args,
+        other => panic!("expected the serve command, got {other:?}"),
+    }
+}
+
+/// The clap error from `mlxcel serve -m models/foo <rest...>`, which must fail.
+fn serve_parse_error(rest: &[&str], expectation: &str) -> clap::Error {
+    Cli::try_parse_from(serve_argv(rest)).expect_err(expectation)
+}
+
+#[test]
+fn serve_accepts_a_space_separated_negative_number_on_every_value_taking_option() {
+    let mut command = Cli::command();
+    command.build();
+    let serve = command
+        .get_subcommands()
+        .find(|sub| sub.get_name() == "serve")
+        .expect("the serve subcommand must exist")
+        .clone();
+
+    let options: Vec<(String, bool)> = serve
+        .get_arguments()
+        .filter(|arg| arg.get_num_args().is_some_and(|r| r.takes_values()))
+        .filter_map(|arg| {
+            arg.get_long()
+                .map(|long| (format!("--{long}"), arg.is_require_equals_set()))
+        })
+        .collect();
+
+    let mut swept = 0usize;
+    let mut exempt: Vec<String> = Vec::new();
+    let mut rejected: Vec<String> = Vec::new();
+    for (long, require_equals) in &options {
+        if *require_equals {
+            // Prove the exemption rather than assume it: an option that
+            // requires `=` must decline a space-separated positive value too,
+            // otherwise a real negative-number rejection could hide here.
+            assert!(
+                Cli::try_parse_from(serve_argv(&[long, "1"])).is_err(),
+                "{long} declares require_equals but bound a space-separated positive value; \
+                 the #1459 sweep exemption no longer describes it"
+            );
+            exempt.push(long.clone());
+            continue;
+        }
+        swept += 1;
+        let unexpected_argument = Cli::try_parse_from(serve_argv(&[long, "-1"]))
+            .is_err_and(|err| err.kind() == clap::error::ErrorKind::UnknownArgument);
+        if unexpected_argument {
+            rejected.push(long.clone());
+        }
+    }
+
+    assert!(
+        rejected.is_empty(),
+        "these `mlxcel serve` options still reject a space-separated negative value that \
+         b10621 accepts: {rejected:?}"
+    );
+    exempt.sort();
+    assert_eq!(
+        exempt, SERVE_REQUIRE_EQUALS_LONGS,
+        "the set of options that take no space-separated value has changed. If a b10621 option \
+         gained require_equals, that is a compatibility regression; if a new mlxcel-only knob \
+         gained it, extend SERVE_REQUIRE_EQUALS_LONGS deliberately"
+    );
+    // 122 value-taking long options at the time of the fix, minus the two
+    // require_equals knobs. The floor guards against a sweep that silently
+    // stops enumerating.
+    assert!(
+        swept >= 100,
+        "only {swept} value-taking long options were swept; the enumeration has collapsed"
+    );
+}
+
+#[test]
+fn serve_negative_seed_predict_and_reasoning_budget_parse_in_space_form() {
+    for rest in [&["--seed", "-1"][..], &["-s", "-1"][..]] {
+        assert_eq!(
+            parse_serve_args(rest).seed,
+            -1,
+            "{rest:?} must bind -1 to the seed"
+        );
+    }
+    for rest in [&["--n-predict", "-1"][..], &["--predict", "-1"][..]] {
+        assert_eq!(
+            parse_serve_args(rest).n_predict,
+            -1,
+            "{rest:?} must bind -1 to the predict budget"
+        );
+    }
+    assert_eq!(
+        parse_serve_args(&["--reasoning-budget", "-1"]).reasoning_budget,
+        -1
+    );
+
+    // -1 is also the default for all three, so a distinct negative is what
+    // proves the token was consumed as the value rather than dropped.
+    assert_eq!(parse_serve_args(&["--seed", "-7"]).seed, -7);
+    assert_eq!(parse_serve_args(&["--n-predict", "-7"]).n_predict, -7);
+    assert_eq!(
+        parse_serve_args(&["--reasoning-budget", "-7"]).reasoning_budget,
+        -7
+    );
+}
+
+#[test]
+fn serve_accepts_a_negative_float_in_space_form() {
+    let args = parse_serve_args(&["--presence-penalty", "-1.5"]);
+    assert!(
+        (args.presence_penalty - (-1.5)).abs() < f32::EPSILON,
+        "--presence-penalty -1.5 must bind -1.5, got {}",
+        args.presence_penalty
+    );
+}
+
+#[test]
+fn serve_equals_form_negative_values_still_parse() {
+    assert_eq!(parse_serve_args(&["--seed=-7"]).seed, -7);
+    assert_eq!(parse_serve_args(&["--n-predict=-7"]).n_predict, -7);
+    assert_eq!(parse_serve_args(&["--predict=-7"]).n_predict, -7);
+    assert_eq!(
+        parse_serve_args(&["--reasoning-budget=-7"]).reasoning_budget,
+        -7
+    );
+}
+
+#[test]
+fn serve_rejects_a_negative_value_in_the_value_parser_for_a_non_negative_option() {
+    for (long, rest) in [
+        ("--port", &["--port", "-1"][..]),
+        ("--ctx-size", &["--ctx-size", "-1"][..]),
+        // Custom unit-interval parser rather than a clap numeric range, so it
+        // exercises the other rejection path.
+        (
+            "--diffusion-threshold",
+            &["--diffusion-threshold", "-1"][..],
+        ),
+    ] {
+        let err = serve_parse_error(
+            rest,
+            "a negative value outside the option's domain must be rejected",
+        );
+        assert_eq!(
+            err.kind(),
+            clap::error::ErrorKind::ValueValidation,
+            "{long} must fail in its value parser, not as an unknown argument"
+        );
+        let text = err.to_string();
+        assert!(
+            text.contains(long) && text.contains("-1"),
+            "the {long} rejection must name the option and the offending value, got: {text}"
+        );
+        assert!(
+            !text.contains("unexpected argument"),
+            "{long} must no longer report the value as an unexpected argument, got: {text}"
+        );
+    }
+}
+
+#[test]
+fn serve_sends_a_negative_parallel_to_the_value_parser_not_the_argv_parser() {
+    // b10621 documents a negative in `--parallel`'s help text while mlxcel's
+    // field is `usize`. Command-wide `allow_negative_numbers` makes `-1` a
+    // candidate value here, so the type parser is what must reject it, with a
+    // message that names the option and the value.
+    let err = serve_parse_error(
+        &["--parallel", "-1"],
+        "--parallel is usize and must reject a negative slot count",
+    );
+    assert_eq!(err.kind(), clap::error::ErrorKind::ValueValidation);
+    let text = err.to_string();
+    assert!(
+        text.contains("parallel") && text.contains("-1"),
+        "the --parallel rejection must name the option and the value, got: {text}"
+    );
+    assert!(
+        !text.contains("unexpected argument"),
+        "--parallel -1 must no longer be an argv-parser error, got: {text}"
+    );
+}
+
+#[test]
+fn serve_still_rejects_a_negative_number_with_no_option_awaiting_a_value() {
+    for rest in [
+        &["-1"][..],
+        // The seed consumes the first negative; the second has nothing pending
+        // and must not be silently absorbed.
+        &["--seed", "-1", "-2"][..],
+    ] {
+        let err = serve_parse_error(
+            rest,
+            "a stray negative number must not be silently consumed",
+        );
+        assert_eq!(
+            err.kind(),
+            clap::error::ErrorKind::UnknownArgument,
+            "{rest:?} must report the stray negative number"
+        );
+    }
+}
+
+#[test]
+fn serve_reports_a_mistyped_flag_after_an_option_instead_of_swallowing_it() {
+    // This is the whole reason the fix is `allow_negative_numbers` and not
+    // `allow_hyphen_values`: the latter takes any `-`-leading token as the
+    // pending option's value, so this typo would bind `--moldel` to the seed
+    // and never be reported.
+    let err = serve_parse_error(
+        &["--seed", "--moldel", "foo"],
+        "a mistyped flag must not be swallowed as the seed value",
+    );
+    assert_eq!(err.kind(), clap::error::ErrorKind::UnknownArgument);
+    assert!(
+        err.to_string().contains("--moldel"),
+        "the diagnostic must name the mistyped flag, got: {err}"
+    );
+}
+
+#[test]
+fn negative_numbers_stay_rejected_on_sibling_subcommands() {
+    // `allow_negative_numbers` is a per-command setting applied to `serve`
+    // only, so the sibling subcommands keep clap's default posture. Pinning it
+    // here records that the blast radius of #1459 is the server surface, not
+    // every `mlxcel` subcommand.
+    let err = Cli::try_parse_from(["mlxcel", "generate", "--max-tokens", "-1"])
+        .expect_err("`generate --max-tokens -1` must keep the default clap rejection");
+    assert_eq!(err.kind(), clap::error::ErrorKind::UnknownArgument);
+}


### PR DESCRIPTION
## Summary

`mlxcel-server` and `mlxcel serve` rejected a space-separated negative value on every option that takes a value, so a `llama-server` command line copied verbatim died in argument parsing before the server started: `mlxcel-server --seed -1` produced `error: unexpected argument '-1' found`. All 122 value-taking long options on each binary behaved that way, while the pinned b10621 reference accepts the space form and proceeds to model loading. Setting `allow_negative_numbers = true` on the two clap commands the shipped binaries actually parse with fixes all of them in one place, and clears the argv-parser divergence recorded against `--seed`, `--predict`, and `--reasoning-budget` in the b10621 manifest.

## Which clap setting, and why

`allow_negative_numbers`, not `allow_hyphen_values`. `allow_hyphen_values` accepts any token beginning with `-` as the pending option's value, so `mlxcel-server --seed --moldel foo` would silently bind `--moldel` as the seed and the typo would never be reported. `allow_negative_numbers` admits only tokens that lex as a number, which is exactly the domain b10621 documents. Both test modules pin that difference so it cannot be traded away later: `a_mistyped_flag_after_an_option_is_reported_not_swallowed` and `serve_reports_a_mistyped_flag_after_an_option_instead_of_swallowing_it` assert `--seed --moldel foo` still fails with `unexpected argument '--moldel' found`, which is precisely what a switch to `allow_hyphen_values` would break.

Command-wide, not per-argument. It is the smaller change, and it is the only form that automatically covers the thirteen b10621 options mlxcel has not implemented yet, which is why this is one issue rather than seven patches to the same two attribute blocks. Its cost is that `-1` becomes a candidate value for options whose domain admits no negative, so the value parsers have to be the ones that reject it. That was verified rather than assumed, on all three rejection paths: `--port -1` fails with `invalid value '-1' for '--port <PORT>': -1 is not in 0..=65535`, `--ctx-size -1` with `invalid digit found in string`, and the custom `parse_unit_interval` behind `--diffusion-threshold` with `must be between 0 and 1, got -1`. Each is asserted on error kind (`ValueValidation`), on the message naming both the option and `-1`, and on the message no longer saying `unexpected argument`.

Placement follows where the arguments live: the root `#[command(...)]` in `src/bin/mlx_server.rs` for `mlxcel-server`, because `ServerArgs` is flattened into the root command; and the `ServeArgs` `#[command(...)]` in `src/main.rs` for `mlxcel serve`, the attribute block that already carries `after_help` for that generated subcommand. Both placements were confirmed by sweeping the built binaries, not inferred from the derive.

The `download` subcommand deliberately keeps clap's default. `allow_negative_numbers` is a per-command setting that does not propagate into subcommands, and `download` has one positional repo-id and no numeric option, so a leading `-1` there is a typo rather than a value; `mlxcel-server download -1` still reports `unexpected argument '-1' found`, and a test pins that. The sibling `mlxcel` subcommands are unaffected for the same reason, pinned by `negative_numbers_stay_rejected_on_sibling_subcommands`.

## Coverage of the seventeen affected options

Four of the seventeen b10621 options that document a negative in their help text exist on mlxcel today, and all four have dedicated assertions rather than only sweep coverage: `--seed` (plus `-s`), `--predict` (plus `-n` and the `--n-predict` alias on `mlxcel-server`, and `--n-predict` plus the `--predict` alias on `mlxcel serve`), `--reasoning-budget`, and `--parallel`. `--parallel` is the mixed case the issue calls out: b10621 documents a negative but mlxcel's field is `usize`, so the argv parser must hand `-1` to the type parser and the type parser must reject it. `a_negative_parallel_reaches_the_value_parser_not_the_argv_parser` asserts exactly that. The other thirteen carry `mlxcel: null` in the manifest, so there is no argument to bind a value to yet; they inherit the setting when their own sub-issues land.

Because `-1` is the default for `--seed`, `--predict`, and `--reasoning-budget`, each is additionally asserted with `-7` so the test proves the token was consumed as the value rather than dropped. A negative float is covered through `--presence-penalty -1.5`. Every `=` form is asserted alongside its space form, and no existing test was rewritten from `=` to space form.

## The two options the sweep exempts

The sweep leaves two of the 122 rejecting a space-separated `-1`: `--apc-enabled` and `--prompt-cache-enabled`. Both declare `require_equals = true`, so they take no space-separated value in any sign. `--apc-enabled 1` and `--apc-enabled true` are rejected the same way `--apc-enabled -1` is, and `--apc-enabled=false` parses; this is not a negative-number defect and no change of this setting can reach it. Neither is a b10621 option (neither string appears anywhere under `compat/llama-server/b10621/`), so no llama-server command line reaches them. Both sweeps skip exactly those two, prove the exemption by asserting each still declines a space-separated positive value, and pin the exempt set by name, so a b10621 option that later gains `require_equals` fails the test instead of disappearing into the carve-out. The remaining 120 of 122 accept the space form on both binaries.

## Manifest

Only the `divergence` list and, where the rule allows, `state` were edited; no entry's `issue` was repointed, since `#1459` owns no shard in `pin.json` and writing it into an entry would fail the ownership gate.

- `compat/llama-server/b10621/sampling-and-grammar.json`, `--seed`: the argv-parser divergence string is removed. The entry stays `deferred` at issue 1436 because its second divergence survives (every negative maps to the random-seed sentinel, while b10621 parses with `std::stoul`), and a `supported` entry with a non-empty divergence is a hard error.
- `compat/llama-server/b10621/runtime-and-context.json`, `--predict`: divergence list is now empty, so the entry flips `deferred` to `supported`, keeping issue 1450. It already satisfied the `supported` obligations: a named test, an mlxcel claim block, the canonical `--predict` spelling in `accepted_spellings`, and `mlxcel.env` equal to the b10621 `LLAMA_ARG_N_PREDICT`.
- `compat/llama-server/b10621/chat-templates.json`, `--reasoning-budget`: same, flipping to `supported` and keeping issue 1447, with `LLAMA_ARG_THINK_BUDGET` matching and the `-1`/`0`/`N` semantics already covered end to end by `tests/thinking_budget.rs`.

`field:seed` in `sampling-and-grammar.json` is byte-identical: its divergence is an HTTP 400 on a seed below -1, which is field validation owned by #1436, not argv parsing. Flipping the two option entries to `supported` removes them from the `--check-issues-open` tracking, which is correct here: both linked sub-issues stay open and keep their broader scope, and either can record a new divergence on these entries if a later audit finds one. All three shards were rewritten through the validator's own `canonical_dump` shape, so serialization and ordering are unchanged.

## What changed

- `src/bin/mlx_server.rs`: `allow_negative_numbers = true` on the root `mlxcel-server` command, with a comment recording why it is not `allow_hyphen_values`; nine parser tests in the existing `#[cfg(test)] mod tests` block, including the enumerated sweep over every value-taking long option.
- `src/main.rs`: `allow_negative_numbers = true` on the `ServeArgs` command attributes.
- `src/main_tests.rs`: the matching nine tests for `mlxcel serve`, including its own sweep and a guard that sibling subcommands keep the default posture.
- `compat/llama-server/b10621/{sampling-and-grammar,runtime-and-context,chat-templates}.json`: the three manifest edits described above.

## Test plan

- [x] `make verify-llama-compat`: OK, 249 help entries, 323 spellings, 53 routes, 74 native fields, states `{'deferred': 352, 'supported': 24}`, and all eight validator negative cases pass.
- [x] `cargo test --profile test-fast --features metal,accelerate --bin mlxcel-server`: 26 passed, 0 failed.
- [x] `cargo test --profile test-fast --features metal,accelerate --bin mlxcel`: 212 passed, 0 failed.
- [x] `cargo test --profile test-fast --features metal,accelerate --test llama_compat_manifest`: green, so the flipped states did not disturb the claim-versus-binary conformance in either direction.
- [x] `cargo test --profile test-fast --features metal,accelerate --test cli_help_consistency`: green, so the operator-facing help surface is unchanged.
- [x] `cargo fmt --all -- --check`: clean.
- [x] `cargo clippy --profile test-fast --features metal,accelerate --bin mlxcel --bin mlxcel-server --tests -- -D warnings`: clean.
- [x] Built binaries, both entry points: `--seed -1`, `--predict -1`, `-n -1`, `--n-predict -1`, `--reasoning-budget -1`, `--presence-penalty -1.5` and `--seed=-1` all reach model loading and fail only on the missing model path; `--port -1`, `--ctx-size -1` and `--parallel -1` fail with a value-parse error naming the option and `-1`; a bare `-1` and `download -1` still report `unexpected argument`.
- [x] Flag-surface sweep over every `takes_value` long option on both binaries: 120 of 122 accept the space-separated `-1`, and the two that do not are the `require_equals` options described above, which decline a space-separated positive value identically.

Closes #1459
