### PR TITLE
feat(server): apply b10621 RoPE runtime overrides before model construction

### DIFF
--- a/compat/llama-server/b10621/runtime-and-context.json
+++ b/compat/llama-server/b10621/runtime-and-context.json
@@ -20,9 +20,12 @@
       "discovery": "help-entry-head",
       "state": "deferred",
       "issue": 1450,
-      "test": "tests/llama_compat_manifest.rs",
-      "notes": "Spelling and env accepted; logical-batch semantics equivalence with llama.cpp batching is owned by #1450.",
-      "divergence": [],
+      "test": "src/server/routes/props_tests.rs",
+      "notes": "Accepted as an alias for --prefill-chunk-size, which is the logical prefill batch and does have an observable effect on chunked prefill. The resolved value is now reported as `n_batch` in /props. It is not b10621's n_batch: the default differs (512 against 2048) and mlxcel schedules chunked prefill rather than filling a llama_batch, so a given value does not produce the same per-forward token count.",
+      "divergence": [
+        "default is 512 (mlxcel's --prefill-chunk-size default); b10621 defaults to 2048",
+        "maps onto mlxcel's chunked-prefill chunk size rather than llama.cpp's logical llama_batch, so equal values do not produce equal per-forward token counts"
+      ],
       "mlxcel": {
         "accepted_spellings": [
           "--batch-size"
@@ -206,8 +209,11 @@
       "state": "deferred",
       "issue": 1450,
       "test": null,
-      "notes": null,
-      "divergence": [],
+      "notes": "Not accepted, and the behaviour differs in both directions. b10621 defaults context shift OFF, so a request that outgrows its context fails. mlxcel front-trims the KV live window (keeping a 4-token attention sink) once --ctx-size or --max-kv-size bounds it, which is a context shift that is always on and not switchable; with neither flag set nothing bounds the window at all.",
+      "divergence": [
+        "no flag: KV front-trimming is unconditional once a context bound exists and cannot be disabled",
+        "b10621 defaults context shift to disabled and fails an over-long request; mlxcel shifts silently"
+      ],
       "mlxcel": null
     },
     {
@@ -319,8 +325,8 @@
       "discovery": "help-entry-head",
       "state": "supported",
       "issue": 1450,
-      "test": "tests/llama_compat_manifest.rs",
-      "notes": "Same semantics: 0 = derive from the model.",
+      "test": "src/server/routes/props_tests.rs",
+      "notes": "Same semantics: 0 = derive from the model, and the total is shared across slots (ctx_size / slots) exactly as llama-server splits n_ctx across n_parallel. The resolved per-slot window is now reported as `n_ctx` in /props and logged at startup.",
       "divergence": [],
       "mlxcel": {
         "accepted_spellings": [
@@ -351,8 +357,11 @@
       "state": "deferred",
       "issue": 1450,
       "test": null,
-      "notes": null,
-      "divergence": [],
+      "notes": "Not accepted. mlxcel does pin a leading attention-sink prefix when the KV live window exceeds its cap, but the length is the fixed MAX_KV_SIZE_SINK_KEEP = 4 in src/server/batch/scheduler.rs, not an operator-settable count, and there is no -1 = keep-all form. Making it settable is what #1450 leaves open.",
+      "divergence": [
+        "no flag: the retained prefix is a fixed 4 tokens rather than an operator-settable count",
+        "b10621's -1 (retain the whole initial prompt) has no representation"
+      ],
       "mlxcel": null
     },
     {
@@ -399,12 +408,16 @@
       "discovery": "help-entry-head",
       "state": "deferred",
       "issue": 1450,
-      "test": "tests/llama_compat_manifest.rs",
-      "notes": "Spelling and env match, but the default drifts: b10621 defaults to -1 (auto) while mlxcel defaults to 4 slots. #1450 owns default/precedence alignment.",
-      "divergence": [],
+      "test": "src/bin/mlx_server.rs",
+      "notes": "Spelling and env match and the flag genuinely sizes both the per-slot context share (ctx_size / slots) and the decode batch width. Two things still differ: b10621 defaults to -1 (auto) while mlxcel defaults to 4, and mlxcel's field is usize so -1 is rejected by the value parser with a message naming the option and the value rather than resolving to auto.",
+      "divergence": [
+        "default is 4 server slots; b10621 defaults to -1 (auto)",
+        "-1 is rejected with a value-parser diagnostic rather than resolving to an automatic slot count"
+      ],
       "mlxcel": {
         "accepted_spellings": [
-          "--parallel"
+          "--parallel",
+          "--n-parallel"
         ],
         "env": "LLAMA_ARG_N_PARALLEL",
         "env_binding": "clap",
@@ -463,12 +476,18 @@
       "default": "loaded from model",
       "description": "RoPE base frequency, used by NTK-aware scaling (default: loaded from model) (env: LLAMA_ARG_ROPE_FREQ_BASE)",
       "discovery": "help-entry-head",
-      "state": "deferred",
+      "state": "supported",
       "issue": 1450,
-      "test": null,
-      "notes": null,
+      "test": "tests/llama_compat_rope_freq_base.rs",
+      "notes": "Replaces the checkpoint's rope_theta before the model is constructed, and feeds the llama3 band arithmetic as well as the plain rotation, so the frequency table and the stored base cannot drift apart. On Gemma 3 it reaches the global-attention layers only; the sliding layers keep rope_local_base_freq, which is llama.cpp's separate rope_freq_base_train_swa.",
       "divergence": [],
-      "mlxcel": null
+      "mlxcel": {
+        "accepted_spellings": [
+          "--rope-freq-base"
+        ],
+        "env": "LLAMA_ARG_ROPE_FREQ_BASE",
+        "env_binding": "clap"
+      }
     },
     {
       "kind": "option",
@@ -485,12 +504,18 @@
       "default": null,
       "description": "RoPE frequency scaling factor, expands context by a factor of 1/N (env: LLAMA_ARG_ROPE_FREQ_SCALE)",
       "discovery": "help-entry-head",
-      "state": "deferred",
+      "state": "supported",
       "issue": 1450,
-      "test": null,
-      "notes": null,
+      "test": "tests/llama_compat_rope_scaling_override.rs",
+      "notes": "b10621's `rope_freq_scale = N`. Applied as a linear scheme when the checkpoint names no scheme or names \"default\"/\"linear\", matching the flag's own \"defaults to linear unless specified by the model\". On a checkpoint that declares a banded scheme (llama3) a bare scale is refused: b10621 multiplies its rope_freq_scale into that rotation and mlxcel's llama3 table has no such multiplier, so composing them would change the rotation in a way neither side describes.",
       "divergence": [],
-      "mlxcel": null
+      "mlxcel": {
+        "accepted_spellings": [
+          "--rope-freq-scale"
+        ],
+        "env": "LLAMA_ARG_ROPE_FREQ_SCALE",
+        "env_binding": "clap"
+      }
     },
     {
       "kind": "option",
@@ -507,12 +532,18 @@
       "default": null,
       "description": "RoPE context scaling factor, expands context by a factor of N (env: LLAMA_ARG_ROPE_SCALE)",
       "discovery": "help-entry-head",
-      "state": "deferred",
+      "state": "supported",
       "issue": 1450,
-      "test": null,
-      "notes": null,
+      "test": "tests/llama_compat_rope_scaling_override.rs",
+      "notes": "b10621's `rope_freq_scale = 1/N`, normalized at the CLI edge so `--rope-scale 8` and `--rope-freq-scale 0.125` are one stored value. Passing both with values that are not reciprocals is refused rather than resolved by precedence, because clap gives mlxcel two independent options where b10621 has one field that the later flag simply overwrites.",
       "divergence": [],
-      "mlxcel": null
+      "mlxcel": {
+        "accepted_spellings": [
+          "--rope-scale"
+        ],
+        "env": "LLAMA_ARG_ROPE_SCALE",
+        "env_binding": "clap"
+      }
     },
     {
       "kind": "option",
@@ -529,12 +560,18 @@
       "default": null,
       "description": "RoPE frequency scaling method, defaults to linear unless specified by the model (env: LLAMA_ARG_ROPE_SCALING_TYPE)",
       "discovery": "help-entry-head",
-      "state": "deferred",
+      "state": "supported",
       "issue": 1450,
-      "test": null,
-      "notes": null,
+      "test": "tests/llama_compat_rope_scaling_override.rs",
+      "notes": "Same value domain {none,linear,yarn} and the same LLAMA_ARG_ROPE_SCALING_TYPE binding. `none` and `linear` are applied to the checkpoint's rope_scaling block before the model is constructed, so before any KV cache exists. `yarn` parses and is refused with a diagnostic naming the families that serve YaRN from their own config: mlxcel's shared RoPE path builds \"default\", \"linear\" and \"llama3\" tables only, and b10621 itself documents the flag as \"defaults to linear unless specified by the model\", so a refusal is the only reading that does not change the rotation silently. An override that reaches no RoPE code path refuses to serve rather than starting (models::rope_overrides::verify_applied).",
       "divergence": [],
-      "mlxcel": null
+      "mlxcel": {
+        "accepted_spellings": [
+          "--rope-scaling"
+        ],
+        "env": "LLAMA_ARG_ROPE_SCALING_TYPE",
+        "env_binding": "clap"
+      }
     },
     {
       "kind": "option",
@@ -577,8 +614,10 @@
       "state": "deferred",
       "issue": 1450,
       "test": null,
-      "notes": null,
-      "divergence": [],
+      "notes": "Not accepted. Sliding-window families (Gemma 3/4, Exaone 4, gpt-oss, RecurrentGemma, Step 3.5, Mellum, Ministral 3, AFMoE, DeepSeek V4) build their own RotatingKVCache inside each model's make_cache from the checkpoint's sliding_window, and nothing on the server reaches into that construction. Forcing a full-size SWA cache needs a plumbing path into every one of those call sites.",
+      "divergence": [
+        "no flag: the SWA window is the checkpoint's and cannot be widened to full size from the server"
+      ],
       "mlxcel": null
     },
     {
@@ -599,9 +638,12 @@
       "discovery": "help-entry-head",
       "state": "deferred",
       "issue": 1450,
-      "test": "tests/llama_compat_manifest.rs",
-      "notes": "Spelling and env accepted; physical-batch semantics equivalence is owned by #1450.",
-      "divergence": [],
+      "test": "src/server/routes/props_tests.rs",
+      "notes": "Accepted, logged as not applicable at startup, and reported in /props as `n_ubatch` at the same value as `n_batch`. MLX on unified memory has no separate physical micro-batch to size, so there is no quantity for this to set; the value itself is read only to decide whether to emit the notice.",
+      "divergence": [
+        "the value is not used: mlxcel has no physical micro-batch distinct from the logical prefill chunk on unified memory",
+        "default is unset rather than b10621's 512"
+      ],
       "mlxcel": {
         "accepted_spellings": [
           "--ubatch-size"
@@ -627,10 +669,19 @@
       "discovery": "help-entry-head",
       "state": "deferred",
       "issue": 1450,
-      "test": null,
-      "notes": null,
-      "divergence": [],
-      "mlxcel": null
+      "test": "src/cli/rope_args_tests.rs",
+      "notes": "Spelling and env accepted. b10621's sentinel default (-1.0) means \"use the values the model was trained with\" and is accepted inert, so a deployment script that spells out the upstream defaults keeps working. Any other value is refused at startup with a diagnostic naming every non-sentinel flag at once: mlxcel's shared RoPE path (models::rope_utils::RopeScalingKind) has no YaRN arm, so there is nothing for these to tune and accepting them would leave the rotation unchanged without saying so. Checkpoints whose own config declares YaRN (DeepSeek V2/V3.2/V4, gpt-oss, Mellum, TeleChat3) build it from that config and are unaffected.",
+      "divergence": [
+        "non-sentinel values are refused at startup instead of tuning the rotation; only the b10621 sentinel (-1.0) is accepted",
+        "mlxcel's shared RoPE path implements default / linear / llama3 frequency tables and has no YaRN arm to receive these parameters"
+      ],
+      "mlxcel": {
+        "accepted_spellings": [
+          "--yarn-attn-factor"
+        ],
+        "env": "LLAMA_ARG_YARN_ATTN_FACTOR",
+        "env_binding": "clap"
+      }
     },
     {
       "kind": "option",
@@ -649,10 +700,19 @@
       "discovery": "help-entry-head",
       "state": "deferred",
       "issue": 1450,
-      "test": null,
-      "notes": null,
-      "divergence": [],
-      "mlxcel": null
+      "test": "src/cli/rope_args_tests.rs",
+      "notes": "Spelling and env accepted. b10621's sentinel default (-1.0) means \"use the values the model was trained with\" and is accepted inert, so a deployment script that spells out the upstream defaults keeps working. Any other value is refused at startup with a diagnostic naming every non-sentinel flag at once: mlxcel's shared RoPE path (models::rope_utils::RopeScalingKind) has no YaRN arm, so there is nothing for these to tune and accepting them would leave the rotation unchanged without saying so. Checkpoints whose own config declares YaRN (DeepSeek V2/V3.2/V4, gpt-oss, Mellum, TeleChat3) build it from that config and are unaffected.",
+      "divergence": [
+        "non-sentinel values are refused at startup instead of tuning the rotation; only the b10621 sentinel (-1.0) is accepted",
+        "mlxcel's shared RoPE path implements default / linear / llama3 frequency tables and has no YaRN arm to receive these parameters"
+      ],
+      "mlxcel": {
+        "accepted_spellings": [
+          "--yarn-beta-fast"
+        ],
+        "env": "LLAMA_ARG_YARN_BETA_FAST",
+        "env_binding": "clap"
+      }
     },
     {
       "kind": "option",
@@ -671,10 +731,19 @@
       "discovery": "help-entry-head",
       "state": "deferred",
       "issue": 1450,
-      "test": null,
-      "notes": null,
-      "divergence": [],
-      "mlxcel": null
+      "test": "src/cli/rope_args_tests.rs",
+      "notes": "Spelling and env accepted. b10621's sentinel default (-1.0) means \"use the values the model was trained with\" and is accepted inert, so a deployment script that spells out the upstream defaults keeps working. Any other value is refused at startup with a diagnostic naming every non-sentinel flag at once: mlxcel's shared RoPE path (models::rope_utils::RopeScalingKind) has no YaRN arm, so there is nothing for these to tune and accepting them would leave the rotation unchanged without saying so. Checkpoints whose own config declares YaRN (DeepSeek V2/V3.2/V4, gpt-oss, Mellum, TeleChat3) build it from that config and are unaffected.",
+      "divergence": [
+        "non-sentinel values are refused at startup instead of tuning the rotation; only the b10621 sentinel (-1.0) is accepted",
+        "mlxcel's shared RoPE path implements default / linear / llama3 frequency tables and has no YaRN arm to receive these parameters"
+      ],
+      "mlxcel": {
+        "accepted_spellings": [
+          "--yarn-beta-slow"
+        ],
+        "env": "LLAMA_ARG_YARN_BETA_SLOW",
+        "env_binding": "clap"
+      }
     },
     {
       "kind": "option",
@@ -693,10 +762,19 @@
       "discovery": "help-entry-head",
       "state": "deferred",
       "issue": 1450,
-      "test": null,
-      "notes": null,
-      "divergence": [],
-      "mlxcel": null
+      "test": "src/cli/rope_args_tests.rs",
+      "notes": "Spelling and env accepted. b10621's sentinel default (-1.0) means \"use the values the model was trained with\" and is accepted inert, so a deployment script that spells out the upstream defaults keeps working. Any other value is refused at startup with a diagnostic naming every non-sentinel flag at once: mlxcel's shared RoPE path (models::rope_utils::RopeScalingKind) has no YaRN arm, so there is nothing for these to tune and accepting them would leave the rotation unchanged without saying so. Checkpoints whose own config declares YaRN (DeepSeek V2/V3.2/V4, gpt-oss, Mellum, TeleChat3) build it from that config and are unaffected.",
+      "divergence": [
+        "non-sentinel values are refused at startup instead of tuning the rotation; only the b10621 sentinel (-1.0) is accepted",
+        "mlxcel's shared RoPE path implements default / linear / llama3 frequency tables and has no YaRN arm to receive these parameters"
+      ],
+      "mlxcel": {
+        "accepted_spellings": [
+          "--yarn-ext-factor"
+        ],
+        "env": "LLAMA_ARG_YARN_EXT_FACTOR",
+        "env_binding": "clap"
+      }
     },
     {
       "kind": "option",
@@ -715,10 +793,19 @@
       "discovery": "help-entry-head",
       "state": "deferred",
       "issue": 1450,
-      "test": null,
-      "notes": null,
-      "divergence": [],
-      "mlxcel": null
+      "test": "src/cli/rope_args_tests.rs",
+      "notes": "Spelling and env accepted. b10621's sentinel default (0) means \"use the values the model was trained with\" and is accepted inert, so a deployment script that spells out the upstream defaults keeps working. Any other value is refused at startup with a diagnostic naming every non-sentinel flag at once: mlxcel's shared RoPE path (models::rope_utils::RopeScalingKind) has no YaRN arm, so there is nothing for these to tune and accepting them would leave the rotation unchanged without saying so. Checkpoints whose own config declares YaRN (DeepSeek V2/V3.2/V4, gpt-oss, Mellum, TeleChat3) build it from that config and are unaffected.",
+      "divergence": [
+        "non-sentinel values are refused at startup instead of tuning the rotation; only the b10621 sentinel (0) is accepted",
+        "mlxcel's shared RoPE path implements default / linear / llama3 frequency tables and has no YaRN arm to receive these parameters"
+      ],
+      "mlxcel": {
+        "accepted_spellings": [
+          "--yarn-orig-ctx"
+        ],
+        "env": "LLAMA_ARG_YARN_ORIG_CTX",
+        "env_binding": "clap"
+      }
     },
     {
       "kind": "native_request_field",
@@ -764,8 +851,11 @@
       "state": "deferred",
       "issue": 1450,
       "test": null,
-      "notes": null,
-      "divergence": [],
+      "notes": "Not accepted on /completion. mlxcel discards exactly the excess over the KV cap on every trim, which is b10621's behaviour only when n_discard happens to equal that excess; the 0 = half-the-context default and any explicit depth have no representation.",
+      "divergence": [
+        "the field is silently dropped: every trim discards exactly the excess over the KV cap",
+        "b10621's 0 = discard half the context default has no equivalent"
+      ],
       "mlxcel": null
     },
     {
@@ -780,8 +870,10 @@
       "state": "deferred",
       "issue": 1450,
       "test": null,
-      "notes": null,
-      "divergence": [],
+      "notes": "Not accepted on /completion. NativeCompletionRequest does not carry n_keep and does not deny unknown fields, so a client that sends it is not told it was dropped. The server-wide retention is the fixed 4-token attention sink described on --keep.",
+      "divergence": [
+        "the field is silently dropped: retention is a fixed 4-token attention sink, server-wide, not per request"
+      ],
       "mlxcel": null
     }
   ]

--- a/docs/llama-server-compat.md
+++ b/docs/llama-server-compat.md
@@ -90,3 +90,38 @@ python3 scripts/compat/extract_b10621_manifest.py \
 ```
 
 The extractor consumes the official binary (`--help` is the authority for options) and the pinned sources (`server.cpp`, `server-http.cpp`, `server-schema.cpp` for routes and native fields). `--archive` verifies the download against the pinned SHA-256 and then requires the `--llama-server` binary to be byte-identical to a member of that verified archive, both before the binary is executed. That second half matters because the extractor runs the binary with `DYLD_LIBRARY_PATH` / `LD_LIBRARY_PATH` pointed at its own directory: hashing the tarball while executing an unrelated path would be assurance about a file that is never used. The archive is compared through `tarfile` in read mode and is never extracted. Omitting `--archive` runs the binary unverified and the extractor warns on stderr. Regeneration is deterministic: facts are rewritten wholesale, policy fields (`state`, `issue`, `test`, `notes`, `divergence`, `mlxcel`) are preserved by entry id and re-emitted in that canonical key order (a policy key an older schema never wrote is backfilled from the skeleton), `pin.json`'s `shards[name].owners` map is preserved by shard name exactly like `mlxcel_baseline` (a brand-new shard starts with an empty owner set, which needs a human before CI accepts entries in it), and running the extractor twice leaves the worktree clean. Entries that are new upstream land in `_unclassified.json`, which the validator rejects until a human classifies them, so bumping the pin to a newer nightly produces a merge-blocking, reviewable diff instead of silent drift.
+
+## RoPE and YaRN runtime overrides
+
+`--rope-scaling`, `--rope-scale`, `--rope-freq-base` and `--rope-freq-scale` are accepted on both server binaries with b10621's spellings, value domains and `LLAMA_ARG_ROPE_*` bindings, and they change the rotation for real. They rewrite the checkpoint's `rope_scaling` block and `rope_theta` before the model is constructed, which is before any KV cache exists, matching where `llama_model_load` applies them upstream.
+
+| Flag | Environment | Effect |
+|---|---|---|
+| `--rope-scaling {none,linear,yarn}` | `LLAMA_ARG_ROPE_SCALING_TYPE` | `none` drops the checkpoint's block and rotates with the plain `base^(2i/d)` table. `linear` divides positions by `--rope-scale`, or by the checkpoint's own factor when that flag is absent. `yarn` is refused; see below. |
+| `--rope-scale N` | `LLAMA_ARG_ROPE_SCALE` | Expands context by a factor of N (`rope_freq_scale = 1/N`). |
+| `--rope-freq-scale N` | `LLAMA_ARG_ROPE_FREQ_SCALE` | The reciprocal spelling of the same setting. Passing both with values that are not reciprocals is a startup error rather than a silent precedence choice. |
+| `--rope-freq-base N` | `LLAMA_ARG_ROPE_FREQ_BASE` | Replaces `rope_theta`. On Gemma 3 it reaches the global-attention layers only; the sliding layers keep `rope_local_base_freq`, which is llama.cpp's separate `rope_freq_base_train_swa`. |
+
+Two requests are refused instead of being approximated. `--rope-scaling yarn` has no representation: mlxcel's shared RoPE path builds `default`, `linear` and `llama3` frequency tables only, and serving a YaRN request as one of those would change the rotation without saying so. A bare `--rope-scale` or `--rope-freq-scale` on a checkpoint that declares a banded scheme (`llama3`) is refused for the same reason: llama.cpp multiplies its own `rope_freq_scale` into that rotation, mlxcel's banded table has no such multiplier, and dropping either half silently changes the result. Name the scheme (`--rope-scaling linear` or `--rope-scaling none`) to say which rotation you want. Checkpoints whose own `config.json` declares YaRN (DeepSeek V2 / V3.2 / V4, gpt-oss, Mellum, TeleChat3) build it from that config and are unaffected by any of this.
+
+The five `--yarn-*` flags are accepted at b10621's sentinel defaults only (`-1.0`, and `0` for `--yarn-orig-ctx`), which upstream defines as "use the values the model was trained with", so a deployment script that spells out the upstream defaults keeps working. Any other value is a startup error naming every non-sentinel flag at once.
+
+### Which architectures honor the override
+
+The override reaches the six families that resolve their rotation through `src/models/rope_utils.rs`: Llama 3.x (and through it Qwen2 / Qwen2.5, Helium, the `mllama` text decoder, and every VLM whose text backbone is one of those), Qwen3, Qwen3-MoE, Apertus, Gemma 3, and InternLM2 / InternLM3. Other families compute their frequencies inline and would ignore it.
+
+They are not listed anywhere in the code, because a hand-maintained list of honoring architectures goes stale the moment a family is ported. Each seam that consumes the override increments a counter instead, and the model worker refuses to serve when an override was requested and the counter is still zero after the checkpoint loads, naming the checkpoint and the flag. A family that wires itself into `rope_utils` starts being accepted with no list to update; one that does not is reported rather than silently ignored.
+
+### Validating a change to this path
+
+Short prompts cannot see a `rope_scaling` defect: the banded and plain tables agree closely at low positions. Use the teacher-forced logit trace from [`benchmarks.md`](benchmarks.md), which reads `LLAMA_ARG_ROPE_*` from the environment so each arm is one process, and trace positions that are actually long:
+
+```bash
+cargo build --release --features metal,accelerate --example logit_trace
+./target/release/examples/logit_trace MODEL CORPUS.txt 2048 4 8 8192 > ref.tsv
+LLAMA_ARG_ROPE_SCALING_TYPE=none \
+./target/release/examples/logit_trace MODEL CORPUS.txt 2048 4 8 8192 > none.tsv
+python3 scripts/compare_logit_traces.py ref.tsv none.tsv
+```
+
+The sixth argument is the context established before each traced forward, and the traced positions of chunk `c` start at `c * CHUNK_TOKENS`, so a narrow chunk cannot reach a long position however large that argument is. The command above traces positions 0 to 8191 across four chunks. Setting `--rope-freq-base` to the checkpoint's own `rope_theta` is the control: it must come back byte-identical, which is what separates "the override moved the rotation" from "the override plumbing perturbs the model".

--- a/examples/logit_trace.rs
+++ b/examples/logit_trace.rs
@@ -134,6 +134,14 @@ fn main() -> Result<()> {
     // context length can be varied independently.
     let prefill: usize = args.get(6).and_then(|s| s.parse().ok()).unwrap_or(0);
 
+    // The b10621 RoPE override is process-wide (see
+    // `mlxcel::models::rope_overrides`), so comparing two rotations means two
+    // processes, exactly as this harness already handles `MLXCEL_QMV_WIDE`.
+    // Installing it from `LLAMA_ARG_ROPE_*` here means the arms are selected the
+    // same way the server selects them, through one set of flag definitions.
+    let rope_override = mlxcel::cli::rope_args::install_from_env()
+        .map_err(|message| anyhow::anyhow!("{message}"))?;
+
     let text = std::fs::read_to_string(text_file)
         .with_context(|| format!("reading corpus {text_file}"))?;
     let (model, tokenizer) = mlxcel::load_model(std::path::Path::new(model_dir))
@@ -158,6 +166,9 @@ fn main() -> Result<()> {
         .unwrap_or_default();
 
     println!("# model\t{model_dir}");
+    if let Some(over) = rope_override.as_ref() {
+        println!("# rope_override\t{}", over.describe());
+    }
     println!("# corpus\t{text_file}\ttokens\t{}", ids.len());
     println!(
         "# chunks\t{n_chunks}\tchunk_tokens\t{chunk_tokens}\ttopk\t{topk}\tprefill\t{prefill}"

--- a/src/bin/mlx_server.rs
+++ b/src/bin/mlx_server.rs
@@ -16,6 +16,7 @@ use clap::{Args as ClapArgs, Parser, Subcommand};
 use std::path::PathBuf;
 
 use mlxcel::cli::batch_quant_args::BatchKvQuantArgs;
+use mlxcel::cli::rope_args::RopeOverrideArgs;
 use mlxcel::cli::speculative_args::{
     SpeculativeArgs, env_fallback_draft_block_size, env_fallback_draft_kind,
 };
@@ -1139,6 +1140,15 @@ struct ServerArgs {
     #[command(flatten)]
     speculative: SpeculativeArgs,
 
+    /// RoPE / YaRN runtime-override flag group (`--rope-scaling`,
+    /// `--rope-scale`, `--rope-freq-base`, `--rope-freq-scale`, and the five
+    /// `--yarn-*` knobs). Defined once in `mlxcel::cli::rope_args` so both
+    /// server binaries (`mlxcel serve`, `mlxcel-server`) accept the same
+    /// llama-server b10621 command line. Resolved before the model is loaded;
+    /// see `ServerStartupConfig::rope_override`.
+    #[command(flatten)]
+    rope: RopeOverrideArgs,
+
     /// Language-bias options for server-wide output
     /// steering. See `--lang-bias`, `--lang-bias-config`, `--lang-bias-policy`,
     /// and the `--lang-bias-include-*` family of flags.
@@ -1746,6 +1756,7 @@ fn build_startup_input(mut args: ServerArgs) -> anyhow::Result<ServerStartupInpu
         max_denoising_steps: args.max_denoising_steps,
         diffusion_sampler: args.diffusion_sampler.clone(),
         diffusion_threshold: args.diffusion_threshold,
+        rope: args.rope.clone(),
     })
 }
 

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -24,5 +24,6 @@
 pub mod batch_quant_args;
 pub mod flag_surface;
 pub mod max_tokens;
+pub mod rope_args;
 pub mod speculative_args;
 pub mod turbo_args;

--- a/src/cli/rope_args.rs
+++ b/src/cli/rope_args.rs
@@ -1,0 +1,271 @@
+// Copyright 2025-2026 Lablup Inc. and Jeongkyu Shin
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! RoPE and YaRN runtime-override flag group (llama-server b10621 parity).
+//!
+//! One canonical clap definition of `--rope-scaling`, `--rope-scale`,
+//! `--rope-freq-base`, `--rope-freq-scale` and the five `--yarn-*` knobs,
+//! flattened into both server binaries so `mlxcel serve` and `mlxcel-server`
+//! accept the same command line. The upstream definitions are in
+//! [`common/arg.cpp`](https://github.com/ggml-org/llama.cpp/blob/c1d0e7a004015f23bc0233470b747b596f29b264/common/arg.cpp).
+//!
+//! # The two halves, and why they end differently
+//!
+//! The four RoPE flags are implemented: they rewrite the checkpoint's
+//! `rope_scaling` block and `rope_theta` before the model is built, through
+//! [`crate::models::rope_overrides`]. The five YaRN flags are not: mlxcel's
+//! shared RoPE path has no YaRN arm (see
+//! [`crate::models::rope_utils::RopeScalingKind`]), so there is nothing for
+//! `--yarn-beta-fast` to tune.
+//!
+//! They are still defined here rather than left off the binaries, because
+//! b10621 gives all five a sentinel default that means "leave the model's own
+//! values alone" (`-1.00`, and `0` for `--yarn-orig-ctx`). A deployment script
+//! that passes the sentinel is asking for the checkpoint's own behavior and
+//! must keep working; one that passes a real value is asking for something
+//! mlxcel cannot do, and epic #1431's rule is that such a request is refused
+//! with a diagnostic rather than accepted and ignored. [`resolve_yarn_request`]
+//! is that split.
+//!
+//! Used by: mlxcel serve, mlxcel-server.
+
+use clap::Args;
+
+use crate::models::rope_overrides::RopeRuntimeOverride;
+
+/// Shared RoPE / YaRN runtime-override flag group.
+///
+/// Every flag is `Option<_>` with no clap default, so "not given" stays
+/// distinguishable from "given at b10621's default". That distinction is what
+/// lets a sentinel `--yarn-ext-factor -1` be accepted while an ordinary value
+/// is refused, and it keeps the resolved override out of the way entirely for
+/// the overwhelmingly common case where no rotation flag was passed.
+#[derive(Args, Debug, Default, Clone)]
+#[command(next_help_heading = "RoPE / YaRN Options")]
+pub struct RopeOverrideArgs {
+    /// RoPE frequency scaling method: `none`, `linear`, or `yarn`.
+    ///
+    /// Defaults to the scheme the checkpoint's own `rope_scaling` block names.
+    /// `none` drops that block and rotates with the plain `base^(2i/d)` table;
+    /// `linear` divides positions by `--rope-scale` (or by the checkpoint's own
+    /// factor when that flag is absent). `yarn` parses and is then refused:
+    /// mlxcel's shared RoPE path serves `default`, `linear` and `llama3` tables
+    /// only, and serving a YaRN request as one of those would change the
+    /// rotation silently. Checkpoints whose config declares YaRN still load and
+    /// rotate with it.
+    ///
+    /// Applied before the model is constructed, so before any KV cache exists.
+    /// Refused at startup when the loaded architecture computes its RoPE
+    /// frequencies outside the shared path and would ignore the request.
+    #[arg(
+        long = "rope-scaling",
+        env = "LLAMA_ARG_ROPE_SCALING_TYPE",
+        value_name = "{none,linear,yarn}"
+    )]
+    pub rope_scaling: Option<String>,
+
+    /// RoPE context scaling factor: expands context by a factor of N.
+    ///
+    /// The reciprocal spelling of `--rope-freq-scale`; `--rope-scale 8` and
+    /// `--rope-freq-scale 0.125` are the same request. Passing both with values
+    /// that are not reciprocals is refused rather than resolved by precedence.
+    #[arg(long = "rope-scale", env = "LLAMA_ARG_ROPE_SCALE", value_name = "N")]
+    pub rope_scale: Option<f32>,
+
+    /// RoPE base frequency, used by NTK-aware scaling.
+    ///
+    /// Replaces the checkpoint's `rope_theta`. On Gemma 3 this reaches the
+    /// global-attention layers only, matching llama.cpp's separate SWA rope
+    /// parameters.
+    #[arg(
+        long = "rope-freq-base",
+        env = "LLAMA_ARG_ROPE_FREQ_BASE",
+        value_name = "N"
+    )]
+    pub rope_freq_base: Option<f32>,
+
+    /// RoPE frequency scaling factor: expands context by a factor of 1/N.
+    #[arg(
+        long = "rope-freq-scale",
+        env = "LLAMA_ARG_ROPE_FREQ_SCALE",
+        value_name = "N"
+    )]
+    pub rope_freq_scale: Option<f32>,
+
+    /// YaRN: original context size of the model (0 = model training context size).
+    ///
+    /// Accepted at b10621's sentinel default only; see the module docs.
+    #[arg(
+        long = "yarn-orig-ctx",
+        env = "LLAMA_ARG_YARN_ORIG_CTX",
+        value_name = "N"
+    )]
+    pub yarn_orig_ctx: Option<i64>,
+
+    /// YaRN: extrapolation mix factor (0.0 = full interpolation).
+    ///
+    /// Accepted at b10621's sentinel default only; see the module docs.
+    #[arg(
+        long = "yarn-ext-factor",
+        env = "LLAMA_ARG_YARN_EXT_FACTOR",
+        value_name = "N"
+    )]
+    pub yarn_ext_factor: Option<f32>,
+
+    /// YaRN: scale sqrt(t) or attention magnitude.
+    ///
+    /// Accepted at b10621's sentinel default only; see the module docs.
+    #[arg(
+        long = "yarn-attn-factor",
+        env = "LLAMA_ARG_YARN_ATTN_FACTOR",
+        value_name = "N"
+    )]
+    pub yarn_attn_factor: Option<f32>,
+
+    /// YaRN: high correction dim or alpha.
+    ///
+    /// Accepted at b10621's sentinel default only; see the module docs.
+    #[arg(
+        long = "yarn-beta-slow",
+        env = "LLAMA_ARG_YARN_BETA_SLOW",
+        value_name = "N"
+    )]
+    pub yarn_beta_slow: Option<f32>,
+
+    /// YaRN: low correction dim or beta.
+    ///
+    /// Accepted at b10621's sentinel default only; see the module docs.
+    #[arg(
+        long = "yarn-beta-fast",
+        env = "LLAMA_ARG_YARN_BETA_FAST",
+        value_name = "N"
+    )]
+    pub yarn_beta_fast: Option<f32>,
+}
+
+/// b10621's `-1.0` sentinel for the four floating-point YaRN knobs, meaning
+/// "keep whatever the model was trained with".
+///
+/// `common_params` initializes `yarn_ext_factor`, `yarn_attn_factor`,
+/// `yarn_beta_fast` and `yarn_beta_slow` to `-1.0f`, and `llama_context`
+/// substitutes the model's own value for any that is still negative.
+const YARN_SENTINEL: f32 = -1.0;
+
+/// b10621's `0` sentinel for `--yarn-orig-ctx`, meaning "the model's training
+/// context size".
+const YARN_ORIG_CTX_SENTINEL: i64 = 0;
+
+impl RopeOverrideArgs {
+    /// Resolve this group into a RoPE override, refusing what cannot be served.
+    ///
+    /// Two failures are possible and both are startup errors, never warnings:
+    /// an unserveable YaRN request ([`resolve_yarn_request`]) and an
+    /// unserveable or self-contradictory RoPE request
+    /// ([`RopeRuntimeOverride::from_flags`]).
+    pub fn resolve(&self) -> Result<Option<RopeRuntimeOverride>, String> {
+        self.resolve_yarn_request()?;
+        RopeRuntimeOverride::from_flags(
+            self.rope_scaling.as_deref(),
+            self.rope_scale,
+            self.rope_freq_scale,
+            self.rope_freq_base,
+        )
+    }
+
+    /// Accept the five YaRN flags at b10621's sentinels, refuse them otherwise.
+    ///
+    /// The message names every flag that was set to a real value, so an
+    /// operator passing three of them is told about three rather than fixing
+    /// them one restart at a time.
+    pub fn resolve_yarn_request(&self) -> Result<(), String> {
+        let mut requested: Vec<String> = Vec::new();
+
+        for (flag, value) in [
+            ("--yarn-ext-factor", self.yarn_ext_factor),
+            ("--yarn-attn-factor", self.yarn_attn_factor),
+            ("--yarn-beta-slow", self.yarn_beta_slow),
+            ("--yarn-beta-fast", self.yarn_beta_fast),
+        ] {
+            if let Some(value) = value
+                && value != YARN_SENTINEL
+            {
+                requested.push(format!("{flag} {value}"));
+            }
+        }
+        if let Some(value) = self.yarn_orig_ctx
+            && value != YARN_ORIG_CTX_SENTINEL
+        {
+            requested.push(format!("--yarn-orig-ctx {value}"));
+        }
+
+        if requested.is_empty() {
+            return Ok(());
+        }
+
+        Err(format!(
+            "{} requests YaRN rotation parameters, which mlxcel's shared RoPE path does not \
+             implement: it builds \"default\", \"linear\" and \"llama3\" frequency tables only, \
+             so there is nothing for these to tune and accepting them would leave the rotation \
+             unchanged without saying so. Checkpoints whose own config declares YaRN (DeepSeek \
+             V2/V3.2/V4, gpt-oss, Mellum, TeleChat3) build it from that config and are \
+             unaffected. Pass the b10621 defaults ({} / --yarn-orig-ctx 0), or drop the flags, \
+             to use the checkpoint's own values. Tracked by #1450.",
+            requested.join(", "),
+            YARN_SENTINEL
+        ))
+    }
+}
+
+/// Resolve the group from the environment alone.
+///
+/// The server binaries resolve their own [`RopeOverrideArgs`] through clap,
+/// where a flag beats the environment. Out-of-band harnesses have no command
+/// line to parse but still need the override installed in their own process,
+/// because it is process-wide by construction (see
+/// [`crate::models::rope_overrides`]): `examples/logit_trace` compares two
+/// rotations by running two processes, exactly as `docs/benchmarks.md`
+/// prescribes for `MLXCEL_QMV_WIDE`.
+///
+/// Parsing an argv of just the program name makes clap fill every field from
+/// the `LLAMA_ARG_*` variable it is already bound to, so the harness and the
+/// server read the same environment through the same definitions rather than
+/// through a second hand-written reader that can drift.
+pub fn from_env() -> Result<Option<RopeRuntimeOverride>, String> {
+    use clap::Parser;
+
+    #[derive(Parser)]
+    #[command(allow_negative_numbers = true)]
+    struct EnvOnly {
+        #[command(flatten)]
+        rope: RopeOverrideArgs,
+    }
+
+    EnvOnly::try_parse_from(["mlxcel"])
+        .map_err(|e| e.to_string())?
+        .rope
+        .resolve()
+}
+
+/// Resolve the group from the environment and install it process-wide.
+///
+/// Convenience for harnesses; the server installs its own resolved value.
+pub fn install_from_env() -> Result<Option<RopeRuntimeOverride>, String> {
+    let resolved = from_env()?;
+    crate::models::rope_overrides::install(resolved)?;
+    Ok(resolved)
+}
+
+#[cfg(test)]
+#[path = "rope_args_tests.rs"]
+mod tests;

--- a/src/cli/rope_args_tests.rs
+++ b/src/cli/rope_args_tests.rs
@@ -1,0 +1,159 @@
+// Copyright 2025-2026 Lablup Inc. and Jeongkyu Shin
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Unit tests for the b10621 RoPE / YaRN flag group.
+
+use super::*;
+
+fn args() -> RopeOverrideArgs {
+    RopeOverrideArgs::default()
+}
+
+#[test]
+fn an_empty_group_resolves_to_no_override() {
+    assert_eq!(args().resolve().expect("no flags is not an error"), None);
+}
+
+#[test]
+fn the_yarn_sentinels_are_accepted_and_carry_no_override() {
+    // A deployment script that spells out b10621's own defaults is asking for
+    // the checkpoint's behavior, and must keep working.
+    let group = RopeOverrideArgs {
+        yarn_ext_factor: Some(-1.0),
+        yarn_attn_factor: Some(-1.0),
+        yarn_beta_fast: Some(-1.0),
+        yarn_beta_slow: Some(-1.0),
+        yarn_orig_ctx: Some(0),
+        ..args()
+    };
+    group
+        .resolve_yarn_request()
+        .expect("the sentinels mean \"use the model's own values\"");
+    assert_eq!(group.resolve().expect("sentinels only"), None);
+}
+
+#[test]
+fn a_real_yarn_value_is_refused_with_the_flag_named() {
+    let group = RopeOverrideArgs {
+        yarn_beta_fast: Some(32.0),
+        ..args()
+    };
+    let err = group
+        .resolve()
+        .expect_err("mlxcel's shared RoPE path has no YaRN arm");
+    assert!(err.contains("--yarn-beta-fast 32"), "{err}");
+    assert!(err.contains("#1450"), "{err}");
+}
+
+#[test]
+fn every_non_sentinel_yarn_flag_is_named_in_one_message() {
+    // One restart should tell the operator about all of them, not one per run.
+    let group = RopeOverrideArgs {
+        yarn_ext_factor: Some(1.0),
+        yarn_attn_factor: Some(0.5),
+        yarn_beta_slow: Some(1.0),
+        yarn_beta_fast: Some(32.0),
+        yarn_orig_ctx: Some(4096),
+        ..args()
+    };
+    let err = group.resolve().expect_err("five real values");
+    for expected in [
+        "--yarn-ext-factor",
+        "--yarn-attn-factor",
+        "--yarn-beta-slow",
+        "--yarn-beta-fast",
+        "--yarn-orig-ctx 4096",
+    ] {
+        assert!(err.contains(expected), "{expected} missing from: {err}");
+    }
+}
+
+#[test]
+fn a_zero_ext_factor_is_a_real_request_not_a_sentinel() {
+    // b10621 documents `0.0 = full interpolation`, which is a genuine YaRN
+    // setting; only `-1.0` means "leave it alone".
+    let group = RopeOverrideArgs {
+        yarn_ext_factor: Some(0.0),
+        ..args()
+    };
+    let err = group.resolve().expect_err("0.0 is full interpolation");
+    assert!(err.contains("--yarn-ext-factor 0"), "{err}");
+}
+
+#[test]
+fn the_rope_flags_resolve_into_an_override() {
+    let group = RopeOverrideArgs {
+        rope_scaling: Some("linear".to_string()),
+        rope_scale: Some(4.0),
+        ..args()
+    };
+    let over = group
+        .resolve()
+        .expect("valid")
+        .expect("a linear override was requested");
+    assert_eq!(over.freq_scale(), Some(0.25));
+}
+
+#[test]
+fn yarn_is_checked_before_the_rope_flags() {
+    // Both halves are wrong here; the YaRN diagnostic is the more specific of
+    // the two and must be the one the operator sees.
+    let group = RopeOverrideArgs {
+        rope_scale: Some(-1.0),
+        yarn_beta_fast: Some(32.0),
+        ..args()
+    };
+    let err = group.resolve().expect_err("both halves are invalid");
+    assert!(err.contains("--yarn-beta-fast"), "{err}");
+}
+
+#[test]
+fn rope_scaling_yarn_is_refused_even_with_no_yarn_flags() {
+    let group = RopeOverrideArgs {
+        rope_scaling: Some("yarn".to_string()),
+        ..args()
+    };
+    let err = group.resolve().expect_err("yarn has no arm on this path");
+    assert!(err.contains("--rope-scaling yarn"), "{err}");
+}
+
+#[test]
+fn the_group_parses_from_a_command_line_on_a_bare_parser() {
+    use clap::Parser;
+
+    #[derive(Parser)]
+    #[command(allow_negative_numbers = true)]
+    struct Probe {
+        #[command(flatten)]
+        rope: RopeOverrideArgs,
+    }
+
+    let parsed = Probe::try_parse_from([
+        "probe",
+        "--rope-scaling",
+        "linear",
+        "--rope-scale",
+        "8",
+        "--rope-freq-base",
+        "1000000",
+        "--yarn-ext-factor",
+        "-1",
+    ])
+    .expect("the b10621 spellings parse");
+    assert_eq!(parsed.rope.rope_scaling.as_deref(), Some("linear"));
+    assert_eq!(parsed.rope.rope_scale, Some(8.0));
+    assert_eq!(parsed.rope.rope_freq_base, Some(1_000_000.0));
+    // The negative sentinel has to survive argv parsing, not just resolution.
+    assert_eq!(parsed.rope.yarn_ext_factor, Some(-1.0));
+}

--- a/src/commands/serve.rs
+++ b/src/commands/serve.rs
@@ -435,6 +435,7 @@ fn build_startup_input(mut args: crate::ServeArgs) -> anyhow::Result<ServerStart
         max_denoising_steps: args.diffusion.max_denoising_steps,
         diffusion_sampler: args.diffusion.diffusion_sampler,
         diffusion_threshold: args.diffusion.diffusion_threshold,
+        rope: args.rope.clone(),
     })
 }
 

--- a/src/commands/serve_tests.rs
+++ b/src/commands/serve_tests.rs
@@ -117,6 +117,7 @@ fn sample_args() -> crate::ServeArgs {
         turbo: mlxcel::cli::turbo_args::TurboKvCacheArgs::default(),
         batch_quant: mlxcel::cli::batch_quant_args::BatchKvQuantArgs::default(),
         speculative: mlxcel::cli::speculative_args::SpeculativeArgs::default(),
+        rope: mlxcel::cli::rope_args::RopeOverrideArgs::default(),
         decode_storage_backend: None,
         vision_cache_size: 20,
         max_image_payload_size: mlxcel::server::DEFAULT_MAX_IMAGE_PAYLOAD_SIZE,

--- a/src/main.rs
+++ b/src/main.rs
@@ -18,6 +18,7 @@ use std::path::PathBuf;
 
 mod commands;
 use mlxcel::cli::batch_quant_args::BatchKvQuantArgs;
+use mlxcel::cli::rope_args::RopeOverrideArgs;
 use mlxcel::cli::speculative_args::SpeculativeArgs;
 use mlxcel::cli::turbo_args::TurboKvCacheArgs;
 use mlxcel::downloader::DownloadArgs;
@@ -1766,6 +1767,15 @@ pub(crate) struct ServeArgs {
     /// parses on both.
     #[command(flatten)]
     speculative: SpeculativeArgs,
+
+    /// RoPE / YaRN runtime-override flag group (`--rope-scaling`,
+    /// `--rope-scale`, `--rope-freq-base`, `--rope-freq-scale`, and the five
+    /// `--yarn-*` knobs). Defined once in `mlxcel::cli::rope_args` so both
+    /// server binaries (`mlxcel serve`, `mlxcel-server`) accept the same
+    /// llama-server b10621 command line. Resolved before the model is loaded;
+    /// see `ServerStartupConfig::rope_override`.
+    #[command(flatten)]
+    pub(crate) rope: RopeOverrideArgs,
 
     /// Language-bias options for server-wide output
     /// steering. Mirrors the same flags exposed on the `generate` subcommand.

--- a/src/models/apertus.rs
+++ b/src/models/apertus.rs
@@ -437,7 +437,7 @@ impl Attention {
             head_dim,
             scale: 1.0 / (head_dim as f32).sqrt(),
             rope_dims: head_dim,
-            rope_base: args.rope_theta,
+            rope_base: crate::models::rope_overrides::resolve_base(args.rope_theta),
             rope_freqs,
         })
     }

--- a/src/models/dynamic_ntk_rope.rs
+++ b/src/models/dynamic_ntk_rope.rs
@@ -136,7 +136,14 @@ impl DynamicNtkRope {
         scaling: Option<&RopeScalingSpec>,
         model_label: &str,
     ) -> Result<Self, String> {
-        let mode = Self::resolve_mode(scaling, max_position_embeddings, model_label)?;
+        // An operator `--rope-scaling` / `--rope-freq-scale` / `--rope-freq-base`
+        // request replaces the checkpoint's block and base before the schedule
+        // is resolved, so the NTK rescale past `max_position_embeddings` is
+        // computed from the base the operator asked for rather than the one the
+        // checkpoint shipped.
+        let overridden = crate::models::rope_overrides::resolve_spec(scaling);
+        let mode = Self::resolve_mode(overridden.as_ref(), max_position_embeddings, model_label)?;
+        let base = crate::models::rope_overrides::resolve_base(base);
         Ok(Self {
             dims,
             base,

--- a/src/models/gemma3.rs
+++ b/src/models/gemma3.rs
@@ -154,10 +154,19 @@ impl ModelArgs {
     /// only failure available is the one a load error prevents, a `yarn` or
     /// `llama3` block silently decoding at `1.0`, which reads as fluent text.
     pub fn global_rope_scale(&self) -> Result<f32, String> {
-        let Some(block) = self.rope_scaling.as_ref() else {
+        let declared = self
+            .rope_scaling
+            .as_ref()
+            .map(|block| RopeScalingSpec::from_lookup(|key| block.get(key)));
+        // An operator `--rope-scaling` / `--rope-freq-scale` request replaces
+        // the checkpoint's block before it is read, the same way it does on the
+        // shared `rope_utils` path. Gemma 3's global layers are the only ones a
+        // position scale reaches; the sliding layers keep unit scale (see
+        // [`layer_rope_params`]), which is also what llama.cpp does with its
+        // separate SWA rope parameters.
+        let Some(spec) = crate::models::rope_overrides::resolve_spec(declared.as_ref()) else {
             return Ok(1.0);
         };
-        let spec = RopeScalingSpec::from_lookup(|key| block.get(key));
 
         match spec.rope_type() {
             "default" => Ok(1.0),
@@ -210,9 +219,16 @@ fn layer_rope_params(args: &ModelArgs, layer_idx: usize) -> Result<(bool, f32, f
     let global_rope_scale = args.global_rope_scale()?;
 
     Ok(if is_sliding {
+        // The sliding layers keep the checkpoint's local base: llama.cpp holds
+        // Gemma 3's SWA rotation in its own `rope_freq_base_train_swa`, which
+        // `--rope-freq-base` does not reach either.
         (true, args.rope_local_base_freq, 1.0)
     } else {
-        (false, args.rope_theta, global_rope_scale)
+        (
+            false,
+            crate::models::rope_overrides::resolve_base(args.rope_theta),
+            global_rope_scale,
+        )
     })
 }
 

--- a/src/models/llama3.rs
+++ b/src/models/llama3.rs
@@ -1068,7 +1068,7 @@ impl Attention {
             head_dim,
             scale: 1.0 / (head_dim as f32).sqrt(),
             rope_dims: head_dim,
-            rope_base: args.rope_theta,
+            rope_base: crate::models::rope_overrides::resolve_base(args.rope_theta),
             rope_traditional: args.rope_traditional,
             rope_scale,
             rope_freqs,

--- a/src/models/mod.rs
+++ b/src/models/mod.rs
@@ -46,6 +46,13 @@ pub(crate) mod conv_decode;
 // `rope_scaling` block at deserialization so the base never moved.
 pub mod dynamic_ntk_rope;
 pub mod gated_delta;
+// `rope_overrides` carries llama-server b10621's `--rope-scaling`,
+// `--rope-scale`, `--rope-freq-scale` and `--rope-freq-base` from the server
+// CLI down to the RoPE seams in `rope_utils` and `dynamic_ntk_rope` (#1450).
+// It is process-wide because every family reads `config.json` inside its own
+// `load()`, so there is no argument to thread; the applications counter is what
+// keeps that from becoming a silent no-op on a family that is not on the seam.
+pub mod rope_overrides;
 // `rope_utils` is the shared reader for the `rope_scaling` block plus the
 // frequency tables it selects (#1355). It exists because two families needed
 // the same decision and only one made it: Apertus computed the `llama3` table

--- a/src/models/qwen3.rs
+++ b/src/models/qwen3.rs
@@ -652,7 +652,7 @@ impl Attention {
             head_dim,
             scale: 1.0 / (head_dim as f32).sqrt(),
             rope_dims: head_dim,
-            rope_base: args.rope_theta,
+            rope_base: crate::models::rope_overrides::resolve_base(args.rope_theta),
             rope_scale,
             rope_freqs,
         })

--- a/src/models/qwen3_moe.rs
+++ b/src/models/qwen3_moe.rs
@@ -791,7 +791,7 @@ impl Attention {
             head_dim,
             scale: 1.0 / (head_dim as f32).sqrt(),
             rope_dims: head_dim,
-            rope_base: args.rope_theta,
+            rope_base: crate::models::rope_overrides::resolve_base(args.rope_theta),
             rope_scale,
             rope_freqs,
         })

--- a/src/models/rope_overrides.rs
+++ b/src/models/rope_overrides.rs
@@ -1,0 +1,447 @@
+// Copyright 2025-2026 Lablup Inc. and Jeongkyu Shin
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Operator-supplied RoPE overrides, applied to a checkpoint's own
+//! `rope_scaling` block and `rope_theta` before the model is constructed.
+//!
+//! This is the mlxcel side of llama-server b10621's `--rope-scaling`,
+//! `--rope-scale`, `--rope-freq-scale` and `--rope-freq-base`
+//! ([`common/arg.cpp`](https://github.com/ggml-org/llama.cpp/blob/c1d0e7a004015f23bc0233470b747b596f29b264/common/arg.cpp)).
+//! Upstream keeps them on `common_params` and hands them to `llama_model_load`,
+//! which rebuilds the rotation before any KV cache exists. mlxcel has no
+//! equivalent single parameter object reaching every family's loader: each
+//! family reads `config.json` inside its own `load()`, so there is no argument
+//! to thread. The override is therefore a process-wide value installed once,
+//! before the first load, and read at the two seams every family on the shared
+//! RoPE path already goes through.
+//!
+//! # Why the applications counter exists
+//!
+//! An override that reaches no seam is the exact failure epic #1431 is about:
+//! the flag parses, the server starts, and the model rotates with the
+//! checkpoint's own frequencies while the operator believes otherwise. Only six
+//! families route through [`crate::models::rope_utils`]; the rest
+//! (DeepSeek V2/V3/V4, Gemma 4, gpt-oss, Phi-3, Mellum, TeleChat3, Exaone 4,
+//! Hunyuan MoE, and every MRoPE VLM) compute their frequencies inline and would
+//! ignore it silently.
+//!
+//! Rather than maintain a hand-written table of which `ModelType` honors the
+//! override (which goes stale the moment a family is ported), every seam that
+//! consumes the override increments [`applications`]. Server startup compares
+//! that count against zero after the model is loaded and refuses to serve when
+//! an override was requested and never applied. A new family that wires itself
+//! into `rope_utils` starts being accepted without anyone editing a list, and a
+//! family that does not is named in the error.
+//!
+//! # Why YaRN is rejected rather than approximated
+//!
+//! [`RopeScalingKind`](crate::models::rope_utils::RopeScalingKind) implements
+//! `default`, `linear` and `llama3` only. A `yarn` request has no
+//! representation here, and the nearest thing (falling back to the unscaled
+//! table) is precisely the silent degradation this module exists to prevent, so
+//! `--rope-scaling yarn` is refused at the CLI edge. The families that do
+//! implement YaRN (DeepSeek V2/V3.2/V4, gpt-oss, Mellum, TeleChat3) build it
+//! from their checkpoint's own block and are not on this seam either way.
+
+use std::sync::OnceLock;
+use std::sync::atomic::{AtomicUsize, Ordering};
+
+use super::rope_utils::RopeScalingSpec;
+
+/// The scaling scheme `--rope-scaling` can force.
+///
+/// Mirrors b10621's `{none,linear,yarn}` value domain exactly, including
+/// `yarn`: the value parses so the diagnostic can name what is missing, rather
+/// than clap reporting "invalid value" for a scheme llama.cpp accepts.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum RopeScalingTypeOverride {
+    /// `LLAMA_ROPE_SCALING_TYPE_NONE`: rotate with the plain `base^(2i/d)`
+    /// table whatever the checkpoint declares.
+    None,
+    /// `LLAMA_ROPE_SCALING_TYPE_LINEAR`: divide positions by a factor.
+    Linear,
+    /// `LLAMA_ROPE_SCALING_TYPE_YARN`: parsed, then refused. See the module
+    /// documentation.
+    Yarn,
+}
+
+impl RopeScalingTypeOverride {
+    /// Parse the b10621 spelling. `Err` carries the accepted domain.
+    pub fn parse(value: &str) -> Result<Self, String> {
+        match value {
+            "none" => Ok(Self::None),
+            "linear" => Ok(Self::Linear),
+            "yarn" => Ok(Self::Yarn),
+            other => Err(format!(
+                "--rope-scaling {other:?} is not one of {{none,linear,yarn}}"
+            )),
+        }
+    }
+
+    /// The spelling this variant was parsed from.
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::None => "none",
+            Self::Linear => "linear",
+            Self::Yarn => "yarn",
+        }
+    }
+}
+
+/// A resolved RoPE override, ready to apply to a checkpoint's config.
+///
+/// `freq_scale` is stored in llama.cpp's orientation (`rope_freq_scale`, the
+/// multiplier applied to a position), not in the `rope_scaling.factor`
+/// orientation of a HuggingFace config. b10621 derives it two ways and they are
+/// reciprocals of each other: `--rope-scale N` sets `rope_freq_scale = 1/N`
+/// while `--rope-freq-scale N` sets it to `N`. Normalizing at the edge keeps
+/// the inversion in one place instead of at every consumer.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct RopeRuntimeOverride {
+    scaling_type: Option<RopeScalingTypeOverride>,
+    freq_base: Option<f32>,
+    freq_scale: Option<f32>,
+}
+
+impl RopeRuntimeOverride {
+    /// Build an override from the four b10621 flags, or `Ok(None)` when none of
+    /// them was given.
+    ///
+    /// `rope_scale` and `freq_scale` are the raw `--rope-scale` and
+    /// `--rope-freq-scale` values. b10621 writes both into the same
+    /// `rope_freq_scale` field, so the later flag on the command line wins
+    /// there; clap gives mlxcel two independent options, so a request that sets
+    /// both to values that are not reciprocals is ambiguous and is refused
+    /// rather than resolved by an arbitrary precedence.
+    pub fn from_flags(
+        scaling: Option<&str>,
+        rope_scale: Option<f32>,
+        freq_scale: Option<f32>,
+        freq_base: Option<f32>,
+    ) -> Result<Option<Self>, String> {
+        let scaling_type = scaling.map(RopeScalingTypeOverride::parse).transpose()?;
+
+        if let Some(RopeScalingTypeOverride::Yarn) = scaling_type {
+            return Err(
+                "--rope-scaling yarn is not implemented: mlxcel's shared RoPE path serves \
+                 \"default\", \"linear\" and \"llama3\" frequency tables only, and applying a \
+                 YaRN request as any of those would change the rotation without saying so. \
+                 Checkpoints whose own config declares YaRN (DeepSeek V2/V3.2/V4, gpt-oss, \
+                 Mellum, TeleChat3) still load and rotate with it; only the runtime override \
+                 is refused. Tracked by #1450."
+                    .to_string(),
+            );
+        }
+
+        for (flag, value) in [
+            ("--rope-scale", rope_scale),
+            ("--rope-freq-scale", freq_scale),
+            ("--rope-freq-base", freq_base),
+        ] {
+            if let Some(value) = value
+                && !(value.is_finite() && value > 0.0)
+            {
+                return Err(format!(
+                    "{flag} {value} is not a positive finite number; a non-positive or \
+                     non-finite RoPE factor produces infinite or NaN frequencies and every \
+                     logit becomes NaN without an error"
+                ));
+            }
+        }
+
+        // `--rope-scale N` is `rope_freq_scale = 1/N`; `--rope-freq-scale N` is
+        // `rope_freq_scale = N`. Both are accepted, and both spellings of the
+        // same request agree.
+        let from_rope_scale = rope_scale.map(|n| 1.0 / n);
+        let resolved_freq_scale = match (from_rope_scale, freq_scale) {
+            (Some(a), Some(b)) if (a - b).abs() > f32::EPSILON * a.abs().max(b.abs()).max(1.0) => {
+                return Err(format!(
+                    "--rope-scale {} and --rope-freq-scale {} disagree: they are two spellings \
+                     of the same setting and must be reciprocals (--rope-scale N means \
+                     --rope-freq-scale 1/N). Pass one of them.",
+                    rope_scale.unwrap_or_default(),
+                    b
+                ));
+            }
+            (Some(a), _) => Some(a),
+            (None, b) => b,
+        };
+
+        if scaling_type.is_none() && resolved_freq_scale.is_none() && freq_base.is_none() {
+            return Ok(None);
+        }
+
+        Ok(Some(Self {
+            scaling_type,
+            freq_base,
+            freq_scale: resolved_freq_scale,
+        }))
+    }
+
+    /// The scheme this override forces, if it forces one.
+    pub fn scaling_type(&self) -> Option<RopeScalingTypeOverride> {
+        self.scaling_type
+    }
+
+    /// The `rope_theta` replacement, if any.
+    pub fn freq_base(&self) -> Option<f32> {
+        self.freq_base
+    }
+
+    /// The `rope_freq_scale` replacement, if any.
+    pub fn freq_scale(&self) -> Option<f32> {
+        self.freq_scale
+    }
+
+    /// A one-line description for the startup banner and error messages.
+    pub fn describe(&self) -> String {
+        let mut parts = Vec::new();
+        if let Some(kind) = self.scaling_type {
+            parts.push(format!("--rope-scaling {}", kind.as_str()));
+        }
+        if let Some(scale) = self.freq_scale {
+            parts.push(format!("--rope-freq-scale {scale}"));
+        }
+        if let Some(base) = self.freq_base {
+            parts.push(format!("--rope-freq-base {base}"));
+        }
+        parts.join(" ")
+    }
+
+    /// Rewrite a checkpoint's `rope_scaling` block into the one this override
+    /// asks for.
+    ///
+    /// Pure, so the whole decision table is testable without touching the
+    /// process-wide slot: the caller supplies the block the checkpoint declared
+    /// and gets back the block the model should be built from.
+    ///
+    /// | requested scheme | `--rope-freq-scale` | result |
+    /// |---|---|---|
+    /// | `none` | ignored | no block: the plain table |
+    /// | `linear` | given | `{"rope_type": "linear", "factor": 1/scale}` |
+    /// | `linear` | absent | the checkpoint's own factor, or `1.0` |
+    /// | not given | given | as `linear`, matching b10621's "defaults to linear unless specified by the model" |
+    /// | not given | absent | the checkpoint's block, untouched |
+    ///
+    /// The one case with no defensible answer is a scale applied on top of a
+    /// scheme that is not linear, `llama3` above all: b10621 would multiply its
+    /// own `rope_freq_scale` into a YaRN or NTK rotation, mlxcel's `llama3`
+    /// table has no such multiplier, and composing them by dropping one half
+    /// silently changes the rotation. That returns `Err`, which
+    /// [`crate::models::rope_utils::RopeScalingKind::resolve`] turns into a
+    /// recorded rejection and startup turns into a refusal to serve.
+    pub fn apply_to_spec(
+        &self,
+        declared: Option<&RopeScalingSpec>,
+    ) -> Result<Option<RopeScalingSpec>, String> {
+        let declared_type = declared.map(|s| s.rope_type().to_string());
+
+        match self.scaling_type {
+            Some(RopeScalingTypeOverride::None) => Ok(None),
+            Some(RopeScalingTypeOverride::Yarn) => {
+                Err("--rope-scaling yarn is not implemented on this RoPE path".to_string())
+            }
+            Some(RopeScalingTypeOverride::Linear) => Ok(Some(RopeScalingSpec {
+                rope_type: Some("linear".to_string()),
+                factor: Some(self.linear_factor(declared)),
+                ..RopeScalingSpec::default()
+            })),
+            None => {
+                let Some(freq_scale) = self.freq_scale else {
+                    // Base-only override: the block is the checkpoint's.
+                    return Ok(declared.cloned());
+                };
+                match declared_type.as_deref() {
+                    None | Some("default") | Some("linear") => Ok(Some(RopeScalingSpec {
+                        rope_type: Some("linear".to_string()),
+                        factor: Some(1.0 / freq_scale),
+                        ..RopeScalingSpec::default()
+                    })),
+                    Some(other) => Err(format!(
+                        "the checkpoint declares rope_scaling type \"{other}\" and the request \
+                         asks for a frequency scale of {freq_scale} without naming a scheme. \
+                         llama-server would multiply the scale into that scheme's rotation; \
+                         mlxcel's \"{other}\" table has no such multiplier, so composing them \
+                         would change the rotation in a way neither side describes. Pass \
+                         --rope-scaling linear to replace the scheme, or --rope-scaling none \
+                         to drop it."
+                    )),
+                }
+            }
+        }
+    }
+
+    /// The `factor` a forced `linear` scheme should use.
+    ///
+    /// `--rope-freq-scale` when given (as its reciprocal), then the
+    /// checkpoint's own factor when the block already named one, then `1.0`.
+    /// The last case is a deliberate no-op rather than an error: `--rope-scaling
+    /// linear` alone is how an operator asks for "linear, whatever the model
+    /// says", and b10621 resolves it the same way.
+    fn linear_factor(&self, declared: Option<&RopeScalingSpec>) -> f32 {
+        if let Some(freq_scale) = self.freq_scale {
+            return 1.0 / freq_scale;
+        }
+        declared
+            .and_then(|s| s.factor)
+            .filter(|f| f.is_finite() && *f > 0.0)
+            .unwrap_or(1.0)
+    }
+
+    /// The RoPE base after this override, given the checkpoint's own.
+    pub fn apply_to_base(&self, declared: f32) -> f32 {
+        self.freq_base.unwrap_or(declared)
+    }
+}
+
+/// The process-wide override, installed once before the first model load.
+static INSTALLED: OnceLock<Option<RopeRuntimeOverride>> = OnceLock::new();
+
+/// How many times a seam has consumed the installed override.
+static APPLICATIONS: AtomicUsize = AtomicUsize::new(0);
+
+/// The first rejection a seam recorded, if any.
+static REJECTION: OnceLock<String> = OnceLock::new();
+
+/// Install the process-wide override before any model is loaded.
+///
+/// Returns `Err` when an override was already installed with a different value,
+/// which can only mean two startup paths raced or a caller installed after the
+/// first load. Installing the same value twice is accepted so a re-entrant
+/// startup (the server's model-switch path reloads through the same code) is
+/// not an error.
+pub fn install(override_value: Option<RopeRuntimeOverride>) -> Result<(), String> {
+    match INSTALLED.set(override_value) {
+        Ok(()) => Ok(()),
+        Err(_) if INSTALLED.get() == Some(&override_value) => Ok(()),
+        Err(_) => Err(format!(
+            "a RoPE runtime override is already installed ({:?}); it must be set once, before \
+             the first model load",
+            INSTALLED.get()
+        )),
+    }
+}
+
+/// The installed override, if the process has one.
+pub fn installed() -> Option<&'static RopeRuntimeOverride> {
+    INSTALLED.get().and_then(|slot| slot.as_ref())
+}
+
+/// How many RoPE seams have consumed the installed override.
+///
+/// Zero after a model load, with an override installed, means the model's
+/// family does not route through [`crate::models::rope_utils`] and the override
+/// had no effect. See the module documentation.
+pub fn applications() -> usize {
+    APPLICATIONS.load(Ordering::Relaxed)
+}
+
+/// Record that a seam consumed the override.
+pub(crate) fn note_application() {
+    APPLICATIONS.fetch_add(1, Ordering::Relaxed);
+}
+
+/// Record why a seam could not apply the override.
+///
+/// Kept rather than returned because the seams sit inside infallible config
+/// readers ([`crate::models::rope_utils::RopeScalingKind::resolve`] cannot
+/// return a `Result` without a load error for every checkpoint that declares an
+/// unimplemented scheme; see its own documentation). Startup reads this after
+/// the load and refuses to serve.
+pub(crate) fn note_rejection(reason: String) {
+    let _ = REJECTION.set(reason);
+}
+
+/// The first rejection a seam recorded since process start.
+pub fn rejection() -> Option<&'static str> {
+    REJECTION.get().map(String::as_str)
+}
+
+/// Confirm that the override an operator asked for actually reached the model.
+///
+/// Called once, on the worker thread, immediately after the checkpoint loads.
+/// Three outcomes:
+///
+/// - No override installed: `Ok(())`, and nothing was ever consulted.
+/// - Override installed and a seam applied it: `Ok(())`.
+/// - Override installed and either no seam saw it, or a seam saw it and could
+///   not serve it: `Err`, naming the checkpoint and what was asked for.
+///
+/// The error is fatal to serving on purpose. A server that starts, answers
+/// requests, and rotates with the checkpoint's own frequencies while the
+/// operator passed `--rope-freq-base` is the exact silent-acceptance failure
+/// epic #1431 exists to remove, and it is invisible from the outside: the
+/// output is fluent either way.
+pub fn verify_applied(model_label: &str) -> Result<(), String> {
+    let Some(over) = installed() else {
+        return Ok(());
+    };
+    if let Some(reason) = rejection() {
+        return Err(format!(
+            "{model_label}: {} could not be applied: {reason}",
+            over.describe()
+        ));
+    }
+    if applications() == 0 {
+        return Err(format!(
+            "{model_label}: {} was accepted on the command line but reached no RoPE code path,              so the model would rotate with the frequencies its own config.json declares. This              architecture computes its rotary frequencies outside the shared              `models::rope_utils` path, where the override is applied; the families that do              route through it are Llama 3.x (and through it Qwen2 / Qwen2.5, Helium, the mllama              text decoder, and every VLM whose text backbone is one of those), Qwen3,              Qwen3-MoE, Apertus, Gemma 3, and InternLM2 / InternLM3. Drop the flag to serve this              checkpoint with its own rotation.",
+            over.describe()
+        ));
+    }
+    Ok(())
+}
+
+/// Apply the installed override to a checkpoint's block, counting the seam.
+///
+/// Returns the block the model should be built from. With no override
+/// installed this is the checkpoint's own block and nothing is counted, so the
+/// hot path for every ordinary load is one relaxed atomic load.
+pub(crate) fn resolve_spec(declared: Option<&RopeScalingSpec>) -> Option<RopeScalingSpec> {
+    let Some(over) = installed() else {
+        return declared.cloned();
+    };
+    note_application();
+    match over.apply_to_spec(declared) {
+        Ok(spec) => spec,
+        Err(reason) => {
+            note_rejection(reason);
+            declared.cloned()
+        }
+    }
+}
+
+/// Apply the installed override to a checkpoint's `rope_theta`, counting the
+/// seam.
+///
+/// Split from [`resolve_spec`] because a model stores its base and its
+/// frequency table in different places: MLX's `fast_rope` takes a base and
+/// `fast_rope_with_freqs` takes a table, never both, so a family keeps the base
+/// on the attention block and the table on the side. Both have to move together
+/// or a `--rope-freq-base` override would reach the table and not the plain
+/// rotation.
+// Used by: Llama 3.x text (and through it Qwen2 / Qwen2.5, Helium, the mllama
+// text decoder, every VLM whose text backbone is Llama3Model or Qwen2Model),
+// Qwen3, Qwen3-MoE, Apertus, Gemma 3, InternLM3 / InternLM2 via
+// dynamic_ntk_rope, and rope_utils' own table builder.
+pub(crate) fn resolve_base(declared: f32) -> f32 {
+    let Some(over) = installed() else {
+        return declared;
+    };
+    note_application();
+    over.apply_to_base(declared)
+}
+
+#[cfg(test)]
+#[path = "rope_overrides_tests.rs"]
+mod tests;

--- a/src/models/rope_overrides_tests.rs
+++ b/src/models/rope_overrides_tests.rs
@@ -1,0 +1,224 @@
+// Copyright 2025-2026 Lablup Inc. and Jeongkyu Shin
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Unit tests for the b10621 RoPE runtime override.
+//!
+//! Everything here exercises the pure decision table
+//! ([`RopeRuntimeOverride::from_flags`] and
+//! [`RopeRuntimeOverride::apply_to_spec`]). The process-wide slot is
+//! deliberately untested at unit level: it is a `OnceLock` shared by every test
+//! binary thread, so a test that installed one would decide what every other
+//! test in the same process rotates with. The seam that reads it is covered
+//! end-to-end instead, in `tests/llama_compat_rope_scaling_override.rs` and
+//! `tests/llama_compat_rope_freq_base.rs`, one configuration per test binary.
+
+use super::*;
+
+fn spec(rope_type: &str, factor: Option<f32>) -> RopeScalingSpec {
+    RopeScalingSpec {
+        rope_type: Some(rope_type.to_string()),
+        factor,
+        ..RopeScalingSpec::default()
+    }
+}
+
+#[test]
+fn no_flags_means_no_override() {
+    assert_eq!(
+        RopeRuntimeOverride::from_flags(None, None, None, None).expect("no flags is not an error"),
+        None
+    );
+}
+
+#[test]
+fn rope_scale_is_the_reciprocal_of_rope_freq_scale() {
+    // b10621: `--rope-scale N` sets rope_freq_scale = 1/N, `--rope-freq-scale
+    // N` sets it to N. Both spellings of "expand the context 8x" must land on
+    // the same stored value.
+    let from_scale = RopeRuntimeOverride::from_flags(None, Some(8.0), None, None)
+        .expect("valid")
+        .expect("an override");
+    let from_freq = RopeRuntimeOverride::from_flags(None, None, Some(0.125), None)
+        .expect("valid")
+        .expect("an override");
+    assert_eq!(from_scale.freq_scale(), Some(0.125));
+    assert_eq!(from_freq.freq_scale(), Some(0.125));
+}
+
+#[test]
+fn the_two_scale_spellings_may_agree_but_not_disagree() {
+    RopeRuntimeOverride::from_flags(None, Some(8.0), Some(0.125), None)
+        .expect("reciprocal values agree");
+
+    let err = RopeRuntimeOverride::from_flags(None, Some(8.0), Some(0.5), None)
+        .expect_err("non-reciprocal values are ambiguous");
+    assert!(err.contains("--rope-scale"), "{err}");
+    assert!(err.contains("--rope-freq-scale"), "{err}");
+}
+
+#[test]
+fn yarn_is_refused_at_the_edge_with_a_reason() {
+    let err = RopeRuntimeOverride::from_flags(Some("yarn"), None, None, None)
+        .expect_err("yarn has no representation on this path");
+    assert!(err.contains("not implemented"), "{err}");
+    // Naming the families that DO serve YaRN from their own config is what
+    // stops the message reading as "mlxcel cannot do YaRN at all".
+    assert!(err.contains("DeepSeek"), "{err}");
+}
+
+#[test]
+fn an_unknown_scheme_names_the_accepted_domain() {
+    let err = RopeRuntimeOverride::from_flags(Some("dynamic"), None, None, None)
+        .expect_err("b10621 accepts three spellings");
+    assert!(err.contains("{none,linear,yarn}"), "{err}");
+}
+
+#[test]
+fn non_positive_and_non_finite_scalars_are_refused() {
+    for (scale, freq_scale, base) in [
+        (Some(0.0), None, None),
+        (Some(-2.0), None, None),
+        (None, Some(f32::NAN), None),
+        (None, Some(f32::INFINITY), None),
+        (None, None, Some(0.0)),
+        (None, None, Some(-10000.0)),
+    ] {
+        let err = RopeRuntimeOverride::from_flags(None, scale, freq_scale, base).expect_err(
+            "a non-positive or non-finite factor produces NaN logits with no error anywhere",
+        );
+        assert!(err.contains("positive finite"), "{err}");
+    }
+}
+
+#[test]
+fn scaling_none_drops_the_checkpoints_own_block() {
+    let over = RopeRuntimeOverride::from_flags(Some("none"), None, None, None)
+        .expect("valid")
+        .expect("an override");
+    let declared = spec("llama3", Some(8.0));
+    assert_eq!(
+        over.apply_to_spec(Some(&declared)).expect("none applies"),
+        None
+    );
+}
+
+#[test]
+fn scaling_linear_with_a_scale_sets_the_reciprocal_factor() {
+    let over = RopeRuntimeOverride::from_flags(Some("linear"), Some(4.0), None, None)
+        .expect("valid")
+        .expect("an override");
+    let resolved = over
+        .apply_to_spec(None)
+        .expect("linear applies")
+        .expect("a block");
+    assert_eq!(resolved.rope_type(), "linear");
+    assert_eq!(resolved.factor, Some(4.0));
+}
+
+#[test]
+fn scaling_linear_without_a_scale_keeps_the_checkpoints_factor() {
+    let over = RopeRuntimeOverride::from_flags(Some("linear"), None, None, None)
+        .expect("valid")
+        .expect("an override");
+    let declared = spec("llama3", Some(8.0));
+    let resolved = over
+        .apply_to_spec(Some(&declared))
+        .expect("linear applies")
+        .expect("a block");
+    assert_eq!(resolved.rope_type(), "linear");
+    assert_eq!(resolved.factor, Some(8.0));
+}
+
+#[test]
+fn scaling_linear_on_a_checkpoint_with_no_block_is_a_no_op_factor() {
+    let over = RopeRuntimeOverride::from_flags(Some("linear"), None, None, None)
+        .expect("valid")
+        .expect("an override");
+    let resolved = over
+        .apply_to_spec(None)
+        .expect("linear applies")
+        .expect("a block");
+    assert_eq!(resolved.factor, Some(1.0));
+}
+
+#[test]
+fn a_bare_scale_defaults_to_linear_when_the_model_names_no_scheme() {
+    // b10621's help text: "defaults to linear unless specified by the model".
+    let over = RopeRuntimeOverride::from_flags(None, Some(2.0), None, None)
+        .expect("valid")
+        .expect("an override");
+    for declared in [
+        None,
+        Some(spec("default", None)),
+        Some(spec("linear", Some(4.0))),
+    ] {
+        let resolved = over
+            .apply_to_spec(declared.as_ref())
+            .expect("linear applies")
+            .expect("a block");
+        assert_eq!(resolved.rope_type(), "linear");
+        assert_eq!(resolved.factor, Some(2.0));
+    }
+}
+
+#[test]
+fn a_bare_scale_over_a_banded_scheme_is_refused_rather_than_composed() {
+    // The one combination with no defensible answer: llama.cpp multiplies its
+    // own rope_freq_scale into the banded rotation, mlxcel's llama3 table has
+    // no such multiplier, and silently dropping either half changes the
+    // rotation without saying so.
+    let over = RopeRuntimeOverride::from_flags(None, Some(2.0), None, None)
+        .expect("valid")
+        .expect("an override");
+    let declared = spec("llama3", Some(8.0));
+    let err = over
+        .apply_to_spec(Some(&declared))
+        .expect_err("a scale on top of llama3 is ambiguous");
+    assert!(err.contains("llama3"), "{err}");
+    assert!(err.contains("--rope-scaling linear"), "{err}");
+}
+
+#[test]
+fn a_base_only_override_leaves_the_block_alone() {
+    let over = RopeRuntimeOverride::from_flags(None, None, None, Some(1_000_000.0))
+        .expect("valid")
+        .expect("an override");
+    let declared = spec("llama3", Some(8.0));
+    let resolved = over
+        .apply_to_spec(Some(&declared))
+        .expect("a base override touches no block")
+        .expect("a block");
+    assert_eq!(resolved.rope_type(), "llama3");
+    assert_eq!(resolved.factor, Some(8.0));
+    assert_eq!(over.apply_to_base(500_000.0), 1_000_000.0);
+}
+
+#[test]
+fn a_base_is_left_at_the_checkpoints_value_when_no_base_flag_was_given() {
+    let over = RopeRuntimeOverride::from_flags(Some("none"), None, None, None)
+        .expect("valid")
+        .expect("an override");
+    assert_eq!(over.apply_to_base(500_000.0), 500_000.0);
+}
+
+#[test]
+fn describe_names_every_flag_that_was_set() {
+    let over = RopeRuntimeOverride::from_flags(Some("linear"), Some(4.0), None, Some(10_000.0))
+        .expect("valid")
+        .expect("an override");
+    let described = over.describe();
+    assert!(described.contains("--rope-scaling linear"), "{described}");
+    assert!(described.contains("--rope-freq-scale 0.25"), "{described}");
+    assert!(described.contains("--rope-freq-base 10000"), "{described}");
+}

--- a/src/models/rope_utils.rs
+++ b/src/models/rope_utils.rs
@@ -28,6 +28,14 @@
 //! `Qwen2Model`, the `llama` / `mistral` pipeline stage executors and the
 //! tensor-parallel Llama runtime), Qwen3 / Qwen3-MoE, Apertus, Gemma 3, and
 //! InternLM3 / InternLM2 through `dynamic_ntk_rope`.
+//!
+//! Since #1450 this is also the seam llama-server b10621's `--rope-scaling`,
+//! `--rope-scale`, `--rope-freq-scale` and `--rope-freq-base` are applied at:
+//! [`RopeScalingKind::resolve`] consults [`crate::models::rope_overrides`]
+//! before it reads the checkpoint's block or its base. The list above is
+//! therefore also the list of families that honor the override, and a family
+//! added to it starts honoring it with no other change; one that is not on it
+//! is reported at startup rather than silently ignoring the flag.
 
 use mlxcel_core::{MlxArray, UniquePtr};
 use serde::{Deserialize, Deserializer};
@@ -145,6 +153,15 @@ impl RopeScalingKind {
         base: f32,
         model_label: &str,
     ) -> Self {
+        // An operator-supplied `--rope-scaling` / `--rope-scale` /
+        // `--rope-freq-scale` / `--rope-freq-base` replaces the checkpoint's own
+        // block and base here, before the table is built and therefore before
+        // any layer or KV cache exists. With no override installed both calls
+        // hand back what they were given.
+        let overridden = super::rope_overrides::resolve_spec(spec);
+        let spec = overridden.as_ref();
+        let base = super::rope_overrides::resolve_base(base);
+
         let Some(spec) = spec else {
             return Self::Default;
         };

--- a/src/server/cli_input.rs
+++ b/src/server/cli_input.rs
@@ -470,6 +470,11 @@ pub struct ServerStartupInput {
     pub diffusion_sampler: String,
     /// `--diffusion-threshold` (issue #217 phase 3). Diffusion models only.
     pub diffusion_threshold: f32,
+    /// llama-server b10621 RoPE / YaRN runtime overrides, straight off the
+    /// shared clap group. Resolved (and refused, when unserveable) by
+    /// [`ServerStartupInput::into_startup_config`] so both server binaries
+    /// reject the same command lines with the same message.
+    pub rope: crate::cli::rope_args::RopeOverrideArgs,
 }
 
 impl ServerStartupInput {
@@ -482,6 +487,15 @@ impl ServerStartupInput {
     /// confusing state where the operator thinks they configured kwargs but
     /// didn't.
     pub fn into_startup_config(self) -> anyhow::Result<ServerStartupConfig> {
+        // Resolved before anything else so an unserveable rotation request
+        // fails the command line rather than the first token. The two failure
+        // modes are a YaRN request (no arm on the shared RoPE path) and a
+        // self-contradictory RoPE request; both are startup errors by epic
+        // #1431's rule that a value-bearing option is never silently ignored.
+        let rope_override = self
+            .rope
+            .resolve()
+            .map_err(|message| anyhow::anyhow!("{message}"))?;
         let resolution =
             resolve_prefill_chunk_size(self.prefill_chunk_size, self.batch_size, self.ubatch_size);
         // resolve the server-wide thinking budget once, up-front.
@@ -761,6 +775,7 @@ impl ServerStartupInput {
             max_denoising_steps: self.max_denoising_steps,
             diffusion_sampler: self.diffusion_sampler,
             diffusion_threshold: self.diffusion_threshold,
+            rope_override,
         })
     }
 }

--- a/src/server/cli_input_tests.rs
+++ b/src/server/cli_input_tests.rs
@@ -177,6 +177,7 @@ fn sample_input() -> ServerStartupInput {
         max_denoising_steps: None,
         diffusion_sampler: "entropy-bound".to_string(),
         diffusion_threshold: 0.9,
+        rope: crate::cli::rope_args::RopeOverrideArgs::default(),
     }
 }
 

--- a/src/server/model_worker.rs
+++ b/src/server/model_worker.rs
@@ -278,6 +278,18 @@ pub(crate) fn spawn_model_worker_with_batch_config(
                         load_elapsed.as_secs_f64(),
                         snap.active_bytes as f64 / (1024.0 * 1024.0 * 1024.0),
                     );
+                    // A `--rope-scaling` / `--rope-scale` / `--rope-freq-base`
+                    // request that reached no RoPE code path is fatal to
+                    // serving, not a warning: the server would answer every
+                    // request with the checkpoint's own rotation, fluently, and
+                    // nothing downstream would ever say otherwise (#1450).
+                    if let Err(message) =
+                        crate::models::rope_overrides::verify_applied(&worker_model_id)
+                    {
+                        chat_unavailable.store(true, Ordering::Release);
+                        tracing::error!("{message}");
+                        return;
+                    }
                     loaded.store(true, Ordering::Release);
                     (model, tokenizer)
                 }
@@ -965,6 +977,18 @@ pub(crate) fn spawn_legacy_model_worker(
                         load_elapsed.as_secs_f64(),
                         snap.active_bytes as f64 / (1024.0 * 1024.0 * 1024.0),
                     );
+                    // A `--rope-scaling` / `--rope-scale` / `--rope-freq-base`
+                    // request that reached no RoPE code path is fatal to
+                    // serving, not a warning: the server would answer every
+                    // request with the checkpoint's own rotation, fluently, and
+                    // nothing downstream would ever say otherwise (#1450).
+                    if let Err(message) =
+                        crate::models::rope_overrides::verify_applied(&worker_model_id)
+                    {
+                        chat_unavailable.store(true, Ordering::Release);
+                        tracing::error!("{message}");
+                        return;
+                    }
                     loaded.store(true, Ordering::Release);
                     (model, tokenizer)
                 }

