### PR TITLE
feat: accept Responses-native image input parts (#1310)

### DIFF
--- a/docs/responses-api.md
+++ b/docs/responses-api.md
@@ -94,19 +94,28 @@ Phase 1 supports these typed items:
 ```jsonc
 [
   {"type":"message", "role":"user", "content":"hello"},
-  {"type":"message", "role":"system", "content":[{"type":"text", "text":"sys"}]},
+  {"type":"message", "role":"system", "content":[{"type":"input_text", "text":"sys"}]},
+  {"type":"message", "role":"user", "content":[{"type":"input_image", "image_url":"data:image/png;base64,...", "detail":"high"}]},
   {"type":"function_call", "call_id":"call_abc", "name":"f", "arguments":"{}"},
   {"type":"function_call_output", "call_id":"call_abc", "output":"ok"},
+  {"type":"function_call_output", "call_id":"call_img", "output":[{"type":"input_text", "text":"captured"}, {"type":"input_image", "image_url":"data:image/png;base64,..."}]},
   {"type":"reasoning", "content":[{"type":"reasoning_text", "text":"..."}]}
 ]
 ```
 
 `developer` role is treated like `system`. Reasoning input items are accepted and forwarded: the text content is buffered and attached to the parallel `reasoning` field of the following assistant turn. Chat templates that render `message.get('reasoning')` (such as Gemma 4) receive it there. The `preserve_thinking` kwarg controls whether the field survives the rolling-checkpoint strip: `false` (the default, unless the prompt cache is on) drops prior-turn reasoning along with any inline `<think>` blocks; `true` retains it.
 
-Message content parts reuse mlxcel's chat-completions content part types. This
-means `text`, `image_url`, `video_url`, and `input_audio` can deserialize, but
-actual execution still depends on the loaded model's media support. OpenAI
-Responses-specific `input_image` / `input_file` compatibility is not complete.
+Message items and array-valued `function_call_output.output` fields accept the Responses-native part spellings alongside mlxcel's existing chat-completions spellings:
+
+| Part | Fields | Behavior |
+|------|--------|----------|
+| `input_text` | `text: string` | Mapped to a chat-completions `text` part. |
+| `input_image` | `image_url: string`, optional `detail: "auto" \| "low" \| "high"` | Mapped to an `image_url` part; URLs and data URIs use the existing media pipeline. |
+| `input_image` with only `file_id` | `file_id: string` | Rejected with 400 because this server has no uploads store; provide `image_url` instead. |
+| `input_file` | any Responses file fields | Rejected with a named 400; PDF and document ingestion are not implemented. |
+| `text`, `image_url`, `video_url`, `input_audio` | existing chat-completions shapes | Accepted unchanged; execution still depends on the loaded model's media support. |
+
+A string-valued function output is unchanged. In an array-valued function output, text parts are joined with newlines in the tool message, non-text/non-image parts are retained as JSON text, and image parts are emitted in order as an immediately following user image turn. The tool message ends with `[Image output attached in the next message]` when that follow-up is present. Images on user message items remain in place; images on assistant, system, or developer message items are likewise moved to an immediately following user turn because supported chat templates render image placeholders on user turns.
 
 A request with no effective input is rejected with 400 before any model
 dispatch: an empty `input` array, a blank/whitespace-only string or `text`
@@ -235,4 +244,4 @@ Notable gaps:
 - no token-count endpoint;
 - no built-in tools or MCP connector execution;
 - no disk-persisted response store;
-- incomplete OpenAI Responses multimodal part compatibility.
+- no `input_file` ingestion or `file_id` resolution through an uploads store.

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -150,6 +150,9 @@ mod muse_glimmer_template_tests;
 mod reasoning_effort_tests;
 
 #[cfg(test)]
+mod responses_input_parts_tests;
+
+#[cfg(test)]
 mod muse_atem_roundtrip_tests;
 
 #[cfg(test)]

--- a/src/server/responses_input_parts_tests.rs
+++ b/src/server/responses_input_parts_tests.rs
@@ -1,0 +1,421 @@
+// Copyright 2025-2026 Lablup Inc. and Jeongkyu Shin
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::sync::Arc;
+
+use super::chat_request::request_has_effective_input;
+use super::responses_store::{ResponsesStore, ResponsesStoreConfig, StoredResponse};
+use super::responses_translator::{
+    OutboundContext, build_response_object, responses_request_to_chat,
+};
+use super::types::request::{ContentPart, MessageContent, Role};
+use super::types::responses_request::{
+    CreateResponseRequest, INPUT_FILE_UNSUPPORTED, INPUT_IMAGE_FILE_ID_UNSUPPORTED,
+};
+use super::types::responses_response::{ResponseObject, ResponseStatus};
+
+fn request(body: &str) -> CreateResponseRequest {
+    serde_json::from_str(body).expect("request should deserialize")
+}
+
+fn translated(body: &str) -> super::types::request::ChatCompletionRequest {
+    responses_request_to_chat(&request(body), None, None)
+        .expect("request should translate")
+        .chat_request
+}
+
+#[test]
+fn input_text_and_input_image_parts_lower_to_chat_parts() {
+    let chat = translated(
+        r#"{
+            "model":"m",
+            "input":[{
+                "type":"message",
+                "role":"user",
+                "content":[
+                    {"type":"input_text","text":"describe"},
+                    {"type":"input_image","image_url":"data:image/png;base64,aA==","detail":"high"}
+                ]
+            }]
+        }"#,
+    );
+
+    assert_eq!(chat.messages.len(), 1);
+    assert_eq!(chat.messages[0].role, Role::User);
+    let MessageContent::Parts(parts) = &chat.messages[0].content else {
+        panic!("expected content parts");
+    };
+    assert!(matches!(
+        &parts[0],
+        ContentPart::Text { text } if text == "describe"
+    ));
+    let ContentPart::ImageUrl { image_url } = &parts[1] else {
+        panic!("expected image part");
+    };
+    assert_eq!(image_url.url, "data:image/png;base64,aA==");
+    assert_eq!(image_url.detail.as_deref(), Some("high"));
+    assert!(request_has_effective_input(&chat));
+}
+
+#[test]
+fn input_image_file_id_only_is_rejected_with_named_error() {
+    let request = request(
+        r#"{
+            "model":"m",
+            "input":[{
+                "type":"message",
+                "role":"user",
+                "content":[{"type":"input_image","file_id":"file_1"}]
+            }]
+        }"#,
+    );
+    let error = responses_request_to_chat(&request, None, None)
+        .unwrap_err()
+        .to_string();
+    assert_eq!(error, INPUT_IMAGE_FILE_ID_UNSUPPORTED);
+}
+
+#[test]
+fn input_file_part_is_rejected() {
+    let request = request(
+        r#"{
+            "model":"m",
+            "input":[{
+                "type":"message",
+                "role":"user",
+                "content":[{"type":"input_file","file_id":"file_1"}]
+            }]
+        }"#,
+    );
+    let error = responses_request_to_chat(&request, None, None)
+        .unwrap_err()
+        .to_string();
+    assert_eq!(error, INPUT_FILE_UNSUPPORTED);
+}
+
+#[test]
+fn function_output_image_stays_after_tool_result() {
+    let chat = translated(
+        r#"{
+            "model":"m",
+            "input":[
+                {"type":"function_call","call_id":"call_1","name":"screenshot","arguments":"{}"},
+                {
+                    "type":"function_call_output",
+                    "call_id":"call_1",
+                    "output":[
+                        {"type":"input_text","text":"done"},
+                        {"type":"input_image","image_url":"data:image/png;base64,aA=="}
+                    ]
+                }
+            ]
+        }"#,
+    );
+
+    assert_eq!(chat.messages.len(), 3);
+    assert_eq!(chat.messages[0].role, Role::Assistant);
+    assert!(chat.messages[0].tool_calls.is_some());
+    assert_eq!(chat.messages[1].role, Role::Tool);
+    assert_eq!(
+        chat.messages[1].content.text(),
+        "done\n[Image output attached in the next message]"
+    );
+    assert_eq!(chat.messages[2].role, Role::User);
+    let MessageContent::Parts(parts) = &chat.messages[2].content else {
+        panic!("expected image follow-up parts");
+    };
+    assert_eq!(parts.len(), 1);
+    assert!(matches!(parts[0], ContentPart::ImageUrl { .. }));
+    assert!(request_has_effective_input(&chat));
+}
+
+#[test]
+fn function_output_preserves_image_order() {
+    let chat = translated(
+        r#"{
+            "model":"m",
+            "input":[{
+                "type":"function_call_output",
+                "call_id":"call_1",
+                "output":[
+                    {"type":"input_image","image_url":"data:image/png;base64,Zmlyc3Q="},
+                    {"type":"input_image","image_url":"data:image/png;base64,c2Vjb25k"}
+                ]
+            }]
+        }"#,
+    );
+
+    assert_eq!(
+        chat.messages[1].content.image_urls(),
+        vec![
+            "data:image/png;base64,Zmlyc3Q=".to_string(),
+            "data:image/png;base64,c2Vjb25k".to_string(),
+        ]
+    );
+}
+
+#[test]
+fn function_output_preserves_text_alongside_visual_input() {
+    let chat = translated(
+        r#"{
+            "model":"m",
+            "input":[{
+                "type":"function_call_output",
+                "call_id":"call_1",
+                "output":[
+                    {"type":"input_text","text":"captured"},
+                    {"type":"text","text":"red square"},
+                    {"type":"input_image","image_url":"data:image/png;base64,aA=="}
+                ]
+            }]
+        }"#,
+    );
+
+    assert_eq!(
+        chat.messages[0].content.text(),
+        "captured\nred square\n[Image output attached in the next message]"
+    );
+    assert_eq!(chat.messages[1].content.image_urls().len(), 1);
+}
+
+#[test]
+fn function_output_string_form_is_unchanged() {
+    let chat = translated(
+        r#"{
+            "model":"m",
+            "input":[{
+                "type":"function_call_output",
+                "call_id":"call_1",
+                "output":"plain result"
+            }]
+        }"#,
+    );
+
+    assert_eq!(chat.messages.len(), 1);
+    assert_eq!(chat.messages[0].role, Role::Tool);
+    assert_eq!(chat.messages[0].content.text(), "plain result");
+}
+
+#[test]
+fn input_file_inside_function_output_is_rejected() {
+    let request = request(
+        r#"{
+            "model":"m",
+            "input":[{
+                "type":"function_call_output",
+                "call_id":"call_1",
+                "output":[{"type":"input_file","file_id":"file_1"}]
+            }]
+        }"#,
+    );
+    let error = responses_request_to_chat(&request, None, None)
+        .unwrap_err()
+        .to_string();
+    assert_eq!(error, INPUT_FILE_UNSUPPORTED);
+}
+
+#[test]
+fn unknown_function_output_parts_remain_as_json_text() {
+    let chat = translated(
+        r#"{
+            "model":"m",
+            "input":[{
+                "type":"function_call_output",
+                "call_id":"call_1",
+                "output":[
+                    {"type":"input_text","text":"done"},
+                    {"type":"foo","answer":42}
+                ]
+            }]
+        }"#,
+    );
+
+    let tool_text = chat.messages[0].content.text();
+    let (text, raw_json) = tool_text
+        .split_once('\n')
+        .expect("text and leftover JSON should be separate lines");
+    assert_eq!(text, "done");
+    let leftovers: serde_json::Value =
+        serde_json::from_str(raw_json).expect("leftovers should be valid JSON");
+    assert_eq!(leftovers, serde_json::json!([{"type":"foo","answer":42}]));
+}
+
+#[test]
+fn known_non_image_tool_parts_preserve_original_json() {
+    let chat = translated(
+        r#"{
+            "model":"m",
+            "input":[{
+                "type":"function_call_output",
+                "call_id":"call_1",
+                "output":[
+                    {
+                        "type":"input_audio",
+                        "input_audio":{"data":"aGVsbG8="},
+                        "extension":"keep-me"
+                    },
+                    {
+                        "type":"video_url",
+                        "video_url":{"url":"file:///tmp/clip.mp4"},
+                        "vendor_option":7
+                    }
+                ]
+            }]
+        }"#,
+    );
+
+    let leftovers: serde_json::Value =
+        serde_json::from_str(&chat.messages[0].content.text()).expect("valid leftover JSON");
+    assert_eq!(
+        leftovers,
+        serde_json::json!([
+            {
+                "type":"input_audio",
+                "input_audio":{"data":"aGVsbG8="},
+                "extension":"keep-me"
+            },
+            {
+                "type":"video_url",
+                "video_url":{"url":"file:///tmp/clip.mp4"},
+                "vendor_option":7
+            }
+        ])
+    );
+}
+
+#[test]
+fn assistant_message_image_moves_to_following_user_turn() {
+    let chat = translated(
+        r#"{
+            "model":"m",
+            "input":[{
+                "type":"message",
+                "role":"assistant",
+                "content":[
+                    {"type":"input_text","text":"visual result"},
+                    {"type":"input_image","image_url":"data:image/png;base64,aA=="}
+                ]
+            }]
+        }"#,
+    );
+
+    assert_eq!(chat.messages.len(), 2);
+    assert_eq!(chat.messages[0].role, Role::Assistant);
+    assert_eq!(chat.messages[0].content.text(), "visual result");
+    assert!(chat.messages[0].content.image_urls().is_empty());
+    assert_eq!(chat.messages[1].role, Role::User);
+    assert_eq!(chat.messages[1].content.image_urls().len(), 1);
+}
+
+#[test]
+fn non_user_message_preserves_video_and_audio_when_moving_images() {
+    let chat = translated(
+        r#"{
+            "model":"m",
+            "input":[{
+                "type":"message",
+                "role":"assistant",
+                "content":[
+                    {"type":"text","text":"mixed media"},
+                    {"type":"video_url","video_url":{"url":"file:///tmp/clip.mp4","fps":1.0}},
+                    {"type":"input_audio","input_audio":{"data":"aGVsbG8=","format":"wav"}},
+                    {"type":"input_image","image_url":"data:image/png;base64,aA=="}
+                ]
+            }]
+        }"#,
+    );
+
+    let MessageContent::Parts(retained) = &chat.messages[0].content else {
+        panic!("non-image media should keep content in part form");
+    };
+    assert_eq!(retained.len(), 3);
+    assert!(matches!(retained[0], ContentPart::Text { .. }));
+    assert!(matches!(retained[1], ContentPart::VideoUrl { .. }));
+    assert!(matches!(retained[2], ContentPart::InputAudio { .. }));
+    assert!(chat.messages[0].content.image_urls().is_empty());
+    assert_eq!(chat.messages[1].content.image_urls().len(), 1);
+}
+
+fn completed_response(request: &CreateResponseRequest) -> ResponseObject {
+    build_response_object(OutboundContext {
+        response_id: "resp_image_tool".to_string(),
+        model_id: "m".to_string(),
+        created_at: 1.0,
+        completed_at: 2.0,
+        status: ResponseStatus::Completed,
+        prompt_tokens: 1,
+        completion_tokens: 1,
+        cached_tokens: 0,
+        reasoning_tokens: 0,
+        text: "stored answer".to_string(),
+        reasoning_text: None,
+        parsed_tool_calls: None,
+        max_tool_calls: None,
+        request,
+        error: None,
+        incomplete_reason: None,
+        finish_reason: "stop".to_string(),
+    })
+}
+
+#[test]
+fn stored_response_with_image_tool_output_replays_identically() {
+    let original = request(
+        r#"{
+            "model":"m",
+            "input":[
+                {"type":"function_call","call_id":"call_1","name":"screenshot","arguments":"{}"},
+                {
+                    "type":"function_call_output",
+                    "call_id":"call_1",
+                    "output":[
+                        {"type":"input_text","text":"captured"},
+                        {"type":"input_image","image_url":"data:image/png;base64,aA=="}
+                    ]
+                }
+            ]
+        }"#,
+    );
+    let store = Arc::new(ResponsesStore::new(ResponsesStoreConfig::default()));
+    store.insert(
+        "resp_image_tool".to_string(),
+        StoredResponse {
+            response: completed_response(&original),
+            input_items: original.input.clone().into_items(),
+        },
+    );
+
+    let next = request(
+        r#"{
+            "model":"m",
+            "previous_response_id":"resp_image_tool",
+            "input":"continue"
+        }"#,
+    );
+    let replayed = responses_request_to_chat(&next, Some(&store), None)
+        .expect("stored response should replay")
+        .chat_request;
+
+    assert_eq!(replayed.messages[1].role, Role::Tool);
+    assert_eq!(
+        replayed.messages[1].content.text(),
+        "captured\n[Image output attached in the next message]"
+    );
+    assert_eq!(replayed.messages[2].role, Role::User);
+    assert_eq!(replayed.messages[2].content.image_urls().len(), 1);
+    assert_eq!(replayed.messages[3].role, Role::Assistant);
+    assert_eq!(replayed.messages[3].content.text(), "stored answer");
+    assert_eq!(replayed.messages[4].role, Role::User);
+    assert_eq!(replayed.messages[4].content.text(), "continue");
+}

