### PR TITLE
fix(server): point the cache-list test at the store-root spelling

### DIFF
--- a/tests/llama_logging_presets.rs
+++ b/tests/llama_logging_presets.rs
@@ -440,13 +440,20 @@ fn cache_list_reports_the_store_in_b10621s_format() {
     seed_checkpoint(&store, "mlx-community/gemma-3-4b-it-4bit");
 
     for (bin, leading) in invocations() {
-        // `--models-dir` on the command line, not the environment: the
+        // `--model-store-root` on the command line, not the environment: the
         // store `--cache-list` reports must be the one the same invocation
-        // would load from.
+        // would load from. #1438 reserved `--models-dir` for b10621 router
+        // discovery, so naming that spelling here would silently report the
+        // developer's real cache instead of the seeded temporary one, and the
+        // assertion below would depend on whatever happens to be cached.
         let output = run(
             bin,
             &leading,
-            &["--cache-list", "--models-dir", &store.to_string_lossy()],
+            &[
+                "--cache-list",
+                "--model-store-root",
+                &store.to_string_lossy(),
+            ],
             &[],
         );
         assert!(


### PR DESCRIPTION
`cache_list_reports_the_store_in_b10621s_format` fails on merged `main`, reporting ten cached models where it seeds and expects two.

The test was already careful: it seeds a temporary store and names it on the command line rather than through the environment, precisely so the list it asserts is the one that invocation would load from. What breaks it is that it names the store with `--models-dir`, and #1438 reserved that spelling for b10621 router discovery on the two llama-server surfaces. The flag no longer points anywhere, so `--cache-list` falls back to the developer's real cache and reports whatever happens to be in it.

This is a cross-chain collision at the level of flag meaning rather than source text. #1448 and #1438 ran concurrently in different worktrees of the same wave; `--models-dir` was still the store root when this test was written and was not by the time both had merged. Manifest shard ownership keeps two chains out of each other's files but cannot see a shared flag changing meaning underneath them.

The failure is also order dependent, which is why it did not fail at merge time: it passed while the real cache happened to hold few enough models, and only broke once sibling chains downloaded checkpoints for their own real-model validation. The comment now says why the shorter spelling is wrong here, so the next reader does not silently reintroduce it.

Found by the orchestrator's full `make verify` on merged `main`. Two sibling failures on the same commit, a duplicate `no-webui` declaration and the `--models-dir` store-root resolver tests, were fixed independently in #1497 while this was in review; this is the remainder.


## Verification

`make verify` on this change: exit 0, 113 binaries, 9768 passed, 0 failed, 320 ignored. The same gate on merged `main` at `884b6ebe1` reported 1 failed.

Part of #1431.
