### PR TITLE
feat(server): separate the native completion and embedding routes

### DIFF
--- a/compat/llama-server/b10621/routes.json
+++ b/compat/llama-server/b10621/routes.json
@@ -161,9 +161,14 @@
       "discovery": "source-route-registration",
       "state": "deferred",
       "issue": 1441,
-      "test": "src/server/llama_compat_tests.rs",
-      "notes": "mlxcel mounts a native (non-OpenAI) handler here; response-envelope parity with the b10621 native schema is owned by #1441.",
-      "divergence": [],
+      "test": "src/server/routes/native_route_tests.rs",
+      "notes": "Route separation done: /completion and /completions both reach the native handler and answer the b10621 native object (index, content, tokens, id_slot, stop, model, tokens_predicted, tokens_evaluated, generation_settings, prompt, has_new_line, truncated, stop_type, stopping_word, tokens_cached, timings with cache_n), and the streaming form ends with that same object rather than a [DONE] sentinel. The key set and order were taken from a capture of the pinned binary. The remaining differences are listed in divergence and keep this entry deferred; the stop-sequence half is tracked separately as #1466 because the fix belongs to the MLX scheduler and to the field:stop entry in sampling-and-grammar.json.",
+      "divergence": [
+        "String stop sequences reach ServerGenerateOptions and are never enforced on the MLX serving path, so `stop` has no effect on the emitted text and `stop_type` can never report `word` (#1466).",
+        "`generation_settings` echoes the settings mlxcel actually resolved rather than b10621's full task_params block, so keys mlxcel has no analogue for are absent (#1441).",
+        "`id_slot` is always -1: the continuous-batching scheduler exposes no stable per-request slot number (#1441).",
+        "`return_tokens`, `return_progress`, `verbose`, `n_indent`, `t_max_predict_ms` and `n_cmpl` above 1 are refused with a diagnostic rather than honored (#1441)."
+      ],
       "mlxcel": {
         "route": "POST /completion"
       }
@@ -178,9 +183,14 @@
       "discovery": "source-route-registration",
       "state": "deferred",
       "issue": 1441,
-      "test": "src/server/llama_compat_tests.rs",
-      "notes": "SEMANTIC COLLISION: mounted, but mlxcel selects the OpenAI-shaped handler while b10621 serves the native llama-server schema. #1441 owns the split.",
-      "divergence": [],
+      "test": "src/server/routes/native_route_tests.rs",
+      "notes": "Route separation done: /completion and /completions both reach the native handler and answer the b10621 native object (index, content, tokens, id_slot, stop, model, tokens_predicted, tokens_evaluated, generation_settings, prompt, has_new_line, truncated, stop_type, stopping_word, tokens_cached, timings with cache_n), and the streaming form ends with that same object rather than a [DONE] sentinel. The key set and order were taken from a capture of the pinned binary. The remaining differences are listed in divergence and keep this entry deferred; the stop-sequence half is tracked separately as #1466 because the fix belongs to the MLX scheduler and to the field:stop entry in sampling-and-grammar.json.",
+      "divergence": [
+        "String stop sequences reach ServerGenerateOptions and are never enforced on the MLX serving path, so `stop` has no effect on the emitted text and `stop_type` can never report `word` (#1466).",
+        "`generation_settings` echoes the settings mlxcel actually resolved rather than b10621's full task_params block, so keys mlxcel has no analogue for are absent (#1441).",
+        "`id_slot` is always -1: the continuous-batching scheduler exposes no stable per-request slot number (#1441).",
+        "`return_tokens`, `return_progress`, `verbose`, `n_indent`, `t_max_predict_ms` and `n_cmpl` above 1 are refused with a diagnostic rather than honored (#1441)."
+      ],
       "mlxcel": {
         "route": "POST /completions"
       }
@@ -212,10 +222,14 @@
       "discovery": "source-route-registration",
       "state": "deferred",
       "issue": 1441,
-      "test": null,
-      "notes": "Legacy native alias, not mounted. #1441 owns it.",
-      "divergence": [],
-      "mlxcel": null
+      "test": "src/server/routes/native_route_tests.rs",
+      "notes": "Route separation done: /embedding and /embeddings answer b10621's native shape, a bare JSON array of {index, embedding} whose embedding is an array OF arrays, and /v1/embeddings keeps the OpenAI object. /embedding was not mounted at all before this change, and all three paths used to answer the OpenAI shape. The native handler also accepts upstream's legacy `content` spelling for the input. Shape verified against a capture of the pinned binary serving a real embedding checkpoint.",
+      "divergence": [
+        "With no embedding checkpoint loaded the 501 body names the mlxcel flags instead of b10621's \"Start it with `--embeddings`\"; the flag itself is #1452's entry."
+      ],
+      "mlxcel": {
+        "route": "POST /embedding"
+      }
     },
     {
       "kind": "route",
@@ -227,9 +241,11 @@
       "discovery": "source-route-registration",
       "state": "deferred",
       "issue": 1441,
-      "test": "src/server/llama_compat_tests.rs",
-      "notes": "SEMANTIC COLLISION: mounted, but mlxcel selects the OpenAI-shaped handler while b10621 serves the native schema. #1441 owns the split.",
-      "divergence": [],
+      "test": "src/server/routes/native_route_tests.rs",
+      "notes": "Route separation done: /embedding and /embeddings answer b10621's native shape, a bare JSON array of {index, embedding} whose embedding is an array OF arrays, and /v1/embeddings keeps the OpenAI object. /embedding was not mounted at all before this change, and all three paths used to answer the OpenAI shape. The native handler also accepts upstream's legacy `content` spelling for the input. Shape verified against a capture of the pinned binary serving a real embedding checkpoint.",
+      "divergence": [
+        "With no embedding checkpoint loaded the 501 body names the mlxcel flags instead of b10621's \"Start it with `--embeddings`\"; the flag itself is #1452's entry."
+      ],
       "mlxcel": {
         "route": "POST /embeddings"
       }
@@ -521,12 +537,14 @@
       "field_type": "num",
       "description": "Number of completions to generate. If the input has multiple prompts, total outputs will be N prompts times n_cmpl",
       "discovery": "source-schema-declaration",
-      "state": "deferred",
+      "state": "not_applicable",
       "issue": 1441,
-      "test": null,
-      "notes": null,
+      "test": "src/server/routes/native_route_tests.rs",
+      "notes": "No equivalent: mlxcel serves exactly one completion per request, so there is no path that could return b10621's array of results. `n_cmpl` (and its `n` alias) is accepted at 1, the inert value, and any higher value is refused with a 400 naming the field and telling the caller to send one request per completion.",
       "divergence": [],
-      "mlxcel": null
+      "mlxcel": {
+        "field": "n_cmpl"
+      }
     },
     {
       "kind": "native_request_field",
@@ -537,12 +555,14 @@
       "field_type": "num",
       "description": "Specify the minimum line indentation for the generated text in number of whitespace characters. Useful for code completion tasks",
       "discovery": "source-schema-declaration",
-      "state": "deferred",
+      "state": "not_applicable",
       "issue": 1441,
-      "test": null,
-      "notes": null,
+      "test": "src/server/routes/native_route_tests.rs",
+      "notes": "No equivalent: mlxcel has no minimum-indentation stop rule for fill-in-the-middle completions. Accepted at 0, the inert value, and refused with a 400 naming the field otherwise.",
       "divergence": [],
-      "mlxcel": null
+      "mlxcel": {
+        "field": "n_indent"
+      }
     },
     {
       "kind": "native_request_field",
@@ -558,9 +578,11 @@
       "discovery": "source-schema-declaration",
       "state": "deferred",
       "issue": 1441,
-      "test": "src/server/llama_compat_tests.rs",
-      "notes": "VALUE-DOMAIN MISMATCH: NativeCompletionRequest declares n_predict as Option<usize>, so b10621's documented -1 (infinity) is rejected during deserialization. The max_tokens / max_completion_tokens aliases are honored on the OpenAI routes, not here. #1441 owns it.",
-      "divergence": [],
+      "test": "src/server/routes/native_route_tests.rs",
+      "notes": "Accepted, clamped to the effective per-slot context window, and now reachable through b10621's `max_tokens` and `max_completion_tokens` aliases as well. Still deferred because upstream additionally defines `n_predict: 0` as \"evaluate the prompt into the cache and generate nothing\", which mlxcel has not been verified against.",
+      "divergence": [
+        "The `n_predict: 0` prompt-only evaluation upstream defines is unverified on mlxcel (#1441)."
+      ],
       "mlxcel": {
         "field": "n_predict"
       }
@@ -590,12 +612,14 @@
       "field_type": "bool",
       "description": "Include prompt processing progress events in stream mode",
       "discovery": "source-schema-declaration",
-      "state": "deferred",
+      "state": "not_applicable",
       "issue": 1441,
-      "test": null,
-      "notes": null,
+      "test": "src/server/routes/native_route_tests.rs",
+      "notes": "No equivalent: the mlxcel scheduler emits no prompt-processing progress events on this path, so there is nothing to attach to a stream frame. Accepted at false, the inert value, and refused with a 400 naming the field otherwise.",
       "divergence": [],
-      "mlxcel": null
+      "mlxcel": {
+        "field": "return_progress"
+      }
     },
     {
       "kind": "native_request_field",
@@ -606,12 +630,14 @@
       "field_type": "bool",
       "description": "Return the raw generated token ids in the `tokens` field",
       "discovery": "source-schema-declaration",
-      "state": "deferred",
+      "state": "not_applicable",
       "issue": 1441,
-      "test": null,
-      "notes": null,
+      "test": "src/server/routes/native_route_tests.rs",
+      "notes": "No equivalent on this path: mlxcel's streaming decoder emits detokenized text and does not surface the raw token ids to the native route. Accepted at false, the inert value, and refused with a 400 naming the field and pointing at POST /tokenize otherwise.",
       "divergence": [],
-      "mlxcel": null
+      "mlxcel": {
+        "field": "return_tokens"
+      }
     },
     {
       "kind": "native_request_field",
@@ -672,12 +698,14 @@
       "field_type": "num",
       "description": "Set a time limit in milliseconds for the prediction phase. The timeout triggers if generation exceeds this time (measured since the first token) and a newline has been generated. Useful for FIM applications",
       "discovery": "source-schema-declaration",
-      "state": "deferred",
+      "state": "not_applicable",
       "issue": 1441,
-      "test": null,
-      "notes": null,
+      "test": "src/server/routes/native_route_tests.rs",
+      "notes": "No per-request equivalent: mlxcel bounds a stalled decode with the server-wide --decode-timeout / MLXCEL_DECODE_TIMEOUT watchdog, which cannot be narrowed per request. Accepted at -1 or 0, the inert values, and refused with a 400 naming the field and the alternative otherwise.",
       "divergence": [],
-      "mlxcel": null
+      "mlxcel": {
+        "field": "t_max_predict_ms"
+      }
     },
     {
       "kind": "native_request_field",
@@ -690,10 +718,14 @@
       "discovery": "source-schema-declaration",
       "state": "deferred",
       "issue": 1441,
-      "test": null,
-      "notes": null,
-      "divergence": [],
-      "mlxcel": null
+      "test": "src/server/routes/native_route_tests.rs",
+      "notes": "Accepted and honored: a streaming frame carries the timing block when it is set and omits it otherwise, which is the observable half of the field. Deferred because the per-frame block reports the running predicted counts with zeroed prompt figures, while upstream reports the real prefill numbers on every frame.",
+      "divergence": [
+        "Per-frame timings report zeroed prompt_n / prompt_ms rather than the real prefill figures (#1441)."
+      ],
+      "mlxcel": {
+        "field": "timings_per_token"
+      }
     },
     {
       "kind": "native_request_field",
@@ -704,12 +736,14 @@
       "field_type": "bool",
       "description": "Include __verbose field in the response with additional debug information",
       "discovery": "source-schema-declaration",
-      "state": "deferred",
+      "state": "not_applicable",
       "issue": 1441,
-      "test": null,
-      "notes": null,
+      "test": "src/server/routes/native_route_tests.rs",
+      "notes": "No equivalent: mlxcel has no __verbose debug block. Accepted at false, the inert value, and refused with a 400 naming the field and pointing at GET /slots and GET /metrics otherwise.",
       "divergence": [],
-      "mlxcel": null
+      "mlxcel": {
+        "field": "verbose"
+      }
     }
   ]
 }

