### PR TITLE
feat(server): align b10621 embedding and reranking mode and pooling

### DIFF
--- a/compat/llama-server/b10621/embeddings-and-rerank.json
+++ b/compat/llama-server/b10621/embeddings-and-rerank.json
@@ -19,10 +19,18 @@
       "discovery": "help-entry-head",
       "state": "deferred",
       "issue": 1452,
-      "test": null,
-      "notes": null,
-      "divergence": [],
-      "mlxcel": null
+      "test": "src/embeddings/normalize_tests.rs::the_domain_accepts_minus_one_and_above",
+      "notes": "Accepted on both server binaries and honored end to end: the whole b10621 domain is implemented in src/embeddings/normalize.rs with upstream's own arithmetic, including its `norm = sum > 0 ? 1/sum : 0` rule so a zero vector normalizes to zeros rather than NaN. `2` delegates to the L2 kernel every mlxcel embedding response already used, so the default path is unchanged. The value is also readable per request as `embd_normalize` on /embedding, /embeddings and /v1/embeddings, as upstream reads it. b10621 declares no environment variable for this option and neither does mlxcel.",
+      "divergence": [
+        "The default when the flag is unset is the checkpoint's own `normalize` flag (config.json), which is euclidean for every checkpoint that does not set it and none for one that sets it to false; b10621 always defaults to 2 because GGUF carries no such metadata."
+      ],
+      "mlxcel": {
+        "accepted_spellings": [
+          "--embd-normalize"
+        ],
+        "env": null,
+        "env_binding": "clap"
+      }
     },
     {
       "kind": "option",
@@ -43,10 +51,23 @@
       "discovery": "help-entry-head",
       "state": "deferred",
       "issue": 1452,
-      "test": null,
-      "notes": "mlxcel serves embeddings through dedicated models/endpoints rather than a server-wide restriction flag. #1452 owns the mode semantics.",
-      "divergence": [],
-      "mlxcel": null
+      "test": "src/cli/embedding_compat_args_tests.rs::the_embedding_flag_restricts_the_server",
+      "notes": "Both spellings accepted on both server binaries, and the flag does the two things b10621's does: generation routes answer 501 naming the flag (the restriction half, asserted by embedding_rerank_mode_tests.rs), and the embedding routes serve. LLAMA_ARG_EMBEDDINGS is read at runtime rather than through clap because b10621 fires a value-less option from the environment only for its own truthy set (on, enabled, true, 1) and clap's boolish parser both accepts more and errors outside it.",
+      "divergence": [
+        "mlxcel additionally requires an embedding checkpoint to resolve: --embeddings on a server whose -m is a chat model fails at startup naming the flag, where b10621 restricts the loaded model and embeds with it. mlxcel has no path that produces embeddings from a causal chat checkpoint."
+      ],
+      "mlxcel": {
+        "accepted_spellings": [
+          "--embedding",
+          "--embeddings"
+        ],
+        "env": "LLAMA_ARG_EMBEDDINGS",
+        "env_binding": "runtime",
+        "env_test": "src/cli/embedding_compat_args_tests.rs",
+        "defaults": [
+          "false"
+        ]
+      }
     },
     {
       "kind": "option",
@@ -65,10 +86,19 @@
       "discovery": "help-entry-head",
       "state": "deferred",
       "issue": 1452,
-      "test": null,
-      "notes": null,
-      "divergence": [],
-      "mlxcel": null
+      "test": "src/cli/embedding_compat_args_tests.rs::the_three_poolable_values_map_onto_mlxcel_kernels",
+      "notes": "Accepted on both server binaries with LLAMA_ARG_POOLING bound through clap. `mean`, `cls` and `last` map onto mlxcel's Mean, Cls and LastToken kernels and outrank the checkpoint's 1_Pooling/config.json and the MLXCEL_EMBEDDING_POOLING variable; the resolved mode is reported on /props so a value that the checkpoint overrode would be visible. `mlxcel embed --pooling` takes the same three values, so the offline and server surfaces resolve identically.",
+      "divergence": [
+        "`--pooling none` is refused at startup with a diagnostic; b10621 serves it as one embedding vector per token. Every mlxcel embedding family pools inside its own forward pass, before the engine sees the output, so there is no unpooled hidden state left to return.",
+        "`--pooling rank` selects the reranking worker, as `--reranking` does, rather than becoming a pooling type: mlxcel scores a query/document pair through a dedicated reranker head, so there is no pooling kernel for it to name."
+      ],
+      "mlxcel": {
+        "accepted_spellings": [
+          "--pooling"
+        ],
+        "env": "LLAMA_ARG_POOLING",
+        "env_binding": "clap"
+      }
     },
     {
       "kind": "option",
@@ -89,10 +119,24 @@
       "discovery": "help-entry-head",
       "state": "deferred",
       "issue": 1452,
-      "test": null,
-      "notes": null,
-      "divergence": [],
-      "mlxcel": null
+      "test": "src/cli/embedding_compat_args_tests.rs::the_rerank_flag_implies_the_embedding_restriction_as_upstream_does",
+      "notes": "Both spellings accepted on both server binaries, and, as upstream's handler does, the flag also turns generation off rather than only enabling the rerank routes. LLAMA_ARG_RERANKING is read at runtime for the same reason as LLAMA_ARG_EMBEDDINGS. `--pooling rank` is accepted as a synonym, which is how b10621 spells the same request.",
+      "divergence": [
+        "mlxcel additionally requires a reranker to resolve: --reranking on a server whose -m is not a reranker fails at startup naming the flag, where b10621 switches the loaded model to its rank pooling type and scores with it.",
+        "b10621's --reranking sets its embedding flag too, so /v1/embeddings keeps answering there; a mlxcel server in rerank mode has no embedding worker and answers 501 on the embedding routes."
+      ],
+      "mlxcel": {
+        "accepted_spellings": [
+          "--rerank",
+          "--reranking"
+        ],
+        "env": "LLAMA_ARG_RERANKING",
+        "env_binding": "runtime",
+        "env_test": "src/cli/embedding_compat_args_tests.rs",
+        "defaults": [
+          "false"
+        ]
+      }
     }
   ]
 }

--- a/compat/llama-server/b10621/routes.json
+++ b/compat/llama-server/b10621/routes.json
@@ -231,13 +231,11 @@
       "source": "tools/server/server.cpp",
       "condition": null,
       "discovery": "source-route-registration",
-      "state": "deferred",
+      "state": "supported",
       "issue": 1452,
-      "test": "src/server/routes/native_route_tests.rs",
-      "notes": "Route separation done: /embedding and /embeddings answer b10621's native shape, a bare JSON array of {index, embedding} whose embedding is an array OF arrays, and /v1/embeddings keeps the OpenAI object. /embedding was not mounted at all before this change, and all three paths used to answer the OpenAI shape. The native handler also accepts upstream's legacy `content` spelling for the input. Shape verified against a capture of the pinned binary serving a real embedding checkpoint.",
-      "divergence": [
-        "With no embedding checkpoint loaded the 501 body names the mlxcel flags instead of b10621's \"Start it with `--embeddings`\"; the flag itself is #1452's entry."
-      ],
+      "test": "src/server/routes/embedding_rerank_mode_tests.rs::an_embedding_body_with_neither_input_nor_content_uses_the_upstream_wording",
+      "notes": "The native shape (a bare JSON array of {index, embedding} whose embedding is an array OF arrays) landed with #1441 and was verified against a capture of the pinned binary; #1452 closed the rest. The handler accepts upstream's legacy `content` spelling for the input and answers a body carrying neither key with upstream's own \"input\\\" or \\\"content\\\" must be provided\" sentence, reads the per-request `embd_normalize` over the whole b10621 domain, and the 501 body now opens with upstream's \"This server does not support embeddings. Start it with `--embeddings`\" because that flag really is accepted here.",
+      "divergence": [],
       "mlxcel": {
         "route": "POST /embedding"
       }
@@ -250,13 +248,11 @@
       "source": "tools/server/server.cpp",
       "condition": null,
       "discovery": "source-route-registration",
-      "state": "deferred",
+      "state": "supported",
       "issue": 1452,
-      "test": "src/server/routes/native_route_tests.rs",
-      "notes": "Route separation done: /embedding and /embeddings answer b10621's native shape, a bare JSON array of {index, embedding} whose embedding is an array OF arrays, and /v1/embeddings keeps the OpenAI object. /embedding was not mounted at all before this change, and all three paths used to answer the OpenAI shape. The native handler also accepts upstream's legacy `content` spelling for the input. Shape verified against a capture of the pinned binary serving a real embedding checkpoint.",
-      "divergence": [
-        "With no embedding checkpoint loaded the 501 body names the mlxcel flags instead of b10621's \"Start it with `--embeddings`\"; the flag itself is #1452's entry."
-      ],
+      "test": "src/server/routes/native_route_tests.rs::the_native_embedding_path_accepts_the_content_spelling",
+      "notes": "The native shape (a bare JSON array of {index, embedding} whose embedding is an array OF arrays) landed with #1441 and was verified against a capture of the pinned binary; #1452 closed the rest. The handler accepts upstream's legacy `content` spelling for the input and answers a body carrying neither key with upstream's own \"input\\\" or \\\"content\\\" must be provided\" sentence, reads the per-request `embd_normalize` over the whole b10621 domain, and the 501 body now opens with upstream's \"This server does not support embeddings. Start it with `--embeddings`\" because that flag really is accepted here.",
+      "divergence": [],
       "mlxcel": {
         "route": "POST /embeddings"
       }
@@ -289,14 +285,11 @@
       "source": "tools/server/server.cpp",
       "condition": null,
       "discovery": "source-route-registration",
-      "state": "deferred",
+      "state": "supported",
       "issue": 1452,
-      "test": "src/server/llama_compat_tests.rs",
-      "notes": "All four aliases mounted (#1430). Mounted with all four b10621 spellings (#1430); the response omits b10621's top-level \"object\": \"list\" and mlxcel uses the Cohere return_documents/document spelling rather than b10621's TEI return_text. #1452 owns envelope parity.",
-      "divergence": [
-        "The response omits b10621's top-level \"object\": \"list\" (#1452).",
-        "Echoing documents uses the Cohere return_documents/document spelling instead of b10621's TEI return_text (#1452)."
-      ],
+      "test": "src/server/routes/embedding_rerank_mode_tests.rs::the_jina_envelope_carries_the_object_key",
+      "notes": "All four aliases mounted (#1430); #1452 aligned the envelope. The Jina response now carries b10621's top-level \"object\": \"list\", and a request that spells its document list `texts` gets b10621's TEI shape instead: a bare array of {index, score} with `text` echoed under `return_text`. The Cohere `documents` / `return_documents` / `document` spelling mlxcel already served keeps working, and a body carrying both list spellings stays on the Jina envelope. The three shape errors use upstream's own wording. The route is served exactly when the operator asked for reranking; mlxcel spells that request as `--reranking`, `--pooling rank`, `--reranker-model <path>`, or a reranker checkpoint in -m, and the 501 body opens with upstream's \"This server does not support reranking. Start it with `--reranking`\".",
+      "divergence": [],
       "mlxcel": {
         "route": "POST /rerank"
       }
@@ -309,14 +302,11 @@
       "source": "tools/server/server.cpp",
       "condition": null,
       "discovery": "source-route-registration",
-      "state": "deferred",
+      "state": "supported",
       "issue": 1452,
-      "test": "src/server/llama_compat_tests.rs",
-      "notes": "All four aliases mounted (#1430). See POST /rerank for the envelope gap. #1452 owns envelope parity.",
-      "divergence": [
-        "The response omits b10621's top-level \"object\": \"list\" (#1452).",
-        "Echoing documents uses the Cohere return_documents/document spelling instead of b10621's TEI return_text (#1452)."
-      ],
+      "test": "src/server/routes/embedding_rerank_mode_tests.rs::a_texts_request_gets_b10621s_tei_array",
+      "notes": "The /reranking spelling of POST /rerank; all four paths reach one handler. See POST /rerank.",
+      "divergence": [],
       "mlxcel": {
         "route": "POST /reranking"
       }
@@ -482,14 +472,11 @@
       "source": "tools/server/server.cpp",
       "condition": null,
       "discovery": "source-route-registration",
-      "state": "deferred",
+      "state": "supported",
       "issue": 1452,
-      "test": "src/server/llama_compat_tests.rs",
-      "notes": "All four aliases mounted (#1430). See POST /rerank for the envelope gap. #1452 owns envelope parity.",
-      "divergence": [
-        "The response omits b10621's top-level \"object\": \"list\" (#1452).",
-        "Echoing documents uses the Cohere return_documents/document spelling instead of b10621's TEI return_text (#1452)."
-      ],
+      "test": "src/server/routes/embedding_rerank_mode_tests.rs::return_documents_still_echoes_under_the_cohere_spelling",
+      "notes": "The /v1 spelling of POST /rerank; all four paths reach one handler. See POST /rerank.",
+      "divergence": [],
       "mlxcel": {
         "route": "POST /v1/rerank"
       }
@@ -502,14 +489,11 @@
       "source": "tools/server/server.cpp",
       "condition": null,
       "discovery": "source-route-registration",
-      "state": "deferred",
+      "state": "supported",
       "issue": 1452,
-      "test": "src/server/llama_compat_tests.rs",
-      "notes": "All four aliases mounted (#1430). See POST /rerank for the envelope gap. #1452 owns envelope parity.",
-      "divergence": [
-        "The response omits b10621's top-level \"object\": \"list\" (#1452).",
-        "Echoing documents uses the Cohere return_documents/document spelling instead of b10621's TEI return_text (#1452)."
-      ],
+      "test": "src/server/routes/embedding_rerank_mode_tests.rs::the_jina_envelope_carries_the_object_key",
+      "notes": "The /v1/reranking spelling of POST /rerank; all four paths reach one handler. See POST /rerank.",
+      "divergence": [],
       "mlxcel": {
         "route": "POST /v1/reranking"
       }

--- a/docs/embeddings.md
+++ b/docs/embeddings.md
@@ -130,6 +130,22 @@ Micro-batches are right-padded to their longest member (or to a fixed width when
 
 Prompt prefixes are caller-side everywhere: nothing is injected server-side, so an input embeds exactly as it is sent. The `instruction` request field (and `mlxcel embed --instruction`) reaches `EmbeddingModel::format_text`, and only a family that documents a format below does anything with it.
 
+### Pooling and normalization overrides
+
+Two llama-server b10621 flags override what the checkpoint asks for, on the server and on `mlxcel embed` alike (issue #1452):
+
+| Flag | Values | Unset |
+|---|---|---|
+| `--pooling` | `mean`, `cls`, `last` (b10621 also has `none` and `rank`; see below) | `1_Pooling/config.json`, then the family default |
+| `--embd-normalize` | `-1` none, `0` max absolute int16, `1` taxicab, `2` euclidean, above 2 that p-norm | the checkpoint's `config.json` `normalize` flag, which is euclidean unless it says otherwise |
+
+`--pooling` outranks both `1_Pooling/config.json` and the `MLXCEL_EMBEDDING_POOLING` variable, and `GET /props` reports the mode that was really resolved, so a value the checkpoint overrode would be visible rather than assumed. mlxcel's own `max` pooling has no b10621 spelling and stays reachable through `MLXCEL_EMBEDDING_POOLING` and the checkpoint config.
+
+b10621's other two `--pooling` values are not pooling kernels. `rank` is how it puts a model on its reranking path, so mlxcel accepts it as a synonym for `--reranking`. `none` asks for one vector per token, which no mlxcel embedding family can return because each pools inside its own forward pass before the engine sees the output; it is refused at startup with that reason.
+
+`--embd-normalize` is also readable per request as `embd_normalize` on `/embedding`, `/embeddings` and `/v1/embeddings`. A zero vector normalizes to zeros rather than to NaN under every mode, matching upstream.
+
+
 ### BERT and XLM-RoBERTa
 
 One encoder covers both (`src/models/bert.rs`): a post-LayerNorm block stack over absolute position embeddings, selected by a `BertVariant` switch. `model_type: bert` builds position ids as `0..L` and carries a real `token_type_ids` axis; `model_type: xlm-roberta` builds them as `cumsum(input_ids != pad_token_id) * mask + pad_token_id`, so the first real token sits at `pad_token_id + 1` and padding stays at `pad_token_id`. `intfloat/multilingual-e5-small` is a `BertModel` despite shipping the XLM-RoBERTa tokenizer, and follows the BERT rule.

--- a/docs/llama-server-compat.md
+++ b/docs/llama-server-compat.md
@@ -109,6 +109,37 @@ Two `/infill` differences remain, and its manifest entry stays `deferred` for th
 - Text in `input_prefix`, `input_suffix`, `input_extra[].text`, `input_extra[].filename` or `prompt` that contains one of the model's own FIM marker spellings is **refused** with a diagnostic naming the field and the marker. b10621 tokenizes those fields with special-token parsing off, so the marker stays literal text there. mlxcel's generation entry point takes a prompt string that is re-tokenized with parsing on, and a string cannot express "these characters are not that token", so carrying the text through would let a file the client did not write restructure the FIM prompt and return a fluent wrong completion. Failing loudly is the smaller divergence.
 - The FIM context is not truncated to the prefill batch. b10621 keeps only the last `3*(n_batch/4)` prefix tokens and the first `(n_batch/4) - (2 + prompt)` suffix tokens; mlxcel serves the whole prefix and suffix, consistent with its policy everywhere else of clamping an over-long request rather than dropping prompt text.
 
+### Embedding and reranking mode, pooling and normalization (#1452)
+
+b10621's `--embedding` / `--embeddings`, `--rerank` / `--reranking`, `--pooling` and `--embd-normalize` are accepted on both server binaries, with `LLAMA_ARG_EMBEDDINGS`, `LLAMA_ARG_RERANKING` and `LLAMA_ARG_POOLING` bound. The two mode flags do the same two things upstream's do, and one more that upstream never needs.
+
+They **restrict**: generation routes answer `501` naming the flag, so a client sees the same "this server does not generate" it would see from `llama-server --embeddings`. They **select**: a mlxcel server runs a dedicated embedding or reranking worker rather than reusing one set of weights, so `--embeddings` requires an embedding checkpoint to resolve from `-m` or `--embedding-model`, and `--reranking` requires a reranker from `-m` or `--reranker-model`. A command line that asks for a mode nothing can serve fails at startup naming the flag, instead of booting a server whose only route answers 501 forever. That startup refusal is the one behavior upstream does not have, because its `--embeddings` embeds with whatever `-m` happens to be and mlxcel has no path that produces embeddings from a causal chat checkpoint.
+
+`--pooling` maps `mean`, `cls` and `last` onto mlxcel's own kernels, and the flag outranks both the checkpoint's `1_Pooling/config.json` and the `MLXCEL_EMBEDDING_POOLING` variable. The other two values are not pooling kernels at all: `rank` is how b10621 puts a model on its reranking path, so it is accepted as a synonym for `--reranking`, and `none` asks for one vector per token, which mlxcel cannot produce because every embedding family pools inside its own forward pass before the engine sees the output. `none` is refused at startup with that reason. mlxcel's own `max` pooling has no b10621 spelling and stays reachable through `MLXCEL_EMBEDDING_POOLING` and the checkpoint config.
+
+`--embd-normalize` implements the whole b10621 domain with upstream's arithmetic: `-1` none, `0` the max-absolute rescale into the signed int16 range, `1` taxicab, `2` euclidean, and any value above 2 that p-norm. A zero vector normalizes to zeros rather than NaN, which is upstream's `norm = sum > 0 ? 1/sum : 0` rule and matters here because the embedding route refuses a non-finite response with a 500. `2` delegates to the L2 kernel every mlxcel embedding response already used, so the default path produces exactly the numbers it produced before. The value is also readable per request as `embd_normalize` on `/embedding`, `/embeddings` and `/v1/embeddings`, as upstream reads it, and `mlxcel embed` takes the same `--pooling` and `--embd-normalize` so the offline and server surfaces resolve identically.
+
+One default differs: with the flag unset mlxcel follows the checkpoint's own `normalize` flag from `config.json`, which is euclidean for every checkpoint that does not set it and none for one that sets it to `false`. b10621 always defaults to `2`, because GGUF carries no such metadata.
+
+#### Rerank envelope
+
+The four rerank routes now answer b10621's shapes rather than only Cohere's.
+
+| Request spells the document list | Response |
+|---|---|
+| `documents` (Jina / Cohere) | `{"model", "object": "list", "usage", "results": [{"index", "relevance_score"}]}`, with `document` echoed under `return_documents` |
+| `texts` (b10621 / TEI) | a bare array of `{"index", "score"}`, with `text` echoed under `return_text` |
+
+`object` was previously missing from the Jina envelope and the TEI shape was not served at all; both were recorded divergences on all four routes. A body carrying both list spellings stays on the Jina envelope, and the three shape errors (`"query" must be provided`, `"query" must be a string`, `"documents" must be a non-empty string array`) use upstream's wording. The `/embedding` family answers `"input" or "content" must be provided` for the same reason.
+
+#### Readiness in a restricted mode
+
+A server started with `--embeddings` or `--reranking` has no chat worker to be "loaded", and `/health` answered `503 {"status": "loading model"}` for the life of the process, which would make the mode unusable behind any container probe. In those two modes `/health` now reports on the worker the mode selected instead. The change is deliberately scoped to the flags: a server whose `-m` is an embedding checkpoint but that was started without them still reports on the chat provider, so nothing that exists today changes behavior. That wider case, along with the queue-full and loading-body drift, is recorded on `GET /health`'s manifest entry and belongs to #1440.
+
+#### Resolved capability on `/props` and `/v1/models`
+
+`/props` gains a `capabilities` block reporting what the server resolved rather than what was passed: whether generation is on, which mode flag restricted it, and, for each loaded side model, its id plus the pooling and `embd_normalize` really in force. A `--pooling` value the checkpoint overrode is therefore visible. `/v1/models` labels each entry with a `capabilities` array (`completion`, `embedding`, `rerank`), which is what a client needs to tell which id to send where; the field is omitted when empty, so a plain generation deployment keeps exactly the OpenAI object shape.
+
 ## Sharding
 
 The manifest is sharded by area so that the concurrent implementation chains of epic #1431 edit disjoint files. Ownership is machine-readable, not prose: `pin.json`'s `shards` map records, per shard, the set of implementation issue numbers allowed to own entries in it (`shards["authentication"].owners == [1437]`, for example), and `scripts/ci/check_llama_compat_manifest.py` fails an entry whose `issue` is not a member of its own shard's owner set. That is what stops two concurrent chains from editing the same file: the file, not just the reviewer, rejects the second chain's entry.

--- a/src/bin/mlx_server.rs
+++ b/src/bin/mlx_server.rs
@@ -1406,6 +1406,13 @@ struct ServerArgs {
     #[command(flatten)]
     infill: mlxcel::cli::infill_args::InfillArgs,
 
+    /// llama-server b10621 embedding and reranking mode flag group
+    /// (`--embedding`, `--rerank`, `--pooling`, `--embd-normalize`). Defined
+    /// once in `mlxcel::cli::embedding_compat_args` so both server binaries
+    /// accept the same command line.
+    #[command(flatten)]
+    embedding_compat: mlxcel::cli::embedding_compat_args::EmbeddingCompatArgs,
+
     /// Language-bias options for server-wide output
     /// steering. See `--lang-bias`, `--lang-bias-config`, `--lang-bias-policy`,
     /// and the `--lang-bias-include-*` family of flags.
@@ -2151,6 +2158,7 @@ fn build_startup_input(mut args: ServerArgs) -> anyhow::Result<ServerStartupInpu
         rope: args.rope.clone(),
         cache_compat: args.cache_compat.clone(),
         infill: args.infill.clone(),
+        embedding_compat: args.embedding_compat.clone(),
     })
 }
 