--- a/src/server/routes/props.rs
+++ b/src/server/routes/props.rs
@@ -50,6 +50,30 @@ pub(crate) fn default_generation_settings(config: &ServerConfig) -> serde_json::
         // operator typed, because the IDs are what the sampler compares
         // against and what a per-request `dry_sequence_breakers` overrides.
         "dry_sequence_breakers": config.default_dry_sequence_breakers,
+        // Context and batch geometry, reported for the same reason the
+        // sampling defaults are: an operator passes `--ctx-size` and
+        // `--batch-size` and has no other way to confirm what the server
+        // resolved them to (#1450). `n_ctx` is the PER-SLOT window, which is
+        // the number a request is actually bounded by, not the `--ctx-size`
+        // total: `--ctx-size 8192 --parallel 4` gives each slot 2048. That
+        // matches llama-server, whose `/props` also reports the per-slot
+        // `n_ctx` rather than the aggregate. `0` means the checkpoint's own
+        // trained context, which mlxcel does not clamp.
+        "n_ctx": config.context_size,
+        // The logical prefill batch `--batch-size` / `-b` resolves to.
+        // mlxcel has no separate physical micro-batch (`--ubatch-size` is
+        // accepted and ignored on unified memory), so the two are reported at
+        // the same value rather than one of them being invented.
+        "n_batch": config.prefill_chunk_size,
+        "n_ubatch": config.prefill_chunk_size,
+        // The decode batch width `--max-batch-size` (or `--parallel`)
+        // resolved to, before the scheduler's per-family clamp.
+        "n_batch_decode": config.max_batch_size,
+        // The KV live-window cap in tokens, `null` when unbounded. Folds
+        // `--max-kv-size` and the per-slot share of `--ctx-size` together the
+        // way `resolve_context_kv_cap` does, so what is reported is the bound
+        // that is actually enforced.
+        "n_kv_max": config.max_kv_size,
     })
 }
 