--- a/src/server/responses_translator.rs
+++ b/src/server/responses_translator.rs
@@ -39,10 +39,12 @@
 use std::sync::Arc;
 
 use crate::server::types::request::{
-    ChatCompletionRequest, Message, MessageContent, Role, Tool, ToolCallFunction, ToolCallInMessage,
+    ChatCompletionRequest, ContentPart, ImageUrl, Message, MessageContent, Role, Tool,
+    ToolCallFunction, ToolCallInMessage,
 };
 use crate::server::types::responses_request::{
-    CreateResponseRequest, ResponseInputContent, ResponseInputItem, ResponseInputRole, ResponseTool,
+    CreateResponseRequest, INPUT_FILE_UNSUPPORTED, ResponseInputContent, ResponseInputItem,
+    ResponseInputPart, ResponseInputRole, ResponseTool, ResponseToolOutput,
 };
 use crate::server::types::responses_response::{
     ConversationRefEchoed, ResponseErrorBody, ResponseFunctionCallOutput,
@@ -90,6 +92,8 @@ pub enum ResponsesTranslateError {
     TruncationUnsupported(String),
     #[error("max_output_tokens must be > 0")]
     MaxOutputTokensInvalid,
+    #[error("{0}")]
+    InvalidInputPart(String),
 }
 
 /// Inbound translation result. Carries the synthetic
@@ -192,7 +196,9 @@ pub fn responses_request_to_chat(
             tool_calls: None,
         });
     }