--- a/docs/llama-server-compat.md
+++ b/docs/llama-server-compat.md
@@ -46,6 +46,35 @@ Both fields are entry-level, alongside `state`, `issue`, `test` and `mlxcel`. An
 
 Entries may also carry an `mlxcel` claim block describing what the current binaries already accept: `accepted_spellings`, `accepted_on_one_binary_only`, `env`, `env_binding` (`clap` or a tested `runtime` bridge, with `env_test`), `defaults`, `hidden`, `route`, `field`. That is a closed key set; the validator rejects any other key in the block, so a typo'd key fails the gate instead of silently recording a claim nothing checks. Claims are verified by CI regardless of state, so partial support cannot silently regress. A `deferred` entry keeps its claim: mlxcel does mount `POST /rerank` and does accept `--metrics`, and CI holds both to that; the entry is `deferred` because the behavior behind the accepted surface still differs.
 
+## Migrating: what changed to reach b10621
+
+Widening the boundary moves behavior that mlxcel already had. Each item below is a change an existing deployment can notice.
+
+### `--timeout` is the HTTP socket timeout (#1432)
+
+`--timeout` / `LLAMA_ARG_TIMEOUT` is the HTTP socket read/write timeout, default 3600 seconds, as it is in b10621. It used to be a 600-second decode watchdog. That watchdog kept its behavior and its default under the mlxcel-native `--decode-timeout` / `MLXCEL_DECODE_TIMEOUT`, and setting `--timeout` without it logs a migration warning naming both.
+
+The default CORS response follows b10621 too: `--cors-origins *` with credentials enabled echoes the request `Origin` rather than emitting a literal `*`, the method and header lists are sent on `OPTIONS` preflights only, `Access-Control-Expose-Headers` is no longer sent, and an `OPTIONS` to any path is answered before authentication and before routing. The default SSE ping interval moved from 15 to 30 seconds, b10621's `--sse-ping-interval` default. A Unix domain socket is selected by a `--host` ending in `.sock`; `--port 0` with an ordinary host now binds an ephemeral TCP port, and the old `--port 0` socket spelling still works with a deprecation warning.
+
+### `/completions` and `/embeddings` are native routes, not OpenAI aliases (#1441)
+
+b10621 sends `/completion` and `/completions` to one handler and `/v1/completions` to a different one, and does the same for `/embedding` and `/embeddings` against `/v1/embeddings`. mlxcel answered the OpenAI shape on all of them, so a `llama-server` client reading the native schema got an object it could not parse.
+
+| Path | Before | Now |
+|---|---|---|
+| `POST /completion` | native shape, partial | native shape, b10621 key set |
+| `POST /completions` | **OpenAI** shape | **native** shape |
+| `POST /v1/completions` | OpenAI shape | OpenAI shape (unchanged) |
+| `POST /embedding` | not mounted | **native** shape |
+| `POST /embeddings` | **OpenAI** shape | **native** shape |
+| `POST /v1/embeddings` | OpenAI shape | OpenAI shape (unchanged) |
+
+The native completion object carries `index`, `content`, `tokens`, `id_slot`, `stop`, `model`, `tokens_predicted`, `tokens_evaluated`, `generation_settings`, `prompt`, `has_new_line`, `truncated`, `stop_type`, `stopping_word`, `tokens_cached` and `timings` (whose `cache_n` leads). Its streaming form ends with that same object instead of a `[DONE]` sentinel, because b10621's native stream has none. The native embedding response is a bare JSON array of `{index, embedding}` whose `embedding` is an array of arrays.
+
+**A client that was pointing at `/completions` or `/embeddings` and parsing the OpenAI shape must move to `/v1/completions` or `/v1/embeddings`.** Those two paths are unchanged and stay OpenAI compatible.
+
+Native request fields mlxcel has no equivalent for are now refused with a 400 naming the field and the alternative, instead of being accepted and ignored: `n_cmpl` (and its `n` alias) above 1, `n_indent`, `t_max_predict_ms`, `return_progress`, `verbose` and `return_tokens`. Each is still accepted at its inert value, so a client that sends the whole schema at its defaults is not turned away.
+
 ## Sharding
 
 The manifest is sharded by area so that the concurrent implementation chains of epic #1431 edit disjoint files. Ownership is machine-readable, not prose: `pin.json`'s `shards` map records, per shard, the set of implementation issue numbers allowed to own entries in it (`shards["authentication"].owners == [1437]`, for example), and `scripts/ci/check_llama_compat_manifest.py` fails an entry whose `issue` is not a member of its own shard's owner set. That is what stops two concurrent chains from editing the same file: the file, not just the reviewer, rejects the second chain's entry.

