### PR TITLE
feat(server): add Vertex AI (GCP) predict route adapter for b10621

### DIFF
--- a/compat/llama-server/b10621/ui-tools-mcp-gcp.json
+++ b/compat/llama-server/b10621/ui-tools-mcp-gcp.json
@@ -258,12 +258,14 @@
       "source": "tools/server/server-http.cpp",
       "condition": "gcp-compat (AIP_MODE=PREDICTION; registered only when AIP_HEALTH_ROUTE is set)",
       "discovery": "source-gcp-compat",
-      "state": "deferred",
+      "state": "supported",
       "issue": 1456,
-      "test": null,
-      "notes": null,
+      "test": "src/server/gcp_compat_tests.rs::health_alias_mounts_at_a_custom_path_and_skips_collisions",
+      "notes": "Implemented (#1456): with AIP_MODE=PREDICTION and AIP_HEALTH_ROUTE set, the value (leading slash ensured) is mounted as a GET alias of the health handler. As in b10621 the alias is not in the public endpoint set, so with API keys configured it requires a key. An alias naming an already-registered path is skipped: upstream registers a duplicate httplib handler that never matches, so the observable behavior (the existing route answers) is identical.",
       "divergence": [],
-      "mlxcel": null
+      "mlxcel": {
+        "route": "GET ${AIP_HEALTH_ROUTE}"
+      }
     },
     {
       "kind": "route",
@@ -318,12 +320,14 @@
       "source": "tools/server/server-http.cpp",
       "condition": "gcp-compat (AIP_MODE=PREDICTION; path from AIP_PREDICT_ROUTE)",
       "discovery": "source-gcp-compat",
-      "state": "deferred",
+      "state": "supported",
       "issue": 1456,
-      "test": null,
-      "notes": null,
+      "test": "src/server/gcp_compat_tests.rs::predict_fans_out_and_returns_predictions_in_request_order",
+      "notes": "Implemented (#1456): with AIP_MODE=PREDICTION, the predict route (default /predict, leading slash ensured, startup refused on collision with a registered route) fans the instances array (cap 128, upstream's envelope 400s verbatim) out over the camelCase alias of every registered route, built from the same route inventory the router mounts, with direct registered paths accepted too. @requestFormat is stripped, a client stream field is forced false with a warning, per-instance failures become an error object in that slot, and predictions return in request order. Each instance dispatches through the composed router in-process, so authentication, validation, and queue admission apply exactly as on a direct call; AIP_HTTP_PORT (default 8080) overrides --port with upstream's warning. Two internals differ without changing any response: instance concurrency is bounded to 8 at a time (upstream launches all at once, order is preserved either way), and alias collisions such as completions (/completions vs /v1/completions) resolve deterministically to the /v1 route in registration order, where upstream's iteration over an unordered map leaves its winner unspecified.",
       "divergence": [],
-      "mlxcel": null
+      "mlxcel": {
+        "route": "POST ${AIP_PREDICT_ROUTE:-/predict}"
+      }
     },
     {
       "kind": "route",

--- a/docs/environment-variables.md
+++ b/docs/environment-variables.md
@@ -87,6 +87,19 @@ The b10621 GGML runtime options (`--n-gpu-layers`, `--split-mode`, `--mlock`, `-
 
 `LLAMA_ARG_CACHE_REUSE` is an integer minimum reuse chunk size in llama-server, not a prompt-cache enable switch. mlxcel accepts `0` without changing prompt-cache enablement and rejects positive values with an unsupported-setting error. Use `MLXCEL_PROMPT_CACHE_ENABLED` to enable or disable the cache.
 
+## Google Cloud Vertex AI variables (#1456)
+
+Both server entry points implement llama-server b10621's Vertex AI custom-container compatibility, driven purely by the `AIP_*` environment variables Google's platform sets ([custom-container requirements](https://docs.cloud.google.com/vertex-ai/docs/predictions/custom-container-requirements#aip-variables)). With `AIP_MODE` unset (or any value other than `PREDICTION`), nothing is registered and the other variables are ignored.
+
+| Variable | Default | Effect with `AIP_MODE=PREDICTION` |
+|----------|---------|-----------------------------------|
+| `AIP_MODE` | unset | `PREDICTION` (case-sensitive) enables the adapter. |
+| `AIP_HTTP_PORT` | `8080` | Overrides `--port`; a warning is logged when the two differ. An unparsable value fails startup with a diagnostic. |
+| `AIP_HEALTH_ROUTE` | unset | When set, mounted (leading slash ensured) as a GET alias of the health handler. Like the predict route, it is not a public endpoint: with API keys configured it requires a key, as in b10621. |
+| `AIP_PREDICT_ROUTE` | `/predict` | The prediction route (leading slash ensured). Startup fails when it collides with a registered API route. |
+
+`POST` on the predict route takes `{"instances": [{"@requestFormat": "chatCompletions", ...}, ...]}` (at most 128 instances) and answers `{"predictions": [...]}` in request order. `@requestFormat` names the camelCase alias of any registered route (`chatCompletions`, `completions`, `embeddings`, `rerank`, `messages`, `tokenize`, ...) or a registered path verbatim; the field is stripped and the remainder is dispatched through the ordinary handler in-process, so authentication and validation apply exactly as on a direct call. A `stream` field is forced off with a warning, and a per-instance failure becomes an error object in that slot rather than failing the batch. See [`llama-server-compat.md`](llama-server-compat.md) for the manifest entries.
+
 ## Common runtime variables
 
 | Variable | Values | Default | Notes |

--- a/docs/llama-server-compat.md
+++ b/docs/llama-server-compat.md
@@ -175,6 +175,16 @@ The OpenAI Responses retrieve/cancel surface (`GET /v1/responses/:id`, `POST /v1
 
 `GET /metrics` opens with the b10621 `llamacpp:` counter and gauge families name-for-name, carries the `Process-Start-Time-Unix` header, and averages the throughput gauges over the window between two scrapes, so a Prometheus scrape config written for llama-server works unchanged; the `mlxcel_` families follow in the same body. `--sleep-idle-seconds` remains deferred: mlxcel has no idle-sleep lifecycle yet, and `/props` truthfully reports `is_sleeping: false`.
 
+### Vertex AI (GCP) custom-container compatibility (#1456)
+
+b10621 serves Google Cloud Vertex AI custom containers purely from the `AIP_*` environment variables, and mlxcel now does the same on both server binaries. With `AIP_MODE=PREDICTION`: `AIP_HTTP_PORT` (default 8080) overrides `--port` with a logged warning, `AIP_HEALTH_ROUTE` (leading slash ensured) becomes a GET alias of the health handler, and `AIP_PREDICT_ROUTE` (default `/predict`) mounts the prediction fan-out; a predict path colliding with a registered route fails startup before the model load. With `AIP_MODE` unset nothing is registered and the variables are inert.
+
+`POST /predict` accepts `{"instances": [...]}` with at most 128 entries. Each instance names its target in `@requestFormat`, either the camelCase alias of a registered route (`chatCompletions`, `embeddings`, `applyTemplate`, ...) or a registered path verbatim; the field is stripped, a `stream` field is forced off with a warning, and the remainder is dispatched through the composed router in-process with the predict request's own headers, so API-key authentication, request validation, and queue admission apply exactly as they do to a direct call. Results come back as `{"predictions": [...]}` in request order, with per-instance failures as error objects in their slots. The alias table is derived from the same route inventory the router itself mounts, so a newly added route is aliased automatically.
+
+Two internals differ without changing any response, and are recorded in the manifest notes rather than as divergences: instance execution is bounded to eight concurrent dispatches (upstream launches every instance at once; order is preserved either way), and alias collisions such as `completions` (`/completions` native vs `/v1/completions` OpenAI) resolve deterministically to the `/v1` route by registration order, where upstream iterates an unordered map and its winner is unspecified. Neither the predict route nor the health alias is a public endpoint, exactly as in b10621: with API keys configured, Vertex AI must present the key.
+
+The `AIP_*` variables are documented in [`environment-variables.md`](environment-variables.md).
+
 ## Sharding
 
 The manifest is sharded by area so that the concurrent implementation chains of epic #1431 edit disjoint files. Ownership is machine-readable, not prose: `pin.json`'s `shards` map records, per shard, the set of implementation issue numbers allowed to own entries in it (`shards["authentication"].owners == [1437]`, for example), and `scripts/ci/check_llama_compat_manifest.py` fails an entry whose `issue` is not a member of its own shard's owner set. That is what stops two concurrent chains from editing the same file: the file, not just the reviewer, rejects the second chain's entry.

--- a/src/server/app.rs
+++ b/src/server/app.rs
@@ -18,10 +18,10 @@ use axum::{
     Router,
     body::Body,
     extract::{DefaultBodyLimit, State},
-    http::Request,
+    http::{Method, Request},
     middleware::{self, Next},
     response::Response,
-    routing::{get, post},
+    routing::{MethodRouter, get, post},
 };
 use tower_http::trace::TraceLayer;
 
@@ -101,7 +101,9 @@ pub fn create_app(state: AppState) -> Router {
         Router::new().nest(&api_prefix, routes)
     };
 
-    routes
+    let gcp_enabled = state.config.gcp.is_some();
+    let dispatch_cell = state.gcp_dispatch.clone();
+    let app = routes
         // Middleware, innermost first.
         .layer(middleware::from_fn_with_state(state.clone(), api_key_auth))
         .layer(middleware::from_fn_with_state(
@@ -109,79 +111,164 @@ pub fn create_app(state: AppState) -> Router {
             cors_middleware,
         ))
         .layer(TraceLayer::new_for_http())
-        .with_state(state)
+        .with_state(state);
+    // Vertex AI predict adapter (#1456): hand the predict handler the same
+    // composed router the socket serves, so per-instance dispatch runs the
+    // full middleware stack (auth, CORS, tracing) in-process.
+    if gcp_enabled {
+        let _ = dispatch_cell.set(app.clone());
+    }
+    app
 }
 
-/// Register every route, without middleware and without the API prefix.
-fn build_routes(_state: &AppState) -> Router<AppState> {
-    // Audio upload endpoints carry a larger body limit via a sub-router.
-    // Merging keeps the outer auth, CORS, and trace layers applying normally.
-    let audio_routes: Router<AppState> = Router::new()
-        .route("/v1/audio/speech", post(routes::audio_speech))
-        .route(
-            "/v1/audio/transcriptions",
-            post(routes::audio_transcriptions),
-        )
-        .route("/v1/audio/translations", post(routes::audio_translations))
-        .route("/audio/speech", post(routes::audio_speech))
-        .route("/audio/transcriptions", post(routes::audio_transcriptions))
-        .route("/audio/translations", post(routes::audio_translations))
-        .layer(DefaultBodyLimit::max(AUDIO_MAX_UPLOAD_BYTES));
+/// One entry of the route inventory: the path, the `MethodRouter` mounted
+/// there, and the method the Vertex AI predict adapter dispatches with
+/// (#1456). The inventory is the single source [`build_routes`] mounts from
+/// and [`crate::server::gcp_compat::dispatch_table`] derives the camelCase
+/// alias table from, so a route added here is automatically served, aliased,
+/// and considered by the `AIP_PREDICT_ROUTE` collision check. Registration
+/// order is alias priority: the first path producing a given alias wins,
+/// which is why the OpenAI `/v1` routes come first.
+pub(crate) struct RouteRegistration {
+    pub(crate) path: &'static str,
+    /// Method the predict adapter uses when dispatching to this path (the
+    /// registered method; POST preferred when a path serves several).
+    pub(crate) dispatch_method: Method,
+    pub(crate) handler: MethodRouter<AppState>,
+}
 
-    let mut app = Router::new()
+fn reg(
+    path: &'static str,
+    dispatch_method: Method,
+    handler: MethodRouter<AppState>,
+) -> RouteRegistration {
+    RouteRegistration {
+        path,
+        dispatch_method,
+        handler,
+    }
+}
+
+/// The full route table, in registration (= alias priority) order.
+///
+/// Keep every `.route()` of the server in here: [`build_routes`] mounts
+/// exactly this list, so a route bypassing the inventory would not exist.
+pub(crate) fn route_inventory(_config: &crate::server::ServerConfig) -> Vec<RouteRegistration> {
+    let audio_limit = DefaultBodyLimit::max(AUDIO_MAX_UPLOAD_BYTES);
+    let mut inventory = vec![
         // OpenAI API endpoints
-        .route("/v1/chat/completions", post(routes::chat_completions))
+        reg(
+            "/v1/chat/completions",
+            Method::POST,
+            post(routes::chat_completions),
+        ),
         // b10621 realtime control of a live completion (#1444).
-        .route(
+        reg(
             "/v1/chat/completions/control",
+            Method::POST,
             post(routes::chat_completions_control),
-        )
+        ),
         // b10621 resumable-stream lifecycle (#1444): replay, discovery, and
         // stop for streaming completions that carried `X-Conversation-Id`.
-        .route(
+        reg(
             "/v1/stream",
+            Method::GET,
             get(routes::stream_get).delete(routes::stream_delete),
-        )
-        .route("/v1/streams/lookup", post(routes::streams_lookup))
-        .route("/v1/completions", post(routes::completions))
-        .route("/v1/models", get(routes::list_models))
+        ),
+        reg(
+            "/v1/streams/lookup",
+            Method::POST,
+            post(routes::streams_lookup),
+        ),
+        reg("/v1/completions", Method::POST, post(routes::completions)),
+        reg("/v1/models", Method::GET, get(routes::list_models)),
         // Embeddings (OpenAI /v1/embeddings surface), served by the embedding
         // worker when one is loaded; a structured 501 otherwise.
-        .route("/v1/embeddings", post(routes::create_embeddings))
+        reg(
+            "/v1/embeddings",
+            Method::POST,
+            post(routes::create_embeddings),
+        ),
         // Reranking (Cohere / Jina compatible surface), served by the rerank
         // worker when one is loaded; a structured 501 otherwise.
-        .route("/v1/rerank", post(routes::create_rerank))
-        .route("/v1/reranking", post(routes::create_rerank))
+        reg("/v1/rerank", Method::POST, post(routes::create_rerank)),
+        reg("/v1/reranking", Method::POST, post(routes::create_rerank)),
         // Responses API (OpenAI /v1/responses surface).
-        .route("/v1/responses", post(routes::create_response))
-        .route(
+        reg("/v1/responses", Method::POST, post(routes::create_response)),
+        reg(
             "/v1/responses/:id",
+            Method::GET,
             get(routes::retrieve_response).delete(routes::delete_response),
-        )
-        .route("/v1/responses/:id/cancel", post(routes::cancel_response))
+        ),
+        reg(
+            "/v1/responses/:id/cancel",
+            Method::POST,
+            post(routes::cancel_response),
+        ),
         // Anthropic Messages API (/v1/messages surface).
-        .route("/v1/messages", post(routes::anthropic_messages))
-        .route(
+        reg(
+            "/v1/messages",
+            Method::POST,
+            post(routes::anthropic_messages),
+        ),
+        reg(
             "/v1/messages/count_tokens",
+            Method::POST,
             post(routes::anthropic_count_tokens),
-        )
-        // prompt-cache observability endpoints (always mounted
-        // the handlers return a stable "disabled" payload when the cache is
-        // off so monitoring clients can poll without conditional logic).
-        .route("/v1/cache/stats", get(routes::cache_stats))
-        .route("/v1/cache/reset", post(routes::cache_reset))
+        ),
+        // prompt-cache observability endpoints (always mounted; the handlers
+        // return a stable "disabled" payload when the cache is off so
+        // monitoring clients can poll without conditional logic).
+        reg("/v1/cache/stats", Method::GET, get(routes::cache_stats)),
+        reg("/v1/cache/reset", Method::POST, post(routes::cache_reset)),
         // Adaptive B=1 MTP policy state (issue #1257). Always mounted, and
         // returns a well-formed "unavailable" payload when no policy is
-        // running, for the same reason the cache endpoints do: a consumer must
-        // be able to tell "nothing to report" from "this server does not
-        // answer". It is the supported replacement for reading the private
-        // hint files under the mlxcel cache root.
-        .route("/v1/internal/mtp-policy", get(routes::mtp_policy))
-        // Audio routes (speech, transcriptions, translations) come from the
-        // sub-router that carries the larger body-limit layer.
-        .merge(audio_routes)
+        // running: a consumer must be able to tell "nothing to report" from
+        // "this server does not answer". It is the supported replacement for
+        // reading the private hint files under the mlxcel cache root.
+        reg(
+            "/v1/internal/mtp-policy",
+            Method::GET,
+            get(routes::mtp_policy),
+        ),
+        // Audio endpoints carry a larger per-route body limit because real
+        // audio uploads commonly exceed the Axum 2 MiB default.
+        reg(
+            "/v1/audio/speech",
+            Method::POST,
+            post(routes::audio_speech).layer(audio_limit),
+        ),
+        reg(
+            "/v1/audio/transcriptions",
+            Method::POST,
+            post(routes::audio_transcriptions).layer(audio_limit),
+        ),
+        reg(
+            "/v1/audio/translations",
+            Method::POST,
+            post(routes::audio_translations).layer(audio_limit),
+        ),
+        reg(
+            "/audio/speech",
+            Method::POST,
+            post(routes::audio_speech).layer(audio_limit),
+        ),
+        reg(
+            "/audio/transcriptions",
+            Method::POST,
+            post(routes::audio_transcriptions).layer(audio_limit),
+        ),
+        reg(
+            "/audio/translations",
+            Method::POST,
+            post(routes::audio_translations).layer(audio_limit),
+        ),
         // Aliases (some clients use these)
-        .route("/chat/completions", post(routes::chat_completions))
+        reg(
+            "/chat/completions",
+            Method::POST,
+            post(routes::chat_completions),
+        ),
         // BREAKING (#1441): `/completions` and `/embeddings` are llama-server
         // NATIVE routes, not OpenAI aliases. b10621 sends `/completion` and
         // `/completions` to one handler and `/v1/completions` to a different
@@ -189,52 +276,71 @@ fn build_routes(_state: &AppState) -> Router<AppState> {
         // `/v1/embeddings`. mlxcel used to answer the OpenAI shape on all of
         // them, so a llama-server client reading the native schema got an
         // object it could not parse.
-        .route("/completions", post(routes::native_completion))
-        .route("/models", get(routes::list_models))
-        .route("/embedding", post(routes::native_embeddings))
-        .route("/embeddings", post(routes::native_embeddings))
-        .route("/rerank", post(routes::create_rerank))
-        .route("/reranking", post(routes::create_rerank))
-        .route("/responses", post(routes::create_response))
-        .route(
+        reg(
+            "/completions",
+            Method::POST,
+            post(routes::native_completion),
+        ),
+        reg("/models", Method::GET, get(routes::list_models)),
+        reg("/embedding", Method::POST, post(routes::native_embeddings)),
+        reg("/embeddings", Method::POST, post(routes::native_embeddings)),
+        reg("/rerank", Method::POST, post(routes::create_rerank)),
+        reg("/reranking", Method::POST, post(routes::create_rerank)),
+        reg("/responses", Method::POST, post(routes::create_response)),
+        reg(
             "/responses/:id",
+            Method::GET,
             get(routes::retrieve_response).delete(routes::delete_response),
-        )
-        .route("/responses/:id/cancel", post(routes::cancel_response))
-        .route("/messages", post(routes::anthropic_messages))
-        .route(
+        ),
+        reg(
+            "/responses/:id/cancel",
+            Method::POST,
+            post(routes::cancel_response),
+        ),
+        reg("/messages", Method::POST, post(routes::anthropic_messages)),
+        reg(
             "/messages/count_tokens",
+            Method::POST,
             post(routes::anthropic_count_tokens),
-        )
+        ),
         // llama-server compatible endpoints
-        .route("/completion", post(routes::native_completion))
-        .route("/tokenize", post(routes::tokenize))
-        .route("/detokenize", post(routes::detokenize))
+        reg("/completion", Method::POST, post(routes::native_completion)),
+        reg("/tokenize", Method::POST, post(routes::tokenize)),
+        reg("/detokenize", Method::POST, post(routes::detokenize)),
         // Fill-in-the-middle. Mounted unconditionally, like every other route:
         // whether the loaded model can serve it is a property of its
         // vocabulary, and the handler answers 501 naming the missing FIM
         // tokens rather than 404, so a client can tell "this server does not
         // implement infill" from "this model cannot do it" (#1442).
-        .route("/infill", post(routes::infill))
+        reg("/infill", Method::POST, post(routes::infill)),
         // Prompt inspection: render or count a prompt without generating from
         // it (#1442).
-        .route("/apply-template", post(routes::apply_template))
-        .route(
+        reg(
+            "/apply-template",
+            Method::POST,
+            post(routes::apply_template),
+        ),
+        reg(
             "/chat/completions/input_tokens",
+            Method::POST,
             post(routes::chat_input_tokens),
-        )
-        .route(
+        ),
+        reg(
             "/v1/chat/completions/input_tokens",
+            Method::POST,
             post(routes::chat_input_tokens),
-        )
-        .route(
+        ),
+        reg(
             "/responses/input_tokens",
+            Method::POST,
             post(routes::responses_input_tokens),
-        )
-        .route(
+        ),
+        reg(
             "/v1/responses/input_tokens",
+            Method::POST,
             post(routes::responses_input_tokens),
-        );
+        ),
+    ];
 
     // b10621 mounts /props, /slots, /metrics and the slot actions
     // unconditionally and answers its own diagnostics when a gate is off
@@ -242,17 +348,59 @@ fn build_routes(_state: &AppState) -> Router<AppState> {
     // --slots gates GET /slots, --metrics gates GET /metrics, and
     // --slot-save-path gates POST /slots/:id_slot. The handlers own those
     // gates so a disabled surface answers upstream's 501 instead of a 404.
-    app = app
-        .route("/props", get(routes::props).post(routes::post_props))
-        .route("/slots", get(routes::slots))
-        .route("/slots/:id_slot", post(routes::slot_action))
-        .route("/metrics", get(routes::metrics));
+    inventory.push(reg(
+        "/props",
+        Method::POST,
+        get(routes::props).post(routes::post_props),
+    ));
+    inventory.push(reg("/slots", Method::GET, get(routes::slots)));
+    inventory.push(reg(
+        "/slots/:id_slot",
+        Method::POST,
+        post(routes::slot_action),
+    ));
+    inventory.push(reg("/metrics", Method::GET, get(routes::metrics)));
+
+    // Health check
+    inventory.push(reg("/health", Method::GET, get(routes::health_check)));
+    inventory.push(reg("/v1/health", Method::GET, get(routes::health_check)));
+    inventory.push(reg("/", Method::GET, get(routes::health_check)));
+    inventory
+}
+
+/// Register every route, without middleware and without the API prefix.
+fn build_routes(state: &AppState) -> Router<AppState> {
+    let mut app = Router::new();
+    let mut mounted: Vec<&'static str> = Vec::new();
+    for entry in route_inventory(&state.config) {
+        mounted.push(entry.path);
+        app = app.route(entry.path, entry.handler);
+    }
+
+    // Vertex AI (GCP) compat routes (#1456): resolved once at startup from
+    // the AIP_* variables into `config.gcp`; `None` (the default) mounts
+    // nothing. Registered inside the middleware stack, so the predict route
+    // and the health alias require an API key exactly as upstream's do
+    // (neither is in b10621's public endpoint set).
+    if let Some(gcp) = state.config.gcp.as_ref() {
+        if let Some(health_alias) = gcp
+            .path_health
+            .as_deref()
+            .filter(|alias| !mounted.contains(alias))
+        {
+            // A health alias naming an already-registered path is skipped:
+            // upstream registers a duplicate httplib handler that never
+            // matches, so the observable behavior (the existing route
+            // answers) is the same.
+            app = app.route(health_alias, get(routes::health_check));
+        }
+        // Startup refused a colliding AIP_PREDICT_ROUTE before the model
+        // load (`gcp_compat::check_predict_collision`); a collision here
+        // would panic in axum's route registration.
+        app = app.route(&gcp.path_predict, post(crate::server::gcp_compat::predict));
+    }
 
     app
-        // Health check
-        .route("/health", get(routes::health_check))
-        .route("/v1/health", get(routes::health_check))
-        .route("/", get(routes::health_check))
 }
 
 #[cfg(test)]

--- a/src/server/config.rs
+++ b/src/server/config.rs
@@ -363,6 +363,10 @@ impl EmbeddingServingMode {
 /// so route handlers can apply one consistent set of defaults.
 #[derive(Debug, Clone)]
 pub struct ServerConfig {
+    /// Vertex AI (GCP) custom-container compat routes (b10621, #1456).
+    /// Resolved once at startup from `AIP_MODE=PREDICTION` and the other
+    /// `AIP_*` variables; `None` (the default) mounts nothing.
+    pub gcp: Option<crate::server::gcp_compat::GcpRoutes>,
     /// Where a model's thoughts are reported (b10621 `--reasoning-format` /
     /// `LLAMA_ARG_THINK`, issue #1447).
     pub reasoning_format: crate::server::ReasoningFormat,
@@ -755,6 +759,7 @@ pub struct ServerConfig {
 impl Default for ServerConfig {
     fn default() -> Self {
         Self {
+            gcp: None,
             reasoning_format: crate::server::ReasoningFormat::default(),
             skip_chat_parsing: false,
             no_prefill_assistant: false,

--- a/src/server/gcp_compat.rs
+++ b/src/server/gcp_compat.rs
@@ -1,0 +1,404 @@
+// Copyright 2025-2026 Lablup Inc. and Jeongkyu Shin
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Google Cloud Vertex AI custom-container compatibility (b10621, #1456).
+//!
+//! b10621 registers this surface purely from environment variables (upstream
+//! <https://github.com/ggml-org/llama.cpp/blob/main/tools/server/server-http.cpp>,
+//! `gcp_params` and `register_gcp_compat`): with `AIP_MODE=PREDICTION`, the
+//! server serves `AIP_HTTP_PORT` (default 8080, overriding `--port` with a
+//! warning), optionally registers `AIP_HEALTH_ROUTE` as a GET alias of the
+//! health handler, and mounts `AIP_PREDICT_ROUTE` (default `/predict`), which
+//! fans a `{"instances": [{"@requestFormat": "chatCompletions", ...}]}` batch
+//! out over the camelCase alias of every registered route and answers
+//! `{"predictions": [...]}` in request order. Without `AIP_MODE=PREDICTION`
+//! nothing is registered and the other variables are ignored.
+//!
+//! mlxcel implements the same adapter over its real route table:
+//!
+//! - The alias table derives from [`crate::server::app::route_inventory`],
+//!   the single source the router itself is built from, so a route added
+//!   there is aliased automatically. First registration wins on an alias
+//!   collision, which in mlxcel's deterministic registration order resolves
+//!   `completions` and `embeddings` to the OpenAI `/v1` handlers (upstream
+//!   iterates an unordered map, so its winner on those collisions is
+//!   unspecified).
+//! - Each instance is dispatched through the composed router in-process
+//!   (`tower::ServiceExt::oneshot` against the same app the socket serves),
+//!   with the predict request's own headers, so API-key authentication,
+//!   validation, and queue admission apply exactly as they do to a direct
+//!   call of the aliased route.
+//! - Instance execution is bounded to [`GCP_PREDICT_MAX_CONCURRENT`] at a
+//!   time (upstream launches all of them at once); results keep request
+//!   order either way, and the bound keeps one predict batch from flooding
+//!   the decode queue.
+//!
+//! As in b10621, neither the predict route nor the health alias is in the
+//! public (unauthenticated) endpoint set; with API keys configured both
+//! require a key. The Vertex AI variables are documented in
+//! `docs/environment-variables.md`.
+
+use std::collections::HashMap;
+
+use anyhow::{Context, Result, bail};
+use axum::body::Bytes;
+use axum::extract::State;
+use axum::http::{HeaderMap, Method, StatusCode, header};
+use axum::response::{IntoResponse, Response};
+use futures::StreamExt;
+use tower::ServiceExt;
+
+use super::AppState;
+use super::types::ErrorResponse;
+
+/// b10621 caps one predict request at this many instances.
+pub(crate) const GCP_MAX_INSTANCES: usize = 128;
+
+/// mlxcel-side bound on concurrently executing instances of one predict
+/// batch. Upstream runs every instance on its own thread at once; bounding
+/// keeps a full 128-instance batch from monopolising queue admission while
+/// still preserving result order.
+pub(crate) const GCP_PREDICT_MAX_CONCURRENT: usize = 8;
+
+/// Upper bound when collecting an internal handler's response body.
+const GCP_INTERNAL_BODY_LIMIT: usize = 64 * 1024 * 1024;
+
+/// The route-level part of the resolved Vertex AI configuration, carried on
+/// [`crate::server::ServerConfig::gcp`]. `None` there means the adapter is
+/// off (the b10621 default).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct GcpRoutes {
+    /// `AIP_HEALTH_ROUTE`, leading slash ensured; `None` when unset or empty
+    /// (upstream then relies on the ordinary `/health`).
+    pub path_health: Option<String>,
+    /// `AIP_PREDICT_ROUTE`, leading slash ensured; defaults to `/predict`.
+    pub path_predict: String,
+}
+
+/// Everything `AIP_*` resolves to at startup.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct GcpResolution {
+    pub routes: GcpRoutes,
+    /// `AIP_HTTP_PORT` (default 8080). Overrides `--port`; the caller logs
+    /// the b10621 warning when the two differ.
+    pub port: u16,
+}
+
+fn env_with_leading_slash(name: &str, default_value: &str) -> String {
+    let value = std::env::var(name).unwrap_or_default();
+    let value = if value.is_empty() {
+        default_value.to_string()
+    } else {
+        value
+    };
+    if !value.is_empty() && !value.starts_with('/') {
+        format!("/{value}")
+    } else {
+        value
+    }
+}
+
+/// Resolve the `AIP_*` variables, exactly as upstream's `gcp_params` does:
+/// only `AIP_MODE=PREDICTION` activates anything; otherwise every other
+/// variable is ignored and `Ok(None)` is returned.
+///
+/// One deliberate improvement over upstream: an unparsable `AIP_HTTP_PORT`
+/// fails startup with a diagnostic instead of upstream's uncaught `std::stoi`
+/// exception.
+pub fn resolve_from_env() -> Result<Option<GcpResolution>> {
+    if std::env::var("AIP_MODE").unwrap_or_default() != "PREDICTION" {
+        return Ok(None);
+    }
+    let path_health = {
+        let v = env_with_leading_slash("AIP_HEALTH_ROUTE", "");
+        if v.is_empty() { None } else { Some(v) }
+    };
+    let path_predict = env_with_leading_slash("AIP_PREDICT_ROUTE", "/predict");
+    let port_raw = std::env::var("AIP_HTTP_PORT").unwrap_or_default();
+    let port: u16 = if port_raw.is_empty() {
+        8080
+    } else {
+        port_raw.trim().parse().with_context(|| {
+            format!(
+                "AIP_HTTP_PORT={port_raw:?} is not a valid TCP port; Vertex AI \
+                 custom containers must listen on the port this variable names"
+            )
+        })?
+    };
+    Ok(Some(GcpResolution {
+        routes: GcpRoutes {
+            path_health,
+            path_predict,
+        },
+        port,
+    }))
+}
+
+/// Refuse an `AIP_PREDICT_ROUTE` that collides with a registered route,
+/// before the model loads, as upstream's `register_gcp_compat` exits on the
+/// same condition.
+pub(crate) fn check_predict_collision(config: &crate::server::ServerConfig) -> Result<()> {
+    let Some(gcp) = config.gcp.as_ref() else {
+        return Ok(());
+    };
+    let taken = super::app::route_inventory(config)
+        .into_iter()
+        .any(|reg| reg.path == gcp.path_predict);
+    if taken {
+        bail!(
+            "AIP_PREDICT_ROUTE={} conflicts with an existing mlxcel-server \
+             route; pick a path no API route uses (the b10621 default is \
+             /predict)",
+            gcp.path_predict
+        );
+    }
+    Ok(())
+}
+
+/// Derive the camelCase `@requestFormat` alias for a registered path, the
+/// port of upstream's `path_to_gcp_format`: strip a leading `/v1`, strip the
+/// leading `/`, stop before the first `:` path parameter, and capitalise
+/// after `/`, `-`, `_` boundaries (`/v1/chat/completions` becomes
+/// `chatCompletions`, `/apply-template` becomes `applyTemplate`).
+pub(crate) fn path_to_gcp_format(path: &str) -> String {
+    let mut s = path;
+    if s.len() > 3 && s.starts_with("/v1") {
+        s = &s[3..];
+    }
+    s = s.strip_prefix('/').unwrap_or(s);
+    let mut result = String::with_capacity(s.len());
+    let mut cap = false;
+    for c in s.chars() {
+        if c == ':' {
+            break;
+        }
+        if c == '/' || c == '-' || c == '_' {
+            cap = true;
+        } else {
+            if cap {
+                result.extend(c.to_uppercase());
+            } else {
+                result.push(c);
+            }
+            cap = false;
+        }
+    }
+    result
+}
+
+/// One dispatchable target: the canonical path plus the method the route was
+/// registered to serve (POST preferred when a path serves several).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct DispatchTarget {
+    pub(crate) path: String,
+    pub(crate) method: Method,
+}
+
+/// Alias table plus the direct-path set, both derived from the route
+/// inventory in registration order. First registration wins on an alias
+/// collision, as upstream's `emplace` does; empty aliases (the `/` root) are
+/// skipped.
+pub(crate) fn dispatch_table(
+    config: &crate::server::ServerConfig,
+) -> (HashMap<String, DispatchTarget>, HashMap<String, Method>) {
+    let mut aliases: HashMap<String, DispatchTarget> = HashMap::new();
+    let mut direct: HashMap<String, Method> = HashMap::new();
+    for reg in super::app::route_inventory(config) {
+        let alias = path_to_gcp_format(reg.path);
+        if !alias.is_empty() {
+            aliases.entry(alias).or_insert_with(|| DispatchTarget {
+                path: reg.path.to_string(),
+                method: reg.dispatch_method.clone(),
+            });
+        }
+        direct
+            .entry(reg.path.to_string())
+            .or_insert(reg.dispatch_method);
+    }
+    (aliases, direct)
+}
+
+fn envelope_error(message: impl Into<String>) -> Response {
+    ErrorResponse::new(message, "invalid_request_error").into_response()
+}
+
+/// Per-instance error object, upstream's `{"error": format_error_response(..)}`
+/// shape with mlxcel's error detail body.
+fn instance_error(message: impl Into<String>, error_type: &str) -> serde_json::Value {
+    serde_json::json!({
+        "error": {
+            "message": message.into(),
+            "type": error_type,
+            "code": null,
+        }
+    })
+}
+
+/// `POST ${AIP_PREDICT_ROUTE:-/predict}` (b10621 `register_gcp_compat`).
+pub(crate) async fn predict(
+    State(state): State<AppState>,
+    headers: HeaderMap,
+    body: Bytes,
+) -> Response {
+    let data: serde_json::Value = match serde_json::from_slice(&body) {
+        Ok(v) => v,
+        Err(e) => return envelope_error(e.to_string()),
+    };
+    if !data.is_object() {
+        return envelope_error("request body must be a JSON object");
+    }
+    let Some(instances) = data.get("instances").filter(|v| v.is_array()) else {
+        return envelope_error("request body must include an array field named instances");
+    };
+    let instances = instances.as_array().expect("checked is_array");
+    if instances.len() > GCP_MAX_INSTANCES {
+        return envelope_error(format!(
+            "instances array exceeds maximum size of {GCP_MAX_INSTANCES}"
+        ));
+    }
+
+    // The composed router the socket serves; set by `create_app` before the
+    // first request can reach this handler.
+    let Some(app) = state.gcp_dispatch.get().cloned() else {
+        let mut err =
+            ErrorResponse::new("predict dispatch router is not initialised", "server_error");
+        err.status = StatusCode::INTERNAL_SERVER_ERROR;
+        return err.into_response();
+    };
+    let (aliases, direct) = dispatch_table(&state.config);
+    let api_prefix = state.config.api_prefix.clone();
+
+    let futures = instances.iter().cloned().map(|instance| {
+        let app = app.clone();
+        let aliases = &aliases;
+        let direct = &direct;
+        let headers = &headers;
+        let api_prefix = api_prefix.as_str();
+        async move { dispatch_instance(instance, app, aliases, direct, headers, api_prefix).await }
+    });
+    let predictions: Vec<serde_json::Value> = futures::stream::iter(futures)
+        .buffered(GCP_PREDICT_MAX_CONCURRENT)
+        .collect()
+        .await;
+
+    axum::Json(serde_json::json!({ "predictions": predictions })).into_response()
+}
+
+/// Execute one instance; any failure becomes an error object in its slot,
+/// never a whole-batch failure, matching upstream.
+async fn dispatch_instance(
+    instance: serde_json::Value,
+    app: axum::Router,
+    aliases: &HashMap<String, DispatchTarget>,
+    direct: &HashMap<String, Method>,
+    headers: &HeaderMap,
+    api_prefix: &str,
+) -> serde_json::Value {
+    let Some(obj) = instance.as_object() else {
+        return instance_error(
+            "each instance must be a JSON object",
+            "invalid_request_error",
+        );
+    };
+    let Some(format) = obj.get("@requestFormat").and_then(|v| v.as_str()) else {
+        return instance_error(
+            "each instance must include a string @requestFormat",
+            "invalid_request_error",
+        );
+    };
+    let format = format.to_string();
+    let mut payload = obj.clone();
+    payload.remove("@requestFormat");
+    if payload.contains_key("stream") {
+        tracing::warn!(
+            "ignoring client-provided stream field in instance, streaming is \
+             not supported in predict route"
+        );
+        payload.insert("stream".to_string(), serde_json::Value::Bool(false));
+    }
+
+    // Accept both camelCase aliases and direct registered paths, upstream's
+    // two lookups in that order.
+    let target = match aliases.get(&format) {
+        Some(target) => target.clone(),
+        None => match direct.get(&format) {
+            Some(method) => DispatchTarget {
+                path: format.clone(),
+                method: method.clone(),
+            },
+            None => {
+                return instance_error(
+                    format!("no handler registered for @requestFormat: {format}"),
+                    "invalid_request_error",
+                );
+            }
+        },
+    };
+
+    let body = match serde_json::to_vec(&payload) {
+        Ok(b) => b,
+        Err(e) => return instance_error(e.to_string(), "server_error"),
+    };
+    let uri = format!("{api_prefix}{}", target.path);
+    let mut builder = axum::http::Request::builder()
+        .method(target.method.clone())
+        .uri(&uri)
+        .header(header::CONTENT_TYPE, "application/json");
+    // Forward the predict request's own headers (auth included) so the
+    // internal dispatch is authorised exactly as a direct call would be.
+    for (name, value) in headers {
+        if name == header::CONTENT_LENGTH || name == header::CONTENT_TYPE || name == header::HOST {
+            continue;
+        }
+        builder = builder.header(name, value);
+    }
+    let request = match builder.body(axum::body::Body::from(body)) {
+        Ok(r) => r,
+        Err(e) => return instance_error(e.to_string(), "server_error"),
+    };
+    let response = match app.oneshot(request).await {
+        Ok(r) => r,
+        Err(never) => match never {},
+    };
+
+    // A streaming response cannot be represented in a predictions slot;
+    // upstream throws the same refusal from its response parser.
+    let is_stream = response
+        .headers()
+        .get(header::CONTENT_TYPE)
+        .and_then(|v| v.to_str().ok())
+        .is_some_and(|ct| ct.starts_with("text/event-stream"));
+    if is_stream {
+        return instance_error(
+            "predict route does not support streaming responses",
+            "invalid_request_error",
+        );
+    }
+    let bytes = match axum::body::to_bytes(response.into_body(), GCP_INTERNAL_BODY_LIMIT).await {
+        Ok(b) => b,
+        Err(e) => return instance_error(e.to_string(), "server_error"),
+    };
+    if bytes.is_empty() {
+        return serde_json::Value::Null;
+    }
+    match serde_json::from_slice(&bytes) {
+        Ok(v) => v,
+        // Not JSON: return the raw text, as upstream's parser fallback does.
+        Err(_) => serde_json::Value::String(String::from_utf8_lossy(&bytes).into_owned()),
+    }
+}
+
+#[cfg(test)]
+#[path = "gcp_compat_tests.rs"]
+mod tests;

--- a/src/server/gcp_compat_tests.rs
+++ b/src/server/gcp_compat_tests.rs
@@ -1,0 +1,484 @@
+// Copyright 2025-2026 Lablup Inc. and Jeongkyu Shin
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Tests for the Vertex AI (GCP) predict adapter (b10621, #1456).
+
+use std::path::PathBuf;
+use std::sync::{Arc, mpsc};
+
+use axum::body::Body;
+use axum::http::{Request, StatusCode};
+use tower::ServiceExt;
+
+use super::*;
+use crate::server::model_provider::ModelProvider;
+use crate::server::{AppState, ChatTemplateProcessor, ServerConfig, create_app};
+use crate::test_support::env_lock::env_lock;
+use crate::tokenizer::MlxcelTokenizer;
+
+// -- path_to_gcp_format --
+
+#[test]
+fn alias_format_matches_upstream_examples() {
+    assert_eq!(
+        path_to_gcp_format("/v1/chat/completions"),
+        "chatCompletions"
+    );
+    assert_eq!(path_to_gcp_format("/apply-template"), "applyTemplate");
+    assert_eq!(path_to_gcp_format("/v1/embeddings"), "embeddings");
+    assert_eq!(path_to_gcp_format("/v1/messages"), "messages");
+    assert_eq!(path_to_gcp_format("/tokenize"), "tokenize");
+    assert_eq!(path_to_gcp_format("/v1/streams/lookup"), "streamsLookup");
+    // Path parameters stop the conversion.
+    assert_eq!(path_to_gcp_format("/v1/responses/:id"), "responses");
+    assert_eq!(path_to_gcp_format("/v1/responses/:id/cancel"), "responses");
+    // The root produces the empty alias, which the table skips.
+    assert_eq!(path_to_gcp_format("/"), "");
+    // Underscore boundaries capitalise too.
+    assert_eq!(
+        path_to_gcp_format("/v1/messages/count_tokens"),
+        "messagesCountTokens"
+    );
+}
+
+// -- resolve_from_env --
+
+#[test]
+fn without_prediction_mode_every_aip_variable_is_ignored() {
+    let _guard = env_lock();
+    // SAFETY: serialized via the crate-wide ENV_LOCK acquired above.
+    unsafe {
+        std::env::remove_var("AIP_MODE");
+        std::env::set_var("AIP_HTTP_PORT", "not-a-port");
+        std::env::set_var("AIP_PREDICT_ROUTE", "colliding");
+        std::env::set_var("AIP_HEALTH_ROUTE", "hp");
+    }
+    let resolved = resolve_from_env().expect("no error while disabled");
+    assert!(resolved.is_none());
+    // SAFETY: serialized via the crate-wide ENV_LOCK acquired above.
+    unsafe {
+        std::env::set_var("AIP_MODE", "prediction"); // case-sensitive upstream
+    }
+    assert!(resolve_from_env().expect("still disabled").is_none());
+    // SAFETY: serialized via the crate-wide ENV_LOCK acquired above.
+    unsafe {
+        std::env::remove_var("AIP_MODE");
+        std::env::remove_var("AIP_HTTP_PORT");
+        std::env::remove_var("AIP_PREDICT_ROUTE");
+        std::env::remove_var("AIP_HEALTH_ROUTE");
+    }
+}
+
+#[test]
+fn prediction_mode_resolves_defaults_and_leading_slashes() {
+    let _guard = env_lock();
+    // SAFETY: serialized via the crate-wide ENV_LOCK acquired above.
+    unsafe {
+        std::env::set_var("AIP_MODE", "PREDICTION");
+        std::env::remove_var("AIP_HTTP_PORT");
+        std::env::remove_var("AIP_PREDICT_ROUTE");
+        std::env::remove_var("AIP_HEALTH_ROUTE");
+    }
+    let resolved = resolve_from_env().expect("resolves").expect("enabled");
+    assert_eq!(resolved.port, 8080);
+    assert_eq!(resolved.routes.path_predict, "/predict");
+    assert_eq!(resolved.routes.path_health, None);
+
+    // SAFETY: serialized via the crate-wide ENV_LOCK acquired above.
+    unsafe {
+        std::env::set_var("AIP_HTTP_PORT", "9090");
+        std::env::set_var("AIP_PREDICT_ROUTE", "custom-predict");
+        std::env::set_var("AIP_HEALTH_ROUTE", "hp");
+    }
+    let resolved = resolve_from_env().expect("resolves").expect("enabled");
+    assert_eq!(resolved.port, 9090);
+    // Leading slashes are ensured, as upstream's getenv helper does.
+    assert_eq!(resolved.routes.path_predict, "/custom-predict");
+    assert_eq!(resolved.routes.path_health.as_deref(), Some("/hp"));
+
+    // SAFETY: serialized via the crate-wide ENV_LOCK acquired above.
+    unsafe {
+        std::env::set_var("AIP_HTTP_PORT", "not-a-port");
+    }
+    let err = resolve_from_env().expect_err("bad port fails startup");
+    assert!(err.to_string().contains("AIP_HTTP_PORT"));
+
+    // SAFETY: serialized via the crate-wide ENV_LOCK acquired above.
+    unsafe {
+        std::env::remove_var("AIP_MODE");
+        std::env::remove_var("AIP_HTTP_PORT");
+        std::env::remove_var("AIP_PREDICT_ROUTE");
+        std::env::remove_var("AIP_HEALTH_ROUTE");
+    }
+}
+
+// -- dispatch table --
+
+#[test]
+fn alias_collisions_resolve_deterministically_to_the_v1_routes() {
+    let config = ServerConfig::default();
+    let (aliases, direct) = dispatch_table(&config);
+    // `/v1/completions` (OpenAI) and `/completions` (native) both produce
+    // `completions`; registration order makes the OpenAI route win. Same
+    // for `embeddings`.
+    assert_eq!(aliases["completions"].path, "/v1/completions");
+    assert_eq!(aliases["embeddings"].path, "/v1/embeddings");
+    assert_eq!(aliases["chatCompletions"].path, "/v1/chat/completions");
+    assert_eq!(aliases["messages"].path, "/v1/messages");
+    assert_eq!(aliases["rerank"].path, "/v1/rerank");
+    assert_eq!(aliases["tokenize"].path, "/tokenize");
+    assert_eq!(aliases["health"].path, "/health");
+    // The native spellings keep their distinct aliases.
+    assert_eq!(aliases["completion"].path, "/completion");
+    assert_eq!(aliases["embedding"].path, "/embedding");
+    // Direct paths are dispatchable as-is, with their registered method.
+    assert_eq!(direct["/completions"], axum::http::Method::POST);
+    assert_eq!(direct["/v1/models"], axum::http::Method::GET);
+    // The root's empty alias is skipped.
+    assert!(!aliases.contains_key(""));
+}
+
+#[test]
+fn observability_routes_are_always_aliased() {
+    // Since #1440 the /props, /slots and /metrics routes mount
+    // unconditionally (their gates live in the handlers), so their aliases
+    // are always present; /slots/:id_slot collapses onto the earlier
+    // /slots alias by the first-wins rule.
+    let (aliases, _) = dispatch_table(&ServerConfig::default());
+    assert_eq!(aliases["props"].path, "/props");
+    assert_eq!(aliases["slots"].path, "/slots");
+    assert_eq!(aliases["slots"].method, axum::http::Method::GET);
+    assert_eq!(aliases["metrics"].path, "/metrics");
+}
+
+// -- collision check --
+
+#[test]
+fn predict_collision_is_refused_and_free_paths_pass() {
+    let mut config = ServerConfig {
+        gcp: Some(GcpRoutes {
+            path_health: None,
+            path_predict: "/predict".to_string(),
+        }),
+        ..Default::default()
+    };
+    check_predict_collision(&config).expect("/predict is free");
+
+    config.gcp = Some(GcpRoutes {
+        path_health: None,
+        path_predict: "/v1/chat/completions".to_string(),
+    });
+    let err = check_predict_collision(&config).expect_err("collision refused");
+    assert!(err.to_string().contains("AIP_PREDICT_ROUTE"));
+
+    config.gcp = None;
+    check_predict_collision(&config).expect("disabled adapter never collides");
+}
+
+// -- route integration --
+
+fn gcp_config(path_health: Option<&str>, path_predict: &str) -> ServerConfig {
+    ServerConfig {
+        gcp: Some(GcpRoutes {
+            path_health: path_health.map(str::to_string),
+            path_predict: path_predict.to_string(),
+        }),
+        ..Default::default()
+    }
+}
+
+fn app_with(config: ServerConfig) -> axum::Router {
+    let (options_tx, _options_rx) = mpsc::channel();
+    let provider = Arc::new(ModelProvider::recording_for_route_tests(options_tx));
+    let batch_metrics = provider.batch_metrics().clone();
+    let state = AppState::new(
+        provider,
+        config,
+        ChatTemplateProcessor::with_template("ok".to_string()),
+        MlxcelTokenizer::stub(),
+        PathBuf::from("route-test-model"),
+        batch_metrics,
+    );
+    create_app(state)
+}
+
+fn predict_request(uri: &str, body: serde_json::Value, auth: Option<&str>) -> Request<Body> {
+    let mut builder = Request::builder()
+        .method("POST")
+        .uri(uri)
+        .header("content-type", "application/json");
+    if let Some(key) = auth {
+        builder = builder.header("authorization", format!("Bearer {key}"));
+    }
+    builder
+        .body(Body::from(body.to_string()))
+        .expect("request builds")
+}
+
+async fn body_json(response: axum::response::Response) -> serde_json::Value {
+    let bytes = axum::body::to_bytes(response.into_body(), 16 * 1024 * 1024)
+        .await
+        .expect("body collects");
+    serde_json::from_slice(&bytes)
+        .unwrap_or_else(|_| panic!("non-JSON body: {}", String::from_utf8_lossy(&bytes)))
+}
+
+fn chat_instance() -> serde_json::Value {
+    serde_json::json!({
+        "@requestFormat": "chatCompletions",
+        "model": "route-test-model",
+        "messages": [{"role": "user", "content": "hi"}],
+    })
+}
+
+#[tokio::test]
+async fn predict_is_not_mounted_without_the_gcp_config() {
+    let app = app_with(ServerConfig::default());
+    let response = app
+        .oneshot(predict_request(
+            "/predict",
+            serde_json::json!({"instances": []}),
+            None,
+        ))
+        .await
+        .expect("request");
+    assert_eq!(response.status(), StatusCode::NOT_FOUND);
+}
+
+#[tokio::test]
+async fn predict_fans_out_and_returns_predictions_in_request_order() {
+    let app = app_with(gcp_config(None, "/predict"));
+    let body = serde_json::json!({
+        "instances": [
+            chat_instance(),
+            {"@requestFormat": "health"},
+            {"@requestFormat": "definitely-not-a-route"},
+        ]
+    });
+    let response = app
+        .oneshot(predict_request("/predict", body, None))
+        .await
+        .expect("request");
+    assert_eq!(response.status(), StatusCode::OK);
+    let parsed = body_json(response).await;
+    let predictions = parsed["predictions"].as_array().expect("predictions array");
+    assert_eq!(predictions.len(), 3);
+    // Slot 0: a real chat completion object from the recording provider.
+    assert!(
+        predictions[0]["choices"].is_array(),
+        "chat prediction: {parsed}"
+    );
+    // Slot 1: the health handler's body, dispatched as GET.
+    assert!(
+        predictions[1]["status"].is_string(),
+        "health prediction: {parsed}"
+    );
+    // Slot 2: a per-instance error object, not a whole-batch failure.
+    assert_eq!(
+        predictions[2]["error"]["message"],
+        "no handler registered for @requestFormat: definitely-not-a-route"
+    );
+}
+
+#[tokio::test]
+async fn predict_accepts_direct_paths_and_forces_stream_off() {
+    let app = app_with(gcp_config(None, "/predict"));
+    let mut streaming_chat = chat_instance();
+    streaming_chat["@requestFormat"] = serde_json::json!("/v1/chat/completions");
+    streaming_chat["stream"] = serde_json::json!(true);
+    let body = serde_json::json!({ "instances": [streaming_chat] });
+    let response = app
+        .oneshot(predict_request("/predict", body, None))
+        .await
+        .expect("request");
+    assert_eq!(response.status(), StatusCode::OK);
+    let parsed = body_json(response).await;
+    // The stream field was forced off, so the slot carries a full JSON chat
+    // completion, not an SSE stream and not the streaming refusal.
+    assert!(
+        parsed["predictions"][0]["choices"].is_array(),
+        "got: {parsed}"
+    );
+}
+
+#[tokio::test]
+async fn predict_envelope_validation_matches_upstream() {
+    let app = app_with(gcp_config(None, "/predict"));
+
+    // Not a JSON object.
+    let response = app
+        .clone()
+        .oneshot(predict_request("/predict", serde_json::json!([1, 2]), None))
+        .await
+        .expect("request");
+    assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+    let parsed = body_json(response).await;
+    assert_eq!(
+        parsed["error"]["message"],
+        "request body must be a JSON object"
+    );
+
+    // Missing / non-array instances.
+    for body in [
+        serde_json::json!({}),
+        serde_json::json!({"instances": "nope"}),
+    ] {
+        let response = app
+            .clone()
+            .oneshot(predict_request("/predict", body, None))
+            .await
+            .expect("request");
+        assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+        let parsed = body_json(response).await;
+        assert_eq!(
+            parsed["error"]["message"],
+            "request body must include an array field named instances"
+        );
+    }
+
+    // Cap at 128 instances.
+    let too_many: Vec<serde_json::Value> = (0..129)
+        .map(|_| serde_json::json!({"@requestFormat": "health"}))
+        .collect();
+    let response = app
+        .clone()
+        .oneshot(predict_request(
+            "/predict",
+            serde_json::json!({"instances": too_many}),
+            None,
+        ))
+        .await
+        .expect("request");
+    assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+    let parsed = body_json(response).await;
+    assert_eq!(
+        parsed["error"]["message"],
+        "instances array exceeds maximum size of 128"
+    );
+
+    // Per-instance shape errors land in their slots.
+    let body = serde_json::json!({
+        "instances": [42, {"no_format": true}, {"@requestFormat": 7}]
+    });
+    let response = app
+        .oneshot(predict_request("/predict", body, None))
+        .await
+        .expect("request");
+    assert_eq!(response.status(), StatusCode::OK);
+    let parsed = body_json(response).await;
+    let predictions = parsed["predictions"].as_array().expect("array");
+    assert_eq!(
+        predictions[0]["error"]["message"],
+        "each instance must be a JSON object"
+    );
+    for p in &predictions[1..] {
+        assert_eq!(
+            p["error"]["message"],
+            "each instance must include a string @requestFormat"
+        );
+    }
+}
+
+#[tokio::test]
+async fn predict_and_health_alias_require_the_api_key_like_every_route() {
+    let config = ServerConfig {
+        api_keys: crate::server::ApiKeys::from_vec(vec!["key-a".into()]),
+        ..gcp_config(Some("/hp"), "/predict")
+    };
+    let app = app_with(config);
+
+    // Without a key: both answer b10621's 401; neither is public.
+    let response = app
+        .clone()
+        .oneshot(predict_request(
+            "/predict",
+            serde_json::json!({"instances": []}),
+            None,
+        ))
+        .await
+        .expect("request");
+    assert_eq!(response.status(), StatusCode::UNAUTHORIZED);
+    let response = app
+        .clone()
+        .oneshot(
+            Request::builder()
+                .method("GET")
+                .uri("/hp")
+                .body(Body::empty())
+                .expect("request builds"),
+        )
+        .await
+        .expect("request");
+    assert_eq!(response.status(), StatusCode::UNAUTHORIZED);
+
+    // With the key: the batch runs, and the internal dispatch is authorised
+    // by the forwarded credential.
+    let response = app
+        .clone()
+        .oneshot(predict_request(
+            "/predict",
+            serde_json::json!({"instances": [chat_instance()]}),
+            Some("key-a"),
+        ))
+        .await
+        .expect("request");
+    assert_eq!(response.status(), StatusCode::OK);
+    let parsed = body_json(response).await;
+    assert!(parsed["predictions"][0]["choices"].is_array());
+
+    let response = app
+        .oneshot(
+            Request::builder()
+                .method("GET")
+                .uri("/hp")
+                .header("authorization", "Bearer key-a")
+                .body(Body::empty())
+                .expect("request builds"),
+        )
+        .await
+        .expect("request");
+    assert_eq!(response.status(), StatusCode::OK);
+}
+
+#[tokio::test]
+async fn health_alias_mounts_at_a_custom_path_and_skips_collisions() {
+    // A fresh alias answers the health payload.
+    let app = app_with(gcp_config(Some("/hp"), "/predict"));
+    let response = app
+        .oneshot(
+            Request::builder()
+                .method("GET")
+                .uri("/hp")
+                .body(Body::empty())
+                .expect("request builds"),
+        )
+        .await
+        .expect("request");
+    assert_eq!(response.status(), StatusCode::OK);
+
+    // An alias naming an existing route is skipped rather than panicking in
+    // axum's duplicate-route registration; the existing route still answers.
+    let app = app_with(gcp_config(Some("/health"), "/predict"));
+    let response = app
+        .oneshot(
+            Request::builder()
+                .method("GET")
+                .uri("/health")
+                .body(Body::empty())
+                .expect("request builds"),
+        )
+        .await
+        .expect("request");
+    assert_eq!(response.status(), StatusCode::OK);
+}

--- a/src/server/llama_compat_tests.rs
+++ b/src/server/llama_compat_tests.rs
@@ -151,11 +151,18 @@ async fn manifest_route_claims_match_the_mounted_router() {
         let path = entry["path"].as_str().expect("path");
         if path.contains("${") {
             // Synthetic entries for env-configured GCP routes and the Web
-            // UI static mount have no fixed probeable path.
-            assert!(
-                entry["mlxcel"].is_null(),
-                "{id}: synthetic route entries cannot carry a probeable claim"
-            );
+            // UI static mount have no fixed probeable path, so their claims
+            // cannot be verified against the router here. A claim, when one
+            // is recorded (#1456 mounts the GCP pair from `AIP_*`), must
+            // name the synthetic id itself; behavior is covered by
+            // `gcp_compat_tests.rs` against a router with the adapter
+            // enabled.
+            if !entry["mlxcel"].is_null() {
+                assert_eq!(
+                    entry["mlxcel"]["route"], entry["id"],
+                    "{id}: a synthetic route claim must record the entry id"
+                );
+            }
             continue;
         }
         let method = entry["method"].as_str().expect("method");

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -34,6 +34,7 @@ mod dry_breakers;
 pub mod embedding_model;
 pub mod embedding_worker;
 pub(crate) mod florence2_worker;
+pub mod gcp_compat;
 mod http_timeout;
 pub mod infill;
 pub mod kokoro_tts;

--- a/src/server/startup.rs
+++ b/src/server/startup.rs
@@ -1267,6 +1267,9 @@ pub(super) fn build_server_config(
     };
 
     ServerConfig {
+        // Populated by `start_server` after the AIP_* environment variables
+        // resolve (#1456); the builder itself never reads the environment.
+        gcp: None,
         reasoning_format: startup.reasoning_format,
         skip_chat_parsing: startup.skip_chat_parsing,
         no_prefill_assistant: startup.no_prefill_assistant,
@@ -2051,6 +2054,28 @@ fn install_surgery_pipeline_for_server(startup: &ServerStartupConfig) -> Result<
 pub async fn start_server(mut startup: ServerStartupConfig) -> Result<()> {
     initialize_server_logging(&startup)?;
 
+    // Vertex AI (GCP) custom-container compat (b10621, #1456): resolved
+    // purely from the AIP_* environment variables, before anything binds or
+    // loads. With AIP_MODE=PREDICTION, AIP_HTTP_PORT (default 8080)
+    // overrides --port, with upstream's warning when the two differ.
+    let gcp = crate::server::gcp_compat::resolve_from_env()?;
+    if let Some(resolution) = &gcp {
+        if startup.port != resolution.port {
+            tracing::warn!(
+                "Google Cloud Platform compat: overriding server port {} with AIP_HTTP_PORT {}",
+                startup.port,
+                resolution.port
+            );
+        }
+        startup.port = resolution.port;
+        tracing::info!(
+            health_route = %resolution.routes.path_health.as_deref().unwrap_or("(default /health)"),
+            predict_route = %resolution.routes.path_predict,
+            port = resolution.port,
+            "Google Cloud Platform (Vertex AI) compat enabled"
+        );
+    }
+
     // A sampler-order flag that asks for anything but the fixed b10621
     // default chain would silently sample in a different order than the
     // operator requested; fail here, before the multi-GB model load, since
@@ -2265,6 +2290,13 @@ pub async fn start_server(mut startup: ServerStartupConfig) -> Result<()> {
         );
     }
     let mut config = build_server_config(&startup, api_keys);
+
+    // Vertex AI compat routes (#1456): recorded on the config so the router
+    // mounts them, and the predict path is refused now, before the model
+    // load, when it collides with a registered route (upstream exits on the
+    // same condition in `register_gcp_compat`).
+    config.gcp = gcp.map(|resolution| resolution.routes);
+    crate::server::gcp_compat::check_predict_collision(&config)?;
 
     if config.pipeline_parallel_runtime.is_some() && distributed.pipeline_runtime.is_some() {
         anyhow::bail!(

--- a/src/server/state.rs
+++ b/src/server/state.rs
@@ -472,6 +472,10 @@ pub struct AppState {
     /// Unix timestamp of server start, reported as b10621's
     /// `Process-Start-Time-Unix` response header on `GET /metrics`.
     pub started_at_unix: i64,
+    /// The composed router the socket serves, set by `create_app` when the
+    /// Vertex AI predict adapter is enabled (#1456), so per-instance
+    /// dispatch runs through the same middleware stack in-process.
+    pub(crate) gcp_dispatch: Arc<std::sync::OnceLock<axum::Router>>,
 }
 
 /// Cumulative counter snapshot taken at the previous `/metrics` scrape.
@@ -549,6 +553,7 @@ impl AppState {
             slots_debug,
             llama_scrape: Arc::new(std::sync::Mutex::new(LlamaScrapeBaseline::default())),
             started_at_unix: chrono::Utc::now().timestamp(),
+            gcp_dispatch: Arc::new(std::sync::OnceLock::new()),
         }
     }
 
@@ -593,6 +598,7 @@ impl AppState {
             slots_debug,
             llama_scrape: Arc::new(std::sync::Mutex::new(LlamaScrapeBaseline::default())),
             started_at_unix: chrono::Utc::now().timestamp(),
+            gcp_dispatch: Arc::new(std::sync::OnceLock::new()),
         }
     }
 

--- a/tests/gcp_predict_real_model.rs
+++ b/tests/gcp_predict_real_model.rs
@@ -1,0 +1,152 @@
+// Copyright 2025-2026 Lablup Inc. and Jeongkyu Shin
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Real-checkpoint smoke test for the Vertex AI predict adapter (#1456):
+//! boots `mlxcel-server` with `AIP_MODE=PREDICTION` against a dense text
+//! model and exercises one `chatCompletions` batch through
+//! `POST /predict`, asserting the port override and the prediction shapes.
+
+mod common;
+
+use std::net::TcpListener;
+use std::process::{Child, Command, Stdio};
+use std::time::{Duration, Instant};
+
+use common::{repo_binary_path, repo_model_dir};
+
+fn reserve_port() -> u16 {
+    let listener = TcpListener::bind("127.0.0.1:0").expect("bind ephemeral port");
+    let port = listener.local_addr().expect("local addr").port();
+    drop(listener);
+    port
+}
+
+async fn wait_for_health(client: &reqwest::Client, base_url: &str) {
+    let deadline = Instant::now() + Duration::from_secs(120);
+    while Instant::now() < deadline {
+        if let Ok(response) = client.get(format!("{base_url}/health")).send().await
+            && response.status().is_success()
+        {
+            return;
+        }
+        tokio::time::sleep(Duration::from_millis(250)).await;
+    }
+    panic!("server did not become healthy at {base_url}");
+}
+
+fn stop_server(child: &mut Child) {
+    let _ = child.kill();
+    let _ = child.wait();
+}
+
+#[tokio::test]
+#[ignore = "requires local model weights and a built mlxcel-server binary"]
+async fn predict_serves_a_chat_completions_batch_against_a_real_model() {
+    let model_dir = repo_model_dir("mlx/llama-3.2-1b-4bit");
+    if !model_dir.exists() {
+        eprintln!(
+            "skipping: model checkpoint not found at {}",
+            model_dir.display()
+        );
+        return;
+    }
+
+    let aip_port = reserve_port();
+    let flag_port = reserve_port();
+    let model_arg = model_dir.to_string_lossy().to_string();
+    let flag_port_arg = flag_port.to_string();
+
+    // AIP_HTTP_PORT must override --port: the server has to listen on the
+    // Vertex-assigned port, not the flag's.
+    let mut child = Command::new(repo_binary_path("mlxcel-server"))
+        .args([
+            "-m",
+            &model_arg,
+            "--port",
+            &flag_port_arg,
+            "--host",
+            "127.0.0.1",
+        ])
+        .env("AIP_MODE", "PREDICTION")
+        .env("AIP_HTTP_PORT", aip_port.to_string())
+        .env("AIP_HEALTH_ROUTE", "hp")
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .spawn()
+        .expect("spawn mlxcel-server");
+
+    let client = reqwest::Client::new();
+    let base_url = format!("http://127.0.0.1:{aip_port}");
+    wait_for_health(&client, &base_url).await;
+
+    // The AIP health alias answers on the overridden port.
+    let health_alias = client
+        .get(format!("{base_url}/hp"))
+        .send()
+        .await
+        .expect("health alias request");
+    assert!(health_alias.status().is_success());
+
+    // One chatCompletions batch of two instances, dispatched through the
+    // real model; predictions come back in order with generated content.
+    let response = client
+        .post(format!("{base_url}/predict"))
+        .json(&serde_json::json!({
+            "instances": [
+                {
+                    "@requestFormat": "chatCompletions",
+                    "model": "llama-3.2-1b-4bit",
+                    "messages": [{"role": "user", "content": "Reply with one word: hello"}],
+                    "max_tokens": 8,
+                    "temperature": 0
+                },
+                {
+                    "@requestFormat": "chatCompletions",
+                    "model": "llama-3.2-1b-4bit",
+                    "messages": [{"role": "user", "content": "Reply with one word: goodbye"}],
+                    "max_tokens": 8,
+                    "temperature": 0
+                }
+            ]
+        }))
+        .send()
+        .await
+        .expect("predict request");
+    assert!(response.status().is_success(), "predict answered an error");
+    let parsed: serde_json::Value = response.json().await.expect("predict body parses");
+    let predictions = parsed["predictions"].as_array().expect("predictions array");
+    assert_eq!(predictions.len(), 2);
+    for prediction in predictions {
+        let content = prediction["choices"][0]["message"]["content"]
+            .as_str()
+            .unwrap_or_else(|| panic!("prediction is not a chat completion: {prediction}"));
+        assert!(
+            !content.trim().is_empty(),
+            "the model generated no content: {prediction}"
+        );
+    }
+
+    // The flag port must NOT be serving: the override replaced it.
+    let flag_result = client
+        .get(format!("http://127.0.0.1:{flag_port}/health"))
+        .timeout(Duration::from_secs(2))
+        .send()
+        .await;
+    assert!(
+        flag_result.is_err(),
+        "--port must be overridden by AIP_HTTP_PORT"
+    );
+
+    stop_server(&mut child);
+}


### PR DESCRIPTION
## Summary

Implements llama-server b10621's Vertex AI custom-container compatibility (issue #1456): the env-gated `AIP_*` adapter with the predict fan-out route, health alias, and port override, dispatching through mlxcel's real route table in-process.

## What changed

- `src/server/gcp_compat.rs` (new): `AIP_*` resolution (activation only on `AIP_MODE=PREDICTION`, exactly as upstream's `gcp_params`; an unparsable `AIP_HTTP_PORT` fails startup with a diagnostic instead of upstream's uncaught `std::stoi` throw), the `path_to_gcp_format` port, the dispatch table, the predict handler, and the `AIP_PREDICT_ROUTE` collision check.
- `src/server/app.rs`: `build_routes` now mounts from a new `route_inventory`, the single table that also feeds the camelCase alias table and the collision check, so a route added there is served, aliased, and collision-checked automatically (the issue's "no hand-maintained list" requirement). When `config.gcp` is set, the health alias and predict route mount inside the middleware stack, and `create_app` hands the predict handler the composed router so per-instance dispatch runs the full stack (auth, CORS, tracing) via `tower::ServiceExt::oneshot`.
- `src/server/startup.rs`: resolves the environment once in `start_server` (both binaries share it), applies the `AIP_HTTP_PORT` override with upstream's warning wording, records the routes on `ServerConfig::gcp`, and refuses a colliding predict path before the model load.
- Predict semantics matched to the pinned `server-http.cpp`: 128-instance cap, upstream's envelope 400 wordings verbatim, `@requestFormat` stripped, client `stream` forced off with a warning, camelCase alias or direct registered path accepted, per-instance failures as error objects in their slots, `{"predictions": [...]}` in request order, streaming responses refused per instance with upstream's wording. Neither the predict route nor the health alias is public, matching b10621's public endpoint set (the issue body's "public health alias" phrase does not match the pinned source, which only exempts `/health`, `/v1/health` and UI assets from authentication; the source wins). A health alias naming an already-registered path is skipped rather than panicking in axum route registration; upstream's duplicate httplib handler never matches either, so the observable behavior is identical.
- Two internals differ without changing any response and are recorded in the manifest notes, not as divergences: instance concurrency is bounded to 8 at a time (upstream launches all instances at once; order is preserved either way, and the bound keeps one 128-instance batch from flooding queue admission), and alias collisions such as `completions` / `embeddings` resolve deterministically to the `/v1` routes by registration order, where upstream's iteration over an unordered map leaves its winner unspecified.
- `compat/llama-server/b10621/ui-tools-mcp-gcp.json`: both #1456 entries (`POST ${AIP_PREDICT_ROUTE:-/predict}`, `GET ${AIP_HEALTH_ROUTE}`) flip to `supported` with empty divergence. The synthetic-route branch of `src/server/llama_compat_tests.rs` now accepts a recorded claim that names the entry id (still unprobeable there; behavior is covered by `gcp_compat_tests.rs` against a router with the adapter enabled).
- Docs: `docs/environment-variables.md` gains the `AIP_*` table; `docs/llama-server-compat.md` gains the surface section.

## Test plan

- [x] `cargo test --profile test-fast --features metal,accelerate --lib gcp_compat::` (12 tests: alias format, env resolution and defaults, deterministic collisions, conditional-route aliasing, collision check, fan-out order, envelope validation, stream forcing, direct paths, auth on both routes, health-alias collision skip)
- [x] `cargo test --profile test-fast --features metal,accelerate --lib llama_compat_tests` and `--test llama_compat_manifest`
- [x] `python3 scripts/ci/check_llama_compat_manifest.py`
- [x] `cargo clippy --profile test-fast --lib --tests --features metal,accelerate -- -D warnings` and `cargo fmt --all -- --check`
- [x] Real-checkpoint smoke test: `cargo test --profile test-fast --features metal,accelerate --test gcp_predict_real_model -- --ignored` boots `mlxcel-server` with `AIP_MODE=PREDICTION` against `llama-3.2-1b-4bit`, proves the `AIP_HTTP_PORT` override (the `--port` value does not serve), exercises the `/hp` health alias, and runs a two-instance `chatCompletions` batch with non-empty generated content in both slots (passed locally on Apple Silicon)

Closes #1456
