### PR TITLE
fix(server): give the image cardinality route test a model that takes images

### DIFF
--- a/src/server/max_tokens_route_tests.rs
+++ b/src/server/max_tokens_route_tests.rs
@@ -9,6 +9,7 @@ use tower::ServiceExt;
 use super::{
     AppState, ChatTemplateProcessor, ModelProvider, ServerConfig, ServerGenerateOptions, create_app,
 };
+use crate::server::state::ModelMediaSupport;
 use crate::tokenizer::MlxcelTokenizer;
 
 fn route_test_app(config: ServerConfig) -> (axum::Router, mpsc::Receiver<ServerGenerateOptions>) {
@@ -30,16 +31,38 @@ fn route_test_app_with_provider(
     config: ServerConfig,
     provider: Arc<ModelProvider>,
 ) -> axum::Router {
+    create_app(route_test_state(config, provider))
+}
+
+/// Same app, but the loaded model declares it can consume images.
+///
+/// `AppState::new` defaults `media_support` to the all-refusing set, which is
+/// correct for a text-only checkpoint: since #1451 the modality gate refuses an
+/// `image_url` part with 501 `not_supported_error` *before* anything reads the
+/// referenced URL or file. A test that wants to reach the per-request image
+/// checks behind that gate has to say the model could process an image in the
+/// first place, otherwise it only ever exercises the gate.
+fn route_test_app_with_image_support(
+    config: ServerConfig,
+    provider: Arc<ModelProvider>,
+) -> axum::Router {
+    let state = route_test_state(config, provider).with_media_support(ModelMediaSupport {
+        image: true,
+        ..ModelMediaSupport::default()
+    });
+    create_app(state)
+}
+
+fn route_test_state(config: ServerConfig, provider: Arc<ModelProvider>) -> AppState {
     let batch_metrics = provider.batch_metrics().clone();
-    let state = AppState::new(
+    AppState::new(
         provider,
         config,
         ChatTemplateProcessor::with_template("ok".to_string()),
         MlxcelTokenizer::stub(),
         PathBuf::from("route-test-model"),
         batch_metrics,
-    );
-    create_app(state)
+    )
 }
 
 async fn post_json(app: axum::Router, path: &str, body: Value) -> StatusCode {
@@ -245,7 +268,7 @@ fn route_image_cardinality_rejection_does_not_poison_same_worker() {
                     let (options_tx, options_rx) = mpsc::channel();
                     let provider =
                         Arc::new(ModelProvider::recording_for_route_tests(options_tx));
-                    let app = route_test_app_with_provider(capped_config(), provider);
+                    let app = route_test_app_with_image_support(capped_config(), provider);
 
                     let bad = json!({
                         "model": "route-test-model",


### PR DESCRIPTION
`route_image_cardinality_rejection_does_not_poison_same_worker` asserted HTTP 400 and got 501 after #1451, which turned `main` red.

The status change is correct and deliberate. #1451 added a modality gate: a checkpoint that cannot consume an `image_url` part now refuses it with b10621's own `image input is not supported` wording at HTTP 501 `not_supported_error`, before anything reads the referenced URL or file. Before that gate a text-only checkpoint accepted the part, dropped it inside `prepare_request_vlm_embeddings`, and answered from the text alone, so a caller could not tell an ignored image from a described one.

The test was the stale side. `AppState::new` defaults `media_support` to the all-refusing set, which is right for a text-only checkpoint, so the request never reached the per-request cardinality check the test is named for: it only ever exercised the new gate. A `route_test_app_with_image_support` builder now declares that the loaded model could process an image, which puts the test back on the path it is about, and the 400 assertion holds again for the reason it originally held.

The gate itself keeps its own coverage in `src/server/media_tests.rs`, which asserts the 501 status, the `not_supported_error` type and the `image input is not supported` and `audio input is not supported` wording, so this change hides nothing.

Found by the orchestrator's full `make verify` on merged `main`, not by the implementing chain: the test lives in `server::max_tokens_route_tests`, outside the `server::routes` selector that chain ran under the sub-agent watchdog budget.


## Verification

`make verify` on this change: exit 0, 111 binaries, 9483 passed, 0 failed, 319 ignored. Before it, the same gate on merged `main` reported 1 failed. Narrow re-run after rebasing onto `0309f5cf5`: `--lib server::max_tokens_route_tests` 7 passed, plus `--lib server::routes` 268 and `--lib server::media` 66 to confirm the modality gate keeps its own coverage.

Part of #1431.