--- a/src/server/routes/props_tests.rs
+++ b/src/server/routes/props_tests.rs
@@ -70,7 +70,12 @@ fn props_reports_exactly_the_documented_key_set() {
             "dry_sequence_breakers",
             "frequency_penalty",
             "min_p",
+            "n_batch",
+            "n_batch_decode",
+            "n_ctx",
+            "n_kv_max",
             "n_predict",
+            "n_ubatch",
             "presence_penalty",
             "repeat_last_n",
             "repeat_penalty",
@@ -82,6 +87,44 @@ fn props_reports_exactly_the_documented_key_set() {
         "the /props payload key set changed. Adding a key is fine, update this list; \
          losing one is a silent break for anyone reading it back."
     );
+}
+
+/// The resolved context and batch geometry an operator passed on the command
+/// line has to come back out somewhere, or `--ctx-size` and `--batch-size` are
+/// only confirmable by reading the source (#1450). `n_ctx` in particular is the
+/// per-slot window rather than the `--ctx-size` total, which is the number a
+/// single request is bounded by and the one llama-server reports.
+#[test]
+fn props_reports_the_resolved_context_and_batch_geometry() {
+    let config = ServerConfig {
+        context_size: 2048,
+        n_parallel: 4,
+        max_batch_size: 4,
+        prefill_chunk_size: 1024,
+        max_kv_size: Some(2048),
+        ..ServerConfig::default()
+    };
+    let settings = default_generation_settings(&config);
+
+    assert_eq!(settings["n_ctx"], 2048);
+    assert_eq!(settings["n_batch"], 1024);
+    // mlxcel has no separate physical micro-batch, so `n_ubatch` reports the
+    // same logical batch rather than a number nothing enforces.
+    assert_eq!(settings["n_ubatch"], 1024);
+    assert_eq!(settings["n_batch_decode"], 4);
+    assert_eq!(settings["n_kv_max"], 2048);
+}
+
+/// An unbounded KV window is reported as JSON `null`, not as `0`: `0` is a
+/// legal cap value elsewhere in this payload and conflating the two would make
+/// "no limit" and "limit of zero" indistinguishable to a client.
+#[test]
+fn props_reports_an_unbounded_kv_window_as_null() {
+    let settings = default_generation_settings(&ServerConfig {
+        max_kv_size: None,
+        ..ServerConfig::default()
+    });
+    assert!(settings["n_kv_max"].is_null(), "{}", settings["n_kv_max"]);
 }
 
 #[test]