--- a/src/cli/embedding_compat_args.rs
+++ b/src/cli/embedding_compat_args.rs
@@ -1,0 +1,235 @@
+// Copyright 2025-2026 Lablup Inc. and Jeongkyu Shin
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! llama-server b10621 embedding and reranking mode flags (issue #1452).
+//!
+//! Four options, defined once and flattened into both server binaries:
+//! `--embedding` / `--embeddings`, `--rerank` / `--reranking`, `--pooling` and
+//! `--embd-normalize`.
+//!
+//! # What the two mode flags mean here
+//!
+//! b10621 has one model and one set of weights, so `--embeddings` is a
+//! server-wide restriction: it stops generation and turns the embedding
+//! endpoints on. mlxcel loads a dedicated embedding or reranking worker, chosen
+//! today by `--embedding-model` / `--reranker-model` or by detecting what `-m`
+//! is. The flags therefore do two things here, and both halves are needed for
+//! the b10621 behavior to be reproduced rather than approximated:
+//!
+//! 1. They **select**: `--embeddings` requires `-m` (or `--embedding-model`) to
+//!    resolve to an embedding worker, and `--rerank` requires a reranker. A
+//!    command line that asks for the mode and gives no checkpoint that can
+//!    serve it fails at startup, naming the flag, instead of booting a server
+//!    whose embedding route answers 501 forever.
+//! 2. They **restrict**: generation routes answer the same 501 they answer when
+//!    no chat model is loaded, naming the flag that turned generation off. That
+//!    is what a client written against `llama-server --embeddings` observes.
+//!
+//! # `--pooling`
+//!
+//! b10621's five values do not all name a pooling kernel. `mean`, `cls` and
+//! `last` do, and map onto mlxcel's [`PoolingMode`]. `rank` does not: upstream
+//! uses it to put the model on its reranking path, which is exactly what
+//! `--reranking` does, so it is accepted as a synonym for that flag rather than
+//! invented as a pooling kernel that would have nothing to compute. `none`
+//! means "return one vector per token", which mlxcel's embedding pipeline
+//! cannot produce at all: every family pools to `[B, D]` before the engine sees
+//! the output. It is refused at startup with that reason.
+//!
+//! mlxcel's own `max` pooling has no b10621 spelling and stays reachable
+//! through `MLXCEL_EMBEDDING_POOLING` and the checkpoint's own
+//! `1_Pooling/config.json`.
+//!
+//! # `--embd-normalize`
+//!
+//! The whole b10621 domain, `-1`, `0`, `1`, `2` and any `p > 2`, is served; see
+//! [`crate::embeddings::EmbdNormalize`].
+//!
+//! Upstream reference:
+//! <https://github.com/ggml-org/llama.cpp/blob/c1d0e7a004015f23bc0233470b747b596f29b264/common/arg.cpp>
+//!
+//! Used by: mlxcel serve, mlxcel-server.
+
+use clap::Args;
+
+use crate::embeddings::{EmbdNormalize, PoolingMode};
+
+use super::ggml_compat_args::env_flag;
+
+/// Shared embedding and reranking mode flag group.
+#[derive(Args, Debug, Default, Clone)]
+#[command(next_help_heading = "Embeddings and Reranking (llama-server compatibility)")]
+pub struct EmbeddingCompatArgs {
+    /// Serve embeddings only: refuse generation and require an embedding
+    /// checkpoint.
+    ///
+    /// `-m` must be an embedding checkpoint, or `--embedding-model` must name
+    /// one; otherwise startup fails rather than answering 501 forever.
+    #[arg(
+        long = "embedding",
+        visible_alias = "embeddings",
+        action = clap::ArgAction::SetTrue
+    )]
+    pub embedding: bool,
+
+    /// Serve reranking only: refuse generation and require a reranker.
+    ///
+    /// `-m` must be a reranker checkpoint, or `--reranker-model` must name one.
+    #[arg(
+        long = "rerank",
+        visible_alias = "reranking",
+        action = clap::ArgAction::SetTrue
+    )]
+    pub rerank: bool,
+
+    /// Pooling for embeddings: `none`, `mean`, `cls`, `last` or `rank`.
+    ///
+    /// Unset uses the checkpoint's `1_Pooling/config.json`, then the family
+    /// default. `rank` selects reranking, as `--reranking` does. `none` is
+    /// refused: mlxcel pools inside the family and cannot return one vector per
+    /// token.
+    #[arg(
+        long = "pooling",
+        env = "LLAMA_ARG_POOLING",
+        value_name = "{none,mean,cls,last,rank}"
+    )]
+    pub pooling: Option<String>,
+
+    /// Embedding normalization: `-1` none, `0` max absolute int16, `1`
+    /// taxicab, `2` euclidean, above 2 that p-norm.
+    #[arg(long = "embd-normalize", value_name = "N")]
+    pub embd_normalize: Option<i32>,
+}
+
+/// What this group resolves to, once precedence and validation are applied.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub struct EmbeddingCompatResolution {
+    /// `--embedding` / `--embeddings` / `LLAMA_ARG_EMBEDDINGS`, or `--pooling`
+    /// having selected an embedding-only server.
+    pub embedding_only: bool,
+    /// `--rerank` / `--reranking` / `LLAMA_ARG_RERANKING`, or `--pooling rank`.
+    pub rerank_only: bool,
+    /// The pooling kernel `--pooling` asked for, `None` when it named `rank`
+    /// or was not given.
+    pub pooling: Option<PoolingMode>,
+    /// The `--embd-normalize` value, `None` when unset: the checkpoint's own
+    /// `normalize` flag then decides.
+    pub embd_normalize: Option<EmbdNormalize>,
+}
+
+impl EmbeddingCompatArgs {
+    /// Apply precedence and refuse what cannot be served.
+    ///
+    /// Both mode flags read their `LLAMA_ARG_*` variable through
+    /// [`env_flag`] rather than through clap, because b10621 fires a
+    /// value-less option from the environment only for its own truthy set and
+    /// clap's boolish parser both accepts more and errors outside it.
+    ///
+    /// Asking for both modes on the *command line* is refused, because it names
+    /// two workers for one `-m`. The same pair arriving from different layers
+    /// is not: `--reranking` sets the embedding restriction itself, exactly as
+    /// b10621's handler does, so an inherited `LLAMA_ARG_EMBEDDINGS` next to an
+    /// explicit `--rerank` is coherent and resolves to reranking.
+    pub fn resolve(&self) -> Result<EmbeddingCompatResolution, String> {
+        let mut embedding_only = self.embedding || env_flag("LLAMA_ARG_EMBEDDINGS");
+        let mut rerank_only = self.rerank || env_flag("LLAMA_ARG_RERANKING");
+        let mut pooling = None;
+
+        if let Some(raw) = self.pooling.as_deref() {
+            match parse_pooling(raw)? {
+                PoolingChoice::Mode(mode) => pooling = Some(mode),
+                PoolingChoice::Rank => rerank_only = true,
+            }
+        }
+
+        // b10621's `--reranking` sets its embedding flag too, so reranking
+        // implies the same generation restriction.
+        if rerank_only {
+            embedding_only = true;
+        }
+
+        if self.embedding && self.rerank {
+            return Err(
+                "--embeddings and --reranking select different workers: pass one. A single \
+                 mlxcel server loads one embedding checkpoint or one reranker for -m, not both; \
+                 to serve both, pass a chat model to -m with --embedding-model and \
+                 --reranker-model."
+                    .to_string(),
+            );
+        }
+
+        let embd_normalize = self.embd_normalize.map(EmbdNormalize::new).transpose()?;
+
+        Ok(EmbeddingCompatResolution {
+            embedding_only,
+            rerank_only,
+            pooling,
+            embd_normalize,
+        })
+    }
+}
+
+/// What one `--pooling` value selects.
+enum PoolingChoice {
+    /// A pooling kernel mlxcel implements.
+    Mode(PoolingMode),
+    /// b10621's `rank`, which is the reranking path rather than a kernel.
+    Rank,
+}
+
+/// Map one b10621 `--pooling` value onto mlxcel.
+fn parse_pooling(raw: &str) -> Result<PoolingChoice, String> {
+    match raw.trim().to_ascii_lowercase().as_str() {
+        "mean" => Ok(PoolingChoice::Mode(PoolingMode::Mean)),
+        "cls" => Ok(PoolingChoice::Mode(PoolingMode::Cls)),
+        "last" => Ok(PoolingChoice::Mode(PoolingMode::LastToken)),
+        "rank" => Ok(PoolingChoice::Rank),
+        "none" => Err(
+            "--pooling none asks for one embedding vector per token, which mlxcel cannot \
+             produce: every embedding family pools to one vector per input inside its own \
+             forward pass, before the engine sees the output, so there is no unpooled hidden \
+             state left to return. Pass mean, cls or last, or drop the flag to use the \
+             checkpoint's 1_Pooling/config.json. Tracked by #1452."
+                .to_string(),
+        ),
+        other => Err(format!(
+            "--pooling {other} is not a b10621 pooling type: pass none, mean, cls, last or rank"
+        )),
+    }
+}
+
+/// Resolve the group from the environment alone.
+///
+/// Parsing an argv of just the program name makes clap fill `--pooling` from
+/// `LLAMA_ARG_POOLING`, and [`Self::resolve`] reads the two value-less
+/// variables itself, so a caller with no command line still goes through one
+/// set of definitions.
+pub fn from_env() -> Result<EmbeddingCompatResolution, String> {
+    use clap::Parser;
+
+    #[derive(Parser)]
+    struct EnvOnly {
+        #[command(flatten)]
+        embedding_compat: EmbeddingCompatArgs,
+    }
+
+    EnvOnly::try_parse_from(["mlxcel-server"])
+        .map_err(|e| e.to_string())?
+        .embedding_compat
+        .resolve()
+}
+
+#[cfg(test)]
+#[path = "embedding_compat_args_tests.rs"]
+mod embedding_compat_args_tests;

--- a/src/cli/embedding_compat_args_tests.rs
+++ b/src/cli/embedding_compat_args_tests.rs
@@ -1,0 +1,253 @@
+// Copyright 2025-2026 Lablup Inc. and Jeongkyu Shin
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! `--embedding` / `--rerank` / `--pooling` / `--embd-normalize` parsing (#1452).
+
+use super::*;
+
+fn args() -> EmbeddingCompatArgs {
+    EmbeddingCompatArgs::default()
+}
+
+fn resolve(a: EmbeddingCompatArgs) -> EmbeddingCompatResolution {
+    a.resolve().expect("resolves")
+}
+
+fn err(a: EmbeddingCompatArgs) -> String {
+    a.resolve().expect_err("must be refused")
+}
+
+/// Run `body` with the two mode variables forced to a known state, so an
+/// inherited `LLAMA_ARG_EMBEDDINGS` in the developer's shell cannot flip a
+/// test that is about the flags.
+fn with_env<T>(pairs: &[(&str, Option<&str>)], body: impl FnOnce() -> T) -> T {
+    let _guard = crate::test_support::env_lock::env_lock();
+    let keys = ["LLAMA_ARG_EMBEDDINGS", "LLAMA_ARG_RERANKING"];
+    let saved: Vec<(String, Option<String>)> = keys
+        .iter()
+        .chain(pairs.iter().map(|(k, _)| k))
+        .map(|k| ((*k).to_owned(), std::env::var(k).ok()))
+        .collect();
+    unsafe {
+        for key in keys {
+            std::env::remove_var(key);
+        }
+        for (key, value) in pairs {
+            match value {
+                Some(v) => std::env::set_var(key, v),
+                None => std::env::remove_var(key),
+            }
+        }
+    }
+    let out = body();
+    unsafe {
+        for (key, value) in &saved {
+            match value {
+                Some(v) => std::env::set_var(key, v),
+                None => std::env::remove_var(key),
+            }
+        }
+    }
+    out
+}
+
+#[test]
+fn nothing_supplied_resolves_to_nothing_requested() {
+    let resolved = with_env(&[], || resolve(args()));
+    assert_eq!(resolved, EmbeddingCompatResolution::default());
+    assert!(!resolved.embedding_only);
+    assert!(!resolved.rerank_only);
+    assert_eq!(resolved.pooling, None);
+    assert_eq!(resolved.embd_normalize, None);
+}
+
+#[test]
+fn the_embedding_flag_restricts_the_server() {
+    let resolved = with_env(&[], || {
+        resolve(EmbeddingCompatArgs {
+            embedding: true,
+            ..args()
+        })
+    });
+    assert!(resolved.embedding_only);
+    assert!(!resolved.rerank_only);
+}
+
+#[test]
+fn the_rerank_flag_implies_the_embedding_restriction_as_upstream_does() {
+    // b10621's `--reranking` handler sets `params.embedding = true` as well as
+    // the rank pooling type, so generation is off in both modes.
+    let resolved = with_env(&[], || {
+        resolve(EmbeddingCompatArgs {
+            rerank: true,
+            ..args()
+        })
+    });
+    assert!(resolved.rerank_only);
+    assert!(resolved.embedding_only);
+}
+
+#[test]
+fn asking_for_both_modes_is_refused() {
+    let message = with_env(&[], || {
+        err(EmbeddingCompatArgs {
+            embedding: true,
+            rerank: true,
+            ..args()
+        })
+    });
+    assert!(
+        message.contains("--embeddings and --reranking"),
+        "{message}"
+    );
+    assert!(message.contains("--embedding-model"), "{message}");
+}
+
+#[test]
+fn the_three_poolable_values_map_onto_mlxcel_kernels() {
+    for (raw, expected) in [
+        ("mean", PoolingMode::Mean),
+        ("cls", PoolingMode::Cls),
+        ("last", PoolingMode::LastToken),
+        ("MEAN", PoolingMode::Mean),
+        (" cls ", PoolingMode::Cls),
+    ] {
+        let resolved = with_env(&[], || {
+            resolve(EmbeddingCompatArgs {
+                pooling: Some(raw.to_string()),
+                ..args()
+            })
+        });
+        assert_eq!(resolved.pooling, Some(expected), "--pooling {raw}");
+        assert!(!resolved.rerank_only, "--pooling {raw}");
+    }
+}
+
+#[test]
+fn pooling_rank_selects_reranking_rather_than_a_kernel() {
+    let resolved = with_env(&[], || {
+        resolve(EmbeddingCompatArgs {
+            pooling: Some("rank".to_string()),
+            ..args()
+        })
+    });
+    assert_eq!(
+        resolved.pooling, None,
+        "rank is not a pooling kernel; it must not become one"
+    );
+    assert!(resolved.rerank_only);
+    assert!(resolved.embedding_only);
+}
+
+#[test]
+fn pooling_none_is_refused_with_the_reason() {
+    let message = with_env(&[], || {
+        err(EmbeddingCompatArgs {
+            pooling: Some("none".to_string()),
+            ..args()
+        })
+    });
+    assert!(message.contains("--pooling none"), "{message}");
+    assert!(
+        message.contains("one embedding vector per token"),
+        "{message}"
+    );
+    assert!(message.contains("mean, cls or last"), "{message}");
+}
+
+#[test]
+fn an_unknown_pooling_value_names_the_domain() {
+    let message = with_env(&[], || {
+        err(EmbeddingCompatArgs {
+            pooling: Some("max".to_string()),
+            ..args()
+        })
+    });
+    assert!(
+        message.contains("none, mean, cls, last or rank"),
+        "mlxcel's own `max` is not a b10621 spelling: {message}"
+    );
+}
+
+#[test]
+fn the_whole_embd_normalize_domain_is_accepted() {
+    for value in [-1, 0, 1, 2, 3, 9] {
+        let resolved = with_env(&[], || {
+            resolve(EmbeddingCompatArgs {
+                embd_normalize: Some(value),
+                ..args()
+            })
+        });
+        assert_eq!(
+            resolved.embd_normalize.map(EmbdNormalize::value),
+            Some(value)
+        );
+    }
+    let message = with_env(&[], || {
+        err(EmbeddingCompatArgs {
+            embd_normalize: Some(-2),
+            ..args()
+        })
+    });
+    assert!(message.contains("--embd-normalize -2"), "{message}");
+}
+
+#[test]
+fn the_mode_variables_follow_b10621s_truthy_set() {
+    // b10621 fires a value-less option from the environment only for
+    // on/enabled/true/1, so `0` and an empty value leave the flag alone.
+    for (value, expected) in [
+        ("1", true),
+        ("true", true),
+        ("on", true),
+        ("enabled", true),
+        ("0", false),
+        ("false", false),
+        ("", false),
+        ("yes", false),
+    ] {
+        let resolved = with_env(&[("LLAMA_ARG_EMBEDDINGS", Some(value))], || resolve(args()));
+        assert_eq!(
+            resolved.embedding_only, expected,
+            "LLAMA_ARG_EMBEDDINGS={value:?}"
+        );
+        let resolved = with_env(&[("LLAMA_ARG_RERANKING", Some(value))], || resolve(args()));
+        assert_eq!(
+            resolved.rerank_only, expected,
+            "LLAMA_ARG_RERANKING={value:?}"
+        );
+        assert_eq!(resolved.embedding_only, expected);
+    }
+}
+
+#[test]
+fn the_environment_alone_resolves_the_group() {
+    let resolved = with_env(
+        &[
+            ("LLAMA_ARG_EMBEDDINGS", Some("1")),
+            ("LLAMA_ARG_POOLING", Some("cls")),
+        ],
+        || from_env().expect("resolves"),
+    );
+    assert!(resolved.embedding_only);
+    assert_eq!(resolved.pooling, Some(PoolingMode::Cls));
+}
+
+#[test]
+fn a_bad_pooling_value_in_the_environment_is_refused_the_same_way() {
+    let message = with_env(&[("LLAMA_ARG_POOLING", Some("none"))], || {
+        from_env().expect_err("must be refused")
+    });
+    assert!(message.contains("--pooling none"), "{message}");
+}

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -24,6 +24,7 @@
 pub mod batch_quant_args;
 pub mod cache_args;
 pub mod chat_compat_args;
+pub mod embedding_compat_args;
 pub mod flag_surface;
 pub mod ggml_compat_args;
 pub mod infill_args;

--- a/src/commands/embed.rs
+++ b/src/commands/embed.rs
@@ -53,6 +53,18 @@ pub(crate) struct EmbedArgs {
     #[arg(long, value_name = "N")]
     pub(crate) dimensions: Option<usize>,
 
+    /// Pooling override: `mean`, `cls` or `last`, the b10621 `--pooling`
+    /// spellings mlxcel implements. Unset uses the checkpoint's
+    /// `1_Pooling/config.json`, then the family default (#1452).
+    #[arg(long = "pooling", value_name = "{mean,cls,last}")]
+    pub(crate) pooling: Option<String>,
+
+    /// Embedding normalization, b10621's `--embd-normalize` domain: `-1` none,
+    /// `0` max absolute int16, `1` taxicab, `2` euclidean, above 2 that p-norm.
+    /// Unset uses the checkpoint's own `normalize` flag (#1452).
+    #[arg(long = "embd-normalize", value_name = "N")]
+    pub(crate) embd_normalize: Option<i32>,
+
     /// Print one JSON object instead of the text layout.
     #[arg(long)]
     pub(crate) json: bool,
@@ -129,6 +141,25 @@ pub(crate) fn run_embed(args: EmbedArgs) -> Result<()> {
         }
     }
 
+    // `--pooling` and `--embd-normalize` are resolved before the checkpoint is
+    // loaded, because the pooling override has to be installed before the
+    // family constructor reads it and because a bad value should fail the
+    // command line rather than a forward pass (#1452).
+    let normalize_override = match args.embd_normalize {
+        Some(raw) => Some(mlxcel::embeddings::EmbdNormalize::new(raw).map_err(anyhow::Error::msg)?),
+        None => None,
+    };
+    let pooling_override = match args.pooling.as_deref() {
+        Some(raw) => Some(
+            raw.trim()
+                .to_ascii_lowercase()
+                .parse::<mlxcel::embeddings::PoolingMode>()
+                .map_err(|e| anyhow::anyhow!("--pooling {raw}: {e}"))?,
+        ),
+        None => None,
+    };
+    mlxcel::embeddings::set_pooling_override(pooling_override);
+
     let model_dir =
         resolve_model_source_with_override(&args.model, args.models_dir.as_deref(), None)?;
 
@@ -156,6 +187,7 @@ pub(crate) fn run_embed(args: EmbedArgs) -> Result<()> {
     let options = EmbedOptions {
         instruction: args.instruction.clone(),
         dimensions: args.dimensions,
+        normalize: normalize_override,
     };
     let mut labels: Vec<String> = Vec::new();
     let mut vectors: Vec<EmbeddingVector> = Vec::new();

--- a/src/commands/serve.rs
+++ b/src/commands/serve.rs
@@ -586,6 +586,7 @@ fn build_startup_input(mut args: crate::ServeArgs) -> anyhow::Result<ServerStart
         rope: args.rope.clone(),
         cache_compat: args.cache_compat.clone(),
         infill: args.infill.clone(),
+        embedding_compat: args.embedding_compat.clone(),
     })
 }
 