-    messages.extend(input_items_to_messages(&all_items));
+    messages.extend(
+        input_items_to_messages(&all_items).map_err(ResponsesTranslateError::InvalidInputPart)?,
+    );
 
     let tools = function_tools(request.tools.as_deref());
     let tool_choice = request.tool_choice.clone();
@@ -291,6 +297,80 @@ fn function_tools(tools: Option<&[ResponseTool]>) -> Option<Vec<Tool>> {
     if out.is_empty() { None } else { Some(out) }
 }
 
+const IMAGE_OUTPUT_FOLLOWUP: &str = "[Image output attached in the next message]";
+
+fn lower_parts(
+    parts: &[ResponseInputPart],
+    collect_images: bool,
+) -> Result<(Vec<ContentPart>, Vec<ImageUrl>), String> {
+    let mut lowered = Vec::with_capacity(parts.len());
+    let mut images = Vec::new();
+    for part in parts {
+        let content_part = ContentPart::try_from(part)?;
+        if collect_images && let ContentPart::ImageUrl { image_url } = &content_part {
+            images.push(image_url.clone());
+        }
+        lowered.push(content_part);
+    }
+    Ok((lowered, images))
+}
+
+fn lower_tool_output_parts(parts: &[ResponseInputPart]) -> Result<(String, Vec<ImageUrl>), String> {
+    let mut lines = Vec::new();
+    let mut images = Vec::new();
+    let mut leftovers = Vec::new();
+
+    for part in parts {
+        match part {
+            ResponseInputPart::InputText { text } | ResponseInputPart::Text { text } => {
+                lines.push(text.clone());
+            }
+            ResponseInputPart::InputImage { .. } => {
+                let lowered = ContentPart::try_from(part)?;
+                let ContentPart::ImageUrl { image_url } = lowered else {
+                    return Err("input_image did not lower to an image part".to_string());
+                };
+                images.push(image_url);
+            }
+            ResponseInputPart::ImageUrl { image_url } => images.push(image_url.clone()),
+            ResponseInputPart::InputFile { .. } => {
+                return Err(INPUT_FILE_UNSUPPORTED.to_string());
+            }
+            ResponseInputPart::VideoUrl { .. }
+            | ResponseInputPart::InputAudio { .. }
+            | ResponseInputPart::Unknown { .. } => leftovers.push(part.to_json_value()),
+        }
+    }
+
+    if !leftovers.is_empty() {
+        lines.push(
+            serde_json::to_string(&leftovers)
+                .map_err(|err| format!("failed to serialize function_call_output parts: {err}"))?,
+        );
+    }
+    if !images.is_empty() {
+        lines.push(IMAGE_OUTPUT_FOLLOWUP.to_string());
+    }
+
+    Ok((lines.join("\n"), images))
+}
+
+fn image_followup_message(images: Vec<ImageUrl>) -> Message {
+    Message {
+        role: Role::User,
+        content: MessageContent::Parts(
+            images
+                .into_iter()
+                .map(|image_url| ContentPart::ImageUrl { image_url })
+                .collect(),
+        ),
+        name: None,
+        tool_call_id: None,
+        reasoning: None,
+        tool_calls: None,
+    }
+}
+
 /// Convert a flat list of input items into chat-completion messages.
 ///
 /// `function_call` items become assistant messages with `tool_calls`;