--- a/src/server/startup.rs
+++ b/src/server/startup.rs
@@ -416,6 +416,17 @@ pub struct ServerStartupConfig {
     pub diffusion_sampler: String,
     /// `--diffusion-threshold` (issue #217 phase 3).
     pub diffusion_threshold: f32,
+
+    /// Resolved llama-server b10621 RoPE override (`--rope-scaling`,
+    /// `--rope-scale`, `--rope-freq-base`, `--rope-freq-scale`), or `None` when
+    /// the operator asked for the checkpoint's own rotation.
+    ///
+    /// Installed process-wide by [`start_server`] before the model worker
+    /// loads anything, because every model family reads its own `config.json`
+    /// inside its own loader and there is no argument to thread. See
+    /// [`crate::models::rope_overrides`] for why that installation is verified
+    /// afterwards rather than trusted.
+    pub rope_override: Option<crate::models::rope_overrides::RopeRuntimeOverride>,
 }
 
 impl Default for ServerStartupConfig {
@@ -550,6 +561,7 @@ impl Default for ServerStartupConfig {
             max_denoising_steps: None,
             diffusion_sampler: "entropy-bound".to_string(),
             diffusion_threshold: 0.9,
+            rope_override: None,
         }
     }
 }
@@ -1815,9 +1827,54 @@ pub async fn start_server(mut startup: ServerStartupConfig) -> Result<()> {
         anyhow::bail!("--dry-run was requested but --pp-auto was not provided; nothing to plan");
     }
 