--- a/src/commands/serve_tests.rs
+++ b/src/commands/serve_tests.rs
@@ -128,6 +128,7 @@ fn sample_args() -> crate::ServeArgs {
         _mmproj: None,
         cache_compat: mlxcel::cli::cache_args::CacheCompatArgs::default(),
         infill: mlxcel::cli::infill_args::InfillArgs::default(),
+        embedding_compat: mlxcel::cli::embedding_compat_args::EmbeddingCompatArgs::default(),
         estimate_memory: false,
         force_memory: false,
         turbo: mlxcel::cli::turbo_args::TurboKvCacheArgs::default(),

--- a/src/embeddings/engine.rs
+++ b/src/embeddings/engine.rs
@@ -27,7 +27,8 @@ use crate::models::ModelType;
 
 use super::loader::LoadedEmbeddingModel;
 use super::model::{EmbeddingBatch, EmbeddingOutput, ImageInput};
-use super::pooling::{normalize_l2, truncate_dimensions};
+use super::normalize::{EmbdNormalize, apply_embd_normalize};
+use super::pooling::truncate_dimensions;
 use super::tokenize::{EncodeOptions, EncodedBatch, EncodedRow, encode_row, truncate_token_ids};
 
 /// Default `--embedding-batch-size`: texts per forward pass.
@@ -55,6 +56,24 @@ pub struct EmbedOptions {
     /// Keep only the first `dimensions` components (re-normalized when the
     /// family normalizes). Validated against the model width.
     pub dimensions: Option<usize>,
+    /// b10621's `--embd-normalize` / per-request `embd_normalize` (#1452).
+    ///
+    /// `None` keeps the checkpoint's own choice: its `normalize` flag maps onto
+    /// [`EmbdNormalize::EUCLIDEAN`] or [`EmbdNormalize::NONE`], which is what
+    /// every mlxcel embedding response was normalized with before the value
+    /// domain became settable.
+    pub normalize: Option<EmbdNormalize>,
+}
+
+/// What [`EmbeddingEngine::postprocess`] needs, resolved once per request.
+///
+/// Bundled so the two values travel together through `run_rows` and
+/// `forward_batch` rather than growing a second parallel parameter that a
+/// future call site could forget to thread.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct PostOptions {
+    dimensions: Option<usize>,
+    normalize: EmbdNormalize,
 }
 
 /// One embedding result: `shape == [D]` for single-vector models,
@@ -107,6 +126,12 @@ impl EmbeddingEngine {
         }
     }
 
+    /// The pooling this checkpoint resolved, for `/props` (#1452).
+    #[must_use]
+    pub fn pooling(&self) -> super::PoolingMode {
+        self.loaded.model.pooling()
+    }
+
     /// Width `D` of one vector.
     pub fn dim(&self) -> usize {
         self.loaded.limits.dim
@@ -140,6 +165,28 @@ impl EmbeddingEngine {
     /// Texts per forward pass.
     pub fn batch_size(&self) -> usize {
         self.batch_size
+    }
+
+    /// Fold the per-request options and the checkpoint's own `normalize` flag
+    /// into what post-processing needs.
+    ///
+    /// The request wins when it names a normalization; otherwise the
+    /// checkpoint's flag decides, which is the behavior every embedding
+    /// response had before `--embd-normalize` existed.
+    fn post_options(&self, options: &EmbedOptions) -> PostOptions {
+        PostOptions {
+            dimensions: options.dimensions,
+            normalize: options
+                .normalize
+                .unwrap_or_else(|| EmbdNormalize::from_model_flag(self.loaded.model.normalize())),
+        }
+    }
+
+    /// The effective normalization for a request that names none, which is
+    /// what `/props` reports.
+    #[must_use]
+    pub fn default_normalize(&self) -> EmbdNormalize {
+        EmbdNormalize::from_model_flag(self.loaded.model.normalize())
     }
 
     /// Reject a `dimensions` value outside `1..=D`.
@@ -185,7 +232,7 @@ impl EmbeddingEngine {
                 .map_err(|e| EmbeddingEngineError::Internal(e.to_string()))?;
             rows.push(row);
         }
-        self.run_rows(rows, None, options.dimensions)
+        self.run_rows(rows, None, self.post_options(options))
     }
 
     /// Embed verbatim token-id rows (no special tokens added).
@@ -215,7 +262,7 @@ impl EmbeddingEngine {
             let type_ids = needs_type_ids.then(|| vec![0; ids.len()]);
             rows.push(EncodedRow { ids, type_ids });
         }
-        self.run_rows(rows, None, options.dimensions)
+        self.run_rows(rows, None, self.post_options(options))
     }
 
     /// Embed one image (VLM embedders only). The text side of the batch is
@@ -260,7 +307,7 @@ impl EmbeddingEngine {
             type_ids: row.type_ids.map(|_| vec![0; ids.len()]),
             ids,
         };
-        self.run_rows(vec![row], Some(&images), options.dimensions)
+        self.run_rows(vec![row], Some(&images), self.post_options(options))
     }
 
     /// Sort rows by length, cut them into micro-batches, run each, and write
