### PR TITLE
fix: stop swallowing template rejections

### DIFF
--- a/TECHNICAL_REPORTS/1511-template-rejection-surfaces-20260830.en.md
+++ b/TECHNICAL_REPORTS/1511-template-rejection-surfaces-20260830.en.md
@@ -1,0 +1,72 @@
+# Technical Report: PR #1511 - Template rejection surfaces
+
+**Date**: 2026-08-30
+**Status**: Completed
+**Languages**: Rust, Markdown
+**Risk Level**: Medium
+
+## Executive Summary
+
+PR #1511 fixes issue #1176 by keeping chat-template `raise_exception(...)` rejections visible across the Responses API, the offline CLI, and the disaggregated router front end. Deliberate template refusals now stop the request with a named client error, while malformed or unsupported template-engine failures still use the existing fallback path.
+
+## 1. Problem Statement
+
+The single-node `/v1/chat/completions` route already treated template-raised rejections as request errors, but adjacent surfaces could still swallow or misclassify them. `/v1/responses` needed explicit regression coverage for the current `reasoning.effort` forwarding behavior, the offline CLI fell back to the raw user prompt for every template error, and the disaggregated router converted every preparation error into an HTTP 500.
+
+The failure mode was especially risky for reasoning-effort controls. Values are intentionally forwarded verbatim instead of translated between OpenAI and model-specific vocabularies, so a model template that rejects `high` must produce a visible client error rather than silently generating from an unframed fallback prompt.
+
+## 2. Technical Decisions
+
+### 2.1 Preserve the rejection sentinel through preparation
+
+`prepare_chat_request_with_cache` now wraps template rejections with user-facing context while preserving the original render error as the source. This keeps `template_rejection_message` usable at outer route boundaries such as the disaggregated router, without changing the visible error text already used by single-node chat and Responses routes.
+
+### 2.2 Keep CLI fallback only for engine failures
+
+The offline CLI prompt helpers now return `Result<String>`. They return a named error when `template_rejection_message` finds the sentinel, but still return the raw prompt when minijinja cannot render the template for engine-side reasons such as malformed syntax.
+
+### 2.3 Do not translate reasoning values
+
+The Responses translator behavior remains unchanged: `reasoning.effort` is copied into the chat request as-is. The new tests prove that a `high` value reaches the template unchanged and remains rejectable by a model-specific template.
+
+### 2.4 Map router template rejections to 400
+
+The disaggregated router now checks the preserved sentinel after chat request preparation. It returns the same `400 invalid_request_error` response shape for template rejections and leaves unrelated preparation failures on the existing generic 500 path.
+
+## 3. Change Summary
+
+| Category | Count | Summary |
+|---|---:|---|
+| Error propagation | 1 | Preserved the template rejection source through preparation error wrapping. |
+| CLI behavior | 1 | Made CLI prompt resolution fallible only for template rejections. |
+| Router behavior | 1 | Converted disaggregated router template rejections from 500 to 400. |
+| Responses coverage | 2 | Added rejection and engine-fallback regression tests. |
+| CLI coverage | 3 | Updated prompt-helper tests and added rejection-path coverage. |
+| Router coverage | 1 | Added HTTP 400 regression coverage for template rejection. |
+
+## 4. Validation
+
+- `cargo test --bin mlxcel resolve_cli_prompt`: 5 passed.
+- `cargo test --bin mlxcel apply_user_chat_template_wraps_prompt_as_user_message`: 1 passed.
+- `cargo test --bin mlxcel vlm_chat_template`: 4 passed.
+- `cargo test --lib responses_reasoning_effort_template_rejection_survives_translation`: 1 passed.
+- `cargo test --lib responses_template_engine_failure_still_uses_prompt_fallback`: 1 passed.
+- `cargo test --lib router_chat_maps_template_rejection_to_bad_request`: 1 passed.
+- `cargo test --lib template_rejection`: 11 passed.
+- `cargo clippy --lib --tests -- -D warnings`: passed.
+- `cargo clippy --bin mlxcel -- -D warnings`: passed.
+- Hosted PR checks passed: cargo-clippy, cargo-deny, cargo-fmt, OpenXLA feature compile, crate versions, cross-repo refs, kernel dtype keys, llama-compat manifest, Detect changes, and license/cla. MLX pin extraction and OpenXLA feature link were skipped by change detection.
+
+Broad workspace tests, serial all-tests, and cold release builds were not run because the implementation workflow explicitly forbids them for this issue batch.
+
+## 5. Review Notes
+
+- **Correctness**: Template rejections and engine failures now diverge at each affected surface. Responses forwarding remains verbatim, so unsupported value mapping is still delegated to the loaded template.
+- **Security**: Rejection messages continue to use the existing 512-character `TemplateRejection` cap and control-character filtering before reaching HTTP or CLI output. No new logging of prompt contents was added.
+- **Performance**: The new checks inspect an existing error chain only on render failure paths. The successful render and generation paths are unchanged.
+- **Compatibility**: Existing fallback behavior remains for malformed or unsupported templates, preserving serving compatibility for models whose templates mlxcel cannot render.
+
+## 6. Follow-up Actions
+
+- Run a live Qwen3.8 Responses and disaggregated-router smoke test on a deployment with that checkpoint when hardware is available.
+- Keep the documented Responses behavior as verbatim forwarding; if a future product decision introduces value translation, file a separate issue with explicit compatibility requirements.