--- a/src/server/app.rs
+++ b/src/server/app.rs
@@ -170,9 +170,17 @@ fn build_routes(state: &AppState) -> Router<AppState> {
         .merge(audio_routes)
         // Aliases (some clients use these)
         .route("/chat/completions", post(routes::chat_completions))
-        .route("/completions", post(routes::completions))
+        // BREAKING (#1441): `/completions` and `/embeddings` are llama-server
+        // NATIVE routes, not OpenAI aliases. b10621 sends `/completion` and
+        // `/completions` to one handler and `/v1/completions` to a different
+        // one, and does the same for `/embedding` / `/embeddings` against
+        // `/v1/embeddings`. mlxcel used to answer the OpenAI shape on all of
+        // them, so a llama-server client reading the native schema got an
+        // object it could not parse.
+        .route("/completions", post(routes::native_completion))
         .route("/models", get(routes::list_models))
-        .route("/embeddings", post(routes::create_embeddings))
+        .route("/embedding", post(routes::native_embeddings))
+        .route("/embeddings", post(routes::native_embeddings))
         .route("/rerank", post(routes::create_rerank))
         .route("/reranking", post(routes::create_rerank))
         .route("/responses", post(routes::create_response))

--- a/src/server/routes/embeddings.rs
+++ b/src/server/routes/embeddings.rs
@@ -228,8 +228,43 @@ fn embed_items(
     Ok((vectors, prompt_tokens))
 }
 
+/// Which wire shape an embedding response is rendered in.
+///
+/// b10621 routes `/embeddings` and `/embedding` to its native handler and
+/// `/v1/embeddings` to the OpenAI one, and the two shapes genuinely differ:
+/// the native one is a bare JSON array of `{index, embedding}` whose
+/// `embedding` is an array OF arrays, while the OpenAI one is an object with
+/// `object` / `data` / `model` / `usage` and a flat `embedding`. mlxcel used
+/// to answer the OpenAI shape on all three paths (#1441).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum EmbeddingShape {
+    /// `POST /v1/embeddings`.
+    OpenAi,
+    /// `POST /embeddings` and `POST /embedding`.
+    Native,
+}
+
 /// POST /v1/embeddings
 pub async fn create_embeddings(State(state): State<AppState>, Json(body): Json<Value>) -> Response {
+    embeddings_impl(state, body, EmbeddingShape::OpenAi).await
+}
+
+/// POST /embeddings and POST /embedding (the b10621 native routes).
+///
+/// Accepts the native `content` spelling as well as `input`, because upstream's
+/// legacy `/embedding` takes `{"content": ...}`.
+pub async fn native_embeddings(State(state): State<AppState>, Json(body): Json<Value>) -> Response {
+    let mut body = body;
+    if let Some(object) = body.as_object_mut()
+        && !object.contains_key("input")
+        && let Some(content) = object.remove("content")
+    {
+        object.insert("input".to_string(), content);
+    }
+    embeddings_impl(state, body, EmbeddingShape::Native).await
+}
+
+async fn embeddings_impl(state: AppState, body: Value, shape: EmbeddingShape) -> Response {
     let request: EmbeddingsRequest = match serde_json::from_value(body) {
         Ok(request) => request,
         Err(err) => return invalid_request(format!("invalid request body: {err}")).into_response(),
@@ -324,21 +359,41 @@ pub async fn create_embeddings(State(state): State<AppState>, Json(body): Json<V
         .metrics
         .record_request(prompt_tokens, 0, started.elapsed().as_millis() as u64);
 
-    let data = vectors
-        .iter()
-        .enumerate()
-        .map(|(index, vector)| EmbeddingData::from_vector(index, vector, encoding))
-        .collect();
-    Json(EmbeddingsResponse {
-        object: "list".to_string(),
-        data,
-        model: provider.model_id().to_string(),
-        usage: EmbeddingUsage {
-            prompt_tokens,
-            total_tokens: prompt_tokens,
-        },
-    })
-    .into_response()
+    match shape {
+        EmbeddingShape::Native => {
+            // A bare array of `{index, embedding}`, with `embedding` nested one
+            // level deeper than the OpenAI shape: upstream reports one row per
+            // pooled sequence, and mlxcel pools to exactly one.
+            let rows: Vec<Value> = vectors
+                .iter()
+                .enumerate()
+                .map(|(index, vector)| {
+                    serde_json::json!({
+                        "index": index,
+                        "embedding": [vector.values],
+                    })
+                })
+                .collect();
+            Json(rows).into_response()
+        }
+        EmbeddingShape::OpenAi => {
+            let data = vectors
+                .iter()
+                .enumerate()
+                .map(|(index, vector)| EmbeddingData::from_vector(index, vector, encoding))
+                .collect();
+            Json(EmbeddingsResponse {
+                object: "list".to_string(),
+                data,
+                model: provider.model_id().to_string(),
+                usage: EmbeddingUsage {
+                    prompt_tokens,
+                    total_tokens: prompt_tokens,
+                },
+            })
+            .into_response()
+        }
+    }
 }
 
 #[cfg(test)]

--- a/src/server/routes/mod.rs
+++ b/src/server/routes/mod.rs
@@ -50,7 +50,7 @@ pub use cache::{cache_reset, cache_stats};
 pub use chat::chat_completions;
 pub use completions::completions;
 pub use detokenize::detokenize;
-pub use embeddings::create_embeddings;
+pub use embeddings::{create_embeddings, native_embeddings};
 pub use health::health_check;
 pub use metrics::metrics;
 pub use models::list_models;
@@ -138,3 +138,7 @@ pub(crate) fn generation_error_to_response(err: anyhow::Error) -> ErrorResponse 
     };
     response
 }
+
+#[cfg(test)]
+#[path = "native_route_tests.rs"]
+mod native_route_tests;

--- a/src/server/routes/native_completion.rs
+++ b/src/server/routes/native_completion.rs
@@ -36,7 +36,8 @@ use crate::server::request_options::{
 use crate::server::streaming::{sse_channel, sse_response};
 use crate::server::thinking_budget::{pick_budget_alias, resolve_request_budget};
 use crate::server::types::{
-    ErrorResponse, NativeCompletionRequest, NativeCompletionResponse, TimingInfo,
+    ErrorResponse, NativeCompletionChunk, NativeCompletionRequest, NativeCompletionResponse,
+    NativeTimings, StopType,
 };
 use crate::server::{AppState, ServerConfig, ServerGenerateOptions};
 
@@ -102,6 +103,15 @@ pub async fn native_completion(
         }
     };
 
+    // Native fields mlxcel cannot honor are rejected with a diagnostic naming
+    // the field, rather than accepted and ignored (#1441). A value that cannot
+    // change behavior (the upstream default, or an explicit `false`) is inert
+    // and passes, so a client that sends the whole schema with defaults is not
+    // turned away.
+    if let Some(response) = reject_unsupported_native_fields(&request) {
+        return response;
+    }
+
     // b10621 declares `sse_ping_interval` with hard limits (-1, INT32_MAX) at
     // schema-parse time, so an out-of-domain value is rejected whether or not
     // the request streams (#1432).