@@ -300,7 +380,7 @@ fn function_tools(tools: Option<&[ResponseTool]>) -> Option<Vec<Tool>> {
 /// following assistant turn (issue #362) so templates that read
 /// `message.get('reasoning')` see prior thinking. A reasoning item that is not
 /// followed by an assistant turn before the next turn boundary is dropped.
-fn input_items_to_messages(items: &[ResponseInputItem]) -> Vec<Message> {
+fn input_items_to_messages(items: &[ResponseInputItem]) -> Result<Vec<Message>, String> {
     let mut out: Vec<Message> = Vec::new();
     let mut pending_tool_calls: Vec<ToolCallInMessage> = Vec::new();
     let mut pending_reasoning: Option<String> = None;
@@ -330,14 +410,51 @@ fn input_items_to_messages(items: &[ResponseInputItem]) -> Vec<Message> {
                 } else {
                     None
                 };
+                let (message_content, followup_images) = match content {
+                    ResponseInputContent::Text(text) => {
+                        (MessageContent::Text(text.clone()), Vec::new())
+                    }
+                    ResponseInputContent::Parts(parts) => {
+                        let (lowered, images) = lower_parts(parts, converted_role != Role::User)?;
+                        if converted_role == Role::User {
+                            (MessageContent::Parts(lowered), Vec::new())
+                        } else {
+                            let retained = lowered
+                                .into_iter()
+                                .filter(|part| !matches!(part, ContentPart::ImageUrl { .. }))
+                                .collect::<Vec<_>>();
+                            let content = if retained
+                                .iter()
+                                .all(|part| matches!(part, ContentPart::Text { .. }))
+                            {
+                                MessageContent::Text(
+                                    retained
+                                        .iter()
+                                        .filter_map(|part| match part {
+                                            ContentPart::Text { text } => Some(text.as_str()),
+                                            _ => None,
+                                        })
+                                        .collect::<Vec<_>>()
+                                        .join(""),
+                                )
+                            } else {
+                                MessageContent::Parts(retained)
+                            };
+                            (content, images)
+                        }
+                    }
+                };
                 out.push(Message {
                     role: converted_role,
-                    content: convert_content(content),
+                    content: message_content,
                     name: name.clone(),
                     tool_call_id: None,
                     reasoning,
                     tool_calls: None,
                 });
+                if !followup_images.is_empty() {
+                    out.push(image_followup_message(followup_images));
+                }
                 // A turn boundary consumes any leftover reasoning so it cannot
                 // leak onto a later, unrelated assistant turn.
                 pending_reasoning = None;
@@ -367,14 +484,21 @@ fn input_items_to_messages(items: &[ResponseInputItem]) -> Vec<Message> {
                         tool_calls: Some(std::mem::take(&mut pending_tool_calls)),
                     });
                 }
+                let (tool_content, images) = match output {
+                    ResponseToolOutput::Text(text) => (text.clone(), Vec::new()),
+                    ResponseToolOutput::Parts(parts) => lower_tool_output_parts(parts)?,
+                };
                 out.push(Message {
                     role: Role::Tool,
-                    content: MessageContent::Text(output.clone()),
+                    content: MessageContent::Text(tool_content),
                     name: None,
                     tool_call_id: Some(call_id.clone()),
                     reasoning: None,
                     tool_calls: None,
                 });
+                if !images.is_empty() {
+                    out.push(image_followup_message(images));
+                }
                 // A tool-output turn is not an assistant turn, so any buffered
                 // reasoning that was not consumed by the flush above (e.g.
                 // malformed input: Reasoning immediately followed by
@@ -413,7 +537,7 @@ fn input_items_to_messages(items: &[ResponseInputItem]) -> Vec<Message> {
         });
     }
 