--- a/TECHNICAL_REPORTS/1511-template-rejection-surfaces-20260830.ko.md
+++ b/TECHNICAL_REPORTS/1511-template-rejection-surfaces-20260830.ko.md
@@ -1,0 +1,72 @@
+# 기술 보고서: PR #1511 - Template rejection surfaces
+
+**작성일**: 2026-08-30
+**상태**: 완료
+**언어**: Rust, Markdown
+**위험도**: Medium
+
+## 요약
+
+PR #1511은 issue #1176을 해결한다. Chat template의 `raise_exception(...)` rejection이 Responses API, offline CLI, disaggregated router front end에서 사라지지 않도록 보존했다. 의도적인 template refusal은 이제 named client error로 요청을 중단하고, malformed template이나 unsupported template-engine failure는 기존 fallback path를 유지한다.
+
+## 1. 문제 정의
+
+Single-node `/v1/chat/completions` route는 이미 template-raised rejection을 request error로 처리했지만, 인접 surface에서는 이를 삼키거나 잘못 분류할 수 있었다. `/v1/responses`에는 현재 `reasoning.effort` forwarding 동작을 고정하는 regression coverage가 필요했고, offline CLI는 모든 template error에서 raw user prompt로 fallback했으며, disaggregated router는 모든 preparation error를 HTTP 500으로 변환했다.
+
+이 failure mode는 reasoning-effort control에서 특히 위험했다. 값은 OpenAI vocabulary와 model-specific vocabulary 사이에서 의도적으로 translation하지 않고 그대로 전달된다. 따라서 model template이 `high`를 reject하면 unframed fallback prompt로 조용히 generation하지 말고 visible client error를 반환해야 한다.
+
+## 2. 기술적 선택과 그 이유
+
+### 2.1 Preparation 과정에서 rejection sentinel 보존
+
+`prepare_chat_request_with_cache`는 이제 template rejection에 user-facing context를 추가하면서 original render error를 source로 유지한다. 따라서 disaggregated router 같은 outer route boundary에서도 `template_rejection_message`를 계속 사용할 수 있고, single-node chat 및 Responses route가 이미 노출하던 error text는 바뀌지 않는다.
+
+### 2.2 CLI fallback은 engine failure에만 유지
+
+Offline CLI prompt helper는 이제 `Result<String>`을 반환한다. `template_rejection_message`가 sentinel을 찾으면 named error를 반환하고, malformed syntax처럼 minijinja가 engine-side 이유로 render하지 못한 경우에는 기존처럼 raw prompt fallback을 반환한다.
+
+### 2.3 Reasoning value translation 금지 유지
+
+Responses translator 동작은 변경하지 않았다. `reasoning.effort`는 그대로 chat request에 복사된다. 새 test는 `high` 값이 변경 없이 template까지 도달하고, model-specific template이 이를 reject할 수 있음을 증명한다.
+
+### 2.4 Router template rejection을 400으로 매핑
+
+Disaggregated router는 chat request preparation 이후 preserved sentinel을 확인한다. Template rejection에는 single-node route와 같은 `400 invalid_request_error` response shape를 반환하고, 관련 없는 preparation failure는 기존 generic 500 path에 남긴다.
+
+## 3. 변경 요약
+
+| 카테고리 | 변경 수 | 주요 내용 |
+|---|---:|---|
+| Error propagation | 1 | Preparation error wrapping 후에도 template rejection source를 보존. |
+| CLI behavior | 1 | CLI prompt resolution을 template rejection에 대해서만 fallible하게 변경. |
+| Router behavior | 1 | Disaggregated router template rejection을 500에서 400으로 변경. |
+| Responses coverage | 2 | Rejection 및 engine-fallback regression test 추가. |
+| CLI coverage | 3 | Prompt-helper test 업데이트 및 rejection-path coverage 추가. |
+| Router coverage | 1 | Template rejection HTTP 400 regression coverage 추가. |
+
+## 4. 검증
+
+- `cargo test --bin mlxcel resolve_cli_prompt`: 5 passed.
+- `cargo test --bin mlxcel apply_user_chat_template_wraps_prompt_as_user_message`: 1 passed.
+- `cargo test --bin mlxcel vlm_chat_template`: 4 passed.
+- `cargo test --lib responses_reasoning_effort_template_rejection_survives_translation`: 1 passed.
+- `cargo test --lib responses_template_engine_failure_still_uses_prompt_fallback`: 1 passed.
+- `cargo test --lib router_chat_maps_template_rejection_to_bad_request`: 1 passed.
+- `cargo test --lib template_rejection`: 11 passed.
+- `cargo clippy --lib --tests -- -D warnings`: passed.
+- `cargo clippy --bin mlxcel -- -D warnings`: passed.
+- Hosted PR checks passed: cargo-clippy, cargo-deny, cargo-fmt, OpenXLA feature compile, crate versions, cross-repo refs, kernel dtype keys, llama-compat manifest, Detect changes, license/cla. MLX pin extraction과 OpenXLA feature link는 change detection에 의해 skipped였다.
+
+Broad workspace tests, serial all-tests, cold release build는 이 issue batch의 workflow guard가 금지하므로 실행하지 않았다.
+
+## 5. 리뷰 메모
+
+- **Correctness**: 영향을 받은 모든 surface에서 template rejection과 engine failure path가 분리된다. Responses forwarding은 그대로 유지되므로 unsupported value 판단은 계속 loaded template이 담당한다.
+- **Security**: Rejection message는 HTTP 또는 CLI output에 도달하기 전에 기존 `TemplateRejection`의 512자 cap과 control-character filtering을 거친다. Prompt content를 새로 log하지 않는다.
+- **Performance**: 새 검사는 render failure path에서 기존 error chain만 확인한다. 성공적인 render 및 generation path는 변경하지 않았다.
+- **Compatibility**: Malformed 또는 unsupported template에 대한 기존 fallback behavior는 유지되어, mlxcel이 render하지 못하는 template을 가진 model serving compatibility를 보존한다.
+
+## 6. 후속 조치
+
+- 해당 checkpoint를 사용할 수 있는 deployment에서 Qwen3.8 Responses 및 disaggregated-router live smoke test를 실행한다.
+- Responses 동작은 계속 verbatim forwarding으로 문서화한다. 향후 product decision으로 value translation을 도입한다면 별도 issue에서 compatibility requirement를 명시해야 한다.

