### PR TITLE
fix(server): repair three regressions on merged main after wave 3

### DIFF
--- a/src/bin/mlx_server.rs
+++ b/src/bin/mlx_server.rs
@@ -2713,7 +2713,32 @@ mod tests {
     }
 
     #[test]
-    fn legacy_server_mode_resolves_repo_id_from_models_dir_override() {
+    fn legacy_server_mode_resolves_repo_id_from_model_store_root_override() {
+        let tmp = tempfile::tempdir().unwrap();
+        let models_root = tmp.path().join("custom-model-store");
+        let repo_id = "zz-mlxcel-test-owner/zz-mlxcel-test-model";
+        let expected = make_complete_snapshot(&models_root, repo_id);
+        let models_root_arg = models_root.to_string_lossy().to_string();
+
+        let args = parse_server_args(&[
+            "mlxcel-server",
+            "-m",
+            repo_id,
+            "--model-store-root",
+            &models_root_arg,
+        ]);
+        let input = build_startup_input(args).expect("repo-id should resolve from override store");
+
+        assert_eq!(input.model_path, expected);
+    }
+
+    /// The other half of #1438's `--models-dir` swap: the spelling that used to
+    /// mean "store root" now selects b10621 router-mode discovery, so it must
+    /// NOT resolve a repo id against itself as a store. Without this the swap
+    /// could silently regress back and only the renamed test above would notice,
+    /// which it would not, because it no longer uses the spelling.
+    #[test]
+    fn models_dir_no_longer_acts_as_the_model_store_root() {
         let tmp = tempfile::tempdir().unwrap();
         let models_root = tmp.path().join("custom-model-store");
         let repo_id = "zz-mlxcel-test-owner/zz-mlxcel-test-model";
@@ -2727,9 +2752,13 @@ mod tests {
             "--models-dir",
             &models_root_arg,
         ]);
-        let input = build_startup_input(args).expect("repo-id should resolve from override store");
 
-        assert_eq!(input.model_path, expected);
+        if let Ok(input) = build_startup_input(args) {
+            assert_ne!(
+                input.model_path, expected,
+                "--models-dir must not resolve the repo id against itself as a store root"
+            );
+        }
     }
 
     #[test]