-    out
+    Ok(out)
 }
 
 fn convert_role(role: ResponseInputRole) -> Role {
@@ -423,13 +547,6 @@ fn convert_role(role: ResponseInputRole) -> Role {
         // mlxcel treats both as system turns.
         ResponseInputRole::Assistant => Role::Assistant,
         ResponseInputRole::System | ResponseInputRole::Developer => Role::System,
-    }
-}
-
-fn convert_content(content: &ResponseInputContent) -> MessageContent {
-    match content {
-        ResponseInputContent::Text(s) => MessageContent::Text(s.clone()),
-        ResponseInputContent::Parts(parts) => MessageContent::Parts(parts.to_vec()),
     }
 }
 
@@ -846,7 +963,7 @@ mod tests {
             // skipped. The arm must still clear pending_reasoning.
             ResponseInputItem::FunctionCallOutput {
                 call_id: "call_orphan".to_string(),
-                output: "result".to_string(),
+                output: ResponseToolOutput::Text("result".to_string()),
             },
             ResponseInputItem::Message {
                 role: ResponseInputRole::Assistant,
@@ -896,7 +1013,7 @@ mod tests {
             },
             ResponseInputItem::FunctionCallOutput {
                 call_id: "call_1".to_string(),
-                output: "done".to_string(),
+                output: ResponseToolOutput::Text("done".to_string()),
             },
             ResponseInputItem::Message {
                 role: ResponseInputRole::Assistant,

--- a/src/server/routes/responses.rs
+++ b/src/server/routes/responses.rs
@@ -1134,6 +1134,17 @@ fn persist_response(
 mod tests {
     use super::*;
     use crate::server::types::ChatCompletionRequest;
+    use crate::server::types::responses_request::INPUT_IMAGE_FILE_ID_UNSUPPORTED;
+
+    #[test]
+    fn invalid_input_part_maps_to_named_400_response() {
+        let response = translate_error_to_response(ResponsesTranslateError::InvalidInputPart(
+            INPUT_IMAGE_FILE_ID_UNSUPPORTED.to_string(),
+        ));
+        assert_eq!(response.status, StatusCode::BAD_REQUEST);
+        assert_eq!(response.error.error_type, "invalid_request_error");
+        assert_eq!(response.error.message, INPUT_IMAGE_FILE_ID_UNSUPPORTED);
+    }
 
     #[test]
     fn split_reasoning_inline_block_separates_content() {

--- a/src/server/types/mod.rs
+++ b/src/server/types/mod.rs
@@ -22,6 +22,7 @@ pub mod native_completion;
 pub mod request;
 pub mod rerank;
 pub mod response;
+mod responses_input_part;
 pub mod responses_request;
 pub mod responses_response;
 pub mod responses_stream;

--- a/src/server/types/responses_input_part.rs
+++ b/src/server/types/responses_input_part.rs
@@ -1,0 +1,291 @@
+// Copyright 2025-2026 Lablup Inc. and Jeongkyu Shin
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Content parts accepted by the OpenAI Responses API request surface.
+
+use serde::de::{DeserializeOwned, Error as _};
+use serde::{Deserialize, Deserializer};
+
+use super::request::{ContentPart, ImageUrl, InputAudio, VideoUrl};
+
+pub const INPUT_IMAGE_FILE_ID_UNSUPPORTED: &str =
+    "input_image.file_id is not supported by this server. Provide image_url instead.";
+pub const INPUT_FILE_UNSUPPORTED: &str = "input_file is not supported by this server.";
+
+/// Responses-native parts plus the chat-completions spellings accepted by
+/// earlier mlxcel releases.
+///
+/// Unknown objects are retained so a function output can preserve them as
+/// JSON text instead of silently discarding client data.
+#[derive(Debug, Clone)]
+pub enum ResponseInputPart {
+    InputText {
+        text: String,
+    },
+    InputImage {
+        image_url: Option<String>,
+        detail: Option<String>,
+        file_id: Option<String>,
+    },
+    InputFile {
+        raw: serde_json::Map<String, serde_json::Value>,
+    },
+    Text {
+        text: String,
+    },
+    ImageUrl {
+        image_url: ImageUrl,
+    },
+    VideoUrl {
+        raw: serde_json::Map<String, serde_json::Value>,
+    },
+    InputAudio {
+        raw: serde_json::Map<String, serde_json::Value>,
+    },
+    Unknown {
+        part_type: String,
+        raw: serde_json::Map<String, serde_json::Value>,
+    },
+}
+
+impl<'de> Deserialize<'de> for ResponseInputPart {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let value = serde_json::Value::deserialize(deserializer)?;
+        let serde_json::Value::Object(mut raw) = value else {
+            return Err(D::Error::custom("response input part must be an object"));
+        };
+        let part_type = raw
+            .get("type")
+            .and_then(serde_json::Value::as_str)
+            .ok_or_else(|| D::Error::custom("response input part must include a string 'type'"))?
+            .to_string();
+
+        match part_type.as_str() {
+            "input_text" => Ok(Self::InputText {
+                text: required_field(&raw, &part_type, "text")?,
+            }),
+            "input_image" => Ok(Self::InputImage {
+                image_url: optional_field(&raw, "image_url")?,
+                detail: optional_field(&raw, "detail")?,
+                file_id: optional_field(&raw, "file_id")?,
+            }),
+            "input_file" => {
+                raw.remove("type");
+                Ok(Self::InputFile { raw })
+            }
+            "text" => Ok(Self::Text {
+                text: required_field(&raw, &part_type, "text")?,
+            }),
+            "image_url" => Ok(Self::ImageUrl {
+                image_url: required_field(&raw, &part_type, "image_url")?,
+            }),
+            "video_url" => {
+                let _: VideoUrl = required_field(&raw, &part_type, "video_url")?;
+                raw.remove("type");
+                Ok(Self::VideoUrl { raw })
+            }
+            "input_audio" => {
+                let _: InputAudio = required_field(&raw, &part_type, "input_audio")?;
+                raw.remove("type");
+                Ok(Self::InputAudio { raw })
+            }
+            _ => {
+                raw.remove("type");
+                Ok(Self::Unknown { part_type, raw })
+            }
+        }
+    }
+}
+
+fn required_field<T, E>(
+    raw: &serde_json::Map<String, serde_json::Value>,
+    part_type: &str,
+    field: &str,
+) -> Result<T, E>
+where
+    T: DeserializeOwned,
+    E: serde::de::Error,
+{
+    raw.get(field)
+        .cloned()
+        .ok_or_else(|| E::custom(format!("{part_type}.{field} is required")))
+        .and_then(|value| serde_json::from_value(value).map_err(E::custom))
+}
+
+fn optional_field<T, E>(
+    raw: &serde_json::Map<String, serde_json::Value>,
+    field: &str,
+) -> Result<Option<T>, E>
+where
+    T: DeserializeOwned,
+    E: serde::de::Error,
+{
+    serde_json::from_value(raw.get(field).cloned().unwrap_or(serde_json::Value::Null))
+        .map_err(E::custom)
+}
+
+fn typed_field<T>(
+    raw: &serde_json::Map<String, serde_json::Value>,
+    part_type: &str,
+    field: &str,
+) -> Result<T, String>
+where
+    T: DeserializeOwned,
+{
+    let value = raw
+        .get(field)
+        .cloned()
+        .ok_or_else(|| format!("{part_type}.{field} is required"))?;
+    serde_json::from_value(value).map_err(|err| format!("{part_type}.{field} is invalid: {err}"))
+}
+
+impl ResponseInputPart {
+    pub(crate) fn to_json_value(&self) -> serde_json::Value {
+        match self {
+            Self::InputText { text } => serde_json::json!({"type": "input_text", "text": text}),
+            Self::InputImage {
+                image_url,
+                detail,
+                file_id,
+            } => {
+                let mut raw = serde_json::Map::new();
+                raw.insert("type".to_string(), serde_json::json!("input_image"));
+                if let Some(image_url) = image_url {
+                    raw.insert("image_url".to_string(), serde_json::json!(image_url));
+                }
+                if let Some(detail) = detail {
+                    raw.insert("detail".to_string(), serde_json::json!(detail));
+                }
+                if let Some(file_id) = file_id {
+                    raw.insert("file_id".to_string(), serde_json::json!(file_id));
+                }
+                serde_json::Value::Object(raw)
+            }
+            Self::InputFile { raw } => object_with_type("input_file", raw.clone()),
+            Self::Text { text } => serde_json::json!({"type": "text", "text": text}),
+            Self::ImageUrl { image_url } => {
+                serde_json::json!({"type": "image_url", "image_url": image_url})
+            }
+            Self::VideoUrl { raw, .. } => object_with_type("video_url", raw.clone()),
+            Self::InputAudio { raw, .. } => object_with_type("input_audio", raw.clone()),
+            Self::Unknown { part_type, raw } => object_with_type(part_type, raw.clone()),
+        }
+    }
+}
+
+fn object_with_type(
+    part_type: &str,
+    mut raw: serde_json::Map<String, serde_json::Value>,
+) -> serde_json::Value {
+    raw.insert("type".to_string(), serde_json::json!(part_type));
+    serde_json::Value::Object(raw)
+}
+
+impl TryFrom<&ResponseInputPart> for ContentPart {
+    type Error = String;
+
+    fn try_from(part: &ResponseInputPart) -> Result<Self, Self::Error> {
+        match part {
+            ResponseInputPart::InputText { text } | ResponseInputPart::Text { text } => {
+                Ok(ContentPart::Text { text: text.clone() })
+            }
+            ResponseInputPart::InputImage {
+                image_url,
+                detail,
+                file_id,
+            } => match image_url {
+                Some(url) => Ok(ContentPart::ImageUrl {
+                    image_url: ImageUrl {
+                        url: url.clone(),
+                        detail: detail.clone(),
+                        max_soft_tokens: None,
+                    },
+                }),
+                None if file_id.is_some() => Err(INPUT_IMAGE_FILE_ID_UNSUPPORTED.to_string()),
+                None => Err("input_image.image_url is required by this server".to_string()),
+            },
+            ResponseInputPart::InputFile { .. } => Err(INPUT_FILE_UNSUPPORTED.to_string()),
+            ResponseInputPart::ImageUrl { image_url } => Ok(ContentPart::ImageUrl {
+                image_url: image_url.clone(),
+            }),
+            ResponseInputPart::VideoUrl { raw } => Ok(ContentPart::VideoUrl {
+                video_url: typed_field(raw, "video_url", "video_url")?,
+            }),
+            ResponseInputPart::InputAudio { raw } => Ok(ContentPart::InputAudio {
+                input_audio: typed_field(raw, "input_audio", "input_audio")?,
+            }),
+            ResponseInputPart::Unknown { part_type, .. } => Err(format!(
+                "input part type '{part_type}' is not supported by this server"
+            )),
+        }
+    }
+}
+
+impl TryFrom<ResponseInputPart> for ContentPart {
+    type Error = String;
+
+    fn try_from(part: ResponseInputPart) -> Result<Self, Self::Error> {
+        ContentPart::try_from(&part)
+    }
+}
+
+/// String or content-part-array form of a function call result.
+#[derive(Debug, Clone, Deserialize)]
+#[serde(untagged)]
+pub enum ResponseToolOutput {
+    Text(String),
+    Parts(Vec<ResponseInputPart>),
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn native_image_maps_detail_to_chat_image() {
+        let part: ResponseInputPart = serde_json::from_str(
+            r#"{"type":"input_image","image_url":"data:image/png;base64,aA==","detail":"high"}"#,
+        )
+        .unwrap();
+        let ContentPart::ImageUrl { image_url } = ContentPart::try_from(part).unwrap() else {
+            panic!("expected image part");
+        };
+        assert_eq!(image_url.url, "data:image/png;base64,aA==");
+        assert_eq!(image_url.detail.as_deref(), Some("high"));
+        assert_eq!(image_url.max_soft_tokens, None);
+    }
+
+    #[test]
+    fn file_id_only_image_has_named_error() {
+        let part: ResponseInputPart =
+            serde_json::from_str(r#"{"type":"input_image","file_id":"file_1"}"#).unwrap();
+        assert_eq!(
+            ContentPart::try_from(part).unwrap_err(),
+            INPUT_IMAGE_FILE_ID_UNSUPPORTED
+        );
+    }
+
+    #[test]
+    fn unknown_part_retains_its_json_object() {
+        let part: ResponseInputPart =
+            serde_json::from_str(r#"{"type":"foo","answer":42}"#).unwrap();
+        assert_eq!(
+            part.to_json_value(),
+            serde_json::json!({"type":"foo","answer":42})
+        );
+    }
+}

--- a/src/server/types/responses_request.rs
+++ b/src/server/types/responses_request.rs
@@ -28,7 +28,10 @@
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 
-use super::request::{ContentPart, FunctionDefinition, SamplingParams, ToolChoice};
+use super::request::{FunctionDefinition, SamplingParams, ToolChoice};
+pub use super::responses_input_part::{
+    INPUT_FILE_UNSUPPORTED, INPUT_IMAGE_FILE_ID_UNSUPPORTED, ResponseInputPart, ResponseToolOutput,
+};
 
 /// `POST /v1/responses` request body.
 ///
@@ -232,7 +235,10 @@ pub enum ResponseInputItem {
         arguments: String,
     },
     /// Result of a prior function call.
-    FunctionCallOutput { call_id: String, output: String },
+    FunctionCallOutput {
+        call_id: String,
+        output: ResponseToolOutput,
+    },
     /// Reasoning trace from a prior turn (rehydrated). Phase 1 records
     /// the text but does not push it through the thinking-token machinery.
     Reasoning { content: Vec<ReasoningContentPart> },
@@ -264,7 +270,7 @@ pub enum ResponseInputRole {
 #[serde(untagged)]
 pub enum ResponseInputContent {
     Text(String),
-    Parts(Vec<ContentPart>),
+    Parts(Vec<ResponseInputPart>),
 }
 
 impl ResponseInputContent {
@@ -274,7 +280,9 @@ impl ResponseInputContent {
             ResponseInputContent::Parts(parts) => parts
                 .iter()
                 .filter_map(|p| match p {
-                    ContentPart::Text { text } => Some(text.as_str()),
+                    ResponseInputPart::InputText { text } | ResponseInputPart::Text { text } => {
+                        Some(text.as_str())
+                    }
                     _ => None,
                 })
                 .collect::<Vec<_>>()


### PR DESCRIPTION
## Summary

Accept Responses-native input_text and input_image content parts on message items and array-valued function call outputs while retaining the existing chat-completions part spellings.

Unsupported file-backed forms now reach the normal invalid-request path with named errors, and image-bearing tool results are represented as ordered user follow-up turns so the existing media pipeline delivers them to the model.

## What changed

- Added a Responses-specific content-part model with typed validation, lossless JSON preservation for non-text tool-output parts, and raw-only storage for large legacy audio payloads.
- Lowered user image parts in place, moved images from tool and non-user turns to immediately following user turns, and preserved text, video, audio, image order, reasoning boundaries, and stored-response replay.
- Added focused coverage for native/legacy deserialization, file rejection, exact 400 error mapping, effective image-only input, mixed tool outputs, image ordering, unknown JSON, non-user media preservation, and previous-response replay.
- Updated the Responses API documentation with supported part shapes, rejection behavior, and image follow-up semantics.

## Test plan

- [x] cargo check --lib --tests
- [x] cargo test --lib responses_input_parts_tests (13 passed)
- [x] cargo test --lib server::types::responses_input_part::tests (3 passed)
- [x] cargo test --lib server::responses_translator::tests (20 passed)
- [x] cargo test --lib server::types::responses_request::tests (7 passed)
- [x] cargo test --lib server::routes::responses::tests::invalid_input_part_maps_to_named_400_response (1 passed)
- [x] cargo clippy --lib --tests -- -D warnings
- [x] cargo fmt --all -- --check
- [ ] Real Metal/Accelerate workspace and Qwen3-VL checkpoint validation (requires an Apple Metal host and local model assets; this runner is Linux aarch64)

Closes #1310
