### PR TITLE
fix(server): honor string stop sequences on the MLX serving path

### DIFF
--- a/compat/llama-server/b10621/pin.json
+++ b/compat/llama-server/b10621/pin.json
@@ -110,7 +110,8 @@
     "sampling-and-grammar": {
       "owners": [
         1377,
-        1436
+        1436,
+        1466
       ]
     },
     "speculative": {

--- a/compat/llama-server/b10621/routes.json
+++ b/compat/llama-server/b10621/routes.json
@@ -160,11 +160,10 @@
       "condition": null,
       "discovery": "source-route-registration",
       "state": "deferred",
-      "issue": 1466,
+      "issue": 1441,
       "test": "src/server/routes/native_route_tests.rs",
-      "notes": "Route separation done: /completion and /completions both reach the native handler and answer the b10621 native object (index, content, tokens, id_slot, stop, model, tokens_predicted, tokens_evaluated, generation_settings, prompt, has_new_line, truncated, stop_type, stopping_word, tokens_cached, timings with cache_n), and the streaming form ends with that same object rather than a [DONE] sentinel. The key set and order were taken from a capture of the pinned binary. The remaining differences are listed in divergence and keep this entry deferred; the stop-sequence half is tracked separately as #1466 because the fix belongs to the MLX scheduler and to the field:stop entry in sampling-and-grammar.json.",
+      "notes": "Route separation done: /completion and /completions both reach the native handler and answer the b10621 native object (index, content, tokens, id_slot, stop, model, tokens_predicted, tokens_evaluated, generation_settings, prompt, has_new_line, truncated, stop_type, stopping_word, tokens_cached, timings with cache_n), and the streaming form ends with that same object rather than a [DONE] sentinel. The key set and order were taken from a capture of the pinned binary. #1466 closed the stop-sequence half: `stop` now truncates the emitted text, and stop_type reports \"word\" with the matched string in stopping_word, matching the pinned binary on the same request. The remaining differences are listed in divergence and are #1441's, which is why this entry stays deferred and is filed under it.",
       "divergence": [
-        "String stop sequences reach ServerGenerateOptions and are never enforced on the MLX serving path, so `stop` has no effect on the emitted text and `stop_type` can never report `word` (#1466).",
         "`generation_settings` echoes the settings mlxcel actually resolved rather than b10621's full task_params block, so keys mlxcel has no analogue for are absent (#1441).",
         "`id_slot` is always -1: the continuous-batching scheduler exposes no stable per-request slot number (#1441).",
         "`return_tokens`, `return_progress`, `verbose`, `n_indent`, `t_max_predict_ms` and `n_cmpl` above 1 are refused with a diagnostic rather than honored (#1441)."
@@ -182,11 +181,10 @@
       "condition": null,
       "discovery": "source-route-registration",
       "state": "deferred",
-      "issue": 1466,
+      "issue": 1441,
       "test": "src/server/routes/native_route_tests.rs",
-      "notes": "Route separation done: /completion and /completions both reach the native handler and answer the b10621 native object (index, content, tokens, id_slot, stop, model, tokens_predicted, tokens_evaluated, generation_settings, prompt, has_new_line, truncated, stop_type, stopping_word, tokens_cached, timings with cache_n), and the streaming form ends with that same object rather than a [DONE] sentinel. The key set and order were taken from a capture of the pinned binary. The remaining differences are listed in divergence and keep this entry deferred; the stop-sequence half is tracked separately as #1466 because the fix belongs to the MLX scheduler and to the field:stop entry in sampling-and-grammar.json.",
+      "notes": "Route separation done: /completion and /completions both reach the native handler and answer the b10621 native object (index, content, tokens, id_slot, stop, model, tokens_predicted, tokens_evaluated, generation_settings, prompt, has_new_line, truncated, stop_type, stopping_word, tokens_cached, timings with cache_n), and the streaming form ends with that same object rather than a [DONE] sentinel. The key set and order were taken from a capture of the pinned binary. #1466 closed the stop-sequence half: `stop` now truncates the emitted text, and stop_type reports \"word\" with the matched string in stopping_word, matching the pinned binary on the same request. The remaining differences are listed in divergence and are #1441's, which is why this entry stays deferred and is filed under it.",
       "divergence": [
-        "String stop sequences reach ServerGenerateOptions and are never enforced on the MLX serving path, so `stop` has no effect on the emitted text and `stop_type` can never report `word` (#1466).",
         "`generation_settings` echoes the settings mlxcel actually resolved rather than b10621's full task_params block, so keys mlxcel has no analogue for are absent (#1441).",
         "`id_slot` is always -1: the continuous-batching scheduler exposes no stable per-request slot number (#1441).",
         "`return_tokens`, `return_progress`, `verbose`, `n_indent`, `t_max_predict_ms` and `n_cmpl` above 1 are refused with a diagnostic rather than honored (#1441)."

--- a/compat/llama-server/b10621/sampling-and-grammar.json
+++ b/compat/llama-server/b10621/sampling-and-grammar.json
@@ -1374,10 +1374,10 @@
       "field_type": "json",
       "description": "Specify stopping strings. Generation stops when one is produced, and the string is not included in the output",
       "discovery": "source-schema-declaration",
-      "state": "deferred",
-      "issue": 1436,
-      "test": "src/server/llama_compat_tests.rs",
-      "notes": "Deserialized as scalar or array (#1430) and carried to ServerGenerateOptions, but only the default-off OpenXLA worker consumes it (src/server/batch/stop_matcher.rs); the shipped MLX decode path never truncates on a stop string. #1436 owns it.",
+      "state": "supported",
+      "issue": 1466,
+      "test": "src/server/batch/stop_sequence_tests.rs::a_stop_string_truncates_the_text_and_excludes_the_match",
+      "notes": "Deserialized as scalar or array (#1430), carried to ServerGenerateOptions, and enforced on the shipping MLX serving path since #1466: every decoded piece passes through StopMatcher (src/server/batch/stop_matcher.rs) before it reaches the client, so a match truncates the text, the stop string is excluded, generation ends, and the matched string is reported as stopping_word with stop_type \"word\". Verified against the pinned b10621 binary on Qwen3-0.6B: `stop: [\"5\"]` on `Count: 1 2 3` returns content \" 4 \" with tokens_predicted 4 on both.",
       "divergence": [],
       "mlxcel": {
         "field": "stop"

--- a/docs/llama-server-compat.md
+++ b/docs/llama-server-compat.md
@@ -75,6 +75,14 @@ The native completion object carries `index`, `content`, `tokens`, `id_slot`, `s
 
 Native request fields mlxcel has no equivalent for are now refused with a 400 naming the field and the alternative, instead of being accepted and ignored: `n_cmpl` (and its `n` alias) above 1, `n_indent`, `t_max_predict_ms`, `return_progress`, `verbose` and `return_tokens`. Each is still accepted at its inert value, so a client that sends the whole schema at its defaults is not turned away.
 
+### `stop` truncates the output instead of being ignored (#1466)
+
+`stop` is honored on the shipping MLX serving path, on every completion route and in both the streaming and non-streaming forms. Generation ends at the first match, the matched string is excluded from the emitted text, and the native response reports `stop_type: "word"` with the match in `stopping_word`. It was previously parsed and carried into the scheduler and then never read, so a request that asked to stop on a string ran to `n_predict` with the string in its output.
+
+The match runs on decoded text as it is produced, so a stop string that straddles token boundaries is caught, and a decoded piece whose tail could still become one is withheld from the stream until the next piece resolves it. The concatenation of the streamed chunks is therefore always exactly the non-streaming `content`: a client cannot observe text that a later token turns into a match. On a tie, the earliest match in the text wins, and among equal positions the first entry in the request's `stop` list.
+
+The match is against the raw generated stream, as upstream does, not against a reasoning-stripped view of it. On a reasoning model a stop string that appears inside a `<think>` block therefore ends the request there. `/v1/messages` reports that as Anthropic's `stop_reason: "stop_sequence"` with the matched string in `stop_sequence`.
+
 ## Sharding
 
 The manifest is sharded by area so that the concurrent implementation chains of epic #1431 edit disjoint files. Ownership is machine-readable, not prose: `pin.json`'s `shards` map records, per shard, the set of implementation issue numbers allowed to own entries in it (`shards["authentication"].owners == [1437]`, for example), and `scripts/ci/check_llama_compat_manifest.py` fails an entry whose `issue` is not a member of its own shard's owner set. That is what stops two concurrent chains from editing the same file: the file, not just the reviewer, rejects the second chain's entry.
@@ -95,7 +103,7 @@ The manifest is sharded by area so that the concurrent implementation chains of 
 | `ui-tools-mcp-gcp.json` | B | #1435, #1456 |
 | `streams-and-realtime.json` | B | #1444 |
 | `runtime-and-context.json` | C | #1449, #1450, #1453, #1472, #1473 |
-| `sampling-and-grammar.json` | C | #1436, #1377 |
+| `sampling-and-grammar.json` | C | #1436, #1377, #1466 |
 | `speculative.json` | C | #1433 |
 | `logging-and-presets.json` | C | #1448 |
 

--- a/src/server/batch/active.rs
+++ b/src/server/batch/active.rs
@@ -141,6 +141,7 @@ impl std::fmt::Debug for ActiveBatch {
 mod tests {
     use super::*;
     use crate::server::batch::sequence::SequenceState;
+    use crate::server::batch::stop_matcher::StopMatcher;
     use crate::server::model_provider::GenerateEvent;
     use crate::server::model_provider::model_worker::StreamingDecodeState;
     use mlxcel_core::generate::SamplingConfig;
@@ -170,6 +171,7 @@ mod tests {
             generated_tokens: Vec::new(),
             generated_text: String::new(),
             decode_state,
+            stop_matcher: StopMatcher::default(),
             prefill_offset: 0,
             prefill_start_offset: 0,
             already_cached_tokens: 0,

--- a/src/server/batch/mod.rs
+++ b/src/server/batch/mod.rs
@@ -55,10 +55,12 @@ pub(crate) mod speculative_slice;
 mod speculative_slice_tests;
 /// Streaming-safe stop-string matcher (issue #449 M3 Stage 2d). Pure logic with
 /// no device state, so it is always compiled and unit-tested in ordinary
-/// `cargo test`; only the `xla-iree` serve worker consumes it today, so its
-/// items read as dead code when that feature is off.
-#[cfg_attr(not(feature = "xla-iree"), allow(dead_code))]
-mod stop_matcher;
+/// `cargo test`. Both backends drive it: the MLX scheduler through
+/// [`SequenceInfo::stream_decoded_text`] (issue #1466) and the `xla-iree` serve
+/// worker directly.
+pub(crate) mod stop_matcher;
+#[cfg(test)]
+mod stop_sequence_tests;
 /// Pure tick-arbitration policy (issue #908): the decision `decide_action`
 /// used to inline, extracted so the unit tests exercise the real policy
 /// instead of a local copy, and home of the `MLXCEL_MIXED_STEP` prototype.

--- a/src/server/batch/queue.rs
+++ b/src/server/batch/queue.rs
@@ -267,6 +267,7 @@ impl std::fmt::Debug for PrefillQueue {
 mod tests {
     use super::*;
     use crate::server::batch::sequence::SequenceState;
+    use crate::server::batch::stop_matcher::StopMatcher;
     use crate::server::model_provider::GenerateEvent;
     use crate::server::model_provider::model_worker::StreamingDecodeState;
     use mlxcel_core::cache::SequenceId;
@@ -301,6 +302,7 @@ mod tests {
             generated_tokens: Vec::new(),
             generated_text: String::new(),
             decode_state,
+            stop_matcher: StopMatcher::default(),
             prefill_offset: 0,
             prefill_start_offset: 0,
             already_cached_tokens: 0,

--- a/src/server/batch/scheduler.rs
+++ b/src/server/batch/scheduler.rs
@@ -90,6 +90,7 @@ use super::queue::PrefillQueue;
 use super::sequence::{
     BatchSchedulerAction, FinishReason, RequestPriority, SequenceInfo, SequenceState,
 };
+use super::stop_matcher::StopMatcher;
 use super::tick_policy::{
     TickChoice, TickState, decide_tick, mixed_step_enabled, resolve_prefill_grant_interval,
 };
@@ -1187,6 +1188,9 @@ impl BatchScheduler {
             generated_tokens: Vec::new(),
             generated_text: String::new(),
             decode_state,
+            // The prefill-role handoff carries no request options, so no string
+            // stop sequences reach it; the matcher is an exact pass-through.
+            stop_matcher: StopMatcher::default(),
             prefill_offset: 0,
             prefill_start_offset: 0,
             already_cached_tokens: 0,
@@ -1282,6 +1286,9 @@ impl BatchScheduler {
             generated_tokens,
             generated_text: String::new(),
             decode_state,
+            // The decode-role ingest is driven by the handoff frame, which
+            // carries no string stop sequences (#126 B2c scope).
+            stop_matcher: StopMatcher::default(),
             prefill_offset,
             prefill_start_offset: 0,
             already_cached_tokens: 0,
@@ -4122,6 +4129,10 @@ impl BatchScheduler {
             generated_tokens: Vec::new(),
             generated_text: String::new(),
             decode_state,
+            // Honor the request's string stop sequences on the MLX serving path
+            // (issue #1466). Empty / absent leaves the matcher inactive, in
+            // which case every decoded piece is emitted verbatim.
+            stop_matcher: StopMatcher::new(options.stop_sequences.clone().unwrap_or_default()),
             prefill_offset: 0,
             prefill_start_offset,
             already_cached_tokens,
@@ -6760,15 +6771,17 @@ impl BatchScheduler {
         seq.merged_eos = eos_tokens;
         seq.token_history = token_history;
 
-        if let Some(new_text) = seq.decode_state.on_token(first_token, &self.tokenizer) {
-            let event = match token_lp {
-                Some(lp) => GenerateEvent::TokenWithLogprobs(new_text, lp),
-                None => GenerateEvent::Token(new_text),
-            };
-            let _ = seq.response_tx.send(event);
-        }
+        // Stream the first token's text through the request's stop matcher
+        // (issue #1466). A short stop string can complete on this very token, in
+        // which case generation ends here and the matched text is never emitted.
+        let prefill_stop_word = match seq.decode_state.on_token(first_token, &self.tokenizer) {
+            Some(new_text) => seq.stream_decoded_text(new_text, token_lp),
+            None => None,
+        };
 
-        let prefill_finish_reason = if structured_stopped {
+        let prefill_finish_reason = if prefill_stop_word.is_some() {
+            Some(FinishReason::StopSequence)
+        } else if structured_stopped {
             Some(FinishReason::Stop)
         } else if seq.generated_tokens.len() >= seq.max_tokens {
             Some(FinishReason::Length)
@@ -6785,17 +6798,13 @@ impl BatchScheduler {
             // Forward any tail the incremental detokenizer held back (a final
             // token carrying complete text plus a trailing incomplete UTF-8
             // byte) as one last token event before Done, so streaming clients
-            // receive it (issue #633).
-            if let Some(tail) = seq.decode_state.flush(&self.tokenizer) {
-                let _ = seq.response_tx.send(GenerateEvent::Token(tail));
-            }
+            // receive it (issue #633). It goes through the stop matcher too, so
+            // a stop string that only becomes visible in the tail still fires
+            // and the tail is dropped rather than leaked.
+            let tail = seq.decode_state.flush(&self.tokenizer);
+            seq.close_text_stream(tail);
             let cached = seq.already_cached_tokens;
-            let result = seq.decode_state.finish_with_cache(
-                seq.created_at,
-                seq.prompt_tokens.len(),
-                seq.max_tokens,
-                cached,
-            );
+            let result = seq.take_generation_result(&self.tokenizer, cached);
             tracing::info!(
                 prompt_tokens = seq.prompt_tokens.len(),
                 cached_tokens = cached,
@@ -6942,6 +6951,10 @@ impl BatchScheduler {
             victim.prefill_start_offset = 0;
             victim.already_cached_tokens = 0;
             victim.decode_state = StreamingDecodeState::new(&self.tokenizer, &victim.prompt_tokens);
+            // The matcher's held tail and emitted-byte count describe the decode
+            // being discarded, so they reset with it (issue #1466). The
+            // request's stop strings survive: re-prefill must still honor them.
+            victim.stop_matcher.reset();
             victim.token_history.clear();
             victim.merged_eos.clear();
 
@@ -7733,15 +7746,24 @@ impl BatchScheduler {
                 seq.token_history.push(token_val);
             }
 
-            if let Some(new_text) = seq.decode_state.on_token(token_val, &self.tokenizer) {
-                let event = match token_lp {
-                    Some(lp) => GenerateEvent::TokenWithLogprobs(new_text, lp),
-                    None => GenerateEvent::Token(new_text),
-                };
-                let _ = seq.response_tx.send(event);
+            // Stream through the request's stop matcher (issue #1466): text that
+            // could still become a stop string is held back, and a completed
+            // stop string ends the sequence with the match excluded.
+            let stop_word = match seq.decode_state.on_token(token_val, &self.tokenizer) {
+                Some(new_text) => seq.stream_decoded_text(new_text, token_lp),
+                None => None,
+            };
+
+            if stop_word.is_some()
+                && let Err(err) = seq
+                    .state
+                    .transition_to(SequenceState::Finished(FinishReason::StopSequence))
+            {
+                tracing::error!("State transition error: {err}");
             }
 
-            if structured_stopped
+            if !seq.state.is_finished()
+                && structured_stopped
                 && let Err(err) = seq
                     .state
                     .transition_to(SequenceState::Finished(FinishReason::Stop))
@@ -7878,11 +7900,25 @@ impl BatchScheduler {
                 seq.token_history.push(token_val);
             }
 
-            if let Some(new_text) = seq.decode_state.on_token(token_val, &self.tokenizer) {
-                let _ = seq.response_tx.send(GenerateEvent::Token(new_text));
+            // Same stop-string enforcement as the per-row loop (issue #1466).
+            // The fast path excludes penalty-bearing configs, not stop strings,
+            // so it must honor them or a request would silently change behavior
+            // depending on which decode kernel the batch happened to take.
+            let stop_word = match seq.decode_state.on_token(token_val, &self.tokenizer) {
+                Some(new_text) => seq.stream_decoded_text(new_text, None),
+                None => None,
+            };
+
+            if stop_word.is_some()
+                && let Err(err) = seq
+                    .state
+                    .transition_to(SequenceState::Finished(FinishReason::StopSequence))
+            {
+                tracing::error!("State transition error: {err}");
             }
 
-            if seq.generated_tokens.len() >= seq.max_tokens
+            if !seq.state.is_finished()
+                && seq.generated_tokens.len() >= seq.max_tokens
                 && let Err(err) = seq
                     .state
                     .transition_to(SequenceState::Finished(FinishReason::Length))
@@ -8092,15 +8128,22 @@ impl BatchScheduler {
             seq.token_history.push(token_val);
         }
 
-        if let Some(new_text) = seq.decode_state.on_token(token_val, &self.tokenizer) {
-            let event = match token_lp {
-                Some(lp) => GenerateEvent::TokenWithLogprobs(new_text, lp),
-                None => GenerateEvent::Token(new_text),
-            };
-            let _ = seq.response_tx.send(event);
+        // Stop-string enforcement for the single-step decode path (issue #1466).
+        let stop_word = match seq.decode_state.on_token(token_val, &self.tokenizer) {
+            Some(new_text) => seq.stream_decoded_text(new_text, token_lp),
+            None => None,
+        };
+
+        if stop_word.is_some()
+            && let Err(err) = seq
+                .state
+                .transition_to(SequenceState::Finished(FinishReason::StopSequence))
+        {
+            tracing::error!("State transition error: {err}");
         }
 
-        if structured_stopped
+        if !seq.state.is_finished()
+            && structured_stopped
             && let Err(err) = seq
                 .state
                 .transition_to(SequenceState::Finished(FinishReason::Stop))
@@ -8237,16 +8280,12 @@ impl BatchScheduler {
                 // Forward the incremental detokenizer's held tail as one final
                 // token event before Done, so streaming clients are not missing
                 // text the non-streaming result.text still carries (issue #633).
-                if let Some(tail) = seq.decode_state.flush(&self.tokenizer) {
-                    let _ = seq.response_tx.send(GenerateEvent::Token(tail));
-                }
+                // The tail passes through the stop matcher, which also releases
+                // whatever the matcher itself was holding back (issue #1466).
+                let tail = seq.decode_state.flush(&self.tokenizer);
+                seq.close_text_stream(tail);
                 let cached = seq.already_cached_tokens;
-                let result = seq.decode_state.finish_with_cache(
-                    seq.created_at,
-                    seq.prompt_tokens.len(),
-                    seq.max_tokens,
-                    cached,
-                );
+                let result = seq.take_generation_result(&self.tokenizer, cached);
                 // Per-request TTFT / decode-rate telemetry (epic #623 #624).
                 // Recorded once here, where the finished sequence's timings are
                 // available, never on the per-token hot path.
@@ -8269,13 +8308,14 @@ impl BatchScheduler {
 
                 // donate the full KV cache back to
                 // the prompt-cache store on *healthy* finishes (Stop /
-                // Length / Cancelled) so the next turn of the same
-                // conversation can adopt it. `Finished(Error)` paths bypass
+                // StopSequence / Length / Cancelled) so the next turn of the
+                // same conversation can adopt it. `Finished(Error)` paths bypass
                 // this branch — their cache is assumed tainted.
                 let healthy = matches!(
                     seq.state,
                     SequenceState::Finished(
                         FinishReason::Stop
+                            | FinishReason::StopSequence
                             | FinishReason::Length
                             | FinishReason::RepetitionLoop
                             | FinishReason::Cancelled,

--- a/src/server/batch/scheduler_cohort_parity_tests.rs
+++ b/src/server/batch/scheduler_cohort_parity_tests.rs
@@ -68,6 +68,7 @@ use mlxcel_core::generate::SamplingConfig;
 use super::BatchScheduler;
 use crate::server::batch::BatchObservability;
 use crate::server::batch::sequence::{RequestPriority, SequenceInfo, SequenceState};
+use crate::server::batch::stop_matcher::StopMatcher;
 use crate::server::config::{DecodeStorageBackend, PreemptionPolicy};
 use crate::server::model_provider::GenerateEvent;
 use crate::server::model_provider::model_worker::StreamingDecodeState;
@@ -166,6 +167,7 @@ fn make_seq(
         generated_tokens: Vec::new(),
         generated_text: String::new(),
         decode_state,
+        stop_matcher: StopMatcher::default(),
         prefill_offset: 0,
         prefill_start_offset,
         already_cached_tokens: prefill_start_offset,

--- a/src/server/batch/scheduler_prompt_cache_tests.rs
+++ b/src/server/batch/scheduler_prompt_cache_tests.rs
@@ -378,6 +378,7 @@ fn sequence_info_fields_transport_cache_hit_metadata() {
     use std::sync::mpsc;
 
     use crate::server::batch::sequence::{SequenceInfo, SequenceState};
+    use crate::server::batch::stop_matcher::StopMatcher;
     use crate::server::model_provider::GenerateEvent;
     use crate::server::model_provider::model_worker::StreamingDecodeState;
     use mlxcel_core::generate::SamplingConfig;
@@ -402,6 +403,7 @@ fn sequence_info_fields_transport_cache_hit_metadata() {
         generated_tokens: Vec::new(),
         generated_text: String::new(),
         decode_state,
+        stop_matcher: StopMatcher::default(),
         prefill_offset: 0,
         prefill_start_offset: 73,
         already_cached_tokens: 73,

--- a/src/server/batch/scheduler_seed_determinism_tests.rs
+++ b/src/server/batch/scheduler_seed_determinism_tests.rs
@@ -89,6 +89,7 @@ use mlxcel_core::generate::SamplingConfig;
 use super::BatchScheduler;
 use crate::server::batch::BatchObservability;
 use crate::server::batch::sequence::{RequestPriority, SequenceInfo, SequenceState};
+use crate::server::batch::stop_matcher::StopMatcher;
 use crate::server::config::{DecodeStorageBackend, PreemptionPolicy};
 use crate::server::model_provider::GenerateEvent;
 use crate::server::model_provider::model_worker::StreamingDecodeState;
@@ -204,6 +205,7 @@ fn make_seq_with(
         generated_tokens: Vec::new(),
         generated_text: String::new(),
         decode_state,
+        stop_matcher: StopMatcher::default(),
         prefill_offset: 0,
         prefill_start_offset,
         already_cached_tokens: prefill_start_offset,

--- a/src/server/batch/scheduler_tests.rs
+++ b/src/server/batch/scheduler_tests.rs
@@ -35,6 +35,7 @@ use crate::server::batch::queue::PrefillQueue;
 use crate::server::batch::sequence::{
     BatchSchedulerAction, RequestPriority, SequenceInfo, SequenceState,
 };
+use crate::server::batch::stop_matcher::StopMatcher;
 use crate::server::config::{DecodeStorageBackend, PreemptionPolicy};
 use crate::server::model_provider::GenerateEvent;
 use crate::server::model_provider::model_worker::StreamingDecodeState;
@@ -61,6 +62,7 @@ fn make_test_sequence(id_val: u64) -> (SequenceInfo, mpsc::Receiver<GenerateEven
         generated_tokens: Vec::new(),
         generated_text: String::new(),
         decode_state,
+        stop_matcher: StopMatcher::default(),
         prefill_offset: 0,
         prefill_start_offset: 0,
         already_cached_tokens: 0,
@@ -249,6 +251,7 @@ fn make_test_sequence_with_priority(
         generated_tokens: Vec::new(),
         generated_text: String::new(),
         decode_state,
+        stop_matcher: StopMatcher::default(),
         prefill_offset: 0,
         prefill_start_offset: 0,
         already_cached_tokens: 0,

--- a/src/server/batch/sequence.rs
+++ b/src/server/batch/sequence.rs
@@ -43,8 +43,9 @@ use std::time::Instant;
 
 use mlxcel_core::cache::SequenceId;
 use mlxcel_core::generate::SamplingConfig;
-use mlxcel_core::sampling::{LogprobsConfig, SamplerState};
+use mlxcel_core::sampling::{LogprobsConfig, SamplerState, TokenLogprobData};
 
+use super::stop_matcher::StopMatcher;
 use crate::server::model_provider::GenerateEvent;
 use crate::server::model_provider::model_worker::StreamingDecodeState;
 use crate::server::thinking_budget::ThinkingState;
@@ -124,6 +125,13 @@ pub enum SequenceState {
 pub enum FinishReason {
     /// An EOS token was emitted.
     Stop,
+    /// A request-supplied string stop sequence matched the decoded text
+    /// (issue #1466). Distinct from [`Stop`](Self::Stop) so the response layer
+    /// can report b10621's `stop_type: "word"` rather than `"eos"`; the string
+    /// that matched is held by the sequence's
+    /// [`StopMatcher`](super::stop_matcher::StopMatcher), which is the single
+    /// source of truth for it on every serving path.
+    StopSequence,
     /// `max_tokens` was reached.
     Length,
     /// The N-gram loop detector tripped: the raw generated stream collapsed
@@ -147,7 +155,7 @@ impl SequenceState {
     /// Valid transitions:
     /// - `Queued -> Prefilling` (scheduler begins prefill)
     /// - `Prefilling -> Decoding` (prefill complete, enter decode loop)
-    /// - `Prefilling -> Finished(Stop | Length | RepetitionLoop)` (completed on first token)
+    /// - `Prefilling -> Finished(Stop | StopSequence | Length | RepetitionLoop)` (completed on first token)
     /// - `Decoding -> Finished(*)` (normal completion)
     /// - `Decoding -> Queued` (preemptive eviction for re-prefill)
     /// - Any non-terminal state -> `Finished(Cancelled | Error)` (early abort)
@@ -157,6 +165,11 @@ impl SequenceState {
             (SequenceState::Queued, SequenceState::Prefilling) => true,
             (SequenceState::Prefilling, SequenceState::Decoding) => true,
             (SequenceState::Prefilling, SequenceState::Finished(FinishReason::Stop)) => true,
+            // The first sampled token is decoded during prefill, so a stop
+            // string short enough to complete on it finishes the request there.
+            (SequenceState::Prefilling, SequenceState::Finished(FinishReason::StopSequence)) => {
+                true
+            }
             (SequenceState::Prefilling, SequenceState::Finished(FinishReason::Length)) => true,
             (SequenceState::Prefilling, SequenceState::Finished(FinishReason::RepetitionLoop)) => {
                 true
@@ -236,6 +249,14 @@ pub struct SequenceInfo {
     /// Streaming decode helper for incremental text emission.
     /// Used by `BatchScheduler` during prefill and decode steps.
     pub(crate) decode_state: StreamingDecodeState,
+    /// Streaming-safe matcher for the request's string stop sequences
+    /// (issue #1466). Every decoded piece passes through it before reaching
+    /// `response_tx`, so a piece that could still turn into a stop string is
+    /// held back rather than streamed. Inactive
+    /// ([`StopMatcher::default`](super::stop_matcher::StopMatcher::default))
+    /// when the request supplied no `stop` field, in which case it is an exact
+    /// pass-through and the emitted bytes are unchanged.
+    pub(crate) stop_matcher: StopMatcher,
     /// Incrementally maintained token history for penalty-based sampling.
     /// Initialized from prompt tokens during prefill, then appended per decode
     /// step. Avoids O(prompt_len + generated_len) Vec reconstruction on every
@@ -321,6 +342,137 @@ impl SequenceInfo {
     /// Returns `true` if this request carries VLM image data.
     pub fn is_vlm_request(&self) -> bool {
         self.vlm_embeddings.is_some() || !self.images.is_empty()
+    }
+
+    /// Stream one newly decoded piece to the client through the request's stop
+    /// matcher, returning the stop string that matched, if this piece completed
+    /// one (issue #1466).
+    ///
+    /// This is the single funnel every serving path uses to reach `response_tx`
+    /// with generated text: classic decode, the fused batched decode, prefill's
+    /// first token, and the speculative burst driver. Routing all of them
+    /// through one method is what makes the streamed concatenation equal the
+    /// non-streaming text, because the held-back ambiguous tail lives in one
+    /// place instead of being re-derived per call site.
+    ///
+    /// With no stop strings configured the matcher is a pass-through, so the
+    /// event sent is byte-for-byte the one the call site sent before.
+    ///
+    /// A caller that receives `Some(word)` must finish the sequence with
+    /// [`FinishReason::StopSequence`] and stop feeding tokens.
+    pub(crate) fn stream_decoded_text(
+        &mut self,
+        text: String,
+        logprobs: Option<TokenLogprobData>,
+    ) -> Option<String> {
+        // No stop strings: send the piece verbatim, exactly as every call site
+        // did before #1466, without building a `StopChunk` per decoded token.
+        // This is the overwhelmingly common case on the decode hot path.
+        if !self.stop_matcher.is_active() {
+            let event = match logprobs {
+                Some(lp) => GenerateEvent::TokenWithLogprobs(text, lp),
+                None => GenerateEvent::Token(text),
+            };
+            let _ = self.response_tx.send(event);
+            return None;
+        }
+
+        let chunk = self.stop_matcher.push(&text);
+        if !chunk.emit.is_empty() {
+            let event = match logprobs {
+                Some(lp) => GenerateEvent::TokenWithLogprobs(chunk.emit, lp),
+                None => GenerateEvent::Token(chunk.emit),
+            };
+            let _ = self.response_tx.send(event);
+        }
+        chunk.matched
+    }
+
+    /// Close the text stream at the end of generation: push the incremental
+    /// detokenizer's held tail (if any) through the stop matcher, then release
+    /// whatever the matcher itself was holding.
+    ///
+    /// The tail can itself complete a stop string, because `StreamingDecodeState`
+    /// withholds a piece whose trailing bytes are an incomplete UTF-8 sequence,
+    /// so text that completes one can first become visible here. The finish is
+    /// then reclassified as [`FinishReason::StopSequence`], which the caller must
+    /// not have to remember: this method is the only place that closes the
+    /// stream, so folding the reclassification in makes it unmissable.
+    ///
+    /// A `Cancelled` or `Error` finish is never reclassified. Those outcomes
+    /// gate the prompt-cache donate-back and the wire response, and a stop string
+    /// that happens to surface while a request is failing does not make it a
+    /// healthy stop.
+    ///
+    /// After a stop string has already matched the matcher is inert, so neither
+    /// the tail nor the held text is emitted and the client never sees a byte
+    /// past the match.
+    pub(crate) fn close_text_stream(&mut self, tail: Option<String>) {
+        let tail_matched = tail
+            .and_then(|t| self.stream_decoded_text(t, None))
+            .is_some();
+        if !self.stop_matcher.has_matched() {
+            let held = self.stop_matcher.flush();
+            if !held.is_empty() {
+                let _ = self.response_tx.send(GenerateEvent::Token(held));
+            }
+        }
+        if tail_matched
+            && matches!(
+                self.state,
+                SequenceState::Finished(
+                    FinishReason::Stop | FinishReason::Length | FinishReason::RepetitionLoop
+                )
+            )
+        {
+            self.state = SequenceState::Finished(FinishReason::StopSequence);
+        }
+    }
+
+    /// The stop string that ended this request, or `None` when no string stop
+    /// sequence matched.
+    pub(crate) fn matched_stop(&self) -> Option<&str> {
+        self.stop_matcher.matched()
+    }
+
+    /// Build the final [`GenerationResult`] for this sequence, taking the
+    /// incremental decode state with it.
+    ///
+    /// When a string stop sequence matched, the accumulated text is truncated to
+    /// the bytes that actually reached the client, so the non-streaming `text`
+    /// equals the concatenation of the streamed chunks, and the finish is
+    /// stamped as [`StopKind::Word`] carrying the matched string. Otherwise this
+    /// is exactly the `finish_with_cache` the call sites used before.
+    ///
+    /// Takes `&mut self` rather than `self` because every call site still needs
+    /// the sequence afterwards (prompt-cache donate-back reads `prompt_tokens`
+    /// and `generated_tokens`). The decode state is swapped out for an empty
+    /// one, which is never read again.
+    ///
+    /// [`StopKind::Word`]: crate::server::model_provider::StopKind::Word
+    pub(crate) fn take_generation_result(
+        &mut self,
+        tokenizer: &crate::tokenizer::MlxcelTokenizer,
+        cached_tokens: usize,
+    ) -> crate::server::model_provider::GenerationResult {
+        let state = std::mem::replace(
+            &mut self.decode_state,
+            StreamingDecodeState::new(tokenizer, &[]),
+        );
+        let prompt_len = self.prompt_tokens.len();
+        match self.stop_matcher.matched() {
+            Some(word) => state.finish_stopped_by_word(
+                word.to_string(),
+                self.stop_matcher.emitted_len(),
+                self.created_at,
+                prompt_len,
+                self.max_tokens,
+                cached_tokens,
+            ),
+            None => {
+                state.finish_with_cache(self.created_at, prompt_len, self.max_tokens, cached_tokens)
+            }
+        }
     }
 }
 

--- a/src/server/batch/serving_handoff_parity_tests.rs
+++ b/src/server/batch/serving_handoff_parity_tests.rs
@@ -67,6 +67,7 @@ use crate::distributed::tcp_transport::{TcpTransport, TcpTransportConfig};
 use crate::distributed::transport::Transport;
 use crate::server::batch::BatchObservability;
 use crate::server::batch::sequence::{RequestPriority, SequenceInfo, SequenceState};
+use crate::server::batch::stop_matcher::StopMatcher;
 use crate::server::config::{DecodeStorageBackend, PreemptionPolicy};
 use crate::server::model_provider::GenerateEvent;
 use crate::server::model_provider::model_worker::StreamingDecodeState;
@@ -166,6 +167,7 @@ fn make_request(
         generated_tokens: Vec::new(),
         generated_text: String::new(),
         decode_state,
+        stop_matcher: StopMatcher::default(),
         prefill_offset: 0,
         prefill_start_offset: 0,
         already_cached_tokens: 0,

--- a/src/server/batch/speculative_burst.rs
+++ b/src/server/batch/speculative_burst.rs
@@ -2019,15 +2019,18 @@ pub(crate) fn stream_burst_tokens(
             // classic path does the same when `compute_logprobs`
             // returns `None`, e.g. on a sampler override). A fired
             // thinking-budget override also forces plain `Token`.
-            let event = if logprobs_on && !override_fired {
-                match logprobs.get(idx).and_then(|lp| lp.clone()) {
-                    Some(lp) => GenerateEvent::TokenWithLogprobs(new_text, lp),
-                    None => GenerateEvent::Token(new_text),
-                }
+            let lp = if logprobs_on && !override_fired {
+                logprobs.get(idx).and_then(|lp| lp.clone())
             } else {
-                GenerateEvent::Token(new_text)
+                None
             };
-            let _ = seq.response_tx.send(event);
+            // Same stop-string enforcement as the classic decode path
+            // (issue #1466): a speculative request must not outrun its own
+            // stop strings just because its tokens arrive several at a time.
+            if seq.stream_decoded_text(new_text, lp).is_some() {
+                stream.done = true;
+                return true;
+            }
         }
     }
     // Budget saturation terminates the stream even when the last committed
@@ -2049,8 +2052,12 @@ pub(crate) fn finalize_burst_stream(
     mut seq: SequenceInfo,
     stream: &BurstStreamState,
 ) -> FinalizeOutcome {
-    // Final state classification.
-    let finish_reason = if stream.hit_eos {
+    // Final state classification. A matched string stop sequence outranks the
+    // budget: the request ended because the caller's own stop string appeared,
+    // not because it ran out of tokens (issue #1466).
+    let finish_reason = if seq.matched_stop().is_some() {
+        FinishReason::StopSequence
+    } else if stream.hit_eos {
         FinishReason::Stop
     } else if seq.generated_tokens.len() >= stream.max_tokens {
         FinishReason::Length
@@ -2064,15 +2071,18 @@ pub(crate) fn finalize_burst_stream(
     // classify the finish for the prompt-cache donate gate
     // BEFORE `finish_reason` is moved into `transition_to`. Mirrors the
     // `healthy` gate in `scheduler.rs::finalize_completed` — only
-    // `Stop` / `Length` / `Cancelled` finishes donate their cache back.
-    // `finalize_burst_success` only ever classifies `Stop` or `Length`
-    // (the `Error` / `Cancelled` outcomes never reach this function),
-    // so this is always `true` here; computing it explicitly keeps the
-    // burst path's gate bit-identical to the classic path's and robust
-    // if the classification above ever gains a new arm.
+    // `Stop` / `StopSequence` / `Length` / `Cancelled` finishes donate their
+    // cache back. `finalize_burst_success` only ever classifies `Stop`,
+    // `StopSequence` or `Length` (the `Error` / `Cancelled` outcomes never
+    // reach this function), so this is always `true` here; computing it
+    // explicitly keeps the burst path's gate bit-identical to the classic
+    // path's and robust if the classification above ever gains a new arm.
     let healthy_finish = matches!(
         finish_reason,
-        FinishReason::Stop | FinishReason::Length | FinishReason::Cancelled
+        FinishReason::Stop
+            | FinishReason::StopSequence
+            | FinishReason::Length
+            | FinishReason::Cancelled
     );
     if let Err(err) = seq
         .state
@@ -2083,17 +2093,13 @@ pub(crate) fn finalize_burst_stream(
 
     let tokens_generated = seq.generated_tokens.len();
     // Forward the incremental detokenizer's held tail as one final token event
-    // before Done so streaming clients receive it (issue #633).
-    if let Some(tail) = seq.decode_state.flush(tokenizer) {
-        let _ = seq.response_tx.send(GenerateEvent::Token(tail));
-    }
+    // before Done so streaming clients receive it (issue #633), through the stop
+    // matcher so a stop string that only completes in the tail still fires and
+    // the tail is dropped rather than leaked (issue #1466).
+    let tail = seq.decode_state.flush(tokenizer);
+    seq.close_text_stream(tail);
     let cached = seq.already_cached_tokens;
-    let result = seq.decode_state.finish_with_cache(
-        seq.created_at,
-        seq.prompt_tokens.len(),
-        seq.max_tokens,
-        cached,
-    );
+    let result = seq.take_generation_result(tokenizer, cached);
     tracing::info!(
         prompt_tokens = seq.prompt_tokens.len(),
         generated_tokens = tokens_generated,

--- a/src/server/batch/speculative_burst_tests.rs
+++ b/src/server/batch/speculative_burst_tests.rs
@@ -82,6 +82,7 @@ use mlxcel_core::weights::WeightMap;
 use mlxcel_core::{MlxArray, UniquePtr, from_slice_f32};
 
 use crate::server::batch::sequence::{RequestPriority, SequenceInfo, SequenceState};
+use crate::server::batch::stop_matcher::StopMatcher;
 use crate::server::model_provider::GenerateEvent;
 use crate::server::model_provider::model_worker::StreamingDecodeState;
 use crate::server::thinking_budget::ThinkingState;
@@ -118,6 +119,7 @@ fn make_test_sequence() -> (SequenceInfo, mpsc::Receiver<GenerateEvent>) {
         generated_tokens: Vec::new(),
         generated_text: String::new(),
         decode_state,
+        stop_matcher: StopMatcher::default(),
         prefill_offset: 0,
         prefill_start_offset: 0,
         already_cached_tokens: 0,

--- a/src/server/batch/speculative_slice_tests.rs
+++ b/src/server/batch/speculative_slice_tests.rs
@@ -59,6 +59,7 @@ use mlxcel_core::weights::WeightMap;
 use mlxcel_core::{MlxArray, UniquePtr, from_slice_f32};
 
 use crate::server::batch::sequence::{RequestPriority, SequenceInfo, SequenceState};
+use crate::server::batch::stop_matcher::StopMatcher;
 use crate::server::model_provider::GenerateEvent;
 use crate::server::model_provider::model_worker::StreamingDecodeState;
 use crate::server::thinking_budget::ThinkingState;
@@ -275,6 +276,7 @@ fn make_slice_sequence_with_id(
         generated_tokens: Vec::new(),
         generated_text: String::new(),
         decode_state,
+        stop_matcher: StopMatcher::default(),
         prefill_offset: 0,
         prefill_start_offset: 0,
         already_cached_tokens: 0,

--- a/src/server/batch/stop_matcher.rs
+++ b/src/server/batch/stop_matcher.rs
@@ -31,20 +31,31 @@
 //! test below.
 //!
 //! The matcher is pure (no IREE / device state), so it lives outside the
-//! `xla-iree` cfg gate and its unit tests run in an ordinary `cargo test`. The
-//! OpenXLA serve worker ([`XlaServeWorker`](super::xla_worker)) drives it; nothing
-//! else does today, but it is backend-neutral by construction.
+//! `xla-iree` cfg gate and its unit tests run in an ordinary `cargo test`. Both
+//! serving backends drive it: the MLX [`BatchScheduler`](super::BatchScheduler)
+//! through [`SequenceInfo`](super::SequenceInfo) (issue #1466) and the OpenXLA
+//! serve worker ([`XlaServeWorker`](super::xla_worker)).
 
 /// The result of feeding one decoded piece to a [`StopMatcher`].
 pub(crate) struct StopChunk {
     /// Text that is safe to emit to the client now. May be empty when the whole
     /// piece is held back as a potential stop-string prefix.
     pub emit: String,
-    /// `true` once a stop string has fully matched. The caller should emit
-    /// [`StopChunk::emit`] (the text up to the match) and then finalize the
-    /// request with a `stop` finish reason; the matcher will produce nothing
-    /// further.
-    pub stopped: bool,
+    /// The stop string that matched, or `None` while generation continues.
+    ///
+    /// This carries both the stop signal and the identity of what stopped it, so
+    /// the response layer can report b10621's `stopping_word` (issue #1466). It
+    /// used to be a bare `stopped: bool`, which could say that a request had
+    /// been stopped but not by what, and the string cannot be recovered from the
+    /// text afterwards because the match is excluded from it.
+    ///
+    /// On a tie (two stop strings matching at the same index) this is the first
+    /// entry in the request's stop list, the rule `apply_stop_sequences` uses.
+    ///
+    /// `Some` means the request is over: the caller emits
+    /// [`emit`](Self::emit) (the text up to the match) and finalizes with a stop
+    /// finish reason. The matcher produces nothing further.
+    pub matched: Option<String>,
 }
 
 /// Incremental stop-string matcher for one in-flight request.
@@ -65,6 +76,21 @@ pub(crate) struct StopMatcher {
     /// prefix of the full decoded text, so the worker can truncate its decode
     /// buffer to this length to obtain the (stop-truncated) result text.
     emitted_len: usize,
+    /// The stop string that ended the request, recorded on the matcher so a
+    /// caller that finalizes later (the scheduler builds the `Done` event well
+    /// after the matching decode step) can still name it without threading the
+    /// value through its own state.
+    matched: Option<String>,
+}
+
+impl Default for StopMatcher {
+    /// An inactive matcher: no stop strings, so [`push`](Self::push) is a
+    /// pass-through. This is the state of every request that supplies no `stop`
+    /// field, and the construction used by call sites that never had stop
+    /// strings (the disaggregated handoff, test fixtures).
+    fn default() -> Self {
+        Self::new(Vec::<String>::new())
+    }
 }
 
 impl StopMatcher {
@@ -83,6 +109,7 @@ impl StopMatcher {
             stops,
             pending: String::new(),
             emitted_len: 0,
+            matched: None,
         }
     }
 
@@ -100,15 +127,50 @@ impl StopMatcher {
         self.emitted_len
     }
 
+    /// The stop string that ended this request, or `None` while no stop string
+    /// has matched. Sticky: once set it stays set for the life of the matcher,
+    /// so the finalization path can read it long after the matching step.
+    pub(crate) fn matched(&self) -> Option<&str> {
+        self.matched.as_deref()
+    }
+
+    /// Whether a stop string has already matched. Callers use this to classify
+    /// the finish reason without re-running the match.
+    pub(crate) fn has_matched(&self) -> bool {
+        self.matched.is_some()
+    }
+
+    /// Drop all in-flight matching state, keeping the request's stop strings.
+    ///
+    /// Preemptive eviction restarts a sequence's decode from scratch, resetting
+    /// its `StreamingDecodeState` and clearing its generated tokens. The
+    /// matcher's held tail and emitted-byte count describe the discarded decode,
+    /// so they must be reset alongside it or the re-run would be truncated
+    /// against a stale offset.
+    pub(crate) fn reset(&mut self) {
+        self.pending.clear();
+        self.emitted_len = 0;
+        self.matched = None;
+    }
+
     /// Feed one newly decoded piece. Returns the text to emit now and whether a
     /// stop string matched.
     pub(crate) fn push(&mut self, piece: &str) -> StopChunk {
+        // Already stopped: the request is over, so nothing further is emitted.
+        // Generation halts on the matching step, so this is defensive only.
+        if self.matched.is_some() {
+            return StopChunk {
+                emit: String::new(),
+                matched: self.matched.clone(),
+            };
+        }
+
         // No stop strings: emit verbatim, nothing is ever held.
         if self.stops.is_empty() {
             self.emitted_len += piece.len();
             return StopChunk {
                 emit: piece.to_string(),
-                stopped: false,
+                matched: None,
             };
         }
 
@@ -116,13 +178,15 @@ impl StopMatcher {
 
         // Earliest full match across all stop strings wins (same rule as
         // `apply_stop_sequences`). Everything from the match onward is dropped.
-        if let Some(idx) = self.earliest_full_match() {
+        if let Some((idx, which)) = self.earliest_full_match() {
             let emit = self.pending[..idx].to_string();
+            let matched = self.stops[which].clone();
             self.emitted_len += emit.len();
             self.pending.clear();
+            self.matched = Some(matched.clone());
             return StopChunk {
                 emit,
-                stopped: true,
+                matched: Some(matched),
             };
         }
 
@@ -135,26 +199,35 @@ impl StopMatcher {
         self.pending.drain(..cut);
         StopChunk {
             emit,
-            stopped: false,
+            matched: None,
         }
     }
 
     /// Release any held-back tail at the natural end of generation. Because the
     /// tail never completed a stop string, it is real output and must be emitted.
+    ///
+    /// After a match the held text was already dropped, so this returns the
+    /// empty string and the caller emits nothing further.
     pub(crate) fn flush(&mut self) -> String {
         let out = std::mem::take(&mut self.pending);
         self.emitted_len += out.len();
         out
     }
 
-    /// Byte index of the earliest full stop-string occurrence in `pending`, if
-    /// any. Ties (two stops matching at the same index) resolve to that shared
-    /// index, which is all the caller needs for truncation.
-    fn earliest_full_match(&self) -> Option<usize> {
-        let mut best: Option<usize> = None;
-        for s in &self.stops {
-            if let Some(i) = self.pending.find(s.as_str()) {
-                best = Some(best.map_or(i, |b| b.min(i)));
+    /// Byte index of the earliest full stop-string occurrence in `pending` and
+    /// the index into [`Self::stops`] of the string that produced it, if any.
+    ///
+    /// Ties (two stops matching at the same index) resolve to the first entry in
+    /// the request's stop list, because the comparison is strictly-less-than.
+    /// That is exactly what `apply_stop_sequences` does, so the reported
+    /// `stopping_word` agrees with the post-hoc truncation path.
+    fn earliest_full_match(&self) -> Option<(usize, usize)> {
+        let mut best: Option<(usize, usize)> = None;
+        for (n, s) in self.stops.iter().enumerate() {
+            if let Some(i) = self.pending.find(s.as_str())
+                && best.map(|(b, _)| i < b).unwrap_or(true)
+            {
+                best = Some((i, n));
             }
         }
         best
@@ -193,20 +266,21 @@ mod tests {
     use crate::server::anthropic_translator::apply_stop_sequences;
 
     /// Drive a matcher over `pieces` and return everything it emitted (including
-    /// the flushed tail when generation was not stopped by a match).
-    fn run(stops: &[&str], pieces: &[&str]) -> (String, bool) {
+    /// the flushed tail when generation was not stopped by a match) together
+    /// with the stop string that ended it, if any.
+    fn run(stops: &[&str], pieces: &[&str]) -> (String, Option<String>) {
         let mut m = StopMatcher::new(stops.iter().map(|s| s.to_string()));
         let mut out = String::new();
-        let mut stopped = false;
+        let mut matched = None;
         for p in pieces {
             let chunk = m.push(p);
             out.push_str(&chunk.emit);
-            if chunk.stopped {
-                stopped = true;
+            if chunk.matched.is_some() {
+                matched = chunk.matched;
                 break;
             }
         }
-        if !stopped {
+        if matched.is_none() {
             out.push_str(&m.flush());
         }
         assert_eq!(
@@ -214,17 +288,24 @@ mod tests {
             m.emitted_len(),
             "emitted_len must track total emitted bytes"
         );
-        (out, stopped)
+        assert_eq!(
+            m.matched().map(str::to_string),
+            matched,
+            "the matcher must remember the stop string it reported"
+        );
+        assert_eq!(m.has_matched(), matched.is_some());
+        (out, matched)
     }
 
     #[test]
     fn no_stops_is_passthrough() {
-        let (out, stopped) = run(&[], &["hello ", "world"]);
+        let (out, matched) = run(&[], &["hello ", "world"]);
         assert_eq!(out, "hello world");
-        assert!(!stopped);
-        let mut m = StopMatcher::new(Vec::<String>::new());
+        assert_eq!(matched, None);
+        let mut m = StopMatcher::default();
         assert!(!m.is_active());
         assert_eq!(m.push("x").emit, "x");
+        assert!(!m.has_matched());
     }
 
     #[test]
@@ -235,76 +316,78 @@ mod tests {
 
     #[test]
     fn stop_within_single_piece() {
-        let (out, stopped) = run(&["STOP"], &["hello STOP world"]);
+        let (out, matched) = run(&["STOP"], &["hello STOP world"]);
         assert_eq!(out, "hello ");
-        assert!(stopped);
+        assert_eq!(matched.as_deref(), Some("STOP"));
     }
 
     #[test]
     fn stop_split_across_pieces() {
-        let (out, stopped) = run(&["STOP"], &["hel", "lo ", "ST", "OP", " trailing"]);
+        let (out, matched) = run(&["STOP"], &["hel", "lo ", "ST", "OP", " trailing"]);
         assert_eq!(out, "hello ");
-        assert!(stopped);
+        assert_eq!(matched.as_deref(), Some("STOP"));
     }
 
     #[test]
     fn partial_false_alarm_is_flushed() {
         // "ST" looks like the start of "STOP" but resolves to "STxy".
-        let (out, stopped) = run(&["STOP"], &["ST", "xy"]);
+        let (out, matched) = run(&["STOP"], &["ST", "xy"]);
         assert_eq!(out, "STxy");
-        assert!(!stopped);
+        assert_eq!(matched, None);
     }
 
     #[test]
     fn held_tail_flushed_on_natural_end() {
         // Ends mid-prefix; no completion, so the tail is real output.
-        let (out, stopped) = run(&["STOP"], &["hello ST"]);
+        let (out, matched) = run(&["STOP"], &["hello ST"]);
         assert_eq!(out, "hello ST");
-        assert!(!stopped);
+        assert_eq!(matched, None);
     }
 
     #[test]
     fn earliest_of_multiple_stops_wins() {
-        let (out, stopped) = run(&["world", "STOP"], &["a STOP b world"]);
+        let (out, matched) = run(&["world", "STOP"], &["a STOP b world"]);
         assert_eq!(out, "a ");
-        assert!(stopped);
+        assert_eq!(matched.as_deref(), Some("STOP"));
     }
 
     #[test]
     fn stop_at_very_start_emits_nothing() {
-        let (out, stopped) = run(&["STOP"], &["STOP rest"]);
+        let (out, matched) = run(&["STOP"], &["STOP rest"]);
         assert_eq!(out, "");
-        assert!(stopped);
+        assert_eq!(matched.as_deref(), Some("STOP"));
     }
 
     #[test]
     fn overlapping_repeats_match_first_occurrence() {
         // "aa" with input "aaa" fed one char at a time matches at index 0.
-        let (out, stopped) = run(&["aa"], &["a", "a", "a"]);
+        let (out, matched) = run(&["aa"], &["a", "a", "a"]);
         assert_eq!(out, "");
-        assert!(stopped);
+        assert_eq!(matched.as_deref(), Some("aa"));
         assert_eq!(apply_stop_sequences("aaa", Some(&["aa".to_string()])).0, "");
     }
 
     #[test]
     fn unicode_stop_string() {
-        let (out, stopped) = run(&["café"], &["a ca", "fé b"]);
+        let (out, matched) = run(&["café"], &["a ca", "fé b"]);
         assert_eq!(out, "a ");
-        assert!(stopped);
+        assert_eq!(matched.as_deref(), Some("café"));
     }
 
     #[test]
     fn unicode_partial_does_not_split_codepoint() {
         // Feeding a multibyte char that is a stop prefix then diverging must not
         // panic on a non-boundary slice and must flush the real text.
-        let (out, stopped) = run(&["→end"], &["x→", "y"]);
+        let (out, matched) = run(&["→end"], &["x→", "y"]);
         assert_eq!(out, "x→y");
-        assert!(!stopped);
+        assert_eq!(matched, None);
     }
 
     /// The streamed result must equal `apply_stop_sequences` on the whole text,
-    /// for every chunking. This ties the incremental matcher to the established
-    /// truncation semantics.
+    /// for every chunking, and so must the stop string it reports. This ties the
+    /// incremental matcher to the established truncation semantics, identity
+    /// included, so the `stopping_word` the response layer prints cannot drift
+    /// from the text it printed.
     #[test]
     fn matches_apply_stop_sequences_for_all_chunkings() {
         let cases: &[(&str, &[&str])] = &[
@@ -312,6 +395,7 @@ mod tests {
             ("no match here", &["STOP"]),
             ("end at THE END now", &["THE END"]),
             ("pick earliest: B then A", &["A", "B"]),
+            ("tie at the same index", &["tie", "tie at"]),
             ("aaa", &["aa"]),
             ("café au lait", &["au"]),
             ("trailing prefix ST", &["STOP"]),
@@ -319,17 +403,19 @@ mod tests {
         ];
         for (text, stops) in cases {
             let owned: Vec<String> = stops.iter().map(|s| s.to_string()).collect();
-            let expected = apply_stop_sequences(text, Some(&owned)).0;
+            let (expected, expected_stop) = apply_stop_sequences(text, Some(&owned));
 
             // Whole string in one piece.
-            let (whole, _) = run(stops, &[text]);
+            let (whole, whole_stop) = run(stops, &[text]);
             assert_eq!(whole, expected, "whole-string chunking: {text:?}");
+            assert_eq!(whole_stop, expected_stop, "whole-string stop: {text:?}");
 
             // Char-by-char.
             let chars: Vec<String> = text.chars().map(|c| c.to_string()).collect();
             let char_refs: Vec<&str> = chars.iter().map(String::as_str).collect();
-            let (per_char, _) = run(stops, &char_refs);
+            let (per_char, per_char_stop) = run(stops, &char_refs);
             assert_eq!(per_char, expected, "char-by-char chunking: {text:?}");
+            assert_eq!(per_char_stop, expected_stop, "char-by-char stop: {text:?}");
 
             // Byte-pair-ish split at each char boundary.
             for split in 1..text.chars().count() {
@@ -339,9 +425,71 @@ mod tests {
                     .map(|(i, _)| i)
                     .unwrap_or(text.len());
                 let (a, b) = text.split_at(idx);
-                let (two, _) = run(stops, &[a, b]);
+                let (two, two_stop) = run(stops, &[a, b]);
                 assert_eq!(two, expected, "two-piece split at {split} of {text:?}");
+                assert_eq!(
+                    two_stop, expected_stop,
+                    "two-piece stop at {split} of {text:?}"
+                );
             }
         }
+    }
+
+    /// The whole point of the matcher for the MLX path: no matter where the
+    /// token boundaries fall, the client sees exactly the truncated text and
+    /// never a byte of the stop string. Asserted over every chunking, against
+    /// the concatenation of the emitted pieces rather than a final buffer.
+    #[test]
+    fn streamed_concatenation_never_leaks_a_partial_match() {
+        let text = "count 1 2 3 4 5 6";
+        let stops = ["5", "4 5"];
+        let owned: Vec<String> = stops.iter().map(|s| s.to_string()).collect();
+        let (expected, expected_stop) = apply_stop_sequences(text, Some(&owned));
+        // "4 5" starts before the bare "5", so the earliest match wins and the
+        // reported word is the longer one, matching `apply_stop_sequences`.
+        assert_eq!(expected, "count 1 2 3 ");
+        assert_eq!(expected_stop.as_deref(), Some("4 5"));
+
+        for split in 1..text.chars().count() {
+            let idx = text.char_indices().nth(split).map(|(i, _)| i).unwrap();
+            let (a, b) = text.split_at(idx);
+            let mut m = StopMatcher::new(owned.clone());
+            let mut streamed = String::new();
+            for piece in [a, b] {
+                let chunk = m.push(piece);
+                // Every emitted piece must remain a prefix of the final text,
+                // which is what "a partial match is never leaked" means.
+                let candidate = format!("{streamed}{}", chunk.emit);
+                assert!(
+                    expected.starts_with(&candidate),
+                    "leaked {candidate:?} at split {split}"
+                );
+                streamed = candidate;
+                if chunk.matched.is_some() {
+                    assert_eq!(chunk.matched, expected_stop);
+                    break;
+                }
+            }
+            assert_eq!(streamed, expected, "split {split}");
+        }
+    }
+
+    /// Once a stop string matched, the matcher is inert: a caller that pushes
+    /// again (a late token from an in-flight batch step) emits nothing more and
+    /// keeps reporting the same stop string.
+    #[test]
+    fn push_after_match_is_inert() {
+        let mut m = StopMatcher::new(vec!["STOP".to_string()]);
+        let first = m.push("a STOP b");
+        assert_eq!(first.emit, "a ");
+        assert_eq!(first.matched.as_deref(), Some("STOP"));
+
+        let after = m.push("more text");
+        assert!(after.emit.is_empty());
+        assert!(after.matched.is_some());
+        assert_eq!(after.matched.as_deref(), Some("STOP"));
+        assert_eq!(m.emitted_len(), "a ".len());
+        assert!(m.flush().is_empty());
+        assert_eq!(m.matched(), Some("STOP"));
     }
 }

--- a/src/server/batch/stop_sequence_tests.rs
+++ b/src/server/batch/stop_sequence_tests.rs
@@ -1,0 +1,285 @@
+// Copyright 2025-2026 Lablup Inc. and Jeongkyu Shin
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! String stop sequences on the MLX serving path (issue #1466).
+//!
+//! Before this, `ServerGenerateOptions::stop_sequences` was parsed, carried into
+//! the scheduler, and never read: a request that asked to stop on `"5"` ran to
+//! `max_tokens` and the stop string appeared in the output. These tests drive
+//! the funnel every MLX decode site now goes through
+//! ([`SequenceInfo::stream_decoded_text`], [`SequenceInfo::close_text_stream`],
+//! [`SequenceInfo::take_generation_result`]) with a real
+//! [`StreamingDecodeState`], asserting the four properties the issue's
+//! acceptance criteria name:
+//!
+//! 1. the non-streaming text is truncated at the match and excludes it,
+//! 2. the concatenation of streamed chunks equals that text at every token
+//!    boundary, so a partial match is never leaked,
+//! 3. the matched stop string reaches the response layer, and
+//! 4. the finish reason separates a stop-string match from EOS and from length.
+//!
+//! The decode stream is driven a few UTF-8 bytes per token through the
+//! all-byte-fallback stub tokenizer, which is a harsher chunking than a real
+//! model produces and the one where a naive matcher leaks a partial match.
+
+use std::sync::Arc;
+use std::sync::atomic::AtomicBool;
+use std::sync::mpsc;
+use std::time::Instant;
+
+use mlxcel_core::cache::SequenceId;
+use mlxcel_core::generate::SamplingConfig;
+
+use super::RequestPriority;
+use super::sequence::{FinishReason, SequenceInfo, SequenceState};
+use super::stop_matcher::StopMatcher;
+use crate::server::model_provider::model_worker::StreamingDecodeState;
+use crate::server::model_provider::{GenerateEvent, GenerationResult, StopKind};
+use crate::tokenizer::MlxcelTokenizer;
+
+/// One decoded run: what the client received, the finished result, and the
+/// terminal state the scheduler would have recorded.
+struct Run {
+    streamed: String,
+    result: GenerationResult,
+    finished_as: SequenceState,
+}
+
+/// The `<0xXX>` token ids for the UTF-8 bytes of `s` (token id == byte value in
+/// [`MlxcelTokenizer::stub_all_byte_fallback`]).
+fn byte_ids(s: &str) -> Vec<i32> {
+    s.bytes().map(|b| b as i32).collect()
+}
+
+fn make_sequence(
+    tokenizer: &MlxcelTokenizer,
+    stops: &[&str],
+    max_tokens: usize,
+) -> (SequenceInfo, mpsc::Receiver<GenerateEvent>) {
+    let (tx, rx) = mpsc::channel();
+    let prompt_tokens: Vec<i32> = Vec::new();
+    let decode_state = StreamingDecodeState::new(tokenizer, &prompt_tokens);
+    let seq = SequenceInfo {
+        seq_id: SequenceId::from_raw(1),
+        state: SequenceState::Decoding,
+        prompt_tokens,
+        sampling: SamplingConfig::default(),
+        max_tokens,
+        eos_token_ids: Vec::new(),
+        priority: RequestPriority::Normal,
+        logprobs_config: Default::default(),
+        vlm_embeddings: None,
+        images: Vec::new(),
+        audio: Vec::new(),
+        generated_tokens: Vec::new(),
+        generated_text: String::new(),
+        decode_state,
+        stop_matcher: StopMatcher::new(stops.iter().map(|s| s.to_string())),
+        prefill_offset: 0,
+        prefill_start_offset: 0,
+        already_cached_tokens: 0,
+        response_tx: tx,
+        cancelled: Arc::new(AtomicBool::new(false)),
+        created_at: Instant::now(),
+        prefill_start: None,
+        first_token_time: None,
+        token_history: Vec::new(),
+        sampler_state: None,
+        merged_eos: Vec::new(),
+        thinking: crate::server::thinking_budget::ThinkingState::disabled(),
+        structured: None,
+    };
+    (seq, rx)
+}
+
+/// Drive `text` through the decode funnel `chunk_bytes` tokens at a time,
+/// mirroring what `decode_single_step` does per sampled token, then finish the
+/// sequence the way `finalize_completed` does.
+fn drive(text: &str, stops: &[&str], max_tokens: usize, chunk_bytes: usize) -> Run {
+    let tokenizer = MlxcelTokenizer::stub_all_byte_fallback();
+    let (mut seq, rx) = make_sequence(&tokenizer, stops, max_tokens);
+
+    for ids in byte_ids(text).chunks(chunk_bytes.max(1)) {
+        if seq.state.is_finished() {
+            break;
+        }
+        let mut piece: Option<String> = None;
+        for &id in ids {
+            seq.generated_tokens.push(id);
+            if let Some(t) = seq.decode_state.on_token(id, &tokenizer) {
+                piece.get_or_insert_with(String::new).push_str(&t);
+            }
+        }
+        if let Some(t) = piece
+            && seq.stream_decoded_text(t, None).is_some()
+        {
+            seq.state
+                .transition_to(SequenceState::Finished(FinishReason::StopSequence))
+                .expect("stop-sequence finish is legal from Decoding");
+            break;
+        }
+        if seq.generated_tokens.len() >= seq.max_tokens {
+            seq.state
+                .transition_to(SequenceState::Finished(FinishReason::Length))
+                .expect("length finish is legal from Decoding");
+        }
+    }
+    if !seq.state.is_finished() {
+        seq.state
+            .transition_to(SequenceState::Finished(FinishReason::Stop))
+            .expect("eos finish is legal from Decoding");
+    }
+
+    let tail = seq.decode_state.flush(&tokenizer);
+    seq.close_text_stream(tail);
+    let result = seq.take_generation_result(&tokenizer, 0);
+    let finished_as = std::mem::replace(&mut seq.state, SequenceState::Queued);
+
+    let mut streamed = String::new();
+    while let Ok(event) = rx.try_recv() {
+        match event {
+            GenerateEvent::Token(t) | GenerateEvent::TokenWithLogprobs(t, _) => {
+                streamed.push_str(&t);
+            }
+            GenerateEvent::Done(_) | GenerateEvent::Error(_) => {}
+        }
+    }
+
+    Run {
+        streamed,
+        result,
+        finished_as,
+    }
+}
+
+/// A stop string truncates the non-streaming text at the match, and the matched
+/// text itself is never part of the output.
+#[test]
+fn a_stop_string_truncates_the_text_and_excludes_the_match() {
+    let run = drive(" 4 5 6 7 8", &["5"], 64, 1);
+    assert_eq!(run.result.text, " 4 ");
+    assert!(!run.result.text.contains('5'));
+    assert_eq!(run.streamed, run.result.text);
+}
+
+/// The concatenation of the streamed chunks equals the non-streaming text for
+/// every chunking, so a held-back partial match never reaches the client.
+#[test]
+fn streamed_chunks_equal_the_non_streaming_text_at_every_boundary() {
+    for chunk_bytes in 1..=6 {
+        let run = drive("count 1 2 END of line", &["END"], 64, chunk_bytes);
+        assert_eq!(run.streamed, run.result.text, "chunk_bytes = {chunk_bytes}");
+        assert_eq!(run.result.text, "count 1 2 ", "chunk_bytes = {chunk_bytes}");
+    }
+}
+
+/// The matched stop string reaches the response layer, which is what b10621's
+/// `stopping_word` needs and what the text alone cannot supply, because the
+/// match is excluded from it.
+#[test]
+fn the_matched_stop_string_reaches_the_result() {
+    let run = drive("a END b", &["zzz", "END"], 64, 1);
+    assert_eq!(run.result.stop_kind, StopKind::Word("END".to_string()));
+    assert_eq!(run.result.stop_kind.word(), Some("END"));
+    assert!(matches!(
+        run.finished_as,
+        SequenceState::Finished(FinishReason::StopSequence)
+    ));
+}
+
+/// The finish reason separates the three outcomes. Before the fix the wire
+/// answer could only be "length" or "stop", and a stop-string match was
+/// indistinguishable from an EOS token because it was never detected at all.
+#[test]
+fn the_finish_reason_separates_word_eos_and_limit() {
+    let word = drive("a END b", &["END"], 64, 1);
+    assert_eq!(word.result.stop_kind, StopKind::Word("END".to_string()));
+    assert_eq!(word.result.finish_reason, "stop");
+    assert!(matches!(
+        word.finished_as,
+        SequenceState::Finished(FinishReason::StopSequence)
+    ));
+
+    let eos = drive("a b", &["END"], 64, 1);
+    assert_eq!(eos.result.stop_kind, StopKind::Eos);
+    assert_eq!(eos.result.finish_reason, "stop");
+    assert!(matches!(
+        eos.finished_as,
+        SequenceState::Finished(FinishReason::Stop)
+    ));
+
+    let limit = drive("abcdef", &["END"], 4, 1);
+    assert_eq!(limit.result.stop_kind, StopKind::Limit);
+    assert_eq!(limit.result.finish_reason, "length");
+    assert!(matches!(
+        limit.finished_as,
+        SequenceState::Finished(FinishReason::Length)
+    ));
+}
+
+/// A stop string completing on the last budgeted token is a stop-word finish,
+/// not a length finish: the request ended because the caller's own stop string
+/// appeared, and telling an OpenAI client "length" would invite a continuation.
+#[test]
+fn a_match_on_the_last_budgeted_token_reports_stop_not_length() {
+    // "ab!" is three bytes, so three tokens, and the budget is exactly three.
+    let run = drive("ab!", &["!"], 3, 1);
+    assert_eq!(run.result.text, "ab");
+    assert_eq!(run.result.stop_kind, StopKind::Word("!".to_string()));
+    assert_eq!(run.result.finish_reason, "stop");
+}
+
+/// Multibyte text is truncated on character boundaries, and a partial UTF-8
+/// sequence the detokenizer held is still released as real output when it turns
+/// out not to complete a stop string.
+#[test]
+fn a_multibyte_stream_is_truncated_on_character_boundaries() {
+    let matched = drive("한국어 STOP 텍스트", &["STOP"], 128, 1);
+    assert_eq!(matched.result.text, "한국어 ");
+    assert_eq!(matched.streamed, matched.result.text);
+
+    let unmatched = drive("한국어 텍스트", &["STOP"], 128, 1);
+    assert_eq!(unmatched.result.text, "한국어 텍스트");
+    assert_eq!(unmatched.streamed, unmatched.result.text);
+    assert_eq!(unmatched.result.stop_kind, StopKind::Eos);
+}
+
+/// With no stop strings the funnel is a pass-through: every decoded piece is
+/// streamed verbatim and nothing is truncated, which is the pre-#1466 behavior
+/// that must not change for a request that supplies no `stop` field.
+#[test]
+fn without_stop_strings_nothing_is_held_or_truncated() {
+    let run = drive("plain output with 5 and END inside", &[], 128, 1);
+    assert_eq!(run.result.text, "plain output with 5 and END inside");
+    assert_eq!(run.streamed, run.result.text);
+    assert_eq!(run.result.stop_kind, StopKind::Eos);
+}
+
+/// Preemptive eviction restarts a decode from scratch. The matcher's held tail
+/// and emitted-byte count describe the discarded run, so `reset` must clear them
+/// while keeping the request's stop strings, or the re-run would truncate
+/// against a stale offset.
+#[test]
+fn eviction_reset_keeps_the_stop_strings_and_drops_the_progress() {
+    let mut matcher = StopMatcher::new(vec!["END".to_string()]);
+    assert_eq!(matcher.push("abc EN").emit, "abc ");
+    matcher.reset();
+    assert_eq!(matcher.emitted_len(), 0);
+    assert!(!matcher.has_matched());
+    assert!(matcher.is_active());
+    // The re-run still stops on the same string.
+    let chunk = matcher.push("abc END");
+    assert_eq!(chunk.emit, "abc ");
+    assert_eq!(chunk.matched.as_deref(), Some("END"));
+}

--- a/src/server/batch/xla_worker.rs
+++ b/src/server/batch/xla_worker.rs
@@ -426,7 +426,7 @@ impl<E: XlaServingEngine> XlaServeWorker<E> {
                             if !chunk.emit.is_empty() {
                                 let _ = state.response_tx.send(GenerateEvent::Token(chunk.emit));
                             }
-                            chunk.stopped.then(|| state.stop.emitted_len())
+                            chunk.matched.is_some().then(|| state.stop.emitted_len())
                         } else {
                             let _ = state.response_tx.send(GenerateEvent::Token(piece));
                             None

--- a/src/server/diffusion_worker.rs
+++ b/src/server/diffusion_worker.rs
@@ -42,7 +42,7 @@ use crate::models::llada2_moe::{Llada2FinishReason, Llada2GenerateOptions};
 use crate::models::{DiffusionGemmaModel, Llada2MoeModel};
 use crate::server::ServerGenerateOptions;
 use crate::server::model_provider::model_worker::{StreamingDecodeState, decode_request_images};
-use crate::server::model_provider::{GenerateEvent, GenerationResult, ModelRequest};
+use crate::server::model_provider::{GenerateEvent, GenerationResult, ModelRequest, StopKind};
 use crate::tokenizer::MlxcelTokenizer;
 
 /// Serve-level diffusion knobs resolved once on the worker thread from the
@@ -388,6 +388,16 @@ fn serve_streaming_request<G>(
                 0,
             );
             gen_result.finish_reason = finish_reason.to_string();
+            // Keep `stop_kind` consistent with the reason the diffusion engine
+            // actually reported (issue #1466). `finish_with_cache` derived it
+            // from the token counts, which disagrees when the engine stops on
+            // its own at exactly `max_new_tokens`. A diffusion request carries
+            // no string stop sequences, so `Word` is not reachable here.
+            gen_result.stop_kind = if gen_result.finish_reason == "length" {
+                StopKind::Limit
+            } else {
+                StopKind::Eos
+            };
             let _ = response_tx.send(GenerateEvent::Done(gen_result));
         }
         Err(err) => {

--- a/src/server/florence2_worker.rs
+++ b/src/server/florence2_worker.rs
@@ -57,7 +57,7 @@ use crate::models::florence2::{
 };
 use crate::server::ServerGenerateOptions;
 use crate::server::model_provider::model_worker::decode_request_images;
-use crate::server::model_provider::{GenerateEvent, GenerationResult, ModelRequest};
+use crate::server::model_provider::{GenerateEvent, GenerationResult, ModelRequest, StopKind};
 
 /// Error message sent for an audio/video Florence-2 request.
 pub(crate) const FLORENCE2_MEDIA_UNSUPPORTED_MSG: &str =
@@ -404,6 +404,13 @@ fn handle_florence2_request(
         prompt_eval_ms: 0,
         generation_only_ms: elapsed_ms,
         finish_reason: finish_reason.to_string(),
+        // Florence-2 has no string stop sequences: the task decode is
+        // model-owned and ends on EOS or the token budget (issue #1466).
+        stop_kind: if finish_reason == "length" {
+            StopKind::Limit
+        } else {
+            StopKind::Eos
+        },
         logprobs: None,
         cached_tokens: 0,
         structured_output: Some(structured),

--- a/src/server/model_provider.rs
+++ b/src/server/model_provider.rs
@@ -151,6 +151,41 @@ pub enum GenerateEvent {
     Error(String),
 }
 
+/// Why a generation ended, at the granularity the native `llama-server`
+/// response needs (issue #1466).
+///
+/// [`GenerationResult::finish_reason`] is the OpenAI wire string and collapses
+/// an end-of-sequence token and a string stop-sequence match into one `"stop"`.
+/// That is correct for the OpenAI routes and insufficient for b10621's
+/// `stop_type` / `stopping_word` pair, so the distinction (and the matched
+/// string) lives here instead of being re-derived from the text, which is
+/// impossible once the stop string has been excluded from it.
+#[derive(Debug, Clone, PartialEq, Eq, Default)]
+pub enum StopKind {
+    /// Generation ended without reaching the budget: an EOS token, a structured
+    /// -output completion, the repetition-loop guard, or an early bail. Maps to
+    /// b10621's `stop_type: "eos"`.
+    #[default]
+    Eos,
+    /// The `max_tokens` / `n_predict` budget was reached. Maps to
+    /// b10621's `stop_type: "limit"`.
+    Limit,
+    /// A request-supplied string stop sequence matched. The payload is that
+    /// string, which b10621 reports as `stopping_word` and which is excluded
+    /// from the returned text. Maps to `stop_type: "word"`.
+    Word(String),
+}
+
+impl StopKind {
+    /// The matched stop string, when a string stop sequence ended the request.
+    pub fn word(&self) -> Option<&str> {
+        match self {
+            StopKind::Word(w) => Some(w.as_str()),
+            _ => None,
+        }
+    }
+}
+
 /// Result of a generation
 #[derive(Debug, Clone)]
 pub struct GenerationResult {
@@ -161,6 +196,10 @@ pub struct GenerationResult {
     pub prompt_eval_ms: u64,
     pub generation_only_ms: u64,
     pub finish_reason: String,
+    /// Why generation ended, distinguishing a string stop-sequence match from
+    /// an EOS token and from the length limit (issue #1466). `finish_reason`
+    /// stays the OpenAI string and cannot express that three-way split.
+    pub stop_kind: StopKind,
     /// Per-token log probability data; `None` when logprobs were not requested
     pub logprobs: Option<Vec<TokenLogprobData>>,
     /// Number of prompt tokens that were satisfied by the KV prefix cache.

--- a/src/server/model_provider_test_support.rs
+++ b/src/server/model_provider_test_support.rs
@@ -26,6 +26,20 @@ impl ModelProvider {
                         ..
                     } => {
                         drop(queue_reservation);
+                        // A request carrying string stop sequences is answered
+                        // as a generation that one of them ended (issue #1466),
+                        // so route tests can assert the b10621
+                        // `stop_type` / `stopping_word` mapping without a model.
+                        // A request without `stop` keeps the empty canned
+                        // generation every other route test depends on.
+                        let stop_kind = options
+                            .stop_sequences
+                            .as_deref()
+                            .and_then(<[String]>::first)
+                            .map(|word| {
+                                crate::server::model_provider::StopKind::Word(word.clone())
+                            })
+                            .unwrap_or(crate::server::model_provider::StopKind::Eos);
                         let _ = options_tx.send(options);
                         let _ = response_tx.send(GenerateEvent::Done(GenerationResult {
                             text: String::new(),
@@ -35,6 +49,7 @@ impl ModelProvider {
                             prompt_eval_ms: 0,
                             generation_only_ms: 0,
                             finish_reason: "stop".to_string(),
+                            stop_kind,
                             logprobs: None,
                             cached_tokens: 0,
                             structured_output: None,

--- a/src/server/model_provider_tests.rs
+++ b/src/server/model_provider_tests.rs
@@ -22,8 +22,8 @@ use mlxcel_core::sampling::{LogprobsConfig, TokenLogprobData};
 
 use super::{
     ChatWorkerGoneError, DECODE_HANG_TIMEOUT, GenerateEvent, GenerationResult, ModelProvider,
-    ModelRequest, QueueReservationMode, SingleStreamQueueReservation, drain_generation_events,
-    send_shutdown_signal, tokenize_prompt_for_generation,
+    ModelRequest, QueueReservationMode, SingleStreamQueueReservation, StopKind,
+    drain_generation_events, send_shutdown_signal, tokenize_prompt_for_generation,
     tokenize_prompt_for_generation_with_ordered_media, validated_decode_hang_timeout,
 };
 use crate::server::batch::BatchObservability;
@@ -39,6 +39,7 @@ fn sample_result() -> GenerationResult {
         prompt_eval_ms: 4,
         generation_only_ms: 6,
         finish_reason: "stop".to_string(),
+        stop_kind: StopKind::Eos,
         logprobs: None,
         cached_tokens: 0,
         structured_output: None,
@@ -427,6 +428,7 @@ fn drain_generation_events_impl_survives_long_prefill_before_first_token() {
             prompt_eval_ms: 79,
             generation_only_ms: 1,
             finish_reason: "stop".to_string(),
+            stop_kind: StopKind::Eos,
             logprobs: None,
             cached_tokens: 0,
             structured_output: None,

--- a/src/server/model_worker.rs
+++ b/src/server/model_worker.rs
@@ -46,7 +46,7 @@ use crate::vlm_runtime::{
 };
 use crate::worker_failfast::run_core_thread_or_abort;
 
-use super::{GenerationResult, ModelRequest};
+use super::{GenerationResult, ModelRequest, StopKind};
 
 /// Configuration for the scheduler, passed from `ModelProvider` to the
 /// worker thread.
@@ -2832,11 +2832,8 @@ pub(crate) fn build_generation_result_with_cache(
     max_tokens: usize,
     cached_tokens: usize,
 ) -> GenerationResult {
-    let finish_reason = if completion_tokens >= max_tokens {
-        "length"
-    } else {
-        "stop"
-    };
+    let hit_limit = completion_tokens >= max_tokens;
+    let finish_reason = if hit_limit { "length" } else { "stop" };
 
     GenerationResult {
         text,
@@ -2846,6 +2843,15 @@ pub(crate) fn build_generation_result_with_cache(
         prompt_eval_ms,
         generation_only_ms: elapsed_ms.saturating_sub(prompt_eval_ms),
         finish_reason: finish_reason.to_string(),
+        // The EOS-or-length split this function has always made. A string
+        // stop-sequence match cannot be seen from the token counts, so the
+        // scheduler overrides this through `finish_stopped_by_word`
+        // (issue #1466); every other producer keeps the derived value.
+        stop_kind: if hit_limit {
+            StopKind::Limit
+        } else {
+            StopKind::Eos
+        },
         logprobs: None,
         cached_tokens,
         // Structured coordinate output is produced only by the Florence-2
@@ -3092,11 +3098,25 @@ impl StreamingDecodeState {
     /// it is floored to the nearest boundary defensively rather than panicking.
     #[cfg(feature = "xla-iree")]
     pub(crate) fn finish_truncated(
+        self,
+        keep_bytes: usize,
+        start: Instant,
+        prompt_token_count: usize,
+        max_tokens: usize,
+    ) -> GenerationResult {
+        self.finish_truncated_with_cache(keep_bytes, start, prompt_token_count, max_tokens, 0)
+    }
+
+    /// [`finish_truncated`](Self::finish_truncated) with the prompt-prefix cache
+    /// count, for the MLX scheduler (issue #1466), which reports
+    /// `usage.cached_tokens` on every finish.
+    pub(crate) fn finish_truncated_with_cache(
         mut self,
         keep_bytes: usize,
         start: Instant,
         prompt_token_count: usize,
         max_tokens: usize,
+        cached_tokens: usize,
     ) -> GenerationResult {
         if keep_bytes < self.generated_text.len() {
             let mut cut = keep_bytes;
@@ -3105,7 +3125,36 @@ impl StreamingDecodeState {
             }
             self.generated_text.truncate(cut);
         }
-        self.finish_with_cache(start, prompt_token_count, max_tokens, 0)
+        self.finish_with_cache(start, prompt_token_count, max_tokens, cached_tokens)
+    }
+
+    /// Finish a request that a string stop sequence ended (issue #1466):
+    /// truncate the accumulated text to the bytes that actually reached the
+    /// client, then stamp the finish as a stop-word match.
+    ///
+    /// The wire `finish_reason` is forced to `"stop"` even when the stop string
+    /// completed on the last budgeted token, because the request did not run out
+    /// of budget: it was ended by the caller's own stop string, and reporting
+    /// `"length"` would tell an OpenAI client to continue.
+    pub(crate) fn finish_stopped_by_word(
+        self,
+        word: String,
+        keep_bytes: usize,
+        start: Instant,
+        prompt_token_count: usize,
+        max_tokens: usize,
+        cached_tokens: usize,
+    ) -> GenerationResult {
+        let mut result = self.finish_truncated_with_cache(
+            keep_bytes,
+            start,
+            prompt_token_count,
+            max_tokens,
+            cached_tokens,
+        );
+        result.finish_reason = "stop".to_string();
+        result.stop_kind = StopKind::Word(word);
+        result
     }
 }
 

--- a/src/server/model_worker_tests.rs
+++ b/src/server/model_worker_tests.rs
@@ -339,10 +339,73 @@ fn build_generation_result_computes_finish_reason_and_generation_split() {
     let stop = build_generation_result("ok".to_string(), 10, 3, 120, 40, 8);
     assert_eq!(stop.finish_reason, "stop");
     assert_eq!(stop.generation_only_ms, 80);
+    // The EOS-or-length split this function makes carries into `stop_kind`
+    // (issue #1466); only the scheduler can know about a stop-word match, and it
+    // overrides the value through `finish_stopped_by_word`.
+    assert_eq!(stop.stop_kind, crate::server::model_provider::StopKind::Eos);
 
     let length = build_generation_result("ok".to_string(), 10, 8, 50, 60, 8);
     assert_eq!(length.finish_reason, "length");
     assert_eq!(length.generation_only_ms, 0);
+    assert_eq!(
+        length.stop_kind,
+        crate::server::model_provider::StopKind::Limit
+    );
+}
+
+/// `finish_stopped_by_word` truncates the accumulated text to the bytes that
+/// actually reached the client and stamps the finish as a stop-word match, even
+/// when the budget was exhausted on the same token (issue #1466). Reporting
+/// `"length"` there would tell an OpenAI client to ask for a continuation of a
+/// request its own stop string ended.
+#[test]
+fn finish_stopped_by_word_truncates_and_overrides_the_finish_reason() {
+    use std::time::Instant;
+
+    let tokenizer = stub_all_byte_fallback();
+    let mut state = StreamingDecodeState::new(&tokenizer, &[]);
+    let ids = byte_fallback_ids("abcXYZ");
+    for id in &ids {
+        let _ = state.on_token(*id, &tokenizer);
+    }
+    let _ = state.flush(&tokenizer);
+
+    // Budget equals the token count, so the underlying builder would say
+    // "length" on its own.
+    let result = state.finish_stopped_by_word(
+        "XYZ".to_string(),
+        "abc".len(),
+        Instant::now(),
+        0,
+        ids.len(),
+        0,
+    );
+    assert_eq!(result.text, "abc");
+    assert_eq!(result.finish_reason, "stop");
+    assert_eq!(
+        result.stop_kind,
+        crate::server::model_provider::StopKind::Word("XYZ".to_string())
+    );
+    assert_eq!(result.completion_tokens, ids.len());
+}
+
+/// A `keep_bytes` that lands inside a multi-byte character is floored to the
+/// nearest boundary rather than panicking. The matcher only ever reports whole
+/// emitted pieces, so this is defence in depth.
+#[test]
+fn finish_truncated_floors_a_keep_length_inside_a_character() {
+    use std::time::Instant;
+
+    let tokenizer = stub_all_byte_fallback();
+    let mut state = StreamingDecodeState::new(&tokenizer, &[]);
+    for id in byte_fallback_ids("가나다") {
+        let _ = state.on_token(id, &tokenizer);
+    }
+    let _ = state.flush(&tokenizer);
+
+    // 4 bytes lands one byte into the second character (each is 3 bytes).
+    let result = state.finish_truncated_with_cache(4, Instant::now(), 0, 99, 0);
+    assert_eq!(result.text, "가");
 }
 
 // ── Byte-fallback streaming regression tests ───────────────────
@@ -377,46 +440,12 @@ fn simulate_byte_fallback_stream(
     (chunks, result.text)
 }
 
-/// Build a HuggingFace tokenizer whose vocab contains every byte-fallback token
-/// `<0x00>`..`<0xFF>` (token id == byte value) plus a couple of regular ASCII
-/// word tokens, with a `ByteFallback` decoder. This lets a test drive the
-/// incremental detokenizer with the exact byte sequence of any UTF-8 string, so
-/// byte-exactness can be checked against a one-shot decode of the same ids.
+/// The all-byte-fallback stub tokenizer, which lets these tests drive the
+/// incremental detokenizer with the exact byte sequence of any UTF-8 string.
+/// Lives on `MlxcelTokenizer` beside the other test stubs so the stop-sequence
+/// tests (#1466) can drive the same byte-level stream.
 fn stub_all_byte_fallback() -> MlxcelTokenizer {
-    let mut vocab_entries: Vec<String> = (0u16..=255)
-        .map(|b| format!("\"<0x{b:02X}>\": {b}"))
-        .collect();
-    // Regular word tokens after the 256 byte ids, exercising the mixed
-    // regular-piece + byte-fallback path.
-    vocab_entries.push("\"Hello\": 256".to_string());
-    vocab_entries.push("\"world\": 257".to_string());
-    let vocab = vocab_entries.join(", ");
-    let json = format!(
-        r#"{{
-            "version": "1.0",
-            "truncation": null,
-            "padding": null,
-            "added_tokens": [],
-            "normalizer": null,
-            "pre_tokenizer": null,
-            "post_processor": null,
-            "decoder": {{"type": "ByteFallback"}},
-            "model": {{
-                "type": "BPE",
-                "dropout": null,
-                "unk_token": null,
-                "continuing_subword_prefix": null,
-                "end_of_word_suffix": null,
-                "fuse_unk": false,
-                "byte_fallback": true,
-                "vocab": {{{vocab}}},
-                "merges": []
-            }}
-        }}"#
-    );
-    let tokenizer = tokenizers::Tokenizer::from_bytes(json.as_bytes())
-        .expect("failed to build all-byte-fallback stub tokenizer");
-    MlxcelTokenizer::HuggingFace(tokenizer)
+    MlxcelTokenizer::stub_all_byte_fallback()
 }
 
 /// The `<0xXX>` token ids for the UTF-8 bytes of `s` in [`stub_all_byte_fallback`]

--- a/src/server/routes/anthropic.rs
+++ b/src/server/routes/anthropic.rs
@@ -263,13 +263,19 @@ async fn non_stream_messages(
     let (visible_text, reasoning_text) =
         split_visible_reasoning(&result.text, parsed_tools.as_ref());
 
-    // Anthropic stop sequences: truncate visible text defensively (the
-    // scheduler already halts on native stop sequences, but a match may
-    // land inside a buffered chunk). Skip when tool calls were produced.
+    // Anthropic stop sequences: the scheduler now truncates on a native stop
+    // sequence and reports which one matched (issue #1466), so prefer its
+    // answer. `apply_stop_sequences` stays as the fallback for a match that
+    // only becomes visible after reasoning/tool splitting, and it can no longer
+    // find a scheduler-truncated match because the string is gone from the text.
+    // Skip both when tool calls were produced.
     let (final_text, stop_sequence) = if parsed_tool_calls.is_some() {
         (visible_text, None)
     } else {
-        apply_stop_sequences(&visible_text, request.stop_sequences.as_deref())
+        let (text, matched) =
+            apply_stop_sequences(&visible_text, request.stop_sequences.as_deref());
+        let matched = matched.or_else(|| result.stop_kind.word().map(str::to_string));
+        (text, matched)
     };
 
     let content_blocks = build_content_blocks(
@@ -542,12 +548,16 @@ async fn stream_messages(
         }
 
         // Stop-sequence detection on the visible text (skip when tool calls
-        // were produced, mirroring upstream).
+        // were produced, mirroring upstream). The scheduler's own match wins
+        // when it fired, because it truncated the streamed text and the string
+        // is no longer present to be found here (issue #1466).
         let stop_sequence = if parsed_calls.is_some() {
             None
         } else {
             let visible = visible_acc.lock().map(|g| g.clone()).unwrap_or_default();
-            apply_stop_sequences(&visible, stop_sequences.as_deref()).1
+            apply_stop_sequences(&visible, stop_sequences.as_deref())
+                .1
+                .or_else(|| result.stop_kind.word().map(str::to_string))
         };
 
         let stop_reason = anthropic_stop_reason(

--- a/src/server/routes/native_completion.rs
+++ b/src/server/routes/native_completion.rs
@@ -30,6 +30,7 @@ use axum::{
 use crate::server::batch::RequestPriority;
 use crate::server::config::ReasoningBudgetOverride;
 use crate::server::media::MediaRequestMetadata;
+use crate::server::model_provider::StopKind;
 use crate::server::request_options::{
     RequestOptionOverrides, build_server_generate_options, resolve_server_max_tokens,
 };
@@ -187,7 +188,7 @@ async fn non_stream_native_completion(
             tokens_predicted: result.completion_tokens,
             tokens_evaluated: result.prompt_tokens,
             cached_tokens: result.cached_tokens,
-            finish_reason: result.finish_reason.as_str(),
+            stop_kind: &result.stop_kind,
             prompt_ms,
             predicted_ms: gen_ms,
         },
@@ -204,28 +205,32 @@ struct NativeOutcome<'a> {
     tokens_predicted: usize,
     tokens_evaluated: usize,
     cached_tokens: usize,
-    finish_reason: &'a str,
+    /// Why generation ended, at b10621's granularity: the `n_predict` budget, an
+    /// EOS token, or a string stop sequence, in which case it carries the
+    /// matched string (issue #1466). `GenerationResult::finish_reason` is the
+    /// OpenAI wire string and collapses the last two into one `"stop"`, so it
+    /// cannot drive `stop_type` and is not carried here.
+    stop_kind: &'a StopKind,
     prompt_ms: f64,
     predicted_ms: f64,
 }
 
 /// Assemble the b10621 native completion object.
 ///
-/// `stop_type` is derived from the finish reason. mlxcel cannot yet report
-/// `word`, because string stop sequences are not enforced on the MLX serving
-/// path at all (they reach `ServerGenerateOptions::stop_sequences` and are
-/// never read); that gap has its own issue and is recorded on the route's
-/// manifest entry, which is why `POST /completion` is not claimed as
-/// `supported` here.
+/// `stop_type` and `stopping_word` come from the scheduler's `StopKind`, which
+/// distinguishes a string stop-sequence match from an EOS token and from the
+/// `n_predict` budget. The matched string cannot be recovered from `content`,
+/// because b10621 (and mlxcel, since #1466) excludes it from the returned text.
 fn build_native_response(
     state: &AppState,
     request: &NativeCompletionRequest,
     options: &ServerGenerateOptions,
     outcome: NativeOutcome<'_>,
 ) -> NativeCompletionResponse {
-    let stop_type = match outcome.finish_reason {
-        "length" => StopType::Limit,
-        _ => StopType::Eos,
+    let (stop_type, stopping_word) = match outcome.stop_kind {
+        StopKind::Word(word) => (StopType::Word, word.clone()),
+        StopKind::Limit => (StopType::Limit, String::new()),
+        StopKind::Eos => (StopType::Eos, String::new()),
     };
     NativeCompletionResponse {
         index: 0,
@@ -246,7 +251,7 @@ fn build_native_response(
         // prompt, so no request reaches here with a dropped prefix.
         truncated: false,
         stop_type,
-        stopping_word: String::new(),
+        stopping_word,
         tokens_cached: outcome.cached_tokens,
         timings: NativeTimings::new(
             outcome.cached_tokens,
@@ -381,7 +386,7 @@ async fn stream_native_completion(
                         tokens_predicted: result.completion_tokens,
                         tokens_evaluated: result.prompt_tokens,
                         cached_tokens: result.cached_tokens,
-                        finish_reason: result.finish_reason.as_str(),
+                        stop_kind: &result.stop_kind,
                         prompt_ms: result.prompt_eval_ms as f64,
                         predicted_ms: result.generation_only_ms as f64,
                     },

--- a/src/server/routes/native_route_tests.rs
+++ b/src/server/routes/native_route_tests.rs
@@ -153,6 +153,39 @@ async fn the_native_completion_echoes_the_prompt_and_stop_metadata() {
     );
 }
 
+/// A matched string stop sequence must reach the wire as b10621 reports it:
+/// `stop_type: "word"` with the matched string in `stopping_word` (issue #1466).
+/// Before the fix the field could only ever be `""`, because nothing on the MLX
+/// serving path detected a stop-string match at all.
+#[tokio::test]
+async fn a_matched_stop_string_is_reported_as_stop_type_word() {
+    let (_, body) = post(
+        "/completion",
+        serde_json::json!({"prompt": "hello", "n_predict": 30, "stop": ["5"]}),
+    )
+    .await;
+    assert_eq!(body["stop_type"], "word", "{body}");
+    assert_eq!(body["stopping_word"], "5", "{body}");
+    // The request's stop list is echoed back in the resolved settings, so a
+    // client can see the server acted on the value it sent.
+    assert_eq!(
+        body["generation_settings"]["stop"],
+        serde_json::json!(["5"])
+    );
+}
+
+/// `/completions` shares the handler, so the same mapping must hold there.
+#[tokio::test]
+async fn the_completions_alias_reports_the_matched_stop_string_too() {
+    let (_, body) = post(
+        "/completions",
+        serde_json::json!({"prompt": "hello", "n_predict": 30, "stop": "5"}),
+    )
+    .await;
+    assert_eq!(body["stop_type"], "word", "{body}");
+    assert_eq!(body["stopping_word"], "5", "{body}");
+}
+
 #[tokio::test]
 async fn n_predict_accepts_the_openai_aliases() {
     // b10621 declares `max_tokens` and `max_completion_tokens` as aliases, so

--- a/src/tokenizer/mod.rs
+++ b/src/tokenizer/mod.rs
@@ -119,6 +119,53 @@ impl MlxcelTokenizer {
         Self::HuggingFace(tokenizer)
     }
 
+    /// Build a tokenizer whose vocab holds every byte-fallback token
+    /// `<0x00>`..`<0xFF>` (token id == byte value) plus two regular ASCII word
+    /// tokens, with a `ByteFallback` decoder.
+    ///
+    /// This lets a test drive the incremental detokenizer with the exact byte
+    /// sequence of any UTF-8 string, so streaming behavior can be checked at
+    /// every token boundary against a one-shot decode of the same ids. Shared by
+    /// the detokenizer regression tests and the stop-sequence tests (#1466),
+    /// which need the same byte-level control over the decoded stream.
+    #[cfg(test)]
+    pub(crate) fn stub_all_byte_fallback() -> Self {
+        let mut vocab_entries: Vec<String> = (0u16..=255)
+            .map(|b| format!("\"<0x{b:02X}>\": {b}"))
+            .collect();
+        // Regular word tokens after the 256 byte ids, exercising the mixed
+        // regular-piece + byte-fallback path.
+        vocab_entries.push("\"Hello\": 256".to_string());
+        vocab_entries.push("\"world\": 257".to_string());
+        let vocab = vocab_entries.join(", ");
+        let json = format!(
+            r#"{{
+            "version": "1.0",
+            "truncation": null,
+            "padding": null,
+            "added_tokens": [],
+            "normalizer": null,
+            "pre_tokenizer": null,
+            "post_processor": null,
+            "decoder": {{"type": "ByteFallback"}},
+            "model": {{
+                "type": "BPE",
+                "dropout": null,
+                "unk_token": null,
+                "continuing_subword_prefix": null,
+                "end_of_word_suffix": null,
+                "fuse_unk": false,
+                "byte_fallback": true,
+                "vocab": {{{vocab}}},
+                "merges": []
+            }}
+        }}"#
+        );
+        let tokenizer = tokenizers::Tokenizer::from_bytes(json.as_bytes())
+            .expect("failed to build all-byte-fallback stub tokenizer");
+        Self::HuggingFace(tokenizer)
+    }
+
     pub fn encode(&self, text: &str, add_special_tokens: bool) -> Result<Vec<u32>> {
         match self {
             Self::HuggingFace(t) => {


### PR DESCRIPTION
## Summary

`stop` was accepted on every completion route, deserialized as a scalar or an array, and threaded all the way into `ServerGenerateOptions::stop_sequences`, and then never read on the shipping MLX path. The only consumer in the tree was the `xla-iree`-gated serve worker, compiled out of release builds, so no production configuration honored it. This makes the MLX batch scheduler enforce string stop sequences, exclude the match from the output, report which string matched, and separate a stop-string finish from an EOS token and from the length limit.

## What changed

- `src/server/batch/stop_matcher.rs`: `StopChunk`'s `stopped: bool` becomes `matched: Option<String>`, and the matcher records the match stickily so a caller that finalizes several steps later can still name it. The string cannot be recovered from the text afterwards, because the match is excluded from it. Ties resolve to the first entry in the request's stop list, the rule `apply_stop_sequences` already uses, and `matches_apply_stop_sequences_for_all_chunkings` now asserts the reported string as well as the text across every chunking. Adds `reset` for preemptive eviction and a `Default` for the paths that never carry stop strings.
- `src/server/batch/sequence.rs`: `SequenceInfo` gains the request's `StopMatcher` plus the three methods every MLX decode site now goes through: `stream_decoded_text` (the single way any of them reaches `response_tx` with generated text), `close_text_stream` (the single way any of them closes it), and `take_generation_result`. `FinishReason` gains `StopSequence`, legal from `Prefilling` as well as `Decoding` because a short stop string can complete on the first sampled token.
- `src/server/batch/scheduler.rs`: five emission sites and two finalization sites route through that funnel. The emission sites are prefill's first token, the per-row batched decode, the fused batched decode, and the single-step decode. Eviction resets the matcher alongside the decode state it describes, keeping the stop strings. `StopSequence` joins the healthy set that donates its KV back to the prompt cache.
- `src/server/batch/speculative_burst.rs`: `stream_burst_tokens` stops the burst on a match rather than letting a speculative request outrun its own stop strings, and `finalize_burst_stream` classifies the finish accordingly. The tick-cooperative slice path drives the same helper, so it is covered too.
- `src/server/model_provider.rs` / `src/server/model_worker.rs`: `GenerationResult` gains `stop_kind: StopKind` (`Eos` / `Limit` / `Word(String)`). `finish_reason` stays the OpenAI wire string, which collapses a stop-word match and an EOS token into one `"stop"` and so cannot drive b10621's `stop_type`. `finish_stopped_by_word` truncates the accumulated text to the bytes that actually reached the client and forces `"stop"`, so a match on the last budgeted token does not report `"length"` and invite an OpenAI client to ask for a continuation.
- `src/server/routes/native_completion.rs`: `stop_type` and `stopping_word` come from `StopKind` instead of being derived from the finish reason with `word` unreachable. This is the pair #1441 recorded as blocked.
- `src/server/routes/anthropic.rs`: prefers the scheduler's match over the post-hoc `apply_stop_sequences` pass, which can no longer find anything because the string is gone from the text. Without this the route would have regressed from `stop_reason: "stop_sequence"` to `"end_turn"`.
- `src/server/diffusion_worker.rs` / `src/server/florence2_worker.rs`: keep `stop_kind` consistent with the finish reason each worker reports itself.
- `src/tokenizer/mod.rs`: the all-byte-fallback stub tokenizer moves from `model_worker_tests.rs` onto `MlxcelTokenizer` beside the other test stubs, so the new tests can drive the same byte-level stream.

## Manifest

`field:stop` in `sampling-and-grammar.json` moves from `deferred` to `supported` and is filed under #1466, which needs #1466 in that shard's `owners` in `pin.json` and in the ownership table in `docs/llama-server-compat.md`. That shard's declared owners are #1377 and #1436; this edit touches only the `field:stop` entry, under the orchestrator's explicit authorization for this run, and no sibling chain is running.

The `POST /completion` and `POST /completions` route entries (`routes.json`, a shard #1466 already owns) lose the stop-sequence divergence line and **move back to #1441**, which owns every divergence they still record: the `generation_settings` subset, the always-`-1` `id_slot`, and the refused native fields. They have to stay `deferred` for those, and a deferred entry pointing at #1466 would turn the `llama-compat manifest` job red for every open pull request in the repository the moment #1466 closes. This follows the same principle the wave-1 reconciliation applied when it moved them to #1466 in the first place: an entry belongs to the issue that owns closing its remaining gap.

## Behavior note

The match runs on the raw generated stream, as upstream does, not on a reasoning-stripped view of it. On a reasoning model a stop string that appears inside a `<think>` block therefore ends the request there. That is the semantics `stop` already documented itself as having on this server, and it is what the pinned binary does.

## Test plan

Reproduced against `models/mlx/qwen3-0.6b` and compared with the pinned b10621 binary (build 10621, commit `c1d0e7a00`) serving `ggml-org/Qwen3-0.6B-GGUF` on the same requests.

| Request (`Count: 1 2 3`, `n_predict` 30, `temperature` 0, `seed` 1) | Before | b10621 | After |
|---|---|---|---|
| `POST /completion`, no `stop` | `" 4 5 6 7 8 9 10 11 12 13 14 15"`, 30 tokens, `limit` | same shape, `limit` | unchanged |
| `POST /completion`, `stop: ["5"]` | `" 4 5 6 7 8 9 10 11 12 13 14 15"`, 30 tokens, `limit`, `stopping_word: ""` | `" 4 "`, 4 tokens, `word`, `"5"` | `" 4 "`, 4 tokens, `word`, `"5"` |
| `POST /v1/completions`, `stop: ["5"]` | `" 4 5 6 7 8 9 10 11 12 13 14 15"`, `length`, 30 tokens | `" 4 "`, `stop`, 4 tokens | `" 4 "`, `stop`, 4 tokens |
| `POST /completion`, `stop: ["7 8"]` (straddles token boundaries) | not applicable | `" 4 5 6 "`, 10 tokens, `word`, `"7 8"` | `" 4 5 6 "`, 10 tokens, `word`, `"7 8"` |
| `POST /completion`, `stop: ["6", "4"]` (earliest wins) | not applicable | `" "`, 2 tokens, `word`, `"4"` | `" "`, 2 tokens, `word`, `"4"` |

The streaming form of each concatenates to exactly the non-streaming `content`, on `/completion` and `/v1/completions` both. `/v1/messages` with `stop_sequences: ["5"]` reported `stop_reason: "max_tokens"`, `stop_sequence: null` before and reports `"stop_sequence"`, `"5"` after.

- [x] `cargo test --profile test-fast --features metal,accelerate --lib server::`: 2187 passed, 0 failed, 8 ignored
- [x] `cargo test --profile test-fast --features metal,accelerate --test llama_compat_manifest`: 4 passed, including the archive-gated conformance test
- [x] `cargo clippy --profile test-fast --features metal,accelerate --lib --tests -- -D warnings`: clean
- [x] `cargo fmt --all -- --check`: clean
- [x] `python3 scripts/ci/check_llama_compat_manifest.py`: OK: 46 supported, 12 aliased, 61 not_applicable, 257 deferred, 19 distinct deferred issues
- [x] `python3 scripts/ci/check_cross_repo_refs.py`: no bare 3+-digit refs added
- [x] Generated cross-check of all 17 shard ownership rows in `docs/llama-server-compat.md` against `pin.json`: 0 mismatches

Closes #1466