@@ -149,6 +159,9 @@ async fn non_stream_native_completion(
     let mut options = build_native_options(&request, &state);
     options.priority = priority;
     options.reasoning_budget = budget_override;
+    // The response echoes the settings that were actually used, so keep a copy
+    // before the options are moved into the generator.
+    let options_snapshot = options.clone();
 
     let result = state
         .model_provider
@@ -164,40 +177,119 @@ async fn non_stream_native_completion(
         result.generation_time_ms,
     );
 
-    Ok(Json(NativeCompletionResponse {
-        content: result.text,
-        stop: result.finish_reason == "stop",
-        generation_settings: serde_json::json!({}),
-        model: state.display_model_id().to_string(),
-        tokens_predicted: result.completion_tokens,
-        tokens_evaluated: result.prompt_tokens,
-        timings: TimingInfo {
-            prompt_n: result.prompt_tokens,
+    Ok(Json(build_native_response(
+        &state,
+        &request,
+        &options_snapshot,
+        NativeOutcome {
+            content: result.text,
+            tokens: Vec::new(),
+            tokens_predicted: result.completion_tokens,
+            tokens_evaluated: result.prompt_tokens,
+            cached_tokens: result.cached_tokens,
+            finish_reason: result.finish_reason.as_str(),
             prompt_ms,
-            prompt_per_token_ms: if result.prompt_tokens > 0 {
-                prompt_ms / result.prompt_tokens as f64
-            } else {
-                0.0
-            },
-            prompt_per_second: if prompt_ms > 0.0 {
-                result.prompt_tokens as f64 / (prompt_ms / 1000.0)
-            } else {
-                0.0
-            },
-            predicted_n: result.completion_tokens,
             predicted_ms: gen_ms,
-            predicted_per_token_ms: if result.completion_tokens > 0 {
-                gen_ms / result.completion_tokens as f64
-            } else {
-                0.0
-            },
-            predicted_per_second: if gen_ms > 0.0 {
-                result.completion_tokens as f64 / (gen_ms / 1000.0)
-            } else {
-                0.0
-            },
         },
-    }))
+    )))
+}
+
+/// The parts of a finished generation the native response is built from.
+///
+/// Grouped into one struct so the streaming and non-streaming paths build the
+/// final object through exactly one function and cannot drift apart.
+struct NativeOutcome<'a> {
+    content: String,
+    tokens: Vec<i32>,
+    tokens_predicted: usize,
+    tokens_evaluated: usize,
+    cached_tokens: usize,
+    finish_reason: &'a str,
+    prompt_ms: f64,
+    predicted_ms: f64,
+}
+
+/// Assemble the b10621 native completion object.
+///
+/// `stop_type` is derived from the finish reason. mlxcel cannot yet report
+/// `word`, because string stop sequences are not enforced on the MLX serving
+/// path at all (they reach `ServerGenerateOptions::stop_sequences` and are
+/// never read); that gap has its own issue and is recorded on the route's
+/// manifest entry, which is why `POST /completion` is not claimed as
+/// `supported` here.
+fn build_native_response(
+    state: &AppState,
+    request: &NativeCompletionRequest,
+    options: &ServerGenerateOptions,
+    outcome: NativeOutcome<'_>,
+) -> NativeCompletionResponse {
+    let stop_type = match outcome.finish_reason {
+        "length" => StopType::Limit,
+        _ => StopType::Eos,
+    };
+    NativeCompletionResponse {
+        index: 0,
+        has_new_line: outcome.content.contains('\n'),
+        content: outcome.content,
+        tokens: outcome.tokens,
+        // mlxcel's continuous-batching scheduler does not expose a stable
+        // per-request slot number, so the "no numbered slot" sentinel upstream
+        // uses on its own streaming frames is reported here as well.
+        id_slot: -1,
+        stop: true,
+        model: state.display_model_id().to_string(),
+        tokens_predicted: outcome.tokens_predicted,
+        tokens_evaluated: outcome.tokens_evaluated,
+        generation_settings: native_generation_settings(request, options),
+        prompt: request.prompt.clone(),
+        // The server clamps an over-long request rather than truncating the
+        // prompt, so no request reaches here with a dropped prefix.
+        truncated: false,
+        stop_type,
+        stopping_word: String::new(),
+        tokens_cached: outcome.cached_tokens,
+        timings: NativeTimings::new(
+            outcome.cached_tokens,
+            outcome.tokens_evaluated,
+            outcome.prompt_ms,
+            outcome.tokens_predicted,
+            outcome.predicted_ms,
+        ),
+    }
+}
+
+/// The resolved generation settings echoed back on the response.
+///
+/// b10621 echoes its whole `task_params` here (49 keys). mlxcel reports the
+/// settings it actually resolved and acts on; a key mlxcel has no analogue for
+/// is omitted rather than reported with an invented value, which would be a
+/// worse answer than its absence.
+fn native_generation_settings(
+    request: &NativeCompletionRequest,
+    options: &ServerGenerateOptions,
+) -> serde_json::Value {
+    let sampling = &options.sampling;
+    serde_json::json!({
+        "seed": sampling.seed.unwrap_or(u64::MAX),
+        "temperature": sampling.temperature,
+        "top_k": sampling.top_k,
+        "top_p": sampling.top_p,
+        "min_p": sampling.min_p,
+        "xtc_probability": sampling.xtc_probability,
+        "xtc_threshold": sampling.xtc_threshold,
+        "repeat_penalty": sampling.repetition_penalty,
+        "presence_penalty": sampling.presence_penalty,
+        "frequency_penalty": sampling.frequency_penalty,
+        "dry_multiplier": sampling.dry_multiplier,
+        "dry_base": sampling.dry_base,
+        "dry_allowed_length": sampling.dry_allowed_length,
+        "dry_penalty_last_n": sampling.dry_penalty_last_n,
+        "dry_sequence_breakers": sampling.dry_sequence_breakers,
+        "stop": options.stop_sequences.clone().unwrap_or_default(),
+        "max_tokens": options.max_tokens,
+        "n_predict": options.max_tokens,
+        "stream": request.stream.unwrap_or(false),
+    })
 }
 
 async fn stream_native_completion(
@@ -216,6 +308,7 @@ async fn stream_native_completion(
     let mut options = build_native_options(&request, &state);
     options.priority = priority;
     options.reasoning_budget = budget_override;
+    let options_snapshot = options.clone();
     let prompt = request.prompt.clone();
 
     let queue_reservation = match state.model_provider.reserve_single_stream_queue_slot() {
@@ -229,9 +322,13 @@ async fn stream_native_completion(
     // `--sse-ping-interval` (#1432); the caller resolved and validated it.
     let (events, stream, cancelled, keepalive) = sse_channel(100, ping_interval);
     let finish_events = events.clone();
+    let timings_per_token = request.timings_per_token.unwrap_or(false);
+    let started = std::time::Instant::now();
 
     tokio::task::spawn_blocking(move || {
         let token_events = finish_events.clone();
+        let emitted = std::sync::Arc::new(std::sync::atomic::AtomicUsize::new(0));
+        let emitted_for_tokens = emitted.clone();
 
         let result = state
             .model_provider
@@ -245,28 +342,125 @@ async fn stream_native_completion(
                 queue_reservation,
                 cancelled,
                 |token, _lp| {
-                    let chunk = serde_json::json!({
-                        "content": token,
-                        "stop": false,
-                    });
+                    let n =
+                        emitted_for_tokens.fetch_add(1, std::sync::atomic::Ordering::Relaxed) + 1;
+                    // Upstream's per-token frame is small: the full metadata
+                    // block belongs to the final frame alone. `timings` is
+                    // attached here only under `timings_per_token`.
+                    let chunk = NativeCompletionChunk {
+                        index: 0,
+                        content: token.to_string(),
+                        tokens: Vec::new(),
+                        stop: false,
+                        id_slot: -1,
+                        tokens_predicted: n,
+                        tokens_evaluated: 0,
+                        timings: timings_per_token.then(|| {
+                            NativeTimings::new(0, 0, 0.0, n, started.elapsed().as_millis() as f64)
+                        }),
+                        prompt_progress: None,
+                    };
                     let _ = token_events.json(&chunk);
                 },
             );
 
-        // Send final chunk
-        let stop = match &result {
-            Ok(r) => r.finish_reason == "stop",
-            Err(_) => true,
-        };
-        let final_chunk = serde_json::json!({
-            "content": "",
-            "stop": true,
-            "stop_type": if stop { "stop" } else { "limit" },
-        });
-        let _ = finish_events.json(&final_chunk);
+        // The final frame is the whole non-streaming object with `stop: true`,
+        // built through the same function so the two shapes cannot drift.
+        // There is no `[DONE]` sentinel: b10621's native stream ends with this
+        // frame, and emitting one would be an extra event no llama-server
+        // client expects.
+        match result {
+            Ok(result) => {
+                let final_frame = build_native_response(
+                    &state,
+                    &request,
+                    &options_snapshot,
+                    NativeOutcome {
+                        content: String::new(),
+                        tokens: Vec::new(),
+                        tokens_predicted: result.completion_tokens,
+                        tokens_evaluated: result.prompt_tokens,
+                        cached_tokens: result.cached_tokens,
+                        finish_reason: result.finish_reason.as_str(),
+                        prompt_ms: result.prompt_eval_ms as f64,
+                        predicted_ms: result.generation_only_ms as f64,
+                    },
+                );
+                let _ = finish_events.json(&final_frame);
+            }
+            Err(err) => {
+                // A failed generation still terminates the stream with a frame
+                // the client can act on rather than a silent close.
+                let _ = finish_events.json(&serde_json::json!({
+                    "error": {
+                        "code": 500,
+                        "message": err.to_string(),
+                        "type": "server_error",
+                    }
+                }));
+            }
+        }
     });
 
     sse_response(stream, keepalive)
+}
+
+/// Reject the native fields mlxcel has no equivalent for.
+///
+/// The epic's policy is that a flag or field whose value has observable
+/// semantics must not be silently ignored. Each field below is accepted at its
+/// inert value and refused otherwise, with a message naming the field and what
+/// to use instead, so a `llama-server` request that depends on one fails
+/// loudly here instead of returning a plausible-looking wrong answer.
+fn reject_unsupported_native_fields(request: &NativeCompletionRequest) -> Option<Response> {
+    let refuse = |message: String| -> Option<Response> {
+        Some(ErrorResponse::new(message, "invalid_request_error").into_response())
+    };
+
+    if request.n_cmpl.is_some_and(|n| n != 1) {
+        return refuse(
+            "n_cmpl (alias n) above 1 is not supported on /completion; mlxcel serves one \
+             completion per request. Send one request per completion"
+                .to_string(),
+        );
+    }
+    if request.n_indent.is_some_and(|n| n != 0) {
+        return refuse(
+            "n_indent is not supported on /completion; mlxcel has no minimum-indentation \
+             stop rule for fill-in-the-middle completions"
+                .to_string(),
+        );
+    }
+    if request.t_max_predict_ms.is_some_and(|t| t > 0) {
+        return refuse(
+            "t_max_predict_ms is not supported per request; bound a stalled decode with the \
+             server-wide --decode-timeout / MLXCEL_DECODE_TIMEOUT instead"
+                .to_string(),
+        );
+    }
+    if request.return_progress.unwrap_or(false) {
+        return refuse(
+            "return_progress is not supported on /completion; the mlxcel scheduler emits no \
+             prompt-processing progress events on this path"
+                .to_string(),
+        );
+    }
+    if request.verbose.unwrap_or(false) {
+        return refuse(
+            "verbose is not supported on /completion; mlxcel has no __verbose debug block. \
+             Use GET /slots and GET /metrics for per-request observability"
+                .to_string(),
+        );
+    }
+    if request.return_tokens.unwrap_or(false) {
+        return refuse(
+            "return_tokens is not supported on /completion; mlxcel's streaming decoder emits \
+             detokenized text and does not surface the raw token ids on this path. Use POST \
+             /tokenize on the returned content"
+                .to_string(),
+        );
+    }
+    None
 }
 
 fn build_native_options(

--- a/src/server/routes/native_route_tests.rs
+++ b/src/server/routes/native_route_tests.rs
@@ -1,0 +1,274 @@
+// Copyright 2025-2026 Lablup Inc. and Jeongkyu Shin
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Native versus OpenAI route separation (#1441).
+//!
+//! `llama-server` b10621 sends `/completion` and `/completions` to one handler
+//! and `/v1/completions` to a different one, and does the same for
+//! `/embedding` / `/embeddings` against `/v1/embeddings`. mlxcel answered the
+//! OpenAI shape on all of them. These tests assert the split by the shape of
+//! the body each path returns, which is the only thing a client can observe.
+
+use std::path::PathBuf;
+use std::sync::{Arc, mpsc};
+
+use axum::Router;
+use axum::body::Body;
+use axum::http::{Method, Request, StatusCode, header};
+use tower::ServiceExt;
+
+use crate::server::{AppState, ChatTemplateProcessor, ModelProvider, ServerConfig, create_app};
+use crate::tokenizer::MlxcelTokenizer;
+
+fn app() -> Router {
+    let (options_tx, _options_rx) = mpsc::channel();
+    let provider = Arc::new(ModelProvider::recording_for_route_tests(options_tx));
+    let batch_metrics = provider.batch_metrics().clone();
+    let state = AppState::new(
+        provider,
+        ServerConfig::default(),
+        ChatTemplateProcessor::with_template("ok".to_string()),
+        MlxcelTokenizer::stub(),
+        PathBuf::from("native-route-test-model"),
+        batch_metrics,
+    );
+    create_app(state)
+}
+
+async fn post(path: &str, body: serde_json::Value) -> (StatusCode, serde_json::Value) {
+    let request = Request::builder()
+        .method(Method::POST)
+        .uri(path)
+        .header(header::CONTENT_TYPE, "application/json")
+        .body(Body::from(body.to_string()))
+        .expect("request builds");
+    let response = app().oneshot(request).await.expect("router responds");
+    let status = response.status();
+    let bytes = axum::body::to_bytes(response.into_body(), 1024 * 1024)
+        .await
+        .expect("body collects");
+    let parsed = serde_json::from_slice(&bytes).unwrap_or(serde_json::Value::Null);
+    (status, parsed)
+}
+
+/// The native completion body, whose shape is what separates the handlers.
+fn native_prompt() -> serde_json::Value {
+    serde_json::json!({"prompt": "hello", "n_predict": 4})
+}
+
+#[tokio::test]
+async fn the_native_completion_paths_answer_the_native_shape() {
+    // `content` at the top level with `tokens_predicted` beside it is the
+    // native object; the OpenAI one nests text under `choices`.
+    for path in ["/completion", "/completions"] {
+        let (status, body) = post(path, native_prompt()).await;
+        assert_eq!(status, StatusCode::OK, "{path}: {body}");
+        assert!(
+            body.get("content").is_some(),
+            "{path} must answer the native shape, got {body}"
+        );
+        assert!(
+            body.get("choices").is_none(),
+            "{path} must not answer the OpenAI shape, got {body}"
+        );
+        assert!(body.get("tokens_predicted").is_some(), "{path}: {body}");
+    }
+}
+
+#[tokio::test]
+async fn the_v1_completion_path_stays_openai() {
+    let (status, body) = post(
+        "/v1/completions",
+        serde_json::json!({"model": "native-route-test-model", "prompt": "hello", "max_tokens": 4}),
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK, "{body}");
+    assert!(
+        body.get("choices").is_some(),
+        "/v1/completions must stay OpenAI compatible, got {body}"
+    );
+    assert_eq!(body["object"], "text_completion");
+    assert!(
+        body.get("content").is_none(),
+        "/v1/completions must not answer the native shape, got {body}"
+    );
+}
+
+#[tokio::test]
+async fn the_native_completion_response_carries_the_b10621_key_set() {
+    let (_, body) = post("/completion", native_prompt()).await;
+    for key in [
+        "index",
+        "content",
+        "tokens",
+        "id_slot",
+        "stop",
+        "model",
+        "tokens_predicted",
+        "tokens_evaluated",
+        "generation_settings",
+        "prompt",
+        "has_new_line",
+        "truncated",
+        "stop_type",
+        "stopping_word",
+        "tokens_cached",
+        "timings",
+    ] {
+        assert!(body.get(key).is_some(), "missing {key} in {body}");
+    }
+    assert!(
+        body["timings"].get("cache_n").is_some(),
+        "timings must lead with cache_n: {body}"
+    );
+    assert!(
+        body["generation_settings"]
+            .as_object()
+            .is_some_and(|m| !m.is_empty()),
+        "generation_settings must report the resolved settings, got {body}"
+    );
+}
+
+#[tokio::test]
+async fn the_native_completion_echoes_the_prompt_and_stop_metadata() {
+    let (_, body) = post("/completion", native_prompt()).await;
+    assert_eq!(body["prompt"], "hello");
+    assert_eq!(body["index"], 0);
+    assert_eq!(body["stop"], true);
+    assert_eq!(body["stopping_word"], "");
+    assert!(
+        ["limit", "eos"].contains(&body["stop_type"].as_str().unwrap_or("")),
+        "stop_type must be one of the reasons mlxcel can distinguish: {body}"
+    );
+}
+
+#[tokio::test]
+async fn n_predict_accepts_the_openai_aliases() {
+    // b10621 declares `max_tokens` and `max_completion_tokens` as aliases, so
+    // the same body reaches the native route whichever spelling a client uses.
+    for key in ["n_predict", "max_tokens", "max_completion_tokens"] {
+        let (status, body) = post(
+            "/completion",
+            serde_json::json!({"prompt": "hello", key: 4}),
+        )
+        .await;
+        assert_eq!(status, StatusCode::OK, "{key}: {body}");
+        assert_eq!(
+            body["generation_settings"]["n_predict"], 4,
+            "{key} must resolve the token budget: {body}"
+        );
+    }
+}
+
+#[tokio::test]
+async fn unsupported_native_fields_are_refused_with_a_diagnostic() {
+    // The epic's rule is that a field whose value has observable semantics is
+    // never silently ignored. Each of these names the field and the
+    // alternative.
+    for (field, body) in [
+        ("n_cmpl", serde_json::json!({"prompt": "hi", "n_cmpl": 2})),
+        ("n_cmpl", serde_json::json!({"prompt": "hi", "n": 2})),
+        (
+            "n_indent",
+            serde_json::json!({"prompt": "hi", "n_indent": 4}),
+        ),
+        (
+            "t_max_predict_ms",
+            serde_json::json!({"prompt": "hi", "t_max_predict_ms": 500}),
+        ),
+        (
+            "return_progress",
+            serde_json::json!({"prompt": "hi", "return_progress": true}),
+        ),
+        (
+            "verbose",
+            serde_json::json!({"prompt": "hi", "verbose": true}),
+        ),
+        (
+            "return_tokens",
+            serde_json::json!({"prompt": "hi", "return_tokens": true}),
+        ),
+    ] {
+        let (status, response) = post("/completion", body).await;
+        assert_eq!(
+            status,
+            StatusCode::BAD_REQUEST,
+            "{field} must be refused, got {response}"
+        );
+        let message = response["error"]["message"].as_str().unwrap_or_default();
+        assert!(
+            message.contains(field),
+            "the diagnostic must name {field}, got {message:?}"
+        );
+    }
+}
+
+#[tokio::test]
+async fn the_inert_value_of_an_unsupported_field_is_accepted() {
+    // A client that sends the whole schema at its defaults must not be turned
+    // away: only a value that would change behavior is refused.
+    let (status, body) = post(
+        "/completion",
+        serde_json::json!({
+            "prompt": "hello",
+            "n_predict": 4,
+            "n_cmpl": 1,
+            "n_indent": 0,
+            "t_max_predict_ms": -1,
+            "return_progress": false,
+            "verbose": false,
+            "return_tokens": false,
+        }),
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK, "{body}");
+}
+
+#[tokio::test]
+async fn an_unknown_native_field_is_ignored_as_upstream_ignores_it() {
+    // b10621 has no deny-unknown-fields equivalent: an unrecognised key is
+    // accepted and the request succeeds. Rejecting here would turn away a
+    // request llama-server serves.
+    let (status, body) = post(
+        "/completion",
+        serde_json::json!({"prompt": "hello", "n_predict": 4, "totally_unknown_field": 123}),
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK, "{body}");
+}
+
+#[tokio::test]
+async fn the_native_embedding_paths_are_mounted_and_separate_from_v1() {
+    // No embedding model is loaded in this fixture, so all three answer 501.
+    // What matters here is that the native paths resolve at all: `/embedding`
+    // was not mounted before this change.
+    for path in ["/embedding", "/embeddings", "/v1/embeddings"] {
+        let (status, body) = post(path, serde_json::json!({"input": "hello"})).await;
+        assert_ne!(status, StatusCode::NOT_FOUND, "{path} must be mounted");
+        assert_ne!(
+            status,
+            StatusCode::METHOD_NOT_ALLOWED,
+            "{path} must accept POST"
+        );
+        assert_eq!(status, StatusCode::NOT_IMPLEMENTED, "{path}: {body}");
+    }
+}
+
+#[tokio::test]
+async fn the_native_embedding_path_accepts_the_content_spelling() {
+    // Upstream's legacy `/embedding` takes `{"content": ...}` rather than
+    // `{"input": ...}`; reaching the same 501 proves the body parsed.
+    let (status, _) = post("/embedding", serde_json::json!({"content": "hello"})).await;
+    assert_eq!(status, StatusCode::NOT_IMPLEMENTED);
+}

--- a/src/server/types/mod.rs
+++ b/src/server/types/mod.rs
@@ -18,6 +18,7 @@ pub mod anthropic_request;
 pub mod anthropic_response;
 pub mod anthropic_stream;
 pub mod embeddings;
+pub mod native_completion;
 pub mod request;
 pub mod rerank;
 pub mod response;
@@ -29,6 +30,7 @@ pub mod stream;
 // Anthropic types are accessed through their module paths (e.g.
 // `types::anthropic_request::AnthropicRequest`) to avoid colliding with the
 // OpenAI type glob below (both define `Tool`, `Role`, `MessageContent`, etc.).
+pub use native_completion::*;
 pub use request::*;
 pub use response::*;
 pub use responses_request::*;

--- a/src/server/types/native_completion.rs
+++ b/src/server/types/native_completion.rs
@@ -1,0 +1,164 @@
+// Copyright 2025-2026 Lablup Inc. and Jeongkyu Shin
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Response types for the native `llama-server` completion routes (#1441).
+//!
+//! These are the shapes `POST /completion` and `POST /completions` answer
+//! with. They are NOT the OpenAI shapes: `POST /v1/completions` keeps
+//! [`crate::server::types::CompletionResponse`]. b10621 routes the two
+//! spellings to two different handlers
+//! (<https://github.com/ggml-org/llama.cpp/blob/c1d0e7a004015f23bc0233470b747b596f29b264/tools/server/server.cpp>),
+//! and mlxcel used to answer the OpenAI shape on all three.
+//!
+//! The field set and its order come from a capture of the pinned b10621
+//! binary, not from a reading of the source: `index`, `content`, `tokens`,
+//! `id_slot`, `stop`, `model`, `tokens_predicted`, `tokens_evaluated`,
+//! `generation_settings`, `prompt`, `has_new_line`, `truncated`, `stop_type`,
+//! `stopping_word`, `tokens_cached`, `timings`.
+
+use serde::Serialize;
+
+/// Why generation stopped, in b10621's vocabulary.
+///
+/// Upstream emits this as a bare string on the `stop_type` field. `none`
+/// appears on a non-final streaming frame, where generation has not stopped.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "lowercase")]
+pub enum StopType {
+    /// Generation is still running (streaming frames only).
+    None,
+    /// The `n_predict` budget was reached.
+    Limit,
+    /// A stop string matched; `stopping_word` carries it.
+    Word,
+    /// The model emitted an end-of-sequence token.
+    Eos,
+}
+
+/// Timing block. `cache_n` leads, matching b10621's field order.
+#[derive(Debug, Clone, Serialize)]
+pub struct NativeTimings {
+    /// Prompt tokens served from the KV prefix cache rather than re-prefilled.
+    pub cache_n: usize,
+    pub prompt_n: usize,
+    pub prompt_ms: f64,
+    pub prompt_per_token_ms: f64,
+    pub prompt_per_second: f64,
+    pub predicted_n: usize,
+    pub predicted_ms: f64,
+    pub predicted_per_token_ms: f64,
+    pub predicted_per_second: f64,
+}
+
+impl NativeTimings {
+    /// Build the block from raw counts and millisecond durations, computing
+    /// the four derived rates the way upstream does (zero when the divisor is
+    /// zero rather than producing an infinity or a NaN, which would not be
+    /// serializable as JSON).
+    pub fn new(
+        cache_n: usize,
+        prompt_n: usize,
+        prompt_ms: f64,
+        predicted_n: usize,
+        predicted_ms: f64,
+    ) -> Self {
+        let per_token = |ms: f64, n: usize| if n > 0 { ms / n as f64 } else { 0.0 };
+        let per_second = |ms: f64, n: usize| {
+            if ms > 0.0 {
+                n as f64 / (ms / 1000.0)
+            } else {
+                0.0
+            }
+        };
+        Self {
+            cache_n,
+            prompt_n,
+            prompt_ms,
+            prompt_per_token_ms: per_token(prompt_ms, prompt_n),
+            prompt_per_second: per_second(prompt_ms, prompt_n),
+            predicted_n,
+            predicted_ms,
+            predicted_per_token_ms: per_token(predicted_ms, predicted_n),
+            predicted_per_second: per_second(predicted_ms, predicted_n),
+        }
+    }
+}
+
+/// Prompt-processing progress, emitted on streaming frames when the request
+/// asked for `return_progress`.
+#[derive(Debug, Clone, Serialize)]
+pub struct PromptProgress {
+    pub total: usize,
+    pub cache: usize,
+    pub processed: usize,
+    pub time_ms: u64,
+}
+
+/// The final (or only) native completion result.
+///
+/// Field order matches the capture. `tokens` is always present and is empty
+/// unless the request set `return_tokens`, which is also what upstream does.
+#[derive(Debug, Clone, Serialize)]
+pub struct NativeCompletionResponse {
+    /// Index of this completion. Always `0`: mlxcel serves one completion per
+    /// request, and rejects `n_cmpl > 1` rather than silently ignoring it.
+    pub index: usize,
+    pub content: String,
+    pub tokens: Vec<i32>,
+    /// Scheduler slot that served the request, or `-1` when the request was
+    /// not bound to a numbered slot.
+    pub id_slot: i64,
+    pub stop: bool,
+    pub model: String,
+    pub tokens_predicted: usize,
+    pub tokens_evaluated: usize,
+    /// The resolved sampling and generation settings actually used.
+    pub generation_settings: serde_json::Value,
+    pub prompt: String,
+    /// Whether the emitted content contains a newline. b10621 reports it so a
+    /// FIM client can tell whether the completion crossed a line boundary.
+    pub has_new_line: bool,
+    /// Whether the prompt was truncated to fit the context window.
+    pub truncated: bool,
+    pub stop_type: StopType,
+    /// The stop string that matched, or the empty string.
+    pub stopping_word: String,
+    /// Prompt tokens present in the KV cache after this request.
+    pub tokens_cached: usize,
+    pub timings: NativeTimings,
+}
+
+/// A non-final streaming frame.
+///
+/// Upstream emits a much smaller object per token and only attaches the full
+/// metadata to the final frame. `timings` appears here only under
+/// `timings_per_token`, and `prompt_progress` only under `return_progress`.
+#[derive(Debug, Clone, Serialize)]
+pub struct NativeCompletionChunk {
+    pub index: usize,
+    pub content: String,
+    pub tokens: Vec<i32>,
+    pub stop: bool,
+    pub id_slot: i64,
+    pub tokens_predicted: usize,
+    pub tokens_evaluated: usize,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub timings: Option<NativeTimings>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub prompt_progress: Option<PromptProgress>,
+}
+
+#[cfg(test)]
+#[path = "native_completion_tests.rs"]
+mod native_completion_tests;

--- a/src/server/types/native_completion_tests.rs
+++ b/src/server/types/native_completion_tests.rs
@@ -1,0 +1,200 @@
+// Copyright 2025-2026 Lablup Inc. and Jeongkyu Shin
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Golden-schema tests for the native completion response types (#1441).
+//!
+//! The expected key sets and orders come from a capture of the pinned b10621
+//! binary; see the module docs on `native_completion.rs`.
+
+use super::{
+    NativeCompletionChunk, NativeCompletionResponse, NativeTimings, PromptProgress, StopType,
+};
+
+fn sample() -> NativeCompletionResponse {
+    NativeCompletionResponse {
+        index: 0,
+        content: " Paris.".to_string(),
+        tokens: Vec::new(),
+        id_slot: 3,
+        stop: true,
+        model: "test-model".to_string(),
+        tokens_predicted: 8,
+        tokens_evaluated: 5,
+        generation_settings: serde_json::json!({"n_predict": 8}),
+        prompt: "The capital of France is".to_string(),
+        has_new_line: false,
+        truncated: false,
+        stop_type: StopType::Limit,
+        stopping_word: String::new(),
+        tokens_cached: 12,
+        timings: NativeTimings::new(0, 5, 61.0, 8, 42.0),
+    }
+}
+
+/// The exact top-level key order the pinned binary emits.
+const B10621_KEYS: [&str; 16] = [
+    "index",
+    "content",
+    "tokens",
+    "id_slot",
+    "stop",
+    "model",
+    "tokens_predicted",
+    "tokens_evaluated",
+    "generation_settings",
+    "prompt",
+    "has_new_line",
+    "truncated",
+    "stop_type",
+    "stopping_word",
+    "tokens_cached",
+    "timings",
+];
+
+fn keys(value: &serde_json::Value) -> Vec<String> {
+    value.as_object().expect("object").keys().cloned().collect()
+}
+
+#[test]
+fn the_response_carries_exactly_the_b10621_key_set_in_order() {
+    let json = serde_json::to_value(sample()).expect("serializes");
+    assert_eq!(keys(&json), B10621_KEYS, "key set or order drifted");
+}
+
+#[test]
+fn the_timings_block_leads_with_cache_n() {
+    let json = serde_json::to_value(sample()).expect("serializes");
+    assert_eq!(
+        keys(&json["timings"]),
+        [
+            "cache_n",
+            "prompt_n",
+            "prompt_ms",
+            "prompt_per_token_ms",
+            "prompt_per_second",
+            "predicted_n",
+            "predicted_ms",
+            "predicted_per_token_ms",
+            "predicted_per_second",
+        ]
+    );
+}
+
+#[test]
+fn timings_rates_are_derived_the_way_upstream_derives_them() {
+    let t = NativeTimings::new(4, 10, 100.0, 20, 50.0);
+    assert_eq!(t.prompt_per_token_ms, 10.0);
+    assert_eq!(t.prompt_per_second, 100.0);
+    assert_eq!(t.predicted_per_token_ms, 2.5);
+    assert_eq!(t.predicted_per_second, 400.0);
+}
+
+#[test]
+fn zero_counts_produce_zero_rates_rather_than_nan() {
+    // A NaN or an infinity is not representable in JSON and would serialize
+    // as null, so the divisor guards matter for the wire shape, not just for
+    // arithmetic taste.
+    let t = NativeTimings::new(0, 0, 0.0, 0, 0.0);
+    let json = serde_json::to_value(&t).expect("serializes");
+    for key in [
+        "prompt_per_token_ms",
+        "prompt_per_second",
+        "predicted_per_token_ms",
+        "predicted_per_second",
+    ] {
+        assert!(
+            json[key].is_number(),
+            "{key} must be a number, got {}",
+            json[key]
+        );
+        assert_eq!(json[key].as_f64(), Some(0.0));
+    }
+}
+
+#[test]
+fn stop_type_serializes_as_the_upstream_lowercase_strings() {
+    for (variant, expected) in [
+        (StopType::None, "none"),
+        (StopType::Limit, "limit"),
+        (StopType::Word, "word"),
+        (StopType::Eos, "eos"),
+    ] {
+        assert_eq!(
+            serde_json::to_value(variant).expect("serializes"),
+            serde_json::Value::String(expected.to_string())
+        );
+    }
+}
+
+#[test]
+fn tokens_is_present_and_empty_when_not_requested() {
+    // Upstream always emits the key; `return_tokens` only decides whether it
+    // has content. A client reading `tokens` unconditionally must not break.
+    let json = serde_json::to_value(sample()).expect("serializes");
+    assert_eq!(json["tokens"], serde_json::json!([]));
+}
+
+#[test]
+fn a_streaming_chunk_omits_the_optional_blocks_by_default() {
+    let chunk = NativeCompletionChunk {
+        index: 0,
+        content: "Question".to_string(),
+        tokens: vec![14582],
+        stop: false,
+        id_slot: -1,
+        tokens_predicted: 1,
+        tokens_evaluated: 1,
+        timings: None,
+        prompt_progress: None,
+    };
+    let json = serde_json::to_value(&chunk).expect("serializes");
+    assert_eq!(
+        keys(&json),
+        [
+            "index",
+            "content",
+            "tokens",
+            "stop",
+            "id_slot",
+            "tokens_predicted",
+            "tokens_evaluated",
+        ]
+    );
+}
+
+#[test]
+fn a_streaming_chunk_carries_timings_and_progress_when_requested() {
+    let chunk = NativeCompletionChunk {
+        index: 0,
+        content: String::new(),
+        tokens: vec![0],
+        stop: false,
+        id_slot: -1,
+        tokens_predicted: 0,
+        tokens_evaluated: 1,
+        timings: Some(NativeTimings::new(0, 1, 8.9, 0, 0.0)),
+        prompt_progress: Some(PromptProgress {
+            total: 1,
+            cache: 0,
+            processed: 1,
+            time_ms: 8,
+        }),
+    };
+    let json = serde_json::to_value(&chunk).expect("serializes");
+    assert!(json["timings"].is_object());
+    assert_eq!(
+        keys(&json["prompt_progress"]),
+        ["total", "cache", "processed", "time_ms"]
+    );
+}

--- a/src/server/types/request.rs
+++ b/src/server/types/request.rs
@@ -1043,7 +1043,34 @@ pub struct NativeCompletionRequest {
     pub prompt: String,
     /// Maximum number of tokens to predict. The server silently clamps an
     /// explicit value to the effective per-slot context window.
+    ///
+    /// b10621 declares `max_tokens` and `max_completion_tokens` as aliases of
+    /// this field, so a request written for either OpenAI spelling reaches the
+    /// native route unchanged (#1441).
+    #[serde(alias = "max_tokens", alias = "max_completion_tokens")]
     pub n_predict: Option<usize>,
+    /// Attach the timing block to every streaming frame instead of only the
+    /// final one (#1441).
+    pub timings_per_token: Option<bool>,
+    /// Number of completions to generate. mlxcel serves one completion per
+    /// request; a value above 1 is rejected with a diagnostic rather than
+    /// silently producing one result where b10621 would produce an array.
+    #[serde(alias = "n")]
+    pub n_cmpl: Option<i64>,
+    /// Minimum line indentation for the generated text, a FIM feature with no
+    /// mlxcel equivalent. Rejected when set to a value that would change
+    /// behavior.
+    pub n_indent: Option<i64>,
+    /// Time limit in milliseconds for the prediction phase. mlxcel bounds a
+    /// stalled decode with `--decode-timeout` per server, not per request.
+    pub t_max_predict_ms: Option<i64>,
+    /// Include prompt-processing progress events in stream mode. mlxcel's
+    /// scheduler emits no prefill progress events on this path.
+    pub return_progress: Option<bool>,
+    /// Include an `__verbose` debug block in the response.
+    pub verbose: Option<bool>,
+    /// Return the raw generated token ids in the `tokens` field.
+    pub return_tokens: Option<bool>,
     /// Whether to stream the response
     pub stream: Option<bool>,
     /// Per-request override for the SSE comment ping interval, in seconds

--- a/src/server/types/response.rs
+++ b/src/server/types/response.rs
@@ -535,31 +535,6 @@ impl axum::response::IntoResponse for ErrorResponse {
     }
 }
 
-/// Native llama-server completion response (POST /completion)
-#[derive(Debug, Clone, Serialize)]
-pub struct NativeCompletionResponse {
-    pub content: String,
-    pub stop: bool,
-    pub generation_settings: serde_json::Value,
-    pub model: String,
-    pub tokens_predicted: usize,
-    pub tokens_evaluated: usize,
-    pub timings: TimingInfo,
-}
-
-/// Timing information for generation (llama-server compatible)
-#[derive(Debug, Clone, Serialize)]
-pub struct TimingInfo {
-    pub prompt_n: usize,
-    pub prompt_ms: f64,
-    pub prompt_per_token_ms: f64,
-    pub prompt_per_second: f64,
-    pub predicted_n: usize,
-    pub predicted_ms: f64,
-    pub predicted_per_token_ms: f64,
-    pub predicted_per_second: f64,
-}
-
 /// Tokenize response (POST /tokenize)
 #[derive(Debug, Clone, Serialize)]
 pub struct TokenizeResponse {


### PR DESCRIPTION
## Summary

`POST /completions` and `POST /embeddings` were OpenAI aliases in mlxcel and are **native** `llama-server` routes in b10621. Upstream sends `/completion` and `/completions` to one handler and `/v1/completions` to a different one, and does the same for `/embedding` and `/embeddings` against `/v1/embeddings`. A `llama-server` client reading the native schema got an OpenAI object it could not parse, and `POST /embedding` was not mounted at all.

**This PR deliberately leaves issue 1441 open.** It lands the route separation and the native response schemas, which is the self-contained half of the issue; the remainder is recorded below and in the manifest, because resolving that issue now would force manifest entries into `supported` that are not. (The original wording here used a phrase GitHub reads as a closing keyword and auto-closed issue 1441 on merge; it has been reopened.)

## Release notes (breaking)

| Path | Before | Now |
|---|---|---|
| `POST /completion` | native shape, partial | native shape, full b10621 key set |
| `POST /completions` | **OpenAI** shape | **native** shape |
| `POST /v1/completions` | OpenAI shape | OpenAI shape (unchanged) |
| `POST /embedding` | **not mounted** | **native** shape |
| `POST /embeddings` | **OpenAI** shape | **native** shape |
| `POST /v1/embeddings` | OpenAI shape | OpenAI shape (unchanged) |

A client that was pointing at `/completions` or `/embeddings` and parsing the OpenAI shape must move to `/v1/completions` or `/v1/embeddings`. Those two are unchanged. The native streaming form no longer ends with a `[DONE]` sentinel, because b10621's native stream has none.

## Evidence

The key set, its order, the `stop_type` vocabulary and the embedding nesting all come from a capture of the pinned b10621 binary (build 10621, commit `c1d0e7a00`) serving real checkpoints, not from a reading of the source:

- `POST /completion` returns, in order: `index`, `content`, `tokens`, `id_slot`, `stop`, `model`, `tokens_predicted`, `tokens_evaluated`, `generation_settings`, `prompt`, `has_new_line`, `truncated`, `stop_type`, `stopping_word`, `tokens_cached`, `timings`; `timings` leads with `cache_n`.
- `stop_type` observed values: `limit` (n_predict reached), `word` (stop string matched, with `stopping_word` set and the word excluded from `content`), `eos`.
- Streaming frames are small (`index`, `content`, `tokens`, `stop`, `id_slot`, `tokens_predicted`, `tokens_evaluated`) and the final frame is the whole non-streaming object with `stop: true`. There is no `[DONE]`.
- `POST /embeddings` returns a bare array `[{"index": 0, "embedding": [[<768 floats>]]}]`; `POST /v1/embeddings` returns the OpenAI object with a flat `embedding`.
- An unknown request field is accepted and the request succeeds, so mlxcel keeps accepting one too.

## What changed

- `src/server/types/native_completion.rs` (new): `NativeCompletionResponse`, `NativeCompletionChunk`, `NativeTimings` and `StopType`, with golden-schema tests asserting the captured key set and order. The old partial `NativeCompletionResponse` / `TimingInfo` in `response.rs` are removed.
- `src/server/routes/native_completion.rs`: one `build_native_response` builds both the non-streaming body and the final streaming frame, so the two shapes cannot drift; `reject_unsupported_native_fields` refuses the fields mlxcel cannot honor with a diagnostic naming each one.
- `src/server/routes/embeddings.rs`: the handler is split by wire shape, `native_embeddings` is added for `/embedding` and `/embeddings`, and it accepts upstream's legacy `content` spelling.
- `src/server/app.rs`: `/completions` and `/embeddings` move to the native handlers and `/embedding` is mounted.
- `src/server/types/request.rs`: `n_predict` gains the `max_tokens` / `max_completion_tokens` aliases, and the six fields above are declared so their values can be validated rather than silently dropped.
- `docs/llama-server-compat.md`: a migration section covering this change and #1432's.

## What remains on #1441

- `POST /completion` and `POST /completions` stay `deferred` with three recorded divergences: `stop_type` can never report `word`, `generation_settings` is mlxcel's resolved set rather than upstream's full `task_params`, and `id_slot` is always `-1`.
- **String stop sequences are not enforced at all on the MLX serving path.** They reach `ServerGenerateOptions::stop_sequences` and are never read; only the `xla-iree`-gated worker consumes them. Measured: `/completion` with and without `"stop":["5"]` returns byte-identical text. Filed as #1466, because the fix belongs in the MLX scheduler and to the `field:stop` entry in `sampling-and-grammar.json`, which this chain does not own.
- `field:response_fields`, `field:stream_options` and `field:stream_options.include_usage` are untouched.
- The four `GET /health` / `GET /models` entries filed under this issue carry divergences whose text names #1438 and #1440 as their real owners; they are filed here only because `routes.json`'s owner set is `[1441, 1442, 1452]`. Deciding whether to add those issues to the owner set in `pin.json` needs a call outside this chain, so no entry was repointed.

## Test plan

- [x] `cargo test --profile test-fast --features metal,accelerate --lib -- server::`
- [x] `cargo clippy --lib --bins --tests --features metal,accelerate --profile test-fast -- -D warnings`
- [x] `cargo fmt --all -- --check`
- [x] `python3 scripts/ci/check_llama_compat_manifest.py`
- [x] Response-shape comparison against the pinned b10621 binary serving real checkpoints

Refs #1441