--- a/src/commands/generate.rs
+++ b/src/commands/generate.rs
@@ -41,7 +41,7 @@ use mlxcel::{
     quant_advisor::{advise_quantization, print_quant_advice},
     sampling::{ResolvedSamplingParams, build_sampling_config},
     select_backend,
-    server::chat_template::{ChatMessage, ChatTemplateProcessor},
+    server::chat_template::{ChatMessage, ChatTemplateProcessor, template_rejection_message},
     tokenizer::load_tokenizer,
     vision::merge::InputEmbeddings,
     vlm_runtime::prepared_embedding_refs,
@@ -637,15 +637,27 @@ pub(super) fn validate_muse_glimmer_cli_unsupported_options(
     Ok(())
 }
 
-fn apply_user_chat_template(processor: &ChatTemplateProcessor, user_prompt: &str) -> String {
+fn template_rejection_cli_error(err: &anyhow::Error) -> Option<anyhow::Error> {
+    template_rejection_message(err)
+        .map(|message| anyhow!("chat template rejected the request: {message}"))
+}
+
+fn apply_user_chat_template(
+    processor: &ChatTemplateProcessor,
+    user_prompt: &str,
+) -> Result<String> {
     let messages = [ChatMessage {
         role: "user".to_string(),
         content: user_prompt.to_string(),
     }];
 
-    processor
-        .apply(&messages, None)
-        .unwrap_or_else(|_| user_prompt.to_string())
+    processor.apply(&messages, None).or_else(|err| {
+        if let Some(rejection) = template_rejection_cli_error(&err) {
+            Err(rejection)
+        } else {
+            Ok(user_prompt.to_string())
+        }
+    })
 }
 
 /// Apply chat template with image / video / audio placeholders for VLM models.
@@ -666,7 +678,7 @@ fn apply_vlm_chat_template(
     num_images: usize,
     num_videos: usize,
     num_audios: usize,
-) -> String {
+) -> Result<String> {
     // Only attempt multimodal rendering when the template handles image
     // content items.  Templates that don't (e.g. Vicuna, ChatML) would
     // render the raw JSON list as text, producing garbled output.
@@ -721,9 +733,13 @@ fn apply_vlm_chat_template(
         "content": content_parts,
     }]);
 
-    processor.apply_raw(&messages, None).unwrap_or_else(|_| {
-        // Fallback: text-only template
-        apply_user_chat_template(processor, user_prompt)
+    processor.apply_raw(&messages, None).or_else(|err| {
+        if let Some(rejection) = template_rejection_cli_error(&err) {
+            Err(rejection)
+        } else {
+            // Fallback: text-only template
+            apply_user_chat_template(processor, user_prompt)
+        }
     })
 }
 
@@ -734,13 +750,13 @@ fn resolve_cli_prompt(
     num_images: usize,
     num_videos: usize,
     num_audios: usize,
-) -> String {
+) -> Result<String> {
     if no_chat_template {
-        return user_prompt.to_string();
+        return Ok(user_prompt.to_string());
     }
 
     processor.map_or_else(
-        || user_prompt.to_string(),
+        || Ok(user_prompt.to_string()),
         |processor| {
             // Route an audio-bearing request through the VLM template only when
             // the template actually renders audio content items. This keeps the
@@ -767,7 +783,7 @@ fn load_cli_prompt(
     num_images: usize,
     num_videos: usize,
     num_audios: usize,
-) -> String {
+) -> Result<String> {
     let processor = if no_chat_template {
         None
     } else {
@@ -2267,7 +2283,7 @@ fn run_generate_once(mut args: GenerateArgs) -> Result<()> {
         args.generation.image.len(),
         cli_video_content_part_count(&args.model.model, args.generation.video.len()),
         usize::from(args.generation.audio.is_some()),
-    );
+    )?;
     let mut prompt_tokens = tokenize_prompt(&tokenizer, &prompt)?;
 
     // llama.cpp parity (issue #476): resolve an unlimited `-n -1` into a

--- a/src/commands/generate_tests.rs
+++ b/src/commands/generate_tests.rs
@@ -277,7 +277,7 @@ fn apply_user_chat_template_wraps_prompt_as_user_message() {
         "{{ messages[0].role }}: {{ messages[0].content }}".to_string(),
     );
 
-    let rendered = apply_user_chat_template(&processor, "Hello");
+    let rendered = apply_user_chat_template(&processor, "Hello").unwrap();
 
     assert_eq!(rendered, "user: Hello");
 }
@@ -286,7 +286,7 @@ fn apply_user_chat_template_wraps_prompt_as_user_message() {
 fn resolve_cli_prompt_skips_template_when_disabled() {
     let processor = ChatTemplateProcessor::with_template("wrapped".to_string());
 
-    let prompt = resolve_cli_prompt("Hello", true, Some(&processor), 0, 0, 0);
+    let prompt = resolve_cli_prompt("Hello", true, Some(&processor), 0, 0, 0).unwrap();
 
     assert_eq!(prompt, "Hello");
 }
@@ -295,9 +295,25 @@ fn resolve_cli_prompt_skips_template_when_disabled() {
 fn resolve_cli_prompt_falls_back_on_template_errors() {
     let processor = ChatTemplateProcessor::with_template("{% if %}".to_string());
 
-    let prompt = resolve_cli_prompt("Hello", false, Some(&processor), 0, 0, 0);
+    let prompt = resolve_cli_prompt("Hello", false, Some(&processor), 0, 0, 0).unwrap();
 
     assert_eq!(prompt, "Hello");
+}
+
+#[test]
+fn resolve_cli_prompt_returns_template_rejections() {
+    let processor = ChatTemplateProcessor::with_template(
+        "{% if messages[0].content == 'bad' %}{{ raise_exception('unsupported caller value') }}{% endif %}ok"
+            .to_string(),
+    );
+
+    let err = resolve_cli_prompt("bad", false, Some(&processor), 0, 0, 0)
+        .expect_err("template rejection must stop CLI prompt resolution");
+
+    assert_eq!(
+        err.to_string(),
+        "chat template rejected the request: unsupported caller value"
+    );
 }
 
 #[test]
@@ -315,11 +331,11 @@ fn vlm_chat_template_renders_video_content_part_in_user_turn() {
     let processor = ChatTemplateProcessor::with_template(template);
 
     // One video + the question: marker precedes the text within the turn.
-    let prompt = apply_vlm_chat_template(&processor, "Describe this video.", 0, 1, 0);
+    let prompt = apply_vlm_chat_template(&processor, "Describe this video.", 0, 1, 0).unwrap();
     assert_eq!(prompt, "user: <VID>Describe this video.");
 
     // Image + video together render in image-then-video order.
-    let mixed = apply_vlm_chat_template(&processor, "Q", 1, 1, 0);
+    let mixed = apply_vlm_chat_template(&processor, "Q", 1, 1, 0).unwrap();
     assert_eq!(mixed, "user: <IMG><VID>Q");
 }
 
@@ -352,7 +368,7 @@ fn vlm_chat_template_omits_video_when_template_lacks_video_support() {
     assert!(!processor.supports_video_content());
 
     // num_videos > 0 but the template has no video branch: no marker emitted.
-    let prompt = apply_vlm_chat_template(&processor, "Q", 0, 1, 0);
+    let prompt = apply_vlm_chat_template(&processor, "Q", 0, 1, 0).unwrap();
     assert_eq!(prompt, "user: Q");
 }
 
@@ -377,11 +393,11 @@ fn vlm_chat_template_renders_audio_content_part_in_user_turn() {
     // One audio clip + the question: the audio marker follows the text within
     // the user turn, so `expand_gemma4_audio_tokens` wraps it right after the
     // prompt, matching the server splice and the reference frame.
-    let prompt = apply_vlm_chat_template(&processor, "Transcribe this audio.", 0, 0, 1);
+    let prompt = apply_vlm_chat_template(&processor, "Transcribe this audio.", 0, 0, 1).unwrap();
     assert_eq!(prompt, "user: Transcribe this audio.<|audio|>");
 
     // Image + audio together render as image (before text) then text then audio.
-    let mixed = apply_vlm_chat_template(&processor, "Transcribe this audio.", 1, 0, 1);
+    let mixed = apply_vlm_chat_template(&processor, "Transcribe this audio.", 1, 0, 1).unwrap();
     assert_eq!(mixed, "user: <IMG>Transcribe this audio.<|audio|>");
 }
 
@@ -398,7 +414,7 @@ fn vlm_chat_template_omits_audio_when_template_lacks_audio_support() {
     assert!(!processor.supports_audio_content());
 
     // num_audios > 0 but the template has no audio branch: no marker emitted.
-    let prompt = apply_vlm_chat_template(&processor, "Q", 0, 0, 1);
+    let prompt = apply_vlm_chat_template(&processor, "Q", 0, 0, 1).unwrap();
     assert_eq!(prompt, "user: Q");
 }
 
@@ -419,7 +435,7 @@ fn resolve_cli_prompt_routes_audio_through_vlm_template() {
 
     // Audio follows the text within the user turn (issue #797), matching the
     // reference frame and the server audio-after-text splice.
-    let prompt = resolve_cli_prompt("Transcribe.", false, Some(&processor), 0, 0, 1);
+    let prompt = resolve_cli_prompt("Transcribe.", false, Some(&processor), 0, 0, 1).unwrap();
     assert_eq!(prompt, "user: Transcribe.<|audio|>");
 }
 
@@ -434,8 +450,8 @@ fn resolve_cli_prompt_keeps_text_path_for_audio_on_plain_template() {
     );
     assert!(!processor.supports_audio_content());
 
-    let with_audio = resolve_cli_prompt("Hello", false, Some(&processor), 0, 0, 1);
-    let without_audio = resolve_cli_prompt("Hello", false, Some(&processor), 0, 0, 0);
+    let with_audio = resolve_cli_prompt("Hello", false, Some(&processor), 0, 0, 1).unwrap();
+    let without_audio = resolve_cli_prompt("Hello", false, Some(&processor), 0, 0, 0).unwrap();
     assert_eq!(with_audio, without_audio);
     assert_eq!(with_audio, "user: Hello");
 }
@@ -481,7 +497,7 @@ fn gemma4_unified_audio_prompt_matches_reference_framing() {
     assert!(processor.supports_audio_content());
 
     const PROMPT: &str = "이 음성을 들리는 그대로 한국어로 받아쓰기 하세요.";
-    let prompt = apply_vlm_chat_template(&processor, PROMPT, 0, 0, 1);
+    let prompt = apply_vlm_chat_template(&processor, PROMPT, 0, 0, 1).unwrap();
 
     // The audio marker lands AFTER the prompt text (issue #797).
     let text_pos = prompt.find("받아쓰기").expect("prompt text present");
@@ -515,7 +531,7 @@ fn gemma4_unified_audio_prompt_matches_reference_framing() {
     // (`expand_gemma4_audio_tokens_for_server`). At the marker level that is the
     // text-only prompt with `<|audio|>` inserted before the user turn's first
     // `<turn|>`. It must equal the CLI audio prompt.
-    let text_only = apply_user_chat_template(&processor, PROMPT);
+    let text_only = apply_user_chat_template(&processor, PROMPT).unwrap();
     let server_equiv = text_only.replacen("<turn|>", "<|audio|><turn|>", 1);
     assert_eq!(
         prompt, server_equiv,

--- a/src/server/chat_request.rs
+++ b/src/server/chat_request.rs
@@ -184,16 +184,18 @@ pub(super) fn log_once_sessions() -> &'static Mutex<HashSet<String>> {
 /// it cannot fire on an engine failure the way `ErrorKind::InvalidOperation`
 /// would, and it does not depend on how a template author worded the message.
 ///
-/// The returned error propagates out of [`prepare_chat_request_with_cache`],
-/// which every chat, Responses, and Anthropic route already maps to a 400
-/// before any generation starts, so the streaming routes emit it in place of
-/// the SSE stream rather than mid-stream.
-fn reject_if_template_rejection(err: &anyhow::Error) -> Result<()> {
-    let Some(message) = template_rejection_message(err) else {
-        return Ok(());
+/// The returned error propagates out of [`prepare_chat_request_with_cache`]
+/// with the original render error as its source. That keeps
+/// [`template_rejection_message`] usable at outer route boundaries that need to
+/// distinguish template rejections from generic render failures.
+fn reject_or_return_render_error(err: anyhow::Error) -> Result<anyhow::Error> {
+    let Some(message) = template_rejection_message(&err).map(str::to_string) else {
+        return Ok(err);
     };
     tracing::info!("Chat template rejected the request: {message}");
-    anyhow::bail!("the model's chat template rejected this request: {message}");
+    Err(err.context(format!(
+        "the model's chat template rejected this request: {message}"
+    )))
 }
 
 /// Resolve the chat-template kwargs a request renders with.
@@ -437,8 +439,8 @@ pub(crate) async fn prepare_chat_request_with_cache(
             Err(err) => {
                 // A deliberate template refusal is a client error, not a render
                 // failure: fail the request instead of answering from a
-                // stripped prompt. See `reject_if_template_rejection`.
-                reject_if_template_rejection(&err)?;
+                // stripped prompt. See `reject_or_return_render_error`.
+                let err = reject_or_return_render_error(err)?;
                 tracing::warn!(
                     "Chat template render (raw) failed, using fallback: {:#}",
                     err
@@ -463,7 +465,7 @@ pub(crate) async fn prepare_chat_request_with_cache(
                 // Same split as the raw/multimodal arm above: a template that
                 // refused a caller-supplied value must not degrade to a
                 // fallback prompt.
-                reject_if_template_rejection(&err)?;
+                let err = reject_or_return_render_error(err)?;
                 tracing::warn!("Chat template render failed, using fallback: {:#}", err);
                 // Security (H-1): use pre-stripped messages for the same reason.
                 (render_simple_fallback(&messages), None)

--- a/src/server/responses_translator.rs
+++ b/src/server/responses_translator.rs
@@ -803,8 +803,8 @@ mod tests {
     use std::collections::HashMap;
 
     use super::*;
-    use crate::server::chat_request::resolve_effective_kwargs;
-    use crate::server::chat_template::ChatTemplateProcessor;
+    use crate::server::chat_request::{prepare_chat_request_with_cache, resolve_effective_kwargs};
+    use crate::server::chat_template::{ChatTemplateProcessor, template_rejection_message};
     use crate::server::types::request::SamplingParams;
     use crate::server::types::responses_request::{
         ConversationRef, ResponseInput, ResponseReasoningConfig, ResponseTextConfig,
@@ -912,6 +912,57 @@ mod tests {
             translated.chat_request.reasoning_effort.as_deref(),
             Some("high")
         );
+    }
+
+    #[tokio::test]
+    async fn responses_reasoning_effort_template_rejection_survives_translation() {
+        let mut req = make_request(ResponseInput::Text("think".to_string()));
+        req.reasoning = Some(ResponseReasoningConfig {
+            effort: Some("high".to_string()),
+            summary: None,
+        });
+
+        let translated = responses_request_to_chat(&req, None, None).unwrap();
+        let processor = ChatTemplateProcessor::with_template(
+            "{% if reasoning_effort not in ['low', 'medium'] %}{{ raise_exception('Unexpected reasoning effort ' ~ reasoning_effort) }}{% endif %}ok"
+                .to_string(),
+        );
+        let err = match prepare_chat_request_with_cache(
+            &processor,
+            &translated.chat_request,
+            None,
+            false,
+            false,
+        )
+        .await
+        {
+            Ok(_) => panic!("unsupported Responses effort must remain a template rejection"),
+            Err(err) => err,
+        };
+
+        assert_eq!(
+            template_rejection_message(&err),
+            Some("Unexpected reasoning effort high")
+        );
+    }
+
+    #[tokio::test]
+    async fn responses_template_engine_failure_still_uses_prompt_fallback() {
+        let req = make_request(ResponseInput::Text("plain fallback".to_string()));
+        let translated = responses_request_to_chat(&req, None, None).unwrap();
+        let processor = ChatTemplateProcessor::with_template("{% if %}".to_string());
+
+        let prepared = prepare_chat_request_with_cache(
+            &processor,
+            &translated.chat_request,
+            None,
+            false,
+            false,
+        )
+        .await
+        .expect("engine-side render failure should keep fallback behavior");
+
+        assert_eq!(prepared.prompt, "User: plain fallback\n\nAssistant: ");
     }
 
     #[test]

--- a/src/server/router_front.rs
+++ b/src/server/router_front.rs
@@ -654,7 +654,7 @@ async fn route_chat(state: Arc<RouterState>, request: ChatCompletionRequest) -> 
 
     // Render the chat template and reject multimodal requests (the
     // disaggregated path is text-only for pool-backed Fp16 families).
-    let prepared = super::chat_request::prepare_chat_request_with_cache(
+    let prepared = match super::chat_request::prepare_chat_request_with_cache(
         &state.chat_template,
         &request,
         state.config.chat_template_kwargs.as_ref(),
@@ -662,7 +662,17 @@ async fn route_chat(state: Arc<RouterState>, request: ChatCompletionRequest) -> 
         false,
     )
     .await
-    .map_err(|e| anyhow::anyhow!("{e}"))?;
+    {
+        Ok(prepared) => prepared,
+        Err(err) => {
+            if super::chat_template::template_rejection_message(&err).is_some() {
+                return Ok(
+                    ErrorResponse::new(err.to_string(), "invalid_request_error").into_response()
+                );
+            }
+            return Err(anyhow::anyhow!("{err}"));
+        }
+    };
 
     if has_declared_media(prepared.media) {
         anyhow::bail!("the disaggregated router supports text-only requests");

--- a/src/server/router_front_tests.rs
+++ b/src/server/router_front_tests.rs
@@ -32,7 +32,7 @@ use tower::ServiceExt;
 
 use crate::distributed::tcp_transport::TcpTransportConfig;
 
-async fn router_test_state() -> Arc<RouterState> {
+async fn router_test_state_with_template(template: &str) -> Arc<RouterState> {
     let transport = Arc::new(
         TcpTransport::bind(TcpTransportConfig {
             bind_address: "127.0.0.1:0".to_string(),
@@ -52,13 +52,18 @@ async fn router_test_state() -> Arc<RouterState> {
             Arc::new(config),
             transport,
             reply_to,
-            Arc::new(ChatTemplateProcessor::with_template(
-                "{% for message in messages %}{{ message.content }}{% endfor %}".to_string(),
-            )),
+            Arc::new(ChatTemplateProcessor::with_template(template.to_string())),
             Arc::new(MlxcelTokenizer::stub()),
         )
         .expect("build router test state"),
     )
+}
+
+async fn router_test_state() -> Arc<RouterState> {
+    router_test_state_with_template(
+        "{% for message in messages %}{{ message.content }}{% endfor %}",
+    )
+    .await
 }
 
 async fn post_router_json(path: &str, body: Value) -> Response {
@@ -77,11 +82,31 @@ async fn post_router_json(path: &str, body: Value) -> Response {
         .expect("router response")
 }
 
-async fn error_message(response: Response) -> String {
+async fn post_router_json_with_state(state: Arc<RouterState>, path: &str, body: Value) -> Response {
+    create_router_app(state)
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri(path)
+                .header("content-type", "application/json")
+                .body(Body::from(
+                    serde_json::to_vec(&body).expect("serialize request"),
+                ))
+                .expect("build request"),
+        )
+        .await
+        .expect("router response")
+}
+
+async fn error_body(response: Response) -> Value {
     let bytes = to_bytes(response.into_body(), 64 * 1024)
         .await
         .expect("read response body");
-    let body: Value = serde_json::from_slice(&bytes).expect("JSON error response");
+    serde_json::from_slice(&bytes).expect("JSON error response")
+}
+
+async fn error_message(response: Response) -> String {
+    let body = error_body(response).await;
     body["error"]["message"]
         .as_str()
         .expect("error message")
@@ -147,6 +172,25 @@ async fn router_chat_rejects_invalid_tool_choice_before_rendering() {
     assert_eq!(
         error_message(response).await,
         "Invalid tool_choice value: 'sometimes'. Must be 'auto', 'none', 'required', or a function object."
+    );
+}
+
+#[tokio::test]
+async fn router_chat_maps_template_rejection_to_bad_request() {
+    let state = router_test_state_with_template(
+        "{% if reasoning_effort not in ['low', 'medium'] %}{{ raise_exception('Unexpected reasoning effort ' ~ reasoning_effort) }}{% endif %}ok",
+    )
+    .await;
+    let mut body = chat_request();
+    body["reasoning_effort"] = json!("high");
+
+    let response = post_router_json_with_state(state, "/v1/chat/completions", body).await;
+    assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+    let body = error_body(response).await;
+    assert_eq!(body["error"]["type"], "invalid_request_error");
+    assert_eq!(
+        body["error"]["message"],
+        "the model's chat template rejected this request: Unexpected reasoning effort high"
     );
 }
 


### PR DESCRIPTION
## Summary

- Preserve template-rejection sentinel errors through chat request preparation so downstream routes can distinguish deliberate template refusals from engine-side render failures.
- Return HTTP 400 invalid_request_error from the disaggregated router when a chat template rejects caller-supplied values.
- Make offline CLI prompt resolution return a named error for template rejections while retaining bare-prompt fallback for non-rejection render failures.
- Add committed English and Korean technical reports for this open PR because TECHNICAL_REPORTS/.keep-reports is present.

## Validation

- PASS: cargo test --bin mlxcel resolve_cli_prompt
- PASS: cargo test --bin mlxcel apply_user_chat_template_wraps_prompt_as_user_message
- PASS: cargo test --bin mlxcel vlm_chat_template
- PASS: cargo test --lib responses_reasoning_effort_template_rejection_survives_translation
- PASS: cargo test --lib responses_template_engine_failure_still_uses_prompt_fallback
- PASS: cargo test --lib router_chat_maps_template_rejection_to_bad_request
- PASS: cargo test --lib template_rejection
- PASS: cargo clippy --lib --tests -- -D warnings
- PASS: cargo clippy --bin mlxcel -- -D warnings
- PASS: hosted checks on report commit 998a70bc: cargo-clippy, cargo-deny, cargo-fmt, OpenXLA feature compile, crate versions, cross-repo refs, kernel dtype keys, llama-compat manifest, Detect changes, and license/cla. MLX pin extraction and OpenXLA feature link skipped by change detection.
- SKIP: broad cargo workspace tests and cold release builds per watchdog guard.

## Reports

- TECHNICAL_REPORTS/1511-template-rejection-surfaces-20260830.en.md
- TECHNICAL_REPORTS/1511-template-rejection-surfaces-20260830.ko.md

Closes #1176