@@ -269,7 +316,7 @@ impl EmbeddingEngine {
         &self,
         rows: Vec<EncodedRow>,
         images: Option<&[ImageInput]>,
-        dimensions: Option<usize>,
+        post: PostOptions,
     ) -> Result<EmbedReply, EmbeddingEngineError> {
         let prompt_tokens: usize = rows.iter().map(|r| r.ids.len()).sum();
         let mut order: Vec<usize> = (0..rows.len()).collect();
@@ -283,7 +330,7 @@ impl EmbeddingEngine {
                 self.loaded.pad_token_id,
                 self.loaded.model.pad_to_max_length(),
             );
-            let produced = self.forward_batch(&batch, images, dimensions)?;
+            let produced = self.forward_batch(&batch, images, post)?;
             for (&index, vector) in chunk.iter().zip(produced) {
                 vectors[index] = Some(vector);
             }
@@ -308,7 +355,7 @@ impl EmbeddingEngine {
         &self,
         batch: &EncodedBatch,
         images: Option<&[ImageInput]>,
-        dimensions: Option<usize>,
+        post: PostOptions,
     ) -> Result<Vec<EmbeddingVector>, EmbeddingEngineError> {
         let input_ids = batch.input_ids_array();
         let attention_mask = batch.attention_mask_array();
@@ -326,7 +373,7 @@ impl EmbeddingEngine {
         let output = self.loaded.model.embed(&embed_batch).map_err(|e| {
             EmbeddingEngineError::Internal(format!("embedding forward failed: {e}"))
         })?;
-        self.postprocess(output, &batch.token_counts, dimensions)
+        self.postprocess(output, &batch.token_counts, post)
     }
 
     /// Normalize, truncate and read back one forward pass.
@@ -334,9 +381,9 @@ impl EmbeddingEngine {
         &self,
         output: EmbeddingOutput,
         token_counts: &[usize],
-        dimensions: Option<usize>,
+        post: PostOptions,
     ) -> Result<Vec<EmbeddingVector>, EmbeddingEngineError> {
-        let normalize = self.loaded.model.normalize();
+        let normalize = post.normalize;
         let shape = mlxcel_core::array_shape(&output.embeddings);
         let batch = token_counts.len();
         let expected_rank = if self.multi_vector() { 3 } else { 2 };
@@ -355,14 +402,17 @@ impl EmbeddingEngine {
 
         let mut processed: UniquePtr<MlxArray> =
             mlxcel_core::astype(&output.embeddings, dtype::FLOAT32);
-        if normalize {
-            processed = normalize_l2(&processed);
+        if !normalize.is_none() {
+            processed = apply_embd_normalize(&processed, normalize);
         }
-        let out_width = match dimensions {
+        let out_width = match post.dimensions {
             Some(n) if n < width => {
                 processed = truncate_dimensions(&processed, n);
-                if normalize {
-                    processed = normalize_l2(&processed);
+                // Truncation breaks whatever invariant the normalization
+                // established, so it is re-applied: a Matryoshka prefix of a
+                // unit vector is not a unit vector.
+                if !normalize.is_none() {
+                    processed = apply_embd_normalize(&processed, normalize);
                 }
                 n
             }

--- a/src/embeddings/engine_tests.rs
+++ b/src/embeddings/engine_tests.rs
@@ -125,6 +125,7 @@ fn dimensions_truncates_and_renormalizes() {
     let opts = EmbedOptions {
         instruction: None,
         dimensions: Some(4),
+        normalize: None,
     };
     let reply = e.embed_tokens(&[vec![2, 3]], &opts).unwrap();
     let v = &reply.vectors[0];
@@ -143,6 +144,7 @@ fn dimensions_truncates_and_renormalizes() {
                 &EmbedOptions {
                     instruction: None,
                     dimensions: Some(bad),
+                    normalize: None,
                 },
             )
             .unwrap_err();
@@ -175,6 +177,7 @@ fn multi_vector_reply_has_one_row_per_real_token() {
             &EmbedOptions {
                 instruction: None,
                 dimensions: Some(3),
+                normalize: None,
             },
         )
         .unwrap();

--- a/src/embeddings/mod.rs
+++ b/src/embeddings/mod.rs
@@ -35,6 +35,7 @@ pub mod limits;
 pub mod loader;
 pub mod maxsim;
 pub mod model;
+pub mod normalize;
 pub mod pooling;
 pub mod tokenize;
 
@@ -72,7 +73,8 @@ pub use loader::{
 };
 pub use maxsim::{maxsim, maxsim_mlx};
 pub use model::{EmbeddingBatch, EmbeddingModel, EmbeddingOutput, ImageInput};
+pub use normalize::{EmbdNormalize, apply_embd_normalize};
 pub use pooling::{
-    POOLING_ENV, PoolingConfig, PoolingMode, normalize_l2, pool, resolve_pooling_mode,
-    truncate_dimensions,
+    POOLING_ENV, PoolingConfig, PoolingMode, normalize_l2, pool, pooling_override,
+    resolve_pooling_mode, set_pooling_override, truncate_dimensions,
 };

--- a/src/embeddings/model.rs
+++ b/src/embeddings/model.rs
@@ -79,6 +79,18 @@ pub trait EmbeddingModel {
     /// time through [`super::pooling::resolve_pooling_mode`].
     fn default_pooling(&self) -> PoolingMode;
 
+    /// The pooling this instance actually resolved, after
+    /// `1_Pooling/config.json`, the `--pooling` flag and the environment
+    /// override have been applied (#1452).
+    ///
+    /// Defaults to [`Self::default_pooling`] for the families whose pooling is
+    /// fixed in their forward pass and never consulted the config. `/props`
+    /// reports this, so a family that resolves a mode and does not override
+    /// here would report the family default and be wrong.
+    fn pooling(&self) -> PoolingMode {
+        self.default_pooling()
+    }
+
     /// Whether the engine L2-normalizes the pooled vectors (default `true`;
     /// `config.json` `normalize: false` turns it off for families that
     /// declare it).

--- a/src/embeddings/normalize.rs
+++ b/src/embeddings/normalize.rs
@@ -1,0 +1,168 @@
+// Copyright 2025-2026 Lablup Inc. and Jeongkyu Shin
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! `--embd-normalize`: llama-server b10621's embedding normalization domain
+//! (issue #1452).
+//!
+//! b10621 states the whole domain in one integer, and the integer is not an
+//! enum: `-1` is no normalization, `0` is a max-absolute rescale into the int16
+//! range, `2` is Euclidean, and **every other value is the p-norm with that
+//! `p`**, which is why `1` (taxicab) needs no case of its own. mlxcel had one
+//! behavior, L2, chosen by a per-checkpoint boolean.
+//!
+//! # The zero vector
+//!
+//! Upstream computes `norm = sum > 0 ? 1/sum : 0`, so a zero vector normalizes
+//! to zeros rather than to NaN. That is reproduced here, and it is the reason
+//! this module does not simply divide: dividing by a zero norm would put NaN
+//! into a response body, and the embedding route's finite-value guard would
+//! then answer 500 for an input that upstream serves.
+//!
+//! # Euclidean stays byte-identical
+//!
+//! [`EmbdNormalize::EUCLIDEAN`] delegates to [`super::pooling::normalize_l2`],
+//! which is what every mlxcel embedding response has been normalized with. The
+//! two formulas differ only for a vector whose norm is between zero and 1e-9
+//! (upstream scales it to unit length, `normalize_l2` clamps the divisor), and
+//! reusing the existing kernel means the default path produces exactly the
+//! numbers it produced before this change. The new modes are new behavior; the
+//! default is not.
+//!
+//! Upstream reference: `common_embd_normalize` in
+//! <https://github.com/ggml-org/llama.cpp/blob/c1d0e7a004015f23bc0233470b747b596f29b264/common/common.cpp>
+
+use mlxcel_core::{MlxArray, UniquePtr, dtype};
+
+use super::pooling::normalize_l2;
+
+/// The divisor upstream scales a max-absolute normalization by, so the result
+/// spans the signed int16 range.
+const INT16_SCALE: f32 = 32760.0;
+
+/// One `--embd-normalize` value.
+///
+/// Held as the integer b10621 holds it as, because the domain is open above:
+/// any `p > 2` is a valid p-norm and enumerating them is not possible.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct EmbdNormalize(i32);
+
+impl EmbdNormalize {
+    /// `-1`: leave the vector as the model produced it.
+    pub const NONE: Self = Self(-1);
+    /// `0`: divide by the largest absolute component over 32760, so the result
+    /// spans the signed int16 range.
+    pub const MAX_ABS_INT16: Self = Self(0);
+    /// `1`: the taxicab (L1) norm, served by the p-norm branch.
+    pub const TAXICAB: Self = Self(1);
+    /// `2`: the Euclidean (L2) norm. b10621's default, and mlxcel's previous
+    /// only behavior.
+    pub const EUCLIDEAN: Self = Self(2);
+
+    /// Accept one `--embd-normalize` value.
+    ///
+    /// Every integer at or above `-1` is in the domain. Below `-1` is not: it
+    /// is neither a sentinel nor a usable `p`, and upstream would take the
+    /// p-norm branch with a negative exponent and return values no client can
+    /// interpret, so mlxcel refuses it instead of reproducing that.
+    pub fn new(value: i32) -> Result<Self, String> {
+        if value < -1 {
+            return Err(format!(
+                "--embd-normalize {value} is out of domain: pass -1 for no normalization, 0 for \
+                 the max-absolute int16 rescale, 1 for taxicab, 2 for euclidean, or a value \
+                 above 2 for that p-norm"
+            ));
+        }
+        Ok(Self(value))
+    }
+
+    /// The integer b10621 states this as.
+    #[must_use]
+    pub fn value(self) -> i32 {
+        self.0
+    }
+
+    /// Whether this leaves the vector untouched.
+    #[must_use]
+    pub fn is_none(self) -> bool {
+        self == Self::NONE
+    }
+
+    /// The default a checkpoint's own `normalize` flag selects: Euclidean when
+    /// the checkpoint normalizes, none when it does not.
+    #[must_use]
+    pub fn from_model_flag(normalize: bool) -> Self {
+        if normalize {
+            Self::EUCLIDEAN
+        } else {
+            Self::NONE
+        }
+    }
+}
+
+impl Default for EmbdNormalize {
+    fn default() -> Self {
+        Self::EUCLIDEAN
+    }
+}
+
+impl std::fmt::Display for EmbdNormalize {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.0)
+    }
+}
+
+/// Apply one `--embd-normalize` mode along the last axis.
+///
+/// Returns a fresh f32 array. See the module docs for the zero-vector rule and
+/// for why Euclidean delegates rather than recomputing.
+pub fn apply_embd_normalize(x: &MlxArray, kind: EmbdNormalize) -> UniquePtr<MlxArray> {
+    if kind.is_none() {
+        return mlxcel_core::astype(x, dtype::FLOAT32);
+    }
+    if kind == EmbdNormalize::EUCLIDEAN {
+        return normalize_l2(x);
+    }
+    let x = mlxcel_core::astype(x, dtype::FLOAT32);
+    // The divisor, one per row, keeping the axis so it broadcasts back.
+    let divisor = if kind == EmbdNormalize::MAX_ABS_INT16 {
+        let max_abs = mlxcel_core::max_axis(&mlxcel_core::abs(&x), -1, true);
+        mlxcel_core::divide_scalar(&max_abs, INT16_SCALE)
+    } else {
+        // Every remaining value is a p-norm, taxicab (p = 1) included.
+        mlxcel_core::linalg_norm_ord(&x, f64::from(kind.value()), -1, true)
+    };
+    scale_by_reciprocal(&x, &divisor)
+}
+
+/// `x * (divisor > 0 ? 1/divisor : 0)`, upstream's rule for a row whose
+/// divisor is zero.
+///
+/// The reciprocal is taken of a floored divisor so the arithmetic never
+/// produces an infinity that `where_cond` would then have to discard; the
+/// selection is what zeroes the row, not the division.
+fn scale_by_reciprocal(x: &MlxArray, divisor: &MlxArray) -> UniquePtr<MlxArray> {
+    let zero = mlxcel_core::zeros_like(divisor);
+    let one = mlxcel_core::ones_like(divisor);
+    let positive = mlxcel_core::greater(divisor, &zero);
+    // Substituting 1 where the divisor is zero keeps the reciprocal finite; the
+    // outer selection is what actually zeroes those rows, so no infinity is
+    // ever produced and then discarded.
+    let safe = mlxcel_core::where_cond(&positive, divisor, &one);
+    let scale = mlxcel_core::where_cond(&positive, &mlxcel_core::reciprocal(&safe), &zero);
+    mlxcel_core::multiply(x, &scale)
+}
+
+#[cfg(test)]
+#[path = "normalize_tests.rs"]
+mod normalize_tests;

--- a/src/embeddings/normalize_tests.rs
+++ b/src/embeddings/normalize_tests.rs
@@ -1,0 +1,168 @@
+// Copyright 2025-2026 Lablup Inc. and Jeongkyu Shin
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! `--embd-normalize` numerical tests (#1452).
+//!
+//! Every mode is checked against the closed-form value computed here in Rust,
+//! not against a recorded output, so a kernel change that shifts the numbers
+//! fails rather than being blessed.
+
+use super::*;
+
+/// Run one mode over a `[rows, D]` matrix and read the result back.
+fn normalized(rows: &[Vec<f32>], kind: EmbdNormalize) -> Vec<Vec<f32>> {
+    let width = rows[0].len();
+    let flat: Vec<f32> = rows.iter().flatten().copied().collect();
+    let input = mlxcel_core::from_slice_f32(&flat, &[rows.len() as i32, width as i32]);
+    let out = apply_embd_normalize(&input, kind);
+    mlxcel_core::try_eval(&out).expect("normalization evaluates");
+    let values = mlxcel_core::utils::array_to_vec_f32(&out);
+    values.chunks(width).map(<[f32]>::to_vec).collect()
+}
+
+fn assert_close(actual: &[f32], expected: &[f32], what: &str) {
+    assert_eq!(actual.len(), expected.len(), "{what}: width");
+    for (i, (a, e)) in actual.iter().zip(expected).enumerate() {
+        assert!(
+            (a - e).abs() <= 1e-5 * e.abs().max(1.0),
+            "{what}: component {i} is {a}, expected {e}"
+        );
+    }
+}
+
+const SAMPLE: [f32; 4] = [3.0, -4.0, 0.0, 12.0];
+
+#[test]
+fn the_domain_accepts_minus_one_and_above() {
+    for value in [-1, 0, 1, 2, 3, 7, i32::MAX] {
+        assert_eq!(EmbdNormalize::new(value).expect("in domain").value(), value);
+    }
+    let err = EmbdNormalize::new(-2).expect_err("out of domain");
+    assert!(err.contains("--embd-normalize -2"), "{err}");
+    assert!(err.contains("p-norm"), "{err}");
+}
+
+#[test]
+fn the_default_is_euclidean_and_the_model_flag_maps_onto_the_domain() {
+    assert_eq!(EmbdNormalize::default(), EmbdNormalize::EUCLIDEAN);
+    assert_eq!(EmbdNormalize::EUCLIDEAN.value(), 2);
+    assert_eq!(
+        EmbdNormalize::from_model_flag(true),
+        EmbdNormalize::EUCLIDEAN
+    );
+    assert_eq!(EmbdNormalize::from_model_flag(false), EmbdNormalize::NONE);
+    assert!(EmbdNormalize::NONE.is_none());
+    assert!(!EmbdNormalize::EUCLIDEAN.is_none());
+}
+
+#[test]
+fn none_leaves_the_vector_untouched() {
+    let out = normalized(&[SAMPLE.to_vec()], EmbdNormalize::NONE);
+    assert_close(&out[0], &SAMPLE, "none");
+}
+
+#[test]
+fn euclidean_produces_a_unit_vector() {
+    let out = normalized(&[SAMPLE.to_vec()], EmbdNormalize::EUCLIDEAN);
+    let norm: f32 = SAMPLE.iter().map(|v| v * v).sum::<f32>().sqrt();
+    let expected: Vec<f32> = SAMPLE.iter().map(|v| v / norm).collect();
+    assert_close(&out[0], &expected, "euclidean");
+    let recovered: f32 = out[0].iter().map(|v| v * v).sum::<f32>().sqrt();
+    assert!((recovered - 1.0).abs() < 1e-5, "L2 norm is {recovered}");
+}
+
+#[test]
+fn taxicab_produces_a_unit_l1_vector() {
+    let out = normalized(&[SAMPLE.to_vec()], EmbdNormalize::TAXICAB);
+    let norm: f32 = SAMPLE.iter().map(|v| v.abs()).sum();
+    let expected: Vec<f32> = SAMPLE.iter().map(|v| v / norm).collect();
+    assert_close(&out[0], &expected, "taxicab");
+    let recovered: f32 = out[0].iter().map(|v| v.abs()).sum();
+    assert!((recovered - 1.0).abs() < 1e-5, "L1 norm is {recovered}");
+}
+
+#[test]
+fn a_p_norm_above_two_uses_that_p() {
+    for p in [3, 5] {
+        let kind = EmbdNormalize::new(p).expect("in domain");
+        let out = normalized(&[SAMPLE.to_vec()], kind);
+        let norm = SAMPLE
+            .iter()
+            .map(|v| v.abs().powi(p))
+            .sum::<f32>()
+            .powf(1.0 / p as f32);
+        let expected: Vec<f32> = SAMPLE.iter().map(|v| v / norm).collect();
+        assert_close(&out[0], &expected, &format!("p={p}"));
+    }
+}
+
+#[test]
+fn max_absolute_rescales_into_the_int16_range() {
+    let out = normalized(&[SAMPLE.to_vec()], EmbdNormalize::MAX_ABS_INT16);
+    let divisor = SAMPLE.iter().fold(0.0f32, |m, v| m.max(v.abs())) / 32760.0;
+    let expected: Vec<f32> = SAMPLE.iter().map(|v| v / divisor).collect();
+    assert_close(&out[0], &expected, "max-abs");
+    // The largest component lands exactly on the int16 bound, which is the
+    // point of the mode.
+    let largest = out[0].iter().fold(0.0f32, |m, v| m.max(v.abs()));
+    assert!((largest - 32760.0).abs() < 1e-1, "largest is {largest}");
+}
+
+#[test]
+fn a_zero_vector_normalizes_to_zeros_rather_than_nan() {
+    // Upstream's `norm = sum > 0 ? 1/sum : 0`. A NaN here would reach the
+    // response body and the route's finite-value guard would answer 500 for an
+    // input b10621 serves.
+    for kind in [
+        EmbdNormalize::MAX_ABS_INT16,
+        EmbdNormalize::TAXICAB,
+        EmbdNormalize::EUCLIDEAN,
+        EmbdNormalize::new(3).expect("in domain"),
+    ] {
+        let out = normalized(&[vec![0.0; 4]], kind);
+        for (i, v) in out[0].iter().enumerate() {
+            assert!(
+                v.is_finite() && *v == 0.0,
+                "{kind}: component {i} is {v}, expected 0"
+            );
+        }
+    }
+}
+
+#[test]
+fn rows_are_normalized_independently() {
+    let rows = vec![SAMPLE.to_vec(), vec![1.0, 0.0, 0.0, 0.0], vec![0.0; 4]];
+    let out = normalized(&rows, EmbdNormalize::EUCLIDEAN);
+    assert_eq!(out.len(), 3);
+    assert_close(&out[1], &[1.0, 0.0, 0.0, 0.0], "unit row");
+    assert_close(&out[2], &[0.0; 4], "zero row");
+    let norm: f32 = SAMPLE.iter().map(|v| v * v).sum::<f32>().sqrt();
+    let expected: Vec<f32> = SAMPLE.iter().map(|v| v / norm).collect();
+    assert_close(&out[0], &expected, "first row");
+}
+
+#[test]
+fn euclidean_matches_the_pooling_kernel_it_delegates_to() {
+    // The default path must stay byte-identical to what shipped before this
+    // change, so the delegation is asserted rather than assumed.
+    let input = mlxcel_core::from_slice_f32(&SAMPLE, &[1, 4]);
+    let through_kind = apply_embd_normalize(&input, EmbdNormalize::EUCLIDEAN);
+    let through_kernel = crate::embeddings::normalize_l2(&input);
+    mlxcel_core::try_eval(&through_kind).expect("evaluates");
+    mlxcel_core::try_eval(&through_kernel).expect("evaluates");
+    assert_eq!(
+        mlxcel_core::utils::array_to_vec_f32(&through_kind),
+        mlxcel_core::utils::array_to_vec_f32(&through_kernel)
+    );
+}

--- a/src/embeddings/pooling.rs
+++ b/src/embeddings/pooling.rs
@@ -157,14 +157,68 @@ impl PoolingConfig {
     }
 }
 
-/// Resolve the effective pooling mode for a checkpoint, in order:
-/// `1_Pooling/config.json`, then `family_default`, then the
-/// [`POOLING_ENV`] override (logged when it applies).
+/// Sentinel for "no `--pooling` override installed" in [`POOLING_OVERRIDE`].
+const NO_POOLING_OVERRIDE: u8 = u8::MAX;
+
+/// The operator's `--pooling` choice, installed once at startup (#1452).
+///
+/// A process-wide cell rather than a parameter because the resolution happens
+/// inside each family's constructor, which is reached through the weight
+/// loader and carries no server context. That is the same shape
+/// [`POOLING_ENV`] already had; the flag simply takes precedence over it.
+/// Stored as the discriminant of [`PoolingMode`] so the cell is lock-free and
+/// safe to read from the embedding worker thread.
+static POOLING_OVERRIDE: std::sync::atomic::AtomicU8 =
+    std::sync::atomic::AtomicU8::new(NO_POOLING_OVERRIDE);
+
+/// Install the `--pooling` override.
+///
+/// Called once from startup, before any embedding checkpoint is loaded. Passing
+/// `None` clears it, which is what the server tests need between cases.
+pub fn set_pooling_override(mode: Option<PoolingMode>) {
+    let encoded = match mode {
+        Some(PoolingMode::Cls) => 0,
+        Some(PoolingMode::Mean) => 1,
+        Some(PoolingMode::Max) => 2,
+        Some(PoolingMode::LastToken) => 3,
+        None => NO_POOLING_OVERRIDE,
+    };
+    POOLING_OVERRIDE.store(encoded, std::sync::atomic::Ordering::Relaxed);
+}
+
+/// The installed `--pooling` override, if any.
+#[must_use]
+pub fn pooling_override() -> Option<PoolingMode> {
+    match POOLING_OVERRIDE.load(std::sync::atomic::Ordering::Relaxed) {
+        0 => Some(PoolingMode::Cls),
+        1 => Some(PoolingMode::Mean),
+        2 => Some(PoolingMode::Max),
+        3 => Some(PoolingMode::LastToken),
+        _ => None,
+    }
+}
+
+/// Resolve the effective pooling mode for a checkpoint, in order: the
+/// `--pooling` flag ([`set_pooling_override`]), then the [`POOLING_ENV`]
+/// override, then `1_Pooling/config.json`, then `family_default`. Whichever
+/// wins is logged.
+///
+/// The flag outranks the variable so an operator who exports
+/// `MLXCEL_EMBEDDING_POOLING` in a shell profile can still override it per
+/// invocation, which is the usual precedence for a flag against its own
+/// environment fallback.
 ///
 /// Used by: every embedding family constructor and the test stub.
 pub fn resolve_pooling_mode(model_dir: &Path, family_default: PoolingMode) -> Result<PoolingMode> {
     let from_config = PoolingConfig::read(model_dir)?;
     let resolved = from_config.unwrap_or(family_default);
+    if let Some(forced) = pooling_override() {
+        tracing::info!(
+            target: "mlxcel::embeddings",
+            "--pooling {forced} overrides the resolved pooling mode {resolved}"
+        );
+        return Ok(forced);
+    }
     match std::env::var(POOLING_ENV) {
         Ok(raw) if !raw.trim().is_empty() => {
             let forced: PoolingMode = raw

--- a/src/embeddings/stub.rs
+++ b/src/embeddings/stub.rs
@@ -106,6 +106,10 @@ impl EmbeddingModel for StubEmbeddingModel {
         self.pooling
     }
 
+    fn pooling(&self) -> PoolingMode {
+        self.pooling
+    }
+
     fn multi_vector(&self) -> bool {
         self.multi_vector
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -147,7 +147,9 @@ enum Commands {
     /// `1_Pooling/config.json`, L2 normalization, right-padded batching) and
     /// prints one vector per input, plus the cosine-similarity matrix when
     /// two or more inputs are given. This is the offline validation tool for
-    /// every embedding family.
+    /// every embedding family. `--pooling` and `--embd-normalize` override the
+    /// two defaults with the same values the server's flags take, so a
+    /// configuration can be reproduced here before it is deployed.
     ///
     /// Examples:
     ///
@@ -2031,6 +2033,13 @@ pub(crate) struct ServeArgs {
     /// llama-server b10621 command line.
     #[command(flatten)]
     pub(crate) infill: mlxcel::cli::infill_args::InfillArgs,
+
+    /// llama-server b10621 embedding and reranking mode flag group
+    /// (`--embedding`, `--rerank`, `--pooling`, `--embd-normalize`). Defined
+    /// once in `mlxcel::cli::embedding_compat_args` so both server binaries
+    /// accept the same command line.
+    #[command(flatten)]
+    pub(crate) embedding_compat: mlxcel::cli::embedding_compat_args::EmbeddingCompatArgs,
 
     /// Language-bias options for server-wide output
     /// steering. Mirrors the same flags exposed on the `generate` subcommand.

--- a/src/models/bert_heads.rs
+++ b/src/models/bert_heads.rs
@@ -127,6 +127,10 @@ impl EmbeddingModel for BertEmbeddingModel {
         Self::DEFAULT_POOLING
     }
 
+    fn pooling(&self) -> PoolingMode {
+        self.pooling
+    }
+
     fn embedding_dim(&self) -> usize {
         self.encoder.args().hidden_size
     }

--- a/src/models/gemma3_embedding.rs
+++ b/src/models/gemma3_embedding.rs
@@ -313,6 +313,10 @@ impl EmbeddingModel for Gemma3EmbeddingModel {
         PoolingMode::Mean
     }
 
+    fn pooling(&self) -> PoolingMode {
+        self.pooling
+    }
+
     fn normalize(&self) -> bool {
         self.normalize
     }

--- a/src/models/gemma3_embedding_tests.rs
+++ b/src/models/gemma3_embedding_tests.rs
@@ -561,6 +561,7 @@ fn embeddinggemma_checkpoint_loads_and_ranks_the_matching_document() {
             &crate::embeddings::EmbedOptions {
                 instruction: None,
                 dimensions: Some(256),
+                normalize: None,
             },
         )
         .expect("EmbeddingGemma embeds at 256 dimensions");

--- a/src/models/lfm2_embedding.rs
+++ b/src/models/lfm2_embedding.rs
@@ -208,6 +208,10 @@ impl EmbeddingModel for Lfm2EmbeddingModel {
         PoolingMode::Cls
     }
 
+    fn pooling(&self) -> PoolingMode {
+        self.pooling
+    }
+
     fn normalize(&self) -> bool {
         self.normalize
     }

--- a/src/models/llama_bidirec.rs
+++ b/src/models/llama_bidirec.rs
@@ -254,6 +254,10 @@ impl EmbeddingModel for LlamaBidirecModel {
         PoolingMode::Mean
     }
 
+    fn pooling(&self) -> PoolingMode {
+        self.pooling
+    }
+
     fn normalize(&self) -> bool {
         self.normalize
     }

--- a/src/models/llama_nemotron_vl_embedding.rs
+++ b/src/models/llama_nemotron_vl_embedding.rs
@@ -333,6 +333,10 @@ impl EmbeddingModel for LlamaNemotronVLEmbeddingModel {
         PoolingMode::Mean
     }
 
+    fn pooling(&self) -> PoolingMode {
+        self.pooling
+    }
+
     fn normalize(&self) -> bool {
         self.normalize
     }

--- a/src/models/ministral3_embedding.rs
+++ b/src/models/ministral3_embedding.rs
@@ -181,6 +181,10 @@ impl EmbeddingModel for Ministral3EmbeddingModel {
         PoolingMode::Mean
     }
 
+    fn pooling(&self) -> PoolingMode {
+        self.pooling
+    }
+
     fn normalize(&self) -> bool {
         self.normalize
     }

--- a/src/models/modernbert_heads.rs
+++ b/src/models/modernbert_heads.rs
@@ -142,6 +142,10 @@ impl EmbeddingModel for ModernBertEmbeddingModel {
         PoolingMode::Mean
     }
 
+    fn pooling(&self) -> PoolingMode {
+        self.pooling
+    }
+
     fn embedding_dim(&self) -> usize {
         self.encoder.hidden_size()
     }

--- a/src/models/qwen3_embedding.rs
+++ b/src/models/qwen3_embedding.rs
@@ -131,6 +131,10 @@ impl EmbeddingModel for Qwen3EmbeddingModel {
         PoolingMode::LastToken
     }
 
+    fn pooling(&self) -> PoolingMode {
+        self.pooling
+    }
+
     fn normalize(&self) -> bool {
         self.normalize
     }

--- a/src/models/qwen3_vl_embedding.rs
+++ b/src/models/qwen3_vl_embedding.rs
@@ -354,6 +354,10 @@ impl EmbeddingModel for Qwen3VLEmbeddingModel {
         PoolingMode::LastToken
     }
 
+    fn pooling(&self) -> PoolingMode {
+        self.pooling
+    }
+
     fn normalize(&self) -> bool {
         self.normalize
     }

--- a/src/server/cli_input.rs
+++ b/src/server/cli_input.rs
@@ -525,6 +525,24 @@ pub struct ServerStartupInput {
     /// clap group. `--spm-infill` selects the Suffix/Prefix/Middle ordering
     /// `POST /infill` assembles its prompt in (#1442).
     pub infill: crate::cli::infill_args::InfillArgs,
+    /// llama-server b10621 embedding and reranking mode flags, straight off the
+    /// shared clap group. Resolved (and refused, when unserveable) by
+    /// [`ServerStartupInput::into_startup_config`] (#1452).
+    pub embedding_compat: crate::cli::embedding_compat_args::EmbeddingCompatArgs,
+}
+
+/// Which serving restriction the resolved mode flags select.
+fn embedding_serving_mode(
+    resolved: &crate::cli::embedding_compat_args::EmbeddingCompatResolution,
+) -> crate::server::config::EmbeddingServingMode {
+    use crate::server::config::EmbeddingServingMode;
+    if resolved.rerank_only {
+        EmbeddingServingMode::RerankOnly
+    } else if resolved.embedding_only {
+        EmbeddingServingMode::EmbeddingOnly
+    } else {
+        EmbeddingServingMode::Any
+    }
 }
 
 impl ServerStartupInput {
@@ -546,6 +564,15 @@ impl ServerStartupInput {
             .rope
             .resolve()
             .map_err(|message| anyhow::anyhow!("{message}"))?;
+        // b10621's embedding and reranking mode flags. Resolved here so a
+        // `--pooling none` mlxcel cannot serve, or an out-of-domain
+        // `--embd-normalize`, fails the command line rather than the first
+        // request (#1452).
+        let embedding_compat = self
+            .embedding_compat
+            .resolve()
+            .map_err(|message| anyhow::anyhow!(message))?;
+
         // b10621's prompt-cache and batching spellings, folded onto mlxcel's
         // own settings below. Resolved here for the same reason: a
         // `--cache-reuse` mlxcel cannot serve must fail the command line, not
@@ -845,6 +872,9 @@ impl ServerStartupInput {
             enable_slots: resolve_compat_toggle(self.slots, self.no_slots),
             enable_props: self.props,
             spm_infill: self.infill.spm_infill,
+            embd_normalize: embedding_compat.embd_normalize,
+            embedding_serving_mode: embedding_serving_mode(&embedding_compat),
+            pooling: embedding_compat.pooling,
             enable_metrics: self.metrics || self.metrics_port.is_some(),
             warmup: resolve_compat_toggle(self.warmup, self.no_warmup),
             temperature: self.temperature,

--- a/src/server/cli_input_tests.rs
+++ b/src/server/cli_input_tests.rs
@@ -195,6 +195,7 @@ fn sample_input() -> ServerStartupInput {
         rope: crate::cli::rope_args::RopeOverrideArgs::default(),
         cache_compat: crate::cli::cache_args::CacheCompatArgs::default(),
         infill: crate::cli::infill_args::InfillArgs::default(),
+        embedding_compat: crate::cli::embedding_compat_args::EmbeddingCompatArgs::default(),
     }
 }
 

--- a/src/server/config.rs
+++ b/src/server/config.rs
@@ -302,6 +302,44 @@ pub const DEFAULT_EMBEDDING_REQUEST_TIMEOUT_SECS: u64 = DEFAULT_AUDIO_REQUEST_TI
 /// because each of its rows carries a full image's worth of visual tokens.
 pub const DEFAULT_RERANK_BATCH_SIZE: usize = crate::rerank::DEFAULT_RERANK_BATCH_SIZE;
 
+/// What this server is allowed to serve, per b10621's `--embeddings` and
+/// `--reranking` (#1452).
+///
+/// b10621 has one model and one set of weights, so those flags are a
+/// server-wide restriction rather than a worker selection. mlxcel reproduces
+/// the restriction half here: generation routes answer the same 501 they answer
+/// with no chat model, and the body names the flag that turned them off, so an
+/// operator can tell "this deployment is embedding-only" from "the chat model
+/// failed to load".
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum EmbeddingServingMode {
+    /// No mode flag: every loaded worker serves its routes.
+    #[default]
+    Any,
+    /// `--embeddings`: embedding routes only.
+    EmbeddingOnly,
+    /// `--reranking`: reranking routes only.
+    RerankOnly,
+}
+
+impl EmbeddingServingMode {
+    /// The b10621 flag that selected this mode, or `None` for [`Self::Any`].
+    #[must_use]
+    pub fn flag(self) -> Option<&'static str> {
+        match self {
+            Self::Any => None,
+            Self::EmbeddingOnly => Some("--embeddings"),
+            Self::RerankOnly => Some("--reranking"),
+        }
+    }
+
+    /// Whether generation is refused in this mode.
+    #[must_use]
+    pub fn blocks_generation(self) -> bool {
+        !matches!(self, Self::Any)
+    }
+}
+
 /// Server configuration derived from CLI-compatible startup arguments.
 ///
 /// Default values intentionally track `llama-server` behavior where practical
@@ -358,6 +396,14 @@ pub struct ServerConfig {
     pub enable_slots_endpoint: bool,
     pub enable_props_endpoint: bool,
     pub enable_metrics_endpoint: bool,
+    /// `--embd-normalize`: the server-wide embedding normalization, `None`
+    /// when the operator did not choose one and the checkpoint's own
+    /// `normalize` flag decides (#1452).
+    pub embd_normalize: Option<crate::embeddings::EmbdNormalize>,
+    /// `--embeddings` / `--reranking`: generation is off and this server serves
+    /// only its side-model routes (#1452). Carries the flag that turned it off
+    /// so the 501 body can name it.
+    pub embedding_serving_mode: EmbeddingServingMode,
     /// `--spm-infill`: use the Suffix/Prefix/Middle ordering on `POST /infill`
     /// instead of the default Prefix/Suffix/Middle (#1442).
     ///
@@ -689,6 +735,8 @@ impl Default for ServerConfig {
             enable_slots_endpoint: true,
             enable_props_endpoint: false,
             spm_infill: false,
+            embd_normalize: None,
+            embedding_serving_mode: EmbeddingServingMode::Any,
             enable_metrics_endpoint: false,
             default_temperature: 0.8,
             default_top_p: 0.95,

--- a/src/server/embedding_model.rs
+++ b/src/server/embedding_model.rs
@@ -95,6 +95,19 @@ pub trait EmbeddingModelProvider: Send + Sync {
     /// Whether outputs are `[num_real_tokens, D]` matrices.
     fn multi_vector(&self) -> bool;
 
+    /// The pooling the loaded checkpoint resolved (#1452).
+    ///
+    /// Defaulted so an implementation that predates the capability report, and
+    /// the test doubles, keep compiling; the shipping worker overrides it.
+    fn pooling(&self) -> crate::embeddings::PoolingMode {
+        crate::embeddings::PoolingMode::Mean
+    }
+
+    /// The normalization applied when a request names none (#1452).
+    fn embd_normalize(&self) -> crate::embeddings::EmbdNormalize {
+        crate::embeddings::EmbdNormalize::EUCLIDEAN
+    }
+
     /// Whether `image_url` items are accepted.
     fn supports_images(&self) -> bool {
         false

--- a/src/server/embedding_worker.rs
+++ b/src/server/embedding_worker.rs
@@ -61,6 +61,10 @@ pub(crate) struct EmbeddingWorkerInfo {
     pub supports_images: bool,
     pub batch_size: usize,
     pub model_type: ModelType,
+    /// The pooling this checkpoint resolved, reported by `/props` (#1452).
+    pub pooling: crate::embeddings::PoolingMode,
+    /// The normalization a request that names none gets (#1452).
+    pub embd_normalize: crate::embeddings::EmbdNormalize,
 }
 
 type Reply = mpsc::Sender<Result<EmbedReply, EmbeddingError>>;
@@ -268,6 +272,8 @@ fn worker_loop<L>(
         supports_images: engine.supports_images(),
         batch_size: engine.batch_size(),
         model_type: engine.model_type(),
+        pooling: engine.pooling(),
+        embd_normalize: engine.default_normalize(),
     };
     if ready.send(Ok(info)).is_err() {
         return;
@@ -461,6 +467,14 @@ impl EmbeddingModelProvider for EmbeddingWorkerProvider {
 
     fn multi_vector(&self) -> bool {
         self.worker.info().multi_vector
+    }
+
+    fn pooling(&self) -> crate::embeddings::PoolingMode {
+        self.worker.info().pooling
+    }
+
+    fn embd_normalize(&self) -> crate::embeddings::EmbdNormalize {
+        self.worker.info().embd_normalize
     }
 
     fn supports_images(&self) -> bool {

--- a/src/server/routes/embedding_rerank_mode_tests.rs
+++ b/src/server/routes/embedding_rerank_mode_tests.rs
@@ -1,0 +1,551 @@
+// Copyright 2025-2026 Lablup Inc. and Jeongkyu Shin
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! b10621 embedding and reranking mode, envelope and capability tests (#1452).
+//!
+//! Three things a client can observe and could not before: the rerank envelope
+//! (`object`, and b10621's TEI array for a `texts` request), the resolved
+//! capability block on `/props` and `/v1/models`, and the generation refusal a
+//! `--embeddings` server answers.
+
+use std::path::PathBuf;
+use std::sync::{Arc, mpsc};
+use std::time::Duration;
+
+use axum::Router;
+use axum::body::Body;
+use axum::http::{Method, Request, StatusCode, header};
+use serde_json::{Value, json};
+use tower::ServiceExt;
+
+use crate::rerank::RerankerKind;
+use crate::rerank::stub::stub_loaded_reranker;
+use crate::server::config::EmbeddingServingMode;
+use crate::server::embedding_model::EmbeddingModelProvider;
+use crate::server::embedding_worker::EmbeddingWorkerProvider;
+use crate::server::rerank_model::RerankModelProvider;
+use crate::server::rerank_worker::RerankWorkerProvider;
+use crate::server::{AppState, ChatTemplateProcessor, ModelProvider, ServerConfig, create_app};
+use crate::tokenizer::MlxcelTokenizer;
+
+const EMBEDDING_ID: &str = "stub-embedder";
+const RERANK_ID: &str = "stub-reranker";
+
+fn embedding_provider() -> Arc<dyn EmbeddingModelProvider> {
+    Arc::new(
+        EmbeddingWorkerProvider::from_loader(
+            EMBEDDING_ID.to_string(),
+            4,
+            8,
+            Duration::from_secs(30),
+            || Ok(crate::embeddings::stub::stub_loaded_model(false)),
+        )
+        .expect("stub embedding worker spawns"),
+    )
+}
+
+fn rerank_provider() -> Arc<dyn RerankModelProvider> {
+    Arc::new(
+        RerankWorkerProvider::from_loader(
+            RERANK_ID.to_string(),
+            8,
+            Duration::from_secs(30),
+            || {
+                Ok(stub_loaded_reranker(
+                    RerankerKind::SequenceClassifier,
+                    false,
+                ))
+            },
+        )
+        .expect("stub rerank worker spawns"),
+    )
+}
+
+/// A server with the given side models and serving mode.
+fn app(embedding: bool, rerank: bool, mode: EmbeddingServingMode) -> Router {
+    let (options_tx, _options_rx) = mpsc::channel();
+    let model_provider = Arc::new(ModelProvider::recording_for_route_tests(options_tx));
+    let batch_metrics = model_provider.batch_metrics().clone();
+    let config = ServerConfig {
+        embedding_serving_mode: mode,
+        enable_props_endpoint: true,
+        ..ServerConfig::default()
+    };
+    let state = AppState::new(
+        model_provider,
+        config,
+        ChatTemplateProcessor::with_template("ok".to_string()),
+        MlxcelTokenizer::stub(),
+        PathBuf::from("route-test-model"),
+        batch_metrics,
+    )
+    .with_embedding_model(embedding.then(embedding_provider))
+    .with_rerank_model(rerank.then(rerank_provider));
+    create_app(state)
+}
+
+async fn send(app: Router, method: Method, path: &str, body: Option<Value>) -> (StatusCode, Value) {
+    let builder = Request::builder().method(method).uri(path);
+    let request = match body {
+        Some(value) => builder
+            .header(header::CONTENT_TYPE, "application/json")
+            .body(Body::from(value.to_string())),
+        None => builder.body(Body::empty()),
+    }
+    .expect("request builds");
+    let response = app.oneshot(request).await.expect("router responds");
+    let status = response.status();
+    let bytes = axum::body::to_bytes(response.into_body(), 1024 * 1024)
+        .await
+        .expect("body collects");
+    (
+        status,
+        serde_json::from_slice(&bytes).unwrap_or(Value::Null),
+    )
+}
+
+async fn post(app: Router, path: &str, body: Value) -> (StatusCode, Value) {
+    send(app, Method::POST, path, Some(body)).await
+}
+
+async fn get(app: Router, path: &str) -> (StatusCode, Value) {
+    send(app, Method::GET, path, None).await
+}
+
+fn cohere_body() -> Value {
+    json!({"query": "q", "documents": ["a", "b"]})
+}
+
+// ── rerank envelope ─────────────────────────────────────────────────────────
+
+#[tokio::test]
+async fn the_jina_envelope_carries_the_object_key() {
+    // b10621 emits `"object": "list"`; mlxcel omitted it, which was the
+    // recorded divergence on all four rerank routes.
+    for path in ["/rerank", "/reranking", "/v1/rerank", "/v1/reranking"] {
+        let (status, body) = post(
+            app(false, true, EmbeddingServingMode::Any),
+            path,
+            cohere_body(),
+        )
+        .await;
+        assert_eq!(status, StatusCode::OK, "{path}: {body}");
+        assert_eq!(body["object"], "list", "{path}: {body}");
+        assert!(body["results"].is_array(), "{path}: {body}");
+        assert!(body["usage"]["prompt_tokens"].as_u64().is_some(), "{path}");
+        assert!(body["results"][0]["relevance_score"].is_number(), "{path}");
+    }
+}
+
+#[tokio::test]
+async fn a_texts_request_gets_b10621s_tei_array() {
+    // The document-list spelling decides the response TYPE, not just a key
+    // name: `texts` answers a bare array of {index, score}.
+    let (status, body) = post(
+        app(false, true, EmbeddingServingMode::Any),
+        "/rerank",
+        json!({"query": "q", "texts": ["a", "b"]}),
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK, "{body}");
+    let results = body.as_array().expect("a bare array");
+    assert_eq!(results.len(), 2, "{body}");
+    assert!(results[0]["score"].is_number(), "{body}");
+    assert!(
+        results[0].get("relevance_score").is_none(),
+        "the TEI shape uses `score`, not `relevance_score`: {body}"
+    );
+    assert!(
+        results[0].get("text").is_none(),
+        "no echo without return_text"
+    );
+}
+
+#[tokio::test]
+async fn return_text_echoes_under_the_tei_spelling() {
+    let (_, body) = post(
+        app(false, true, EmbeddingServingMode::Any),
+        "/rerank",
+        json!({"query": "q", "texts": ["a", "b"], "return_text": true}),
+    )
+    .await;
+    let results = body.as_array().expect("a bare array");
+    assert!(results.iter().all(|r| r["text"].is_string()), "{body}");
+}
+
+#[tokio::test]
+async fn return_documents_still_echoes_under_the_cohere_spelling() {
+    // The Cohere surface mlxcel already served must keep working; the TEI
+    // support is additive.
+    let (_, body) = post(
+        app(false, true, EmbeddingServingMode::Any),
+        "/v1/rerank",
+        json!({"query": "q", "documents": ["a", "b"], "return_documents": true}),
+    )
+    .await;
+    assert_eq!(body["object"], "list");
+    assert!(
+        body["results"]
+            .as_array()
+            .expect("results")
+            .iter()
+            .all(|r| r["document"].is_string()),
+        "{body}"
+    );
+}
+
+#[tokio::test]
+async fn a_body_carrying_both_spellings_stays_on_the_jina_envelope() {
+    // `documents` present is the Jina form even when `texts` is there too, so
+    // a client that sends both is not silently switched to the other shape.
+    let (_, body) = post(
+        app(false, true, EmbeddingServingMode::Any),
+        "/rerank",
+        json!({"query": "q", "documents": ["a"], "texts": ["b"]}),
+    )
+    .await;
+    assert_eq!(body["object"], "list", "{body}");
+}
+
+#[tokio::test]
+async fn the_rerank_501_opens_with_the_upstream_sentence() {
+    let (status, body) = post(
+        app(false, false, EmbeddingServingMode::Any),
+        "/rerank",
+        cohere_body(),
+    )
+    .await;
+    assert_eq!(status, StatusCode::NOT_IMPLEMENTED, "{body}");
+    let message = body["error"]["message"].as_str().expect("a message");
+    assert!(
+        message.starts_with("This server does not support reranking. Start it with `--reranking`"),
+        "{message}"
+    );
+}
+
+#[tokio::test]
+async fn the_embedding_501_opens_with_the_upstream_sentence() {
+    for path in ["/embedding", "/embeddings", "/v1/embeddings"] {
+        let (status, body) = post(
+            app(false, false, EmbeddingServingMode::Any),
+            path,
+            json!({"input": "hello"}),
+        )
+        .await;
+        assert_eq!(status, StatusCode::NOT_IMPLEMENTED, "{path}: {body}");
+        let message = body["error"]["message"].as_str().expect("a message");
+        assert!(
+            message.starts_with(
+                "This server does not support embeddings. Start it with `--embeddings`"
+            ),
+            "{path}: {message}"
+        );
+    }
+}
+
+// ── serving mode ────────────────────────────────────────────────────────────
+
+#[tokio::test]
+async fn an_embedding_only_server_refuses_generation_and_names_the_flag() {
+    // The chat worker is loaded and healthy in this harness, so the refusal
+    // can only come from the mode flag.
+    for (path, body) in [
+        (
+            "/v1/chat/completions",
+            json!({"model": "route-test-model", "messages": [{"role": "user", "content": "hi"}]}),
+        ),
+        (
+            "/v1/completions",
+            json!({"model": "route-test-model", "prompt": "hi"}),
+        ),
+        ("/completion", json!({"prompt": "hi"})),
+    ] {
+        let (status, response) = post(
+            app(true, false, EmbeddingServingMode::EmbeddingOnly),
+            path,
+            body,
+        )
+        .await;
+        assert_eq!(status, StatusCode::NOT_IMPLEMENTED, "{path}: {response}");
+        let message = response["error"]["message"].as_str().expect("a message");
+        assert!(message.contains("--embeddings"), "{path}: {message}");
+        assert!(
+            message.contains("generation is disabled"),
+            "{path}: {message}"
+        );
+    }
+}
+
+#[tokio::test]
+async fn a_rerank_only_server_names_its_own_flag() {
+    let (status, body) = post(
+        app(false, true, EmbeddingServingMode::RerankOnly),
+        "/completion",
+        json!({"prompt": "hi"}),
+    )
+    .await;
+    assert_eq!(status, StatusCode::NOT_IMPLEMENTED, "{body}");
+    let message = body["error"]["message"].as_str().expect("a message");
+    assert!(message.contains("--reranking"), "{message}");
+    assert!(message.contains("reranking routes"), "{message}");
+}
+
+#[tokio::test]
+async fn the_side_model_routes_still_serve_in_a_restricted_mode() {
+    // Restricting generation must not restrict the route the mode exists for.
+    let (status, body) = post(
+        app(false, true, EmbeddingServingMode::RerankOnly),
+        "/rerank",
+        cohere_body(),
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK, "{body}");
+}
+
+#[tokio::test]
+async fn an_unrestricted_server_still_generates() {
+    let (status, body) = post(
+        app(true, true, EmbeddingServingMode::Any),
+        "/completion",
+        json!({"prompt": "hi", "n_predict": 1}),
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK, "{body}");
+}
+
+// ── capability reporting ────────────────────────────────────────────────────
+
+#[tokio::test]
+async fn props_reports_the_resolved_side_model_capability() {
+    let (status, body) = get(app(true, true, EmbeddingServingMode::Any), "/props").await;
+    assert_eq!(status, StatusCode::OK, "{body}");
+    let caps = &body["capabilities"];
+    assert_eq!(caps["generation"], true, "{body}");
+    assert!(caps.get("serving_mode").is_none(), "{body}");
+    assert_eq!(caps["embedding"]["model"], EMBEDDING_ID, "{body}");
+    assert!(caps["embedding"]["dim"].as_u64().is_some(), "{body}");
+    assert!(caps["embedding"]["pooling"].is_string(), "{body}");
+    assert!(caps["embedding"]["embd_normalize"].is_number(), "{body}");
+    assert_eq!(caps["reranking"]["model"], RERANK_ID, "{body}");
+    assert_eq!(caps["reranking"]["kind"], "sequence_classifier", "{body}");
+}
+
+#[tokio::test]
+async fn props_reports_a_restricted_server_as_restricted() {
+    let (_, body) = get(
+        app(true, false, EmbeddingServingMode::EmbeddingOnly),
+        "/props",
+    )
+    .await;
+    let caps = &body["capabilities"];
+    assert_eq!(caps["generation"], false, "{body}");
+    assert_eq!(caps["serving_mode"], "--embeddings", "{body}");
+    assert!(caps.get("reranking").is_none(), "{body}");
+}
+
+#[tokio::test]
+async fn props_omits_the_side_model_blocks_when_none_is_loaded() {
+    let (_, body) = get(app(false, false, EmbeddingServingMode::Any), "/props").await;
+    let caps = &body["capabilities"];
+    assert!(caps.get("embedding").is_none(), "{body}");
+    assert!(caps.get("reranking").is_none(), "{body}");
+    assert_eq!(caps["generation"], true, "{body}");
+}
+
+#[tokio::test]
+async fn models_labels_each_entry_with_what_it_can_be_asked_for() {
+    let (status, body) = get(app(true, true, EmbeddingServingMode::Any), "/v1/models").await;
+    assert_eq!(status, StatusCode::OK, "{body}");
+    let entries = body["data"].as_array().expect("data array");
+    let by_id = |id: &str| {
+        entries
+            .iter()
+            .find(|e| e["id"] == id)
+            .unwrap_or_else(|| panic!("{id} is listed: {body}"))
+            .clone()
+    };
+    assert_eq!(
+        by_id("route-test-model")["capabilities"],
+        json!(["completion"])
+    );
+    assert_eq!(by_id(EMBEDDING_ID)["capabilities"], json!(["embedding"]));
+    assert_eq!(by_id(RERANK_ID)["capabilities"], json!(["rerank"]));
+}
+
+#[tokio::test]
+async fn a_restricted_server_does_not_advertise_completion() {
+    let (_, body) = get(
+        app(true, false, EmbeddingServingMode::EmbeddingOnly),
+        "/v1/models",
+    )
+    .await;
+    let primary = body["data"]
+        .as_array()
+        .expect("data array")
+        .iter()
+        .find(|e| e["id"] == "route-test-model")
+        .expect("primary entry")
+        .clone();
+    assert!(
+        primary.get("capabilities").is_none() || primary["capabilities"] == json!([]),
+        "generation is off, so the primary id must not advertise completion: {body}"
+    );
+}
+
+// ── upstream-worded shape errors (#1452) ────────────────────────────────────
+
+#[tokio::test]
+async fn a_rerank_body_missing_its_query_uses_the_upstream_wording() {
+    for (body, expected) in [
+        (json!({"documents": ["a"]}), "\"query\" must be provided"),
+        (
+            json!({"query": 7, "documents": ["a"]}),
+            "\"query\" must be a string",
+        ),
+        (
+            json!({"query": "q"}),
+            "\"documents\" must be a non-empty string array",
+        ),
+        (
+            json!({"query": "q", "documents": []}),
+            "\"documents\" must be a non-empty string array",
+        ),
+        (
+            json!({"query": "q", "texts": []}),
+            "\"documents\" must be a non-empty string array",
+        ),
+    ] {
+        let (status, response) =
+            post(app(false, true, EmbeddingServingMode::Any), "/rerank", body).await;
+        assert_eq!(status, StatusCode::BAD_REQUEST, "{response}");
+        assert_eq!(response["error"]["message"], expected, "{response}");
+    }
+}
+
+#[tokio::test]
+async fn an_embedding_body_with_neither_input_nor_content_uses_the_upstream_wording() {
+    for path in ["/embedding", "/embeddings", "/v1/embeddings"] {
+        let (status, body) = post(
+            app(true, false, EmbeddingServingMode::Any),
+            path,
+            json!({"model": "stub-embedder"}),
+        )
+        .await;
+        assert_eq!(status, StatusCode::BAD_REQUEST, "{path}: {body}");
+        assert_eq!(
+            body["error"]["message"], "\"input\" or \"content\" must be provided",
+            "{path}: {body}"
+        );
+    }
+}
+
+#[tokio::test]
+async fn the_richer_mlxcel_item_forms_still_pass_the_shape_check() {
+    // mlxcel accepts an object query carrying an image, which upstream has no
+    // equivalent for; the b10621-worded checks must not refuse it.
+    let (status, body) = post(
+        app(false, true, EmbeddingServingMode::Any),
+        "/rerank",
+        json!({"query": {"text": "q"}, "documents": [{"text": "a"}]}),
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK, "{body}");
+}
+
+#[tokio::test]
+async fn a_body_carrying_both_document_spellings_is_served_not_refused() {
+    // serde reads `texts` as an alias of `documents` and would reject a body
+    // carrying both as a duplicate field; upstream reads one and ignores the
+    // other, so the redundant key is dropped before deserializing.
+    let (status, body) = post(
+        app(false, true, EmbeddingServingMode::Any),
+        "/rerank",
+        json!({"query": "q", "documents": ["a", "b"], "texts": ["c"]}),
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK, "{body}");
+    assert_eq!(
+        body["results"].as_array().expect("results").len(),
+        2,
+        "{body}"
+    );
+}
+
+// ── readiness in a restricted mode (#1452) ──────────────────────────────────
+
+#[tokio::test]
+async fn a_restricted_server_reports_healthy_once_its_worker_is_up() {
+    // Without this the mode is unusable behind a container probe: there is no
+    // chat worker to be "loaded", so /health would answer 503 for the life of
+    // the process.
+    for (mode, embedding, rerank) in [
+        (EmbeddingServingMode::EmbeddingOnly, true, false),
+        (EmbeddingServingMode::RerankOnly, false, true),
+    ] {
+        let (status, body) = get(app(embedding, rerank, mode), "/health").await;
+        assert_eq!(status, StatusCode::OK, "{mode:?}: {body}");
+        assert_eq!(body["status"], "ok", "{mode:?}: {body}");
+    }
+}
+
+#[tokio::test]
+async fn an_unrestricted_server_keeps_the_chat_oriented_health_answer() {
+    // The mode-aware branch must not change what any server that exists today
+    // reports; the wider "-m is an embedding checkpoint" case belongs to #1440.
+    let (status, body) = get(app(true, true, EmbeddingServingMode::Any), "/health").await;
+    assert_eq!(status, StatusCode::OK, "{body}");
+    assert!(body["batch"].is_object(), "{body}");
+    assert!(body["context_size"].as_u64().is_some(), "{body}");
+}
+
+#[tokio::test]
+async fn props_reports_the_normalization_an_unqualified_request_gets() {
+    // Not the checkpoint's own answer: a server started with
+    // `--embd-normalize 1` serves L1 to a request that names nothing, so
+    // reporting the checkpoint's 2 would describe a server that does not exist.
+    let (options_tx, _options_rx) = mpsc::channel();
+    let model_provider = Arc::new(ModelProvider::recording_for_route_tests(options_tx));
+    let batch_metrics = model_provider.batch_metrics().clone();
+    let config = ServerConfig {
+        enable_props_endpoint: true,
+        embd_normalize: Some(crate::embeddings::EmbdNormalize::TAXICAB),
+        ..ServerConfig::default()
+    };
+    let state = AppState::new(
+        model_provider,
+        config,
+        ChatTemplateProcessor::with_template("ok".to_string()),
+        MlxcelTokenizer::stub(),
+        PathBuf::from("route-test-model"),
+        batch_metrics,
+    )
+    .with_embedding_model(Some(embedding_provider()));
+    let request = Request::builder()
+        .method(Method::GET)
+        .uri("/props")
+        .body(Body::empty())
+        .expect("request builds");
+    let response = create_app(state)
+        .oneshot(request)
+        .await
+        .expect("router responds");
+    let bytes = axum::body::to_bytes(response.into_body(), 1024 * 1024)
+        .await
+        .expect("body collects");
+    let body: Value = serde_json::from_slice(&bytes).expect("json");
+    assert_eq!(
+        body["capabilities"]["embedding"]["embd_normalize"], 1,
+        "{body}"
+    );
+}

--- a/src/server/routes/embeddings.rs
+++ b/src/server/routes/embeddings.rs
@@ -32,7 +32,7 @@ use axum::{
 };
 use serde_json::Value;
 
-use crate::embeddings::{EmbedOptions, EmbeddingVector, ImageInput};
+use crate::embeddings::{EmbdNormalize, EmbedOptions, EmbeddingVector, ImageInput};
 use crate::server::AppState;
 use crate::server::embedding_model::{EmbeddingError, EmbeddingModelProvider};
 use crate::server::media::{
@@ -47,8 +47,14 @@ use crate::server::types::embeddings::{
 };
 
 /// Message of the `501` returned while no embedding model is loaded.
-pub const NO_EMBEDDING_MODEL_MESSAGE: &str =
-    "No embedding model loaded; start with -m <embedding checkpoint> or --embedding-model <path>";
+///
+/// Opens with b10621's own sentence, verbatim, so a client that matches on the
+/// upstream string keeps working, and then names the mlxcel spellings that also
+/// select an embedding worker (#1452). The b10621 flag really is accepted here:
+/// `--embeddings` is a startup error when it resolves no embedder, so a server
+/// that reaches this message was started without asking for embeddings at all.
+pub const NO_EMBEDDING_MODEL_MESSAGE: &str = "This server does not support embeddings. Start it with `--embeddings`, with an embedding \
+     checkpoint in -m, or with --embedding-model <path>.";
 
 fn invalid_request(message: impl Into<String>) -> ErrorResponse {
     ErrorResponse::new(message, "invalid_request_error")
@@ -265,6 +271,16 @@ pub async fn native_embeddings(State(state): State<AppState>, Json(body): Json<V
 }
 
 async fn embeddings_impl(state: AppState, body: Value, shape: EmbeddingShape) -> Response {
+    // b10621 answers a body with neither key with this exact sentence. serde
+    // would answer "missing field `input`", which names only one of the two
+    // spellings the server accepts and is not the string a b10621 client
+    // matches on (#1452).
+    if body
+        .as_object()
+        .is_some_and(|object| !object.contains_key("input") && !object.contains_key("content"))
+    {
+        return invalid_request("\"input\" or \"content\" must be provided").into_response();
+    }
     let request: EmbeddingsRequest = match serde_json::from_value(body) {
         Ok(request) => request,
         Err(err) => return invalid_request(format!("invalid request body: {err}")).into_response(),
@@ -312,9 +328,26 @@ async fn embeddings_impl(state: AppState, body: Value, shape: EmbeddingShape) ->
         Err(err) => return err.into_response(),
     };
 
+    // b10621 reads `embd_normalize` per request, defaulting to the server's
+    // `--embd-normalize` and, when that is unset too, to the checkpoint's own
+    // `normalize` flag (#1452).
+    let normalize = match request.embd_normalize {
+        Some(raw) => match EmbdNormalize::new(raw) {
+            Ok(kind) => Some(kind),
+            Err(message) => {
+                return ErrorResponse::new(
+                    message.replace("--embd-normalize", "embd_normalize"),
+                    "invalid_request_error",
+                )
+                .into_response();
+            }
+        },
+        None => state.config.embd_normalize,
+    };
     let opts = EmbedOptions {
         instruction: request.instruction,
         dimensions: request.dimensions,
+        normalize,
     };
     let started = std::time::Instant::now();
     // The provider blocks on the worker's reply channel, so keep it off the

--- a/src/server/routes/embeddings_tests.rs
+++ b/src/server/routes/embeddings_tests.rs
@@ -511,3 +511,83 @@ async fn non_finite_embeddings_return_500() {
         "{body}"
     );
 }
+
+// ── `embd_normalize` (#1452) ────────────────────────────────────────────────
+
+/// The vectors a request with the given `embd_normalize` comes back with.
+async fn embedded_with(body: serde_json::Value) -> (StatusCode, Value) {
+    post(
+        app_with(Some(stub_provider(false, 4))),
+        "/v1/embeddings",
+        body,
+    )
+    .await
+}
+
+fn first_vector(body: &Value) -> Vec<f32> {
+    body["data"][0]["embedding"]
+        .as_array()
+        .expect("a float array")
+        .iter()
+        .map(|v| v.as_f64().expect("a number") as f32)
+        .collect()
+}
+
+#[tokio::test]
+async fn embd_normalize_minus_one_leaves_the_vector_unnormalized() {
+    let (status, normalized) =
+        embedded_with(serde_json::json!({"input": "hello", "embd_normalize": 2})).await;
+    assert_eq!(status, StatusCode::OK, "{normalized}");
+    let (_, raw) = embedded_with(serde_json::json!({"input": "hello", "embd_normalize": -1})).await;
+
+    let l2 = |v: &[f32]| v.iter().map(|x| x * x).sum::<f32>().sqrt();
+    assert!(
+        (l2(&first_vector(&normalized)) - 1.0).abs() < 1e-4,
+        "embd_normalize 2 must produce a unit vector: {normalized}"
+    );
+    assert!(
+        (l2(&first_vector(&raw)) - 1.0).abs() > 1e-4,
+        "embd_normalize -1 must not normalize: {raw}"
+    );
+}
+
+#[tokio::test]
+async fn embd_normalize_one_produces_a_unit_l1_vector() {
+    let (_, body) = embedded_with(serde_json::json!({"input": "hello", "embd_normalize": 1})).await;
+    let l1: f32 = first_vector(&body).iter().map(|v| v.abs()).sum();
+    assert!((l1 - 1.0).abs() < 1e-4, "L1 norm is {l1}: {body}");
+}
+
+#[tokio::test]
+async fn an_out_of_domain_embd_normalize_is_a_400_naming_the_domain() {
+    let (status, body) =
+        embedded_with(serde_json::json!({"input": "hello", "embd_normalize": -2})).await;
+    assert_eq!(status, StatusCode::BAD_REQUEST, "{body}");
+    let message = body["error"]["message"].as_str().expect("a message");
+    assert!(message.contains("embd_normalize -2"), "{message}");
+    assert!(
+        !message.contains("--embd-normalize"),
+        "a per-request error must name the request field, not the flag: {message}"
+    );
+}
+
+#[tokio::test]
+async fn the_native_route_honors_embd_normalize_too() {
+    // b10621 serves `/embedding` and `/v1/embeddings` from one handler, so the
+    // field cannot be honored on only one of them.
+    let (status, body) = post(
+        app_with(Some(stub_provider(false, 4))),
+        "/embedding",
+        serde_json::json!({"content": "hello", "embd_normalize": 1}),
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK, "{body}");
+    let values: Vec<f32> = body[0]["embedding"][0]
+        .as_array()
+        .expect("the native array-of-arrays shape")
+        .iter()
+        .map(|v| v.as_f64().expect("a number") as f32)
+        .collect();
+    let l1: f32 = values.iter().map(|v| v.abs()).sum();
+    assert!((l1 - 1.0).abs() < 1e-4, "L1 norm is {l1}: {body}");
+}

--- a/src/server/routes/health.rs
+++ b/src/server/routes/health.rs
@@ -36,6 +36,37 @@ fn model_health_fields(state: &AppState) -> (usize, Option<String>) {
     (context_size, tool_call_parser)
 }
 
+/// Readiness of a server restricted to its side-model routes (#1452).
+///
+/// `ok` once the worker the mode selected exists. It cannot be absent in
+/// practice, because `check_serving_mode` refuses to start a server whose mode
+/// resolved no worker, but the check is made here too rather than assumed: this
+/// is the endpoint an operator reads when something did not come up.
+fn side_model_health(state: &AppState) -> (StatusCode, Json<HealthResponse>) {
+    use crate::server::config::EmbeddingServingMode;
+    let ready = match state.config.embedding_serving_mode {
+        EmbeddingServingMode::RerankOnly => state.rerank_model.is_some(),
+        EmbeddingServingMode::EmbeddingOnly => state.embedding_model.is_some(),
+        EmbeddingServingMode::Any => true,
+    };
+    let (status, label) = if ready {
+        (StatusCode::OK, "ok")
+    } else {
+        (StatusCode::SERVICE_UNAVAILABLE, "loading model")
+    };
+    (
+        status,
+        Json(HealthResponse {
+            status: label.to_string(),
+            model: Some(state.display_model_id().to_string()),
+            batch: None,
+            observability: None,
+            context_size: None,
+            tool_call_parser: None,
+        }),
+    )
+}
+
 /// GET /health
 ///
 /// Returns status with batch metrics and observability counters:
@@ -43,6 +74,19 @@ fn model_health_fields(state: &AppState) -> (usize, Option<String>) {
 /// - `{"status": "no slot available", ...}` when all slots are busy and queue is full
 /// - `{"status": "loading model"}` when model is still loading
 pub async fn health_check(State(state): State<AppState>) -> impl IntoResponse {
+    // A server started with b10621's `--embeddings` or `--reranking` has no
+    // chat worker to be "loaded", and reporting it unhealthy forever would make
+    // the mode unusable behind any container probe (#1452). Readiness there is
+    // whether the worker the mode selected came up.
+    //
+    // Deliberately scoped to the mode flags: a server whose `-m` is an
+    // embedding checkpoint but that was started without them still reports on
+    // the chat provider, so nothing that exists today changes behavior. That
+    // wider case, and the queue-full and loading-body drift, are `GET
+    // /health`'s recorded divergences and belong to #1440.
+    if state.config.embedding_serving_mode.blocks_generation() {
+        return side_model_health(&state);
+    }
     if !state.model_provider.is_loaded() {
         return (
             StatusCode::SERVICE_UNAVAILABLE,

--- a/src/server/routes/mod.rs
+++ b/src/server/routes/mod.rs
@@ -69,6 +69,23 @@ pub use tokenize::tokenize;
 /// Explain a terminal generation-unavailable state without exposing worker or
 /// channel implementation details.
 pub(crate) fn chat_unavailable_message(state: &AppState) -> Option<String> {
+    // b10621's `--embeddings` / `--reranking` restrict the server to that
+    // workload, so generation is refused even when a chat model is loaded next
+    // to the side model (#1452). The flag is named in the body, because
+    // "generation is off here" and "the chat model failed to load" are
+    // different operational problems and the 501 is the only place a client
+    // sees either.
+    if let Some(flag) = state.config.embedding_serving_mode.flag() {
+        return Some(format!(
+            "This server was started with {flag} and serves only its {} routes; generation is \
+             disabled. Drop {flag} to serve generation from the same process, or start a second \
+             server with -m <chat model>.",
+            match state.config.embedding_serving_mode {
+                crate::server::config::EmbeddingServingMode::RerankOnly => "reranking",
+                _ => "embedding",
+            }
+        ));
+    }
     if !state.model_provider.is_chat_unavailable() {
         return None;
     }
@@ -146,3 +163,7 @@ pub(crate) fn generation_error_to_response(err: anyhow::Error) -> ErrorResponse 
 #[cfg(test)]
 #[path = "native_route_tests.rs"]
 mod native_route_tests;
+
+#[cfg(test)]
+#[path = "embedding_rerank_mode_tests.rs"]
+mod embedding_rerank_mode_tests;

--- a/src/server/routes/models.rs
+++ b/src/server/routes/models.rs
@@ -24,11 +24,37 @@ use crate::server::types::{ModelInfo, ModelsResponse};
 
 /// GET /v1/models
 pub async fn list_models(State(state): State<AppState>) -> Json<ModelsResponse> {
+    // `capabilities` says what each id may be sent to (#1452). The primary
+    // entry is the interesting one: when `-m` is itself an embedding or
+    // reranker checkpoint its id is the only id on the list, and before this
+    // field a client had no way to tell that sending it to
+    // `/v1/chat/completions` would 501.
+    let mut primary: Vec<&'static str> = Vec::new();
+    if !state.model_provider.is_chat_unavailable()
+        && !state.config.embedding_serving_mode.blocks_generation()
+    {
+        primary.push("completion");
+    }
+    if state
+        .embedding_model
+        .as_ref()
+        .is_some_and(|e| e.model_id() == state.display_model_id())
+    {
+        primary.push("embedding");
+    }
+    if state
+        .rerank_model
+        .as_ref()
+        .is_some_and(|r| r.model_id() == state.display_model_id())
+    {
+        primary.push("rerank");
+    }
     let mut models = vec![ModelInfo {
         id: state.display_model_id().to_string(),
         object: "model".to_string(),
         created: state.model_provider.created_at(),
         owned_by: "user".to_string(),
+        capabilities: primary,
     }];
 
     // A separately loaded embedding model (`--embedding-model`) is listed
@@ -42,6 +68,7 @@ pub async fn list_models(State(state): State<AppState>) -> Json<ModelsResponse> 
             object: "model".to_string(),
             created: embedding.created_at(),
             owned_by: "user".to_string(),
+            capabilities: vec!["embedding"],
         });
     }
 
@@ -55,6 +82,7 @@ pub async fn list_models(State(state): State<AppState>) -> Json<ModelsResponse> 
             object: "model".to_string(),
             created: reranker.created_at(),
             owned_by: "user".to_string(),
+            capabilities: vec!["rerank"],
         });
     }
 

--- a/src/server/routes/props.rs
+++ b/src/server/routes/props.rs
@@ -21,7 +21,9 @@ use axum::{Json, extract::State};
 
 use crate::server::AppState;
 use crate::server::config::ServerConfig;
-use crate::server::types::PropsResponse;
+use crate::server::types::{
+    EmbeddingCapability, PropsResponse, RerankCapability, ServerCapabilities,
+};
 
 /// The `default_generation_settings` object of the `/props` payload.
 ///
@@ -90,7 +92,48 @@ pub async fn props(State(state): State<AppState>) -> Json<PropsResponse> {
         // the startup log.
         kv_cache_mode: state.config.kv_cache_mode.to_string(),
         kv_bits: state.config.batch_kv_quant.bits,
+        capabilities: server_capabilities(&state),
     })
+}
+
+/// Build the resolved capability block (#1452).
+///
+/// Everything here is read from the workers that were really loaded rather than
+/// from the flags that were passed, so a `--pooling` the checkpoint overrode,
+/// or a `--embedding-model` that failed to load, shows up as what happened.
+pub(crate) fn server_capabilities(state: &AppState) -> ServerCapabilities {
+    ServerCapabilities {
+        generation: !state.model_provider.is_chat_unavailable()
+            && !state.config.embedding_serving_mode.blocks_generation(),
+        serving_mode: state.config.embedding_serving_mode.flag(),
+        embedding: state
+            .embedding_model
+            .as_ref()
+            .map(|provider| EmbeddingCapability {
+                model: provider.model_id().to_string(),
+                dim: provider.dim(),
+                pooling: provider.pooling().to_string(),
+                // The value an unqualified request really gets: the
+                // `--embd-normalize` flag when the operator set one, and the
+                // checkpoint's own `normalize` flag otherwise. Reporting the
+                // checkpoint's answer unconditionally would have shown 2 on a
+                // server started with `--embd-normalize 1`, which is the
+                // opposite of what this block is for.
+                embd_normalize: state
+                    .config
+                    .embd_normalize
+                    .unwrap_or_else(|| provider.embd_normalize())
+                    .value(),
+                multi_vector: provider.multi_vector(),
+            }),
+        reranking: state
+            .rerank_model
+            .as_ref()
+            .map(|provider| RerankCapability {
+                model: provider.model_id().to_string(),
+                kind: provider.kind().as_str().to_string(),
+            }),
+    }
 }
 
 #[cfg(test)]

--- a/src/server/routes/props_tests.rs
+++ b/src/server/routes/props_tests.rs
@@ -172,6 +172,7 @@ fn props_reports_the_effective_kv_cache_mode_and_kv_bits() {
         total_slots: 1,
         kv_cache_mode: mlxcel_core::cache::KVCacheMode::Turbo4Asym.to_string(),
         kv_bits: 4,
+        capabilities: no_side_models(),
     };
 
     let payload = serde_json::to_value(&response).expect("PropsResponse serializes");
@@ -192,9 +193,21 @@ fn props_reports_the_kv_keys_even_on_a_default_server() {
         total_slots: config.n_parallel,
         kv_cache_mode: config.kv_cache_mode.to_string(),
         kv_bits: config.batch_kv_quant.bits,
+        capabilities: no_side_models(),
     };
 
     let payload = serde_json::to_value(&response).expect("PropsResponse serializes");
     assert_eq!(payload["kv_cache_mode"], serde_json::json!("fp16"));
     assert_eq!(payload["kv_bits"], serde_json::json!(0));
+}
+
+/// The capability block of a plain generation server: no side models, no mode
+/// restriction.
+fn no_side_models() -> crate::server::types::ServerCapabilities {
+    crate::server::types::ServerCapabilities {
+        generation: true,
+        serving_mode: None,
+        embedding: None,
+        reranking: None,
+    }
 }

--- a/src/server/routes/rerank.rs
+++ b/src/server/routes/rerank.rs
@@ -41,11 +41,15 @@ use crate::server::rerank_model::{RerankError, RerankModelProvider};
 use crate::server::types::ErrorResponse;
 use crate::server::types::rerank::{
     RerankInput, RerankRequest, RerankResponse, RerankResult, RerankUsage, sort_and_truncate,
+    to_tei_results,
 };
 
 /// Message of the `501` returned while no reranker is loaded.
-pub const NO_RERANKER_MODEL_MESSAGE: &str =
-    "No reranker loaded; start with -m <sequence-classifier checkpoint> or --reranker-model <path>";
+///
+/// Opens with b10621's own sentence, verbatim; see
+/// [`super::embeddings::NO_EMBEDDING_MODEL_MESSAGE`] for why (#1452).
+pub const NO_RERANKER_MODEL_MESSAGE: &str = "This server does not support reranking. Start it with `--reranking`, with a \
+     sequence-classifier checkpoint in -m, or with --reranker-model <path>.";
 
 fn invalid_request(message: impl Into<String>) -> ErrorResponse {
     ErrorResponse::new(message, "invalid_request_error")
@@ -155,8 +159,52 @@ async fn to_rerank_item(
     })
 }
 
+/// b10621's shape checks on a rerank body, in its order and its wording.
+///
+/// Returns `None` when the body has the shape upstream accepts; mlxcel's own
+/// richer item forms (an object carrying an image) are validated afterwards,
+/// where they belong, because upstream has no equivalent to compare against.
+fn rerank_shape_error(body: &Value) -> Option<String> {
+    let object = body.as_object()?;
+    match object.get("query") {
+        None => return Some("\"query\" must be provided".to_string()),
+        // Upstream requires a bare string. mlxcel also accepts its own object
+        // form (`{"text": ..., "image": ...}`), which upstream has no
+        // equivalent for, so only a value that is neither is refused here.
+        Some(value) if !value.is_string() && !value.is_object() => {
+            return Some("\"query\" must be a string".to_string());
+        }
+        Some(_) => {}
+    }
+    let documents = object.get("documents").or_else(|| object.get("texts"));
+    match documents {
+        Some(Value::Array(items)) if !items.is_empty() => None,
+        _ => Some("\"documents\" must be a non-empty string array".to_string()),
+    }
+}
+
 /// POST /v1/rerank
 pub async fn create_rerank(State(state): State<AppState>, Json(body): Json<Value>) -> Response {
+    // Which document-list spelling arrived decides the response envelope, and
+    // serde cannot report which alias matched, so it is read off the raw body
+    // before deserializing (#1452).
+    let tei_form = RerankRequest::is_tei_form(&body);
+    // Upstream reads whichever key is present and ignores the other; serde
+    // refuses a body carrying both as a duplicate field, so the redundant one
+    // is dropped first. `documents` wins, which is what `is_tei_form` already
+    // decided the envelope on.
+    let mut body = body;
+    if let Some(object) = body.as_object_mut()
+        && object.contains_key("documents")
+    {
+        object.remove("texts");
+    }
+    // b10621's own wording for the three shape errors, because serde's
+    // "missing field `query`" is not the string a b10621 client matches on and
+    // does not name the `texts` spelling at all (#1452).
+    if let Some(message) = rerank_shape_error(&body) {
+        return invalid_request(message).into_response();
+    }
     let request: RerankRequest = match serde_json::from_value(body) {
         Ok(request) => request,
         Err(err) => return invalid_request(format!("invalid request body: {err}")).into_response(),
@@ -267,6 +315,7 @@ pub async fn create_rerank(State(state): State<AppState>, Json(body): Json<Value
         started.elapsed().as_millis() as u64,
     );
 
+    let echo = request.echoes_items();
     let results = scored
         .scores
         .iter()
@@ -274,14 +323,20 @@ pub async fn create_rerank(State(state): State<AppState>, Json(body): Json<Value
         .map(|(index, &relevance_score)| RerankResult {
             index,
             relevance_score,
-            document: request
-                .return_documents
-                .then(|| request.documents[index].clone()),
+            document: echo.then(|| request.documents[index].clone()),
         })
         .collect();
+    let results = sort_and_truncate(results, request.top_n);
+    if tei_form {
+        // b10621 answers a TEI request with a bare array of {index, score}
+        // and no envelope at all, which is a different top-level type, not a
+        // renamed field.
+        return Json(to_tei_results(results)).into_response();
+    }
     Json(RerankResponse {
         model: provider.model_id().to_string(),
-        results: sort_and_truncate(results, request.top_n),
+        object: RerankResponse::OBJECT,
+        results,
         usage: RerankUsage {
             prompt_tokens: scored.prompt_tokens,
             total_tokens: scored.prompt_tokens,

--- a/src/server/routes/rerank_tests.rs
+++ b/src/server/routes/rerank_tests.rs
@@ -235,11 +235,9 @@ async fn empty_documents_is_400() {
     )
     .await;
     assert_eq!(status, StatusCode::BAD_REQUEST, "{body}");
-    assert!(
-        body["error"]["message"]
-            .as_str()
-            .expect("message")
-            .contains("`documents` must not be empty"),
+    // b10621's own wording since #1452; the message used to be mlxcel's.
+    assert_eq!(
+        body["error"]["message"], "\"documents\" must be a non-empty string array",
         "{body}"
     );
 }
@@ -432,6 +430,22 @@ async fn model_mismatch_is_400() {
 async fn malformed_body_is_400() {
     let app = app_with(Some(text_provider()));
     let (status, body) = post(app, "/v1/rerank", json!({"documents": ["alpha"]})).await;
+    assert_eq!(status, StatusCode::BAD_REQUEST, "{body}");
+    // A missing `query` is one of the three shapes b10621 names itself, so the
+    // body carries upstream's sentence rather than serde's (#1452).
+    assert_eq!(
+        body["error"]["message"], "\"query\" must be provided",
+        "{body}"
+    );
+}
+
+#[tokio::test]
+async fn a_body_that_is_not_an_object_is_still_a_serde_400() {
+    // The b10621-worded checks only cover the three shapes upstream names; a
+    // body that is not an object at all falls through to serde, which is where
+    // mlxcel's own richer item forms are validated too.
+    let app = app_with(Some(text_provider()));
+    let (status, body) = post(app, "/v1/rerank", json!([1, 2, 3])).await;
     assert_eq!(status, StatusCode::BAD_REQUEST, "{body}");
     assert!(
         body["error"]["message"]

--- a/src/server/startup.rs
+++ b/src/server/startup.rs
@@ -143,6 +143,13 @@ pub struct ServerStartupConfig {
     /// (#1442). Forwarded to [`super::config::ServerConfig::spm_infill`].
     pub spm_infill: bool,
 
+    /// `--embd-normalize` (#1452), `None` when unset.
+    pub embd_normalize: Option<crate::embeddings::EmbdNormalize>,
+    /// `--embeddings` / `--reranking` (#1452).
+    pub embedding_serving_mode: crate::server::config::EmbeddingServingMode,
+    /// `--pooling` (#1452), `None` when unset or when it named `rank`.
+    pub pooling: Option<crate::embeddings::PoolingMode>,
+
     // Batch scheduling
     pub max_batch_size: Option<usize>,
     pub max_queue_depth: usize,
@@ -539,6 +546,9 @@ impl Default for ServerStartupConfig {
             enable_slots: true,
             enable_props: false,
             spm_infill: false,
+            embd_normalize: None,
+            embedding_serving_mode: crate::server::config::EmbeddingServingMode::Any,
+            pooling: None,
             enable_metrics: false,
             warmup: true,
             temperature: 0.8,
@@ -1136,6 +1146,8 @@ pub(super) fn build_server_config(
         enable_slots_endpoint: startup.enable_slots,
         enable_props_endpoint: startup.enable_props,
         spm_infill: startup.spm_infill,
+        embd_normalize: startup.embd_normalize,
+        embedding_serving_mode: startup.embedding_serving_mode,
         enable_metrics_endpoint: startup.enable_metrics,
         default_temperature: sampling_defaults.temperature,
         default_top_p: sampling_defaults.top_p,
@@ -2507,6 +2519,12 @@ pub async fn start_server(mut startup: ServerStartupConfig) -> Result<()> {
             config.model_aliases[1..].join(", ")
         );
     }
+    // `--pooling` is installed before any embedding checkpoint is loaded,
+    // because every family resolves its mode inside its own constructor
+    // (#1452). The cell is cleared when the flag was not given so a previous
+    // in-process server (the test harness runs several) cannot leak its
+    // choice into this one.
+    crate::embeddings::set_pooling_override(startup.pooling);
     let embedding_model = resolve_embedding_provider(&startup, &config, &served_chat_id)?;
     // Rerank wiring (#1356) follows the same rule, with one addition: a
     // generative reranker's checkpoint is indistinguishable from a chat
@@ -2514,6 +2532,10 @@ pub async fn start_server(mut startup: ServerStartupConfig) -> Result<()> {
     // the same path in `-m` and `--reranker-model` loads it once on the rerank
     // worker instead of being an error.
     let rerank_model = resolve_rerank_provider(&startup, &config, &served_chat_id)?;
+    // A mode flag that resolved no worker is a command line that cannot do
+    // what it asked for, so it fails here rather than answering 501 to every
+    // request for the life of the process (#1452).
+    check_serving_mode(&config, embedding_model.is_some(), rerank_model.is_some())?;
 
     let state = AppState::with_observability(
         model_provider,
@@ -2535,6 +2557,39 @@ pub async fn start_server(mut startup: ServerStartupConfig) -> Result<()> {
     let app = create_app(state);
 
     serve_http(&startup, app).await
+}
+
+/// Refuse a `--embeddings` / `--reranking` command line that resolved no
+/// worker able to serve that mode (#1452).
+///
+/// b10621 restricts an existing model; mlxcel selects a dedicated worker, so
+/// the flag additionally asserts that one exists. Without this check the flag
+/// would parse, generation would be off, and the only route left would answer
+/// 501 forever, which is the accepted-and-ignored failure epic #1431 exists to
+/// remove.
+pub(crate) fn check_serving_mode(
+    config: &ServerConfig,
+    has_embedding: bool,
+    has_rerank: bool,
+) -> Result<()> {
+    use crate::server::config::EmbeddingServingMode;
+    match config.embedding_serving_mode {
+        EmbeddingServingMode::Any => Ok(()),
+        EmbeddingServingMode::EmbeddingOnly if has_embedding => Ok(()),
+        EmbeddingServingMode::RerankOnly if has_rerank => Ok(()),
+        EmbeddingServingMode::EmbeddingOnly => anyhow::bail!(
+            "--embeddings restricts this server to embedding requests, but no embedding \
+             checkpoint was loaded: pass an embedding checkpoint to -m, or name one with \
+             --embedding-model <path>. `mlxcel list` reports which architectures load as \
+             embedders."
+        ),
+        EmbeddingServingMode::RerankOnly => anyhow::bail!(
+            "--reranking restricts this server to rerank requests, but no reranker was loaded: \
+             pass a sequence-classifier checkpoint to -m, or name a reranker with \
+             --reranker-model <path>. The Qwen3 and Qwen3-VL generative rerankers are only \
+             reachable through --reranker-model."
+        ),
+    }
 }
 
 /// Where the embedding checkpoint comes from.

--- a/src/server/startup_tests.rs
+++ b/src/server/startup_tests.rs
@@ -1365,3 +1365,62 @@ fn loop_detection_env_wrong_field_count_returns_none() {
     let result = with_loop_detection_env(Some("1,20,4,extra"), resolve_loop_detection_env);
     assert!(result.is_none());
 }
+
+// ── b10621 serving-mode gate (#1452) ────────────────────────────────────────
+
+fn mode_config(mode: crate::server::config::EmbeddingServingMode) -> crate::server::ServerConfig {
+    crate::server::ServerConfig {
+        embedding_serving_mode: mode,
+        ..crate::server::ServerConfig::default()
+    }
+}
+
+/// A mode flag that resolved no worker able to serve it fails at startup,
+/// naming the flag and the two ways to give it a checkpoint. Without this the
+/// flag would parse, generation would be off, and the only route left would
+/// answer 501 for the life of the process.
+#[test]
+fn a_mode_flag_with_no_matching_worker_fails_startup() {
+    use crate::server::config::EmbeddingServingMode;
+
+    let err = super::check_serving_mode(
+        &mode_config(EmbeddingServingMode::EmbeddingOnly),
+        false,
+        true,
+    )
+    .expect_err("--embeddings with no embedder must fail");
+    let message = err.to_string();
+    assert!(message.contains("--embeddings"), "{message}");
+    assert!(message.contains("--embedding-model"), "{message}");
+
+    let err =
+        super::check_serving_mode(&mode_config(EmbeddingServingMode::RerankOnly), true, false)
+            .expect_err("--reranking with no reranker must fail");
+    let message = err.to_string();
+    assert!(message.contains("--reranking"), "{message}");
+    assert!(message.contains("--reranker-model"), "{message}");
+}
+
+#[test]
+fn a_mode_flag_with_its_worker_starts() {
+    use crate::server::config::EmbeddingServingMode;
+
+    super::check_serving_mode(
+        &mode_config(EmbeddingServingMode::EmbeddingOnly),
+        true,
+        false,
+    )
+    .expect("--embeddings with an embedder starts");
+    super::check_serving_mode(&mode_config(EmbeddingServingMode::RerankOnly), false, true)
+        .expect("--reranking with a reranker starts");
+}
+
+#[test]
+fn an_unrestricted_server_never_fails_the_mode_gate() {
+    use crate::server::config::EmbeddingServingMode;
+
+    for (embedding, rerank) in [(false, false), (true, false), (false, true), (true, true)] {
+        super::check_serving_mode(&mode_config(EmbeddingServingMode::Any), embedding, rerank)
+            .expect("no mode flag, nothing to check");
+    }
+}

--- a/src/server/types/embeddings.rs
+++ b/src/server/types/embeddings.rs
@@ -37,6 +37,14 @@ pub struct EmbeddingsRequest {
     /// Forwarded to the family's text formatting (instruction prefix).
     #[serde(default)]
     pub instruction: Option<String>,
+    /// b10621's per-request `embd_normalize` (#1452).
+    ///
+    /// Held as the raw integer b10621 states it as, because the domain is open
+    /// above 2 (any `p` is a p-norm) and cannot be an enum. Validated by the
+    /// route so an out-of-domain value is a 400 naming the domain rather than
+    /// a 422 from serde.
+    #[serde(default)]
+    pub embd_normalize: Option<i32>,
     /// Accepted for OpenAI compatibility and ignored.
     #[serde(default)]
     pub user: Option<String>,

--- a/src/server/types/rerank.rs
+++ b/src/server/types/rerank.rs
@@ -31,13 +31,24 @@ pub struct RerankRequest {
     /// The query every document is scored against.
     pub query: RerankInput,
     /// The documents to score; at least one.
+    ///
+    /// b10621 accepts two spellings for this list and answers a **different
+    /// response shape** for each: `documents` is the Jina/Cohere form and
+    /// `texts` is the Text Embeddings Inference form. `texts` is a serde alias
+    /// here, and [`RerankRequest::is_tei_form`] recovers which one arrived so
+    /// the response can follow it (#1452).
+    #[serde(alias = "texts")]
     pub documents: Vec<RerankInput>,
     /// Keep only the `top_n` highest-scoring results.
     #[serde(default)]
     pub top_n: Option<usize>,
-    /// Echo each scored item back in its result entry.
+    /// Echo each scored item back in its result entry (Cohere spelling).
     #[serde(default)]
     pub return_documents: bool,
+    /// Echo each scored item back (b10621 / TEI spelling). Emits `text` rather
+    /// than `document`.
+    #[serde(default)]
+    pub return_text: bool,
     /// Task description for the generative rerankers. Rejected for a
     /// sequence-classifier reranker, which has nowhere to put it.
     #[serde(default)]
@@ -124,7 +135,7 @@ impl RerankInput {
     }
 }
 
-/// One scored document.
+/// One scored document, Jina/Cohere shape.
 #[derive(Debug, Clone, Serialize)]
 pub struct RerankResult {
     /// Position of this document in the request's `documents` list.
@@ -136,6 +147,20 @@ pub struct RerankResult {
     pub document: Option<RerankInput>,
 }
 
+/// One scored document, b10621's TEI shape.
+///
+/// A different envelope, not a different computation: the score is the same
+/// number `relevance_score` carries, and the echo is spelled `text` rather than
+/// `document`. Which one a request gets is decided by the spelling it used for
+/// the document list (#1452).
+#[derive(Debug, Clone, Serialize)]
+pub struct RerankTeiResult {
+    pub index: usize,
+    pub score: f32,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub text: Option<RerankInput>,
+}
+
 /// Token accounting of one request.
 #[derive(Debug, Clone, Serialize, PartialEq, Eq)]
 pub struct RerankUsage {
@@ -143,12 +168,58 @@ pub struct RerankUsage {
     pub total_tokens: usize,
 }
 
-/// `POST /v1/rerank` response body.
+/// `POST /v1/rerank` response body, Jina/Cohere shape.
+///
+/// `object` is emitted because b10621 emits it; it was the recorded divergence
+/// on the four rerank routes before #1452.
 #[derive(Debug, Clone, Serialize)]
 pub struct RerankResponse {
     pub model: String,
+    pub object: &'static str,
     pub results: Vec<RerankResult>,
     pub usage: RerankUsage,
+}
+
+impl RerankResponse {
+    /// The `object` value b10621 emits on this envelope.
+    pub const OBJECT: &'static str = "list";
+}
+
+impl RerankRequest {
+    /// Whether this request used b10621's TEI spelling for the document list.
+    ///
+    /// serde cannot report which alias matched, so the raw body is consulted:
+    /// `texts` present and `documents` absent is the TEI form. A body carrying
+    /// both is the Jina form, which is also what serde deserialized.
+    #[must_use]
+    pub fn is_tei_form(body: &serde_json::Value) -> bool {
+        let Some(object) = body.as_object() else {
+            return false;
+        };
+        object.contains_key("texts") && !object.contains_key("documents")
+    }
+
+    /// Whether the scored items should be echoed, under either spelling.
+    #[must_use]
+    pub fn echoes_items(&self) -> bool {
+        self.return_documents || self.return_text
+    }
+}
+
+/// Turn Jina-shaped results into b10621's TEI array.
+///
+/// Ordering and truncation have already been applied, so this is a pure
+/// renaming of the two keys.
+#[must_use]
+pub fn to_tei_results(results: Vec<RerankResult>) -> Vec<RerankTeiResult> {
+    results
+        .into_iter()
+        .map(|r| RerankTeiResult {
+            index: r.index,
+            score: r.relevance_score,
+            text: r.document,
+        })
+        .collect()
 }
 
 /// Sort scored documents the way the endpoint promises: descending by score,

--- a/src/server/types/response.rs
+++ b/src/server/types/response.rs
@@ -407,6 +407,15 @@ pub struct ModelInfo {
     pub object: String,
     pub created: i64,
     pub owned_by: String,
+    /// What this entry can be asked for: `completion`, `embedding` or
+    /// `rerank` (#1452).
+    ///
+    /// `/v1/models` listed a chat model, an embedding model and a reranker with
+    /// no field distinguishing them, so a client could not tell which id to
+    /// send where. Omitted when empty so the object stays exactly the OpenAI
+    /// shape for a deployment that has only a chat model.
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    pub capabilities: Vec<&'static str>,
 }
 
 /// Models list response
@@ -622,6 +631,57 @@ pub struct PropsResponse {
     /// because it is an independent second route to a quantized cache and is
     /// subject to the same startup substitution.
     pub kv_bits: i32,
+    /// What this server can actually be asked for, resolved at startup
+    /// (#1452).
+    ///
+    /// b10621's own `/props` carries comparable facts (its server binary
+    /// declares `modalities`, `capabilities` and `pooling_type` keys), and for
+    /// the same reason: "is generation on", "is there an embedder", "which
+    /// pooling did it resolve" and "which normalization will an unqualified
+    /// request get" are all decided before the first request and are otherwise
+    /// invisible to a client. The key set here is mlxcel's own, because the
+    /// facts it reports are about mlxcel's dedicated workers. The pooling
+    /// value is the mode the checkpoint really resolved, not the flag that was
+    /// passed, so `--pooling` having been ignored would be visible here.
+    pub capabilities: ServerCapabilities,
+}
+
+/// The resolved side-model capability block of [`PropsResponse`] (#1452).
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+pub struct ServerCapabilities {
+    /// Whether generation routes serve requests.
+    pub generation: bool,
+    /// The b10621 mode flag that restricted this server, `null` when none did.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub serving_mode: Option<&'static str>,
+    /// The embedding worker, absent when none is loaded.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub embedding: Option<EmbeddingCapability>,
+    /// The rerank worker, absent when none is loaded.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub reranking: Option<RerankCapability>,
+}
+
+/// What the loaded embedding checkpoint resolved.
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+pub struct EmbeddingCapability {
+    pub model: String,
+    /// Width of one vector.
+    pub dim: usize,
+    /// The pooling really in force: `cls`, `mean`, `max` or `lasttoken`.
+    pub pooling: String,
+    /// The `--embd-normalize` value an unqualified request gets.
+    pub embd_normalize: i32,
+    /// Whether the family returns one vector per token.
+    pub multi_vector: bool,
+}
+
+/// What the loaded reranker resolved.
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+pub struct RerankCapability {
+    pub model: String,
+    /// `sequence_classifier`, `generative_text` or `generative_vl`.
+    pub kind: String,
 }
 
 /// Slot information (GET /slots)

--- a/tests/embedding_pooling_normalize_real.rs
+++ b/tests/embedding_pooling_normalize_real.rs
@@ -1,0 +1,361 @@
+// Copyright 2025-2026 Lablup Inc. and Jeongkyu Shin
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Real-checkpoint coverage for `--pooling` and `--embd-normalize` (#1452).
+//!
+//! The unit tests behind both flags run on a synthetic 16-wide stub, which is
+//! what makes their arithmetic exact and also what makes them blind to the two
+//! things that only a real checkpoint has: a `1_Pooling/config.json` the flag
+//! has to outrank, and a family whose forward pass actually reads the resolved
+//! mode. Two embedding checkpoints are used because their configs disagree,
+//! `all-MiniLM-L6-v2` says mean and `bge-small-en-v1.5` says cls, so a flag
+//! that silently did nothing would still look right on one of them.
+//!
+//! Every embedding case runs inside **one** `#[test]` function on purpose. The
+//! pooling override is a process-wide cell, and libtest runs the functions of
+//! one binary on parallel threads, so two functions installing different modes
+//! interleave between the `set` and the load that reads it. Splitting these
+//! into four readable tests is exactly what produced a green-looking suite that
+//! silently compared vectors from the wrong pooling mode. One function is how
+//! the ordering is guaranteed without the `--test-threads=1` the chain gate
+//! forbids; the reranker case is separate because it never touches the cell.
+//!
+//! ```bash
+//! cargo test --test embedding_pooling_normalize_real --profile test-fast --features metal,accelerate -- --nocapture
+//! ```
+//!
+//! Each case skips with a message when its checkpoint is absent, so CI stays
+//! green without them.
+
+mod common;
+
+use common::repo_model_dir;
+
+use mlxcel::embeddings::{
+    EmbdNormalize, EmbedOptions, EmbeddingEngine, EmbeddingLoadOptions, PoolingMode,
+    load_embedding_model_with_options, set_pooling_override,
+};
+use mlxcel::initialize_runtime;
+use mlxcel::rerank::{RerankItem, RerankLoadOptions, load_reranker_with_options};
+
+/// `1_Pooling/config.json` says mean.
+const MEAN_CHECKPOINT: &str = "mlx/all-minilm-l6-v2";
+/// `1_Pooling/config.json` says cls.
+const CLS_CHECKPOINT: &str = "mlx/bge-small-en-v1.5";
+/// `BertForSequenceClassification`, a cross-encoder reranker.
+const RERANKER: &str = "mlx/ms-marco-minilm-l6-v2";
+
+const PROMPT: &str = "The giant panda is a bear species endemic to China.";
+
+fn have(name: &str) -> bool {
+    let present = repo_model_dir(name).join("config.json").exists();
+    if !present {
+        eprintln!("Skipping {name}: checkpoint not found");
+    }
+    present
+}
+
+/// Embed one prompt with an explicit pooling override and normalization.
+fn embed(name: &str, pooling: Option<PoolingMode>, normalize: Option<EmbdNormalize>) -> Vec<f32> {
+    set_pooling_override(pooling);
+    let loaded = load_embedding_model_with_options(
+        &repo_model_dir(name),
+        EmbeddingLoadOptions { max_length: None },
+    )
+    .unwrap_or_else(|e| panic!("{name} must load: {e:#}"));
+    let resolved = loaded.model.pooling();
+    if let Some(expected) = pooling {
+        assert_eq!(
+            resolved, expected,
+            "{name}: --pooling {expected} must outrank the checkpoint's own config, got {resolved}"
+        );
+    }
+    let engine = EmbeddingEngine::new(loaded, 4);
+    let reply = engine
+        .embed_texts(
+            &[PROMPT.to_string()],
+            &EmbedOptions {
+                instruction: None,
+                dimensions: None,
+                normalize,
+            },
+        )
+        .unwrap_or_else(|e| panic!("{name} must embed: {e:#}"));
+    reply.vectors[0].values.clone()
+}
+
+fn l1(v: &[f32]) -> f32 {
+    v.iter().map(|x| x.abs()).sum()
+}
+
+fn l2(v: &[f32]) -> f32 {
+    v.iter().map(|x| x * x).sum::<f32>().sqrt()
+}
+
+fn max_abs(v: &[f32]) -> f32 {
+    v.iter().fold(0.0f32, |m, x| m.max(x.abs()))
+}
+
+fn cosine(a: &[f32], b: &[f32]) -> f32 {
+    let dot: f32 = a.iter().zip(b).map(|(x, y)| x * y).sum();
+    dot / (l2(a) * l2(b)).max(1e-9)
+}
+
+/// `||a - b|| / max(||a||, ||b||)`: zero for identical vectors, and unlike
+/// cosine it is not fooled by two vectors that point the same way.
+fn relative_distance(a: &[f32], b: &[f32]) -> f32 {
+    let diff: f32 = a
+        .iter()
+        .zip(b)
+        .map(|(x, y)| (x - y) * (x - y))
+        .sum::<f32>()
+        .sqrt();
+    diff / l2(a).max(l2(b)).max(1e-9)
+}
+
+/// Every `--pooling` and `--embd-normalize` case, in one function so the
+/// process-wide pooling override cannot be changed underneath a load.
+#[test]
+fn pooling_and_normalization_hold_on_real_checkpoints() {
+    if !have(MEAN_CHECKPOINT) || !have(CLS_CHECKPOINT) {
+        return;
+    }
+    let _runtime = initialize_runtime();
+
+    the_pooling_flag_outranks_the_checkpoint_config();
+    an_unset_pooling_flag_leaves_the_checkpoint_config_in_charge();
+    every_normalization_holds_its_invariant();
+    the_unset_normalization_follows_the_checkpoint_and_matches_euclidean();
+
+    set_pooling_override(None);
+}
+
+/// Every b10621 pooling value mlxcel implements, on both checkpoints.
+///
+/// The property under test is that the override reaches the forward pass, and
+/// output that does not change with the mode is what its absence looks like.
+/// `mean` is the reference for that, because it reads every position while
+/// `cls` and `last` each read one: on `bge-small-en-v1.5` those two positions
+/// turn out to hold the same vector to within 1.3e-5, which is a property of a
+/// model trained with CLS pooling and not a pooling bug, so that pair carries
+/// no signal there. `all-MiniLM-L6-v2` separates all three, so the stronger
+/// assertion is made where it means something.
+fn the_pooling_flag_outranks_the_checkpoint_config() {
+    for checkpoint in [MEAN_CHECKPOINT, CLS_CHECKPOINT] {
+        let mut vectors = Vec::new();
+        for mode in [PoolingMode::Mean, PoolingMode::Cls, PoolingMode::LastToken] {
+            let v = embed(checkpoint, Some(mode), Some(EmbdNormalize::NONE));
+            assert!(
+                v.iter().all(|x| x.is_finite()) && !v.is_empty(),
+                "{checkpoint}/{mode}: produced {} values",
+                v.len()
+            );
+            vectors.push((mode, v));
+        }
+        let separation = |a: usize, b: usize| {
+            let value = relative_distance(&vectors[a].1, &vectors[b].1);
+            eprintln!(
+                "{checkpoint}: {} vs {} separation {value:.4}",
+                vectors[a].0, vectors[b].0
+            );
+            value
+        };
+        // Mean against each single-position mode, on both checkpoints.
+        for other in [1usize, 2] {
+            let value = separation(0, other);
+            assert!(
+                value > 1e-3,
+                "{checkpoint}: {} and {} produced the same vector (separation {value:e}), so \
+                 the pooling override did not reach the forward pass",
+                vectors[0].0,
+                vectors[other].0
+            );
+        }
+        // Cls against LastToken, where the two positions are known to differ.
+        if checkpoint == MEAN_CHECKPOINT {
+            let value = separation(1, 2);
+            assert!(
+                value > 1e-3,
+                "{checkpoint}: cls and lasttoken produced the same vector (separation \
+                 {value:e})"
+            );
+        } else {
+            // Recorded rather than asserted: the two positions coincide here.
+            let _ = separation(1, 2);
+        }
+    }
+}
+
+/// With no override installed, `1_Pooling/config.json` still decides, and the
+/// two checkpoints disagree, so a stuck cell would show up here.
+fn an_unset_pooling_flag_leaves_the_checkpoint_config_in_charge() {
+    set_pooling_override(None);
+    for (checkpoint, expected) in [
+        (MEAN_CHECKPOINT, PoolingMode::Mean),
+        (CLS_CHECKPOINT, PoolingMode::Cls),
+    ] {
+        let loaded = load_embedding_model_with_options(
+            &repo_model_dir(checkpoint),
+            EmbeddingLoadOptions { max_length: None },
+        )
+        .unwrap_or_else(|e| panic!("{checkpoint} must load: {e:#}"));
+        assert_eq!(
+            loaded.model.pooling(),
+            expected,
+            "{checkpoint}: 1_Pooling/config.json must still decide when --pooling is unset"
+        );
+    }
+}
+
+/// Each mode's own invariant, on a vector a real model produced.
+fn every_normalization_holds_its_invariant() {
+    set_pooling_override(None);
+    let raw = embed(MEAN_CHECKPOINT, None, Some(EmbdNormalize::NONE));
+    assert!(raw.iter().all(|x| x.is_finite()) && l2(&raw) > 0.0);
+
+    // -1 is deterministic and identical to the model's own output.
+    assert_eq!(
+        embed(MEAN_CHECKPOINT, None, Some(EmbdNormalize::NONE)),
+        raw,
+        "-1 must not touch the vector"
+    );
+
+    // 1, 2 and p > 2: the corresponding norm is one.
+    let taxicab = embed(MEAN_CHECKPOINT, None, Some(EmbdNormalize::TAXICAB));
+    assert!((l1(&taxicab) - 1.0).abs() < 1e-4, "L1 is {}", l1(&taxicab));
+    let euclidean = embed(MEAN_CHECKPOINT, None, Some(EmbdNormalize::EUCLIDEAN));
+    assert!(
+        (l2(&euclidean) - 1.0).abs() < 1e-4,
+        "L2 is {}",
+        l2(&euclidean)
+    );
+    let p3 = EmbdNormalize::new(3).expect("in domain");
+    let cubic = embed(MEAN_CHECKPOINT, None, Some(p3));
+    let norm = cubic.iter().map(|x| x.abs().powi(3)).sum::<f32>().cbrt();
+    assert!((norm - 1.0).abs() < 1e-4, "p=3 norm is {norm}");
+
+    // 0: the largest component lands on the int16 bound.
+    let scaled = embed(MEAN_CHECKPOINT, None, Some(EmbdNormalize::MAX_ABS_INT16));
+    assert!(
+        (max_abs(&scaled) - 32760.0).abs() < 1.0,
+        "max-absolute normalization put the largest component at {}",
+        max_abs(&scaled)
+    );
+
+    // Normalization is a rescale, not a rotation: every mode keeps the
+    // direction the model produced, which is what makes cosine similarity
+    // comparable across them.
+    for (kind, v) in [
+        (EmbdNormalize::MAX_ABS_INT16, &scaled),
+        (EmbdNormalize::TAXICAB, &taxicab),
+        (EmbdNormalize::EUCLIDEAN, &euclidean),
+        (p3, &cubic),
+    ] {
+        assert!(
+            cosine(&raw, v) > 0.9999,
+            "{kind} changed the direction of the vector, not just its length"
+        );
+    }
+}
+
+/// `bge-small-en-v1.5` does not set `normalize: false`, so its default is
+/// euclidean and an unqualified request must be byte-identical to an explicit
+/// `2`. This is the assertion that keeps `--embd-normalize` from changing what
+/// every existing deployment already returns.
+fn the_unset_normalization_follows_the_checkpoint_and_matches_euclidean() {
+    set_pooling_override(None);
+    let implicit = embed(CLS_CHECKPOINT, None, None);
+    let explicit = embed(CLS_CHECKPOINT, None, Some(EmbdNormalize::EUCLIDEAN));
+    assert_eq!(implicit, explicit);
+    assert!(
+        (l2(&implicit) - 1.0).abs() < 1e-4,
+        "L2 is {}",
+        l2(&implicit)
+    );
+}
+
+#[test]
+fn a_real_reranker_orders_documents_and_breaks_ties_by_index() {
+    if !have(RERANKER) {
+        return;
+    }
+    let _runtime = initialize_runtime();
+
+    let loaded = load_reranker_with_options(
+        &repo_model_dir(RERANKER),
+        RerankLoadOptions {
+            batch_size: None,
+            max_length: None,
+        },
+    )
+    .unwrap_or_else(|e| panic!("{RERANKER} must load: {e:#}"));
+
+    let query = RerankItem {
+        text: Some("what is a panda?".to_string()),
+        image: None,
+    };
+    let documents: Vec<RerankItem> = [
+        "Berlin is the capital of Germany.",
+        "The giant panda is a bear species endemic to China.",
+        "A list of prime numbers below one hundred.",
+    ]
+    .into_iter()
+    .map(|text| RerankItem {
+        text: Some(text.to_string()),
+        image: None,
+    })
+    .collect();
+
+    let scored = loaded
+        .reranker
+        .score(&query, &documents, None)
+        .unwrap_or_else(|e| panic!("{RERANKER} must score: {e:#}"));
+    assert_eq!(scored.scores.len(), 3);
+    assert!(
+        scored
+            .scores
+            .iter()
+            .all(|s| s.is_finite() && (0.0..=1.0).contains(s)),
+        "scores must be finite probabilities: {:?}",
+        scored.scores
+    );
+    // The panda passage is the relevant one; a reranker that did not read the
+    // query would not put it first.
+    let best = scored
+        .scores
+        .iter()
+        .enumerate()
+        .max_by(|a, b| a.1.total_cmp(b.1))
+        .expect("a best document")
+        .0;
+    assert_eq!(
+        best, 1,
+        "the relevant document must rank first, got {:?}",
+        scored.scores
+    );
+
+    // The route's ordering contract, applied to the real scores: descending by
+    // score, ties by ascending index.
+    let mut ordered: Vec<usize> = (0..scored.scores.len()).collect();
+    ordered.sort_by(|&a, &b| {
+        scored.scores[b]
+            .total_cmp(&scored.scores[a])
+            .then(a.cmp(&b))
+    });
+    assert_eq!(
+        ordered[0], 1,
+        "ordering: {ordered:?} for {:?}",
+        scored.scores
+    );
+}


### PR DESCRIPTION
## Summary

Lands issue #1452's embedding and reranking surface: the four b10621 mode and shaping options, the two rerank response envelopes, the aligned request errors, and a resolved-capability report on `/props` and `/v1/models`. Six of the ten manifest entries this issue owns flip to `supported`; the four option entries stay `deferred` with their divergences recorded, so this PR does not close the issue.

## What changed

- `src/cli/embedding_compat_args.rs` (new): `--embedding` / `--embeddings`, `--rerank` / `--reranking`, `--pooling` and `--embd-normalize`, defined once and flattened into both server binaries. `LLAMA_ARG_EMBEDDINGS` and `LLAMA_ARG_RERANKING` are read through b10621's own truthy set (`on`, `enabled`, `true`, `1`) rather than clap's boolish parser, which both accepts more and errors outside its vocabulary; `LLAMA_ARG_POOLING` binds through clap because it takes a value.
- `src/embeddings/normalize.rs` (new): b10621's whole `--embd-normalize` domain with upstream's arithmetic, including its `norm = sum > 0 ? 1/sum : 0` rule so a zero vector normalizes to zeros rather than to a NaN the route would refuse with a 500. `2` delegates to the existing L2 kernel, so the default path is numerically unchanged.
- `src/embeddings/pooling.rs`: a process-wide override cell for `--pooling`, installed at startup before any checkpoint loads, because every family resolves its mode inside its own constructor and carries no server context. Precedence is flag, then `MLXCEL_EMBEDDING_POOLING`, then `1_Pooling/config.json`, then the family default.
- `src/embeddings/engine.rs`: `EmbedOptions` carries the normalization, and post-processing applies it (and re-applies it after a `dimensions` truncation, which breaks whatever invariant the first pass established).
- `src/embeddings/model.rs` and nine families: a `pooling()` accessor returning the mode that was really resolved, so `/props` reports what happened rather than the family default.
- `src/server/config.rs`: `EmbeddingServingMode`, the restriction half of the two mode flags, and the resolved `embd_normalize`.
- `src/server/startup.rs`: installs the pooling override, then refuses a mode flag that resolved no worker able to serve it.
- `src/server/routes/mod.rs`: generation routes answer 501 naming the mode flag, even when a chat model is loaded next to the side model.
- `src/server/types/rerank.rs`, `routes/rerank.rs`: `object: "list"` on the Jina envelope, b10621's TEI array for a `texts` request, `return_text` / `text`, and upstream's wording for the three shape errors. A body carrying both list spellings drops the redundant one and stays on the Jina envelope, because serde would otherwise reject it as a duplicate field where upstream reads one and ignores the other.
- `src/server/routes/embeddings.rs`: the per-request `embd_normalize`, and `"input" or "content" must be provided` for a body carrying neither.
- `src/server/routes/props.rs`, `models.rs`: the resolved capability block and the per-entry `capabilities` array.
- `src/commands/embed.rs`: `--pooling` and `--embd-normalize` on the offline path too, so it resolves identically to the server it documents itself against.
- `src/server/routes/health.rs`: a server in one of the two modes reports on the worker the mode selected. It has no chat worker to be "loaded", so `/health` answered `503 {"status": "loading model"}` for the life of the process, which would have made the flag unusable behind a container probe. Scoped to the flags: a server whose `-m` is an embedding checkpoint but that was started without them is unchanged, so `GET /health`'s recorded divergences and its manifest entry stay #1440's.

## Why the four option entries are still `deferred`

Each is implemented and tested; each has one observable difference recorded on its manifest entry.

- `--embedding` and `--rerank`: mlxcel additionally requires a checkpoint that can serve the mode, and fails at startup when none resolves. b10621 restricts whatever `-m` loaded and embeds or scores with it, and mlxcel has no path that produces embeddings from a causal chat checkpoint. `--reranking` also leaves `/v1/embeddings` answering upstream, where a mlxcel server in rerank mode has no embedding worker.
- `--pooling`: `none` is refused rather than served, because every embedding family pools inside its forward pass and there is no unpooled hidden state left to return; `rank` selects the reranking worker rather than becoming a pooling type.
- `--embd-normalize`: with the flag unset mlxcel follows the checkpoint's own `normalize` flag, which is euclidean for every checkpoint that does not set it and none for one that sets it to `false`. b10621 always defaults to `2`, because GGUF carries no such metadata.

## One observation worth recording

`bge-small-en-v1.5` returns the same vector for `--pooling cls` and `--pooling last`, to 1.3e-5 relative. That is the checkpoint, not the pooling: `all-MiniLM-L6-v2` separates the two by 0.90 through the identical code path, the `pool()` kernel's last-token index is unit-tested against right padding, left padding and an all-padding row, and the coincidence reproduces on two unrelated prompts and through the offline `mlxcel embed` path. A BERT trained with CLS pooling collapses its `[SEP]` representation onto `[CLS]`. The real-checkpoint test asserts `mean` against each single-position mode on both checkpoints, and `cls` against `last` only where the two positions are known to differ, so it still fails if the override stops reaching the forward pass.

## Test plan

- [x] `cargo test --profile test-fast --features metal,accelerate --lib -- embeddings::normalize embeddings::pooling cli::embedding_compat server::routes::embedding_rerank_mode server::routes::embeddings server::routes::rerank server::routes::props server::routes::models server::routes::health server::startup server::llama_compat`: 185 passed.
- [x] `cargo test --test embedding_pooling_normalize_real --profile test-fast --features metal,accelerate`: every pooling and normalization path over `all-MiniLM-L6-v2` (mean pooling), `bge-small-en-v1.5` (cls pooling) and the `ms-marco-MiniLM-L6-v2` cross-encoder.
- [x] `python3 scripts/ci/check_llama_compat_manifest.py` and `bash scripts/ci/check_llama_compat_manifest_test.sh`
- [x] `cargo fmt --all -- --check` and `cargo clippy --lib --tests --features metal,accelerate -- -D warnings`
- [x] Live server, `mlxcel-server` against the two real checkpoints:
  - `--embeddings --pooling cls --embd-normalize 1` over `all-MiniLM-L6-v2`: `/props` reported `{"generation": false, "serving_mode": "--embeddings", "embedding": {"pooling": "cls", "embd_normalize": 1, ...}}`, `/v1/models` labelled the entry `["embedding"]`, both embedding shapes served, and `/v1/chat/completions` and `/completion` answered 501 naming the flag.
  - `--reranking` over `ms-marco-MiniLM-L6-v2`: `documents` answered `{"model", "object": "list", "results": [{"index", "relevance_score", "document"}], "usage"}` and `texts` answered `[{"index", "score", "text"}]` on the same query, with the panda passage first at 0.9985 against 0.0000149 for the distractor; generation and `/v1/embeddings` answered 501.
  - `--pooling rank` selected the same reranking mode.
  - `--pooling none`, `--embd-normalize -2`, `--embeddings` on a reranker checkpoint and `--reranking` on an embedding checkpoint each failed at startup with their diagnostic.
  - `LLAMA_ARG_EMBEDDINGS=1 LLAMA_ARG_POOLING=mean` alone started the server and logged the pooling override, so the runtime environment bridge works without any command line.

Refs #1452