+    // Install the b10621 RoPE override before anything can load a checkpoint.
+    // It is process-wide because each model family reads its own `config.json`
+    // inside its own loader, so there is no argument to thread; the worker
+    // confirms it actually reached the model once the load returns
+    // (`rope_overrides::verify_applied`).
+    crate::models::rope_overrides::install(startup.rope_override)
+        .map_err(|message| anyhow::anyhow!("{message}"))?;
+    if let Some(over) = startup.rope_override.as_ref() {
+        tracing::info!(
+            "RoPE runtime override: {} (applied to the checkpoint's rope_scaling block and \
+             rope_theta before the model is built)",
+            over.describe()
+        );
+    }
+
     validate_parallel_context_startup(&startup)?;
     validate_pipeline_parallel_startup(&startup)?;
     let tp_support = resolve_tensor_parallel_runtime_support(&startup)?;
+
+    // One line naming what the context and batch flags actually resolved to.
+    // Until #1450 none of these was logged anywhere: `--ctx-size` reached a
+    // per-slot divisor and a KV cap and the operator had no way to see either
+    // number, so an aggregate that silently became 512 per slot looked exactly
+    // like one that stayed at 8192. The per-slot value is the one a single
+    // request is bounded by, so it is reported next to the total rather than
+    // instead of it.
+    {
+        let slots = effective_parallel_context_slots(
+            startup.n_parallel,
+            startup.max_batch_size,
+            startup.no_batch,
+        );
+        let per_slot = resolve_parallel_context_size(
+            startup.ctx_size,
+            startup.n_parallel,
+            startup.max_batch_size,
+            startup.no_batch,
+        );
+        tracing::info!(
+            ctx_size = startup.ctx_size,
+            ctx_size_per_slot = per_slot,
+            context_slots = slots,
+            n_parallel = startup.n_parallel,
+            prefill_chunk_size = startup.prefill_chunk_size,
+            max_kv_size = ?startup.max_kv_size,
+            "resolved context and batch geometry (0 = the checkpoint's own trained context)"
+        );
+    }
 
     if startup.ubatch_size_provided {
         tracing::info!("--ubatch-size is not applicable on Apple Silicon unified memory; ignored");

--- a/tests/llama_compat_rope_freq_base.rs
+++ b/tests/llama_compat_rope_freq_base.rs
@@ -1,0 +1,126 @@
+// Copyright 2025-2026 Lablup Inc. and Jeongkyu Shin
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! End-to-end contract for llama-server b10621's `--rope-freq-base` override
+//! (issue #1450). One configuration per process; see the header of
+//! `llama_compat_rope_scaling_override.rs` for why.
+//!
+//! # The assertion without a reference run
+//!
+//! A process that has installed a base override cannot also produce the
+//! un-overridden table to compare against, so this checks a property instead:
+//! under `--rope-freq-base B`, two resolves that declare *different* bases must
+//! produce the *same* table, because both were replaced by `B`. Without the
+//! override those two tables differ in every entry, so the property is not
+//! satisfiable by accident. A third resolve pins the absolute value by
+//! declaring `B` itself.
+
+use mlxcel::cli::rope_args::RopeOverrideArgs;
+use mlxcel::models::rope_overrides;
+use mlxcel::models::rope_utils::{RopeScalingKind, RopeScalingSpec};
+
+const DIMS: usize = 64;
+const OVERRIDE_BASE: f32 = 1_000_000.0;
+
+fn llama3_spec() -> RopeScalingSpec {
+    RopeScalingSpec {
+        rope_type: Some("llama3".to_string()),
+        factor: Some(32.0),
+        low_freq_factor: Some(1.0),
+        high_freq_factor: Some(4.0),
+        original_max_position_embeddings: Some(8192.0),
+    }
+}
+
+/// Read a resolved kind's frequency table as `f32`.
+fn table(kind: &RopeScalingKind) -> Vec<f32> {
+    let freqs = kind.freqs().expect("a llama3 block builds a table");
+    let f32s = mlxcel_core::astype(freqs, mlxcel_core::dtype::FLOAT32);
+    mlxcel_core::eval(&f32s);
+    mlxcel_core::array_to_raw_bytes(&f32s)
+        .chunks_exact(4)
+        .map(|c| f32::from_le_bytes([c[0], c[1], c[2], c[3]]))
+        .collect()
+}
+
+#[test]
+fn rope_freq_base_replaces_the_checkpoints_rope_theta_in_the_table() {
+    // Without an override, two different declared bases give two different
+    // tables. Establishing that first is what makes the post-install equality
+    // meaningful rather than vacuous.
+    let before_500k = table(&RopeScalingKind::resolve(
+        Some(&llama3_spec()),
+        DIMS,
+        500_000.0,
+        "probe",
+    ));
+    let before_10k = table(&RopeScalingKind::resolve(
+        Some(&llama3_spec()),
+        DIMS,
+        10_000.0,
+        "probe",
+    ));
+    assert_eq!(before_500k.len(), DIMS / 2);
+    assert!(
+        before_500k
+            .iter()
+            .zip(&before_10k)
+            .any(|(a, b)| (a - b).abs() > 1e-6),
+        "the declared base must matter before anything overrides it"
+    );
+
+    let requested = RopeOverrideArgs {
+        rope_freq_base: Some(OVERRIDE_BASE),
+        ..RopeOverrideArgs::default()
+    }
+    .resolve()
+    .expect("--rope-freq-base is serveable")
+    .expect("it is an override");
+    rope_overrides::install(Some(requested)).expect("first install in this process");
+
+    let after_500k = table(&RopeScalingKind::resolve(
+        Some(&llama3_spec()),
+        DIMS,
+        500_000.0,
+        "probe",
+    ));
+    let after_10k = table(&RopeScalingKind::resolve(
+        Some(&llama3_spec()),
+        DIMS,
+        10_000.0,
+        "probe",
+    ));
+    let at_override = table(&RopeScalingKind::resolve(
+        Some(&llama3_spec()),
+        DIMS,
+        OVERRIDE_BASE,
+        "probe",
+    ));
+
+    assert_eq!(
+        after_500k, after_10k,
+        "under --rope-freq-base the checkpoint's own rope_theta must not reach the table"
+    );
+    assert_eq!(
+        after_500k, at_override,
+        "the table must be the one the requested base builds, not merely a consistent one"
+    );
+    assert_ne!(
+        after_500k, before_500k,
+        "the override must actually move the frequencies"
+    );
+
+    assert_eq!(rope_overrides::rejection(), None);
+    rope_overrides::verify_applied("probe").expect("the override reached the rotation");
+}

--- a/tests/llama_compat_rope_scaling_override.rs
+++ b/tests/llama_compat_rope_scaling_override.rs
@@ -1,0 +1,130 @@
+// Copyright 2025-2026 Lablup Inc. and Jeongkyu Shin
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! End-to-end contract for llama-server b10621's `--rope-scaling` override
+//! (issue #1450).
+//!
+//! # Why this is a whole test binary for one test
+//!
+//! The override is process-wide by construction: every model family reads its
+//! own `config.json` inside its own loader, so there is no argument to thread
+//! from the CLI down to the rotation (see `mlxcel::models::rope_overrides`).
+//! `install` is therefore a `OnceLock`, and a second test in the same process
+//! that installed a different value would decide what the first one rotates
+//! with. `docs/benchmarks.md` handles the same problem for `MLXCEL_QMV_WIDE`
+//! the same way: one configuration per process.
+//!
+//! Cargo gives each `tests/*.rs` file its own binary, so a file with exactly
+//! one test is exactly one configuration. The sibling file
+//! `llama_compat_rope_freq_base.rs` covers `--rope-freq-base` in its own
+//! process for the same reason, and the pure decision table (which needs no
+//! global at all) is unit-tested in `src/models/rope_overrides_tests.rs`.
+//!
+//! # What is asserted
+//!
+//! The whole lifecycle, in the order a server executes it: an uninstalled
+//! process is unaffected, an installed-but-unconsumed override refuses to
+//! serve, a seam consumes it and the rotation actually changes, and the
+//! verification then passes.
+
+use mlxcel::cli::rope_args::RopeOverrideArgs;
+use mlxcel::models::rope_overrides::{self, RopeRuntimeOverride};
+use mlxcel::models::rope_utils::{RopeScalingKind, RopeScalingSpec};
+
+/// The `rope_scaling` block Llama 3.1 / 3.2 checkpoints ship.
+fn llama3_spec() -> RopeScalingSpec {
+    RopeScalingSpec {
+        rope_type: Some("llama3".to_string()),
+        factor: Some(32.0),
+        low_freq_factor: Some(1.0),
+        high_freq_factor: Some(4.0),
+        original_max_position_embeddings: Some(8192.0),
+    }
+}
+
+const DIMS: usize = 64;
+const BASE: f32 = 500_000.0;
+
+#[test]
+fn rope_scaling_none_replaces_the_checkpoints_banded_table_and_is_verified() {
+    // 1. Nothing installed: the checkpoint's own block decides, and the
+    //    post-load verification has nothing to check.
+    assert!(
+        rope_overrides::installed().is_none(),
+        "this binary must start with no override installed"
+    );
+    let declared = RopeScalingKind::resolve(Some(&llama3_spec()), DIMS, BASE, "probe");
+    assert!(
+        declared.freqs().is_some(),
+        "a llama3 block builds a frequency table when nothing overrides it"
+    );
+    assert_eq!(rope_overrides::applications(), 0);
+    rope_overrides::verify_applied("probe")
+        .expect("with no override installed there is nothing to verify");
+
+    // 2. Install what `--rope-scaling none` resolves to, through the same
+    //    flag group the server binaries flatten, so this test cannot pass
+    //    against a value the CLI could never produce.
+    let requested = RopeOverrideArgs {
+        rope_scaling: Some("none".to_string()),
+        ..RopeOverrideArgs::default()
+    }
+    .resolve()
+    .expect("--rope-scaling none is serveable")
+    .expect("it is an override");
+    assert_eq!(
+        requested,
+        RopeRuntimeOverride::from_flags(Some("none"), None, None, None)
+            .expect("valid")
+            .expect("an override"),
+    );
+    rope_overrides::install(Some(requested)).expect("first install in this process");
+
+    // 3. Installed but not yet consumed: refusing to serve is the point. A
+    //    server that started here would answer every request with the
+    //    checkpoint's own rotation and say nothing.
+    let refusal = rope_overrides::verify_applied("some-architecture-off-the-seam")
+        .expect_err("an override that reached no RoPE path must not be served");
+    assert!(
+        refusal.contains("some-architecture-off-the-seam"),
+        "{refusal}"
+    );
+    assert!(refusal.contains("--rope-scaling none"), "{refusal}");
+    // The message has to say which families DO honor it, or an operator has no
+    // way to tell "wrong flag" from "wrong checkpoint".
+    assert!(refusal.contains("Qwen3"), "{refusal}");
+
+    // 4. The seam consumes it, and the rotation changes: the banded table is
+    //    gone and the plain `base^(2i/d)` rotation is back.
+    let overridden = RopeScalingKind::resolve(Some(&llama3_spec()), DIMS, BASE, "probe");
+    assert!(
+        overridden.freqs().is_none(),
+        "--rope-scaling none must drop the checkpoint's llama3 table"
+    );
+    assert_eq!(
+        overridden.scale(),
+        1.0,
+        "the plain table rotates at unit position scale"
+    );
+    assert!(rope_overrides::applications() > 0);
+
+    // 5. Verification now passes, and no seam recorded a rejection.
+    assert_eq!(rope_overrides::rejection(), None);
+    rope_overrides::verify_applied("probe").expect("the override reached the rotation");
+
+    // 6. Re-installing the same value is accepted (the server's model-switch
+    //    path re-enters startup), a different one is not.
+    rope_overrides::install(Some(requested)).expect("the same value installs idempotently");
+    rope_overrides::install(None).expect_err("a different value must not silently replace it");
+}


### PR DESCRIPTION
## Summary

Implements llama-server b10621's four RoPE runtime overrides for real, refuses the five YaRN knobs at anything other than upstream's sentinel, and makes the resolved context and batch geometry observable. Everything in this shard that is not implemented now carries a specific, machine-readable divergence instead of a prose note.

## What changed

- `src/models/rope_overrides.rs` (new): the pure decision table for `--rope-scaling` / `--rope-scale` / `--rope-freq-scale` / `--rope-freq-base`, plus the process-wide slot, the applications counter, and `verify_applied`.
- `src/cli/rope_args.rs` (new): one canonical clap group for the nine b10621 spellings and their `LLAMA_ARG_*` bindings, flattened into both `mlxcel serve` and `mlxcel-server` so the two cannot drift, and `from_env` / `install_from_env` for out-of-band harnesses.
- `src/models/rope_utils.rs`, `dynamic_ntk_rope.rs`, `llama3.rs`, `qwen3.rs`, `qwen3_moe.rs`, `apertus.rs`, `gemma3.rs`: the six families on the shared RoPE path consult the override for both the `rope_scaling` block and the base. On Gemma 3 the base override reaches the global-attention layers only; the sliding layers keep `rope_local_base_freq`, which is llama.cpp's separate `rope_freq_base_train_swa`.
- `src/server/cli_input.rs`, `startup.rs`, `model_worker.rs`: resolve at the CLI edge (an unserveable request fails the command line, not the first token), install before anything can load a checkpoint, and verify after the load returns.
- `src/server/routes/props.rs`: `/props` reports `n_ctx`, `n_batch`, `n_ubatch`, `n_batch_decode` and `n_kv_max`. `n_ctx` is the per-slot window rather than the `--ctx-size` total, matching llama-server and matching what a single request is actually bounded by.
- `examples/logit_trace.rs`: installs the override from `LLAMA_ARG_ROPE_*` and records it in the trace header, so the two arms of a comparison are two processes selected the same way the server selects them.
- `compat/llama-server/b10621/runtime-and-context.json`: four entries to `supported`; thirteen others get precise `divergence` lists.
- `docs/llama-server-compat.md`: an operator-facing section covering the flags, the two refusals, which architectures honor the override and why there is no list of them in the code, and how to validate a change to this path.

## Why the applications counter rather than an architecture list

Every model family reads its own `config.json` inside its own `load()`, so there is no argument to thread from the CLI down to the rotation, and only six families route through `models::rope_utils`. An override reaching none of them would leave the server answering every request with the checkpoint's own frequencies, fluently, with nothing to say otherwise, which is exactly the silent acceptance epic #1431 is about. A hand-maintained table of honoring `ModelType`s goes stale the moment a family is ported, so each seam increments a counter instead and the worker refuses to serve when an override was requested and the counter is still zero after the load. A family that wires itself into `rope_utils` starts being accepted with no list to update; one that does not is named in the error alongside the ones that are.

## What is deliberately refused

`--rope-scaling yarn` has no representation on a path that builds `default`, `linear` and `llama3` tables only, and the nearest thing (falling back to the unscaled table) is the silent degradation this work exists to prevent. A bare `--rope-scale` or `--rope-freq-scale` on a checkpoint declaring a banded scheme is refused for the same reason: llama.cpp multiplies its `rope_freq_scale` into that rotation, mlxcel's banded table has no such multiplier, and dropping either half changes the result without saying so. The five `--yarn-*` flags are accepted at b10621's sentinels (`-1.0`, `0` for `--yarn-orig-ctx`), which upstream defines as "use the values the model was trained with", so a deployment script spelling out the upstream defaults keeps working; any other value is a startup error naming every offending flag in one message.

## Numerical validation

Teacher-forced logit trace per `docs/benchmarks.md`, `mlx-community/Llama-3.2-1B-Instruct-4bit` (`rope_theta` 500000, `rope_scaling` llama3 factor 32), 8192 traced positions across four 2048-wide chunks with 4096 tokens of preceding context, 2464 decided positions at gap >= 2.0. Short prompts are blind to this class of defect, so the shape matters: the traced positions of chunk `c` start at `c * CHUNK_TOKENS`, which is why a narrow chunk cannot reach a long position however large the context argument is.

| Arm | top-1 disagreement | on decided positions | true perplexity |
|---|---|---|---|
| `--rope-freq-base 500000` (== the checkpoint's own) vs no override | 0 / 8192 (0.000%) | 0 / 2464 (0.000%) | 29.5 -> 29.5 |
| `--rope-scaling none` vs the checkpoint's llama3 table | 1352 / 8192 (16.504%) | 14 / 2464 (0.568%) | 29.5 -> 32.2 |
| `--rope-scaling none` vs `--rope-scaling linear --rope-scale 1` | 0 / 8192 (0.000%) | 0 / 2444 (0.000%) | 32.2 -> 32.2 |
| `--rope-freq-base 100000` vs the checkpoint's 500000 | 2496 / 8192 (30.469%) | 131 / 2464 (5.317%) | 29.5 -> 40.7 |
| `--rope-scaling linear --rope-scale 32` vs llama3 factor 32 | 7606 / 8192 (92.847%) | 2283 / 2464 (92.654%) | 29.5 -> 3559 |

The first row is the control that matters most: requesting the base the checkpoint already declares must come back byte-identical, which separates "the override moved the rotation" from "the override plumbing perturbs the model". The third row shows two spellings of one request agreeing byte for byte. The fifth shows `linear` and `llama3` at the same factor are emphatically not the same rotation, which is the conflation a naive implementation would make. Every override degrades long-context quality against a correctly configured checkpoint, which is the expected direction. Note that `scripts/compare_logit_traces.py` prints `exp(mean log-prob)`, the reciprocal of perplexity, so its negative percentages are quality regressions; the table above states true perplexity.

## Scope this issue does not close

`--keep`, `--swa-full`, `--context-shift`, `field:n_keep` and `field:n_discard` stay `deferred`, now with their observable divergences recorded rather than described in prose: the retained prefix is still the fixed 4-token attention sink in `src/server/batch/scheduler.rs`, KV front-trimming is unconditional once a context bound exists and cannot be disabled (b10621 defaults context shift off and fails an over-long request), and sliding-window families build their own `RotatingKVCache` inside each model's `make_cache` with no server-side reach into it. `--parallel` records its two real divergences (default 4 against b10621's -1, and -1 rejected by the value parser); the rejection behavior was deliberately established in #1454 one commit ago, so this PR records it rather than reversing it. `--warmup` and `--escape`, which the issue's scope mentions, live in `model-source.json` (#1434) and `chat-templates.json` (#1447), shards this chain does not own; the manifest gate would reject an edit to either.

## Test plan

- [x] `cargo test --profile test-fast --features metal,accelerate --lib models::rope` (37 passed)
- [x] `cargo test --profile test-fast --features metal,accelerate --lib server::cli_input` (98 passed), `--lib server::startup` (61), `--lib server::llama_compat` (3), `--lib server::routes::props` (8)
- [x] `cargo test --profile test-fast --features metal,accelerate --test llama_compat_manifest` (4 passed, including the archive-gated conformance test run against the verified b10621 macOS arm64 archive via `MLXCEL_LLAMA_B10621_DIR`)
- [x] `cargo test --profile test-fast --features metal,accelerate --test llama_compat_rope_scaling_override` and `--test llama_compat_rope_freq_base` (1 each; one configuration per process, because the override is a `OnceLock`)
- [x] `cargo test --profile test-fast --features metal,accelerate --test cli_help_consistency` (25 passed)
- [x] `python3 scripts/ci/check_llama_compat_manifest.py` and `bash scripts/ci/check_llama_compat_manifest_test.sh`
- [x] `cargo clippy --profile test-fast --features metal,accelerate --lib --bins --tests -- -D warnings`, `cargo fmt --all -- --check`, `python3 scripts/ci/check_cross_repo_refs.py`
- [x] Numerical validation on a real checkpoint, as tabulated above

Closes #1450