--- a/src/bin/mlx_server.rs
+++ b/src/bin/mlx_server.rs
@@ -1335,11 +1335,6 @@ struct ServerArgs {
     #[arg(long = "decode-storage-backend", value_name = "BACKEND")]
     decode_storage_backend: Option<mlxcel::server::DecodeStorageBackend>,
 
-    // llama-server compatibility arguments (accepted but ignored).
-    /// Accepted for llama-server CLI compatibility (ignored: mlxcel has no web UI)
-    #[arg(long, hide = true)]
-    _no_webui: bool,
-
     /// Maximum number of cached post-projection image features per loaded VLM.
     ///
     /// Multi-turn conversations that revisit the same image reuse cached

--- a/src/commands/serve_tests.rs
+++ b/src/commands/serve_tests.rs
@@ -140,7 +140,6 @@ fn sample_args() -> crate::ServeArgs {
         tp_moe_mode: "expert_parallel".to_string(),
         tp_embedding_mode: "replicated".to_string(),
         tp_lm_head_mode: "replicated".to_string(),
-        _no_webui: false,
         ggml_compat: Default::default(),
         spec_compat: mlxcel::cli::spec_compat_args::SpecCompatArgs::default(),
         chat_compat: Default::default(),

--- a/src/main.rs
+++ b/src/main.rs
@@ -2014,11 +2014,6 @@ pub(crate) struct ServeArgs {
     )]
     tp_lm_head_mode: String,
 
-    // llama-server compatibility arguments (accepted but ignored).
-    /// Accepted for llama-server CLI compatibility (ignored, mlxcel has no web UI)
-    #[arg(long, hide = true)]
-    _no_webui: bool,
-
     /// Decode storage backend for continuous batching.
     ///
     /// Accepted values: `auto`, `dense`, `paged`. When omitted, the server

--- a/tests/llama_logging_presets.rs
+++ b/tests/llama_logging_presets.rs
@@ -440,13 +440,20 @@ fn cache_list_reports_the_store_in_b10621s_format() {
     seed_checkpoint(&store, "mlx-community/gemma-3-4b-it-4bit");
 
     for (bin, leading) in invocations() {
-        // `--models-dir` on the command line, not the environment: the
+        // `--model-store-root` on the command line, not the environment: the
         // store `--cache-list` reports must be the one the same invocation
-        // would load from.
+        // would load from. #1438 reserved `--models-dir` for b10621 router
+        // discovery, so pointing this at that spelling would silently report
+        // the developer's real cache instead of the seeded temporary one, and
+        // the assertion below would depend on whatever happens to be cached.
         let output = run(
             bin,
             &leading,
-            &["--cache-list", "--models-dir", &store.to_string_lossy()],
+            &[
+                "--cache-list",
+                "--model-store-root",
+                &store.to_string_lossy(),
+            ],
             &[],
         );
         assert!(


### PR DESCRIPTION
Three regressions the orchestrator's full `make verify` found on merged `main` at `df3accb61`, all confirmed present on a clean checkout of that commit before any fix, so none is an artifact of another.

## The duplicate `--no-webui` declaration

Both binaries declared the long name `no-webui` twice, and clap resolves a duplicate silently in this profile, so the second definition shadowed the first with no error. A bare `_no_webui: bool` compatibility field predates this epic on `ServeArgs` and the server's `Cli`; #1435 then implemented the surface properly, with `UiCompatArgs::no_ui` declaring `--no-ui` and `no-webui` as an alias alongside the twelve enabling forms that are now refused with a diagnostic. The stale field is removed rather than the new alias renamed, because the new declaration carries the classification, the diagnostic and the tests while the old one carried nothing but its own acceptance. Verified on the built binary: `--no-webui` and `--no-ui` are still accepted and inert, and `--webui` is still refused with the `mlxcel ships no web UI` diagnostic.

## The store-root resolver test

#1438 resolved the `--models-dir` semantic collision deliberately: on the two llama-server surfaces that spelling now selects b10621 router-mode discovery, and the mlxcel store-root meaning moved to `--model-store-root`. `legacy_server_mode_resolves_repo_id_from_models_dir_override` predates the swap and still asserted the old meaning, so it drove the resolver into a network fetch for a repo id that exists nowhere. It moves to the new spelling and is renamed to match.

A second test pins the other half of the swap, because renaming alone would have left the reserved spelling unguarded: nothing would notice if `--models-dir` silently went back to resolving a repo id against itself as a store, since the renamed test no longer uses that spelling. `models_dir_no_longer_acts_as_the_model_store_root` asserts it does not, accepting either an error or a different resolved path, since the router branch may legitimately refuse the combination rather than resolve it.

## The `--cache-list` format test

`cache_list_reports_the_store_in_b10621s_format` reported ten cached models where it seeded and expected two. The test was already careful, seeding a temporary store and naming it on the command line rather than through the environment precisely so the list it asserts is the one that invocation would load from, but it named that store with `--models-dir`. After #1438 the flag no longer pointed anywhere, so `--cache-list` fell back to the developer's real cache.

This one is worth calling out as a class. It is a cross-chain collision at the level of flag meaning rather than source text: #1448 and #1438 ran concurrently in different worktrees of the same wave, `--models-dir` was still the store root when the test was written and was not once both had merged. Manifest shard ownership keeps two chains out of each other's files but cannot see a shared flag changing meaning underneath them. The failure is also order-dependent, which is why it did not fail at merge time: it passed while the real cache happened to hold few enough models, and only broke once sibling chains downloaded checkpoints for their own real-model validation.

## Verification

`make verify` on this branch: exit 0, 113 binaries, 9754 passed, 0 failed, 320 ignored. The same gate on merged `main` reported 2 failed, then 1 failed after the first fix.

Part of #1431.
