### PR TITLE
test: make TP crossover assertion deterministic

### DIFF
--- a/TECHNICAL_REPORTS/1512-deterministic-tp-crossover-20260830.en.md
+++ b/TECHNICAL_REPORTS/1512-deterministic-tp-crossover-20260830.en.md
@@ -1,0 +1,69 @@
+# Technical Report: PR #1512 - Deterministic TP Crossover Assertions
+
+**Date**: 2026-08-30
+**Status**: Open PR, ready for central merge
+**Languages**: Rust
+**Risk Level**: Low
+
+## Executive Summary
+
+PR #1512 removes host-scheduler timing noise from `e2e_crossover_larger_models_benefit_more`. The tensor-parallel benchmark path still measures real elapsed time for ordinary `run_tp_benchmark` calls, while crossover analysis now evaluates the hidden-size model through an injected nominal timer. The target test asserts exact model efficiencies and benefit flags, so it checks the property named by the test instead of comparing microsecond wall-clock noise.
+
+## 1. Problem Statement
+
+The previous test compared `large.scaling_efficiency >= small.scaling_efficiency` after `run_crossover_analysis` had measured microsecond `spin_wait` loops with `Instant`. Under loaded full-suite runs, scheduler delay could dominate the 2048-vs-8192 synthetic timing gap and intermittently invert the assertion. The issue thread narrowed live scope to this TP test only; the autotune tests originally mentioned in the same family were already fixed by PR #1096 through a manual timer.
+
+## 2. Technical Decisions
+
+### 2.1 Inject timing at the benchmark harness boundary
+
+A private `BenchmarkTimer` seam now supplies `wait` and `measure`. `run_tp_benchmark` constructs `RealBenchmarkTimer`, preserving real `Instant` and `spin_wait` behavior. `run_crossover_analysis` constructs `NominalBenchmarkTimer`, which advances synthetic elapsed time exactly by requested durations.
+
+### 2.2 Keep crossover analysis deterministic
+
+Crossover analysis is a model-size comparison, not a wall-clock benchmark. It now uses nominal simulated durations for baseline and TP runs so throughput, scaling efficiency, all-reduce overhead, and benefit decisions are stable under host load.
+
+### 2.3 Assert exact model outputs
+
+The target e2e test now requires the 2048 hidden-size TP=2 entry to have scaling efficiency 0.5 and the 8192 hidden-size TP=2 entry to have scaling efficiency 0.8. It also verifies that the smaller model only breaks even while the larger model is beneficial. Missing entries now fail explicitly instead of silently bypassing the assertion.
+
+## 3. Change Summary
+
+| Item | Value |
+|------|-------|
+| Files changed | 2 |
+| Rust lines changed | 133 insertions, 30 deletions |
+| Public API additions | None |
+| Production timing path | Preserved for `run_tp_benchmark` |
+| Crossover timing path | Deterministic nominal timer |
+
+- Added private real and nominal benchmark timers.
+- Routed `run_tp_benchmark` through the real timer without changing its signature.
+- Routed `run_crossover_analysis` through the nominal timer and documented that behavior.
+- Replaced the flaky crossover assertion with exact nominal model expectations and benefit checks.
+
+## 4. Validation
+
+- `cargo fmt --check`: passed.
+- `git diff --check -- src/distributed/tensor_parallel/benchmark.rs tests/tp_e2e.rs`: passed.
+- `cargo test --profile test-fast --test tp_e2e e2e_crossover_larger_models_benefit_more -- --exact --nocapture`: passed, 1 passed, 35 filtered out.
+- `cargo test --profile test-fast -p mlxcel distributed::tensor_parallel::benchmark::tests::crossover_analysis_basic -- --exact --nocapture`: passed, 1 matching unit test passed, remaining filtered tests reported 0 run.
+- Mutation check: temporarily changed crossover compute scaling from quadratic to linear. The exact target test failed on `small-model scaling efficiency 0.6666666666666666 should match the injected nominal model 0.5`, then passed after restoration.
+- `cargo clippy --profile test-fast --test tp_e2e -- -D warnings`: passed.
+
+The focused local validation ran while `/proc/loadavg` reported `12.14 9.86 6.28`. A full workspace or full-suite loaded-host run was not executed because this auto-implementation unit explicitly forbids broad cargo, workspace, and serial all-test commands.
+
+## 5. Review Findings
+
+| Finding | Severity | Resolution |
+|---------|----------|------------|
+| The target assertion depended on microsecond host scheduling | Medium | Replaced the crossover analysis timing source with deterministic injected nominal time |
+| The test could silently pass if either expected entry was absent | Low | Replaced optional `if let` with explicit `expect` checks |
+| Expected constants could be misread as caller-configured timing values | Low | Added comments explaining that the constants come from the hidden-size timing model |
+
+No security issue was introduced. The change does not parse external input, add I/O, expose new APIs, or add unbounded resource use beyond existing configured benchmark loops.
+
+## 6. Remaining Limits
+
+- Hosted CI results should be read from GitHub before central merge.
+- No hardware/model validation is claimed; this path is a simulated tensor-parallel benchmark and does not load real models.

--- a/TECHNICAL_REPORTS/1512-deterministic-tp-crossover-20260830.ko.md
+++ b/TECHNICAL_REPORTS/1512-deterministic-tp-crossover-20260830.ko.md
@@ -1,0 +1,69 @@
+# 기술 보고서: PR #1512 - 결정적 TP 크로스오버 검증
+
+**날짜**: 2026-08-30
+**상태**: 열린 PR, 중앙 병합 준비 완료
+**언어**: Rust
+**위험도**: 낮음
+
+## 요약
+
+PR #1512는 `e2e_crossover_larger_models_benefit_more`에서 호스트 스케줄러 타이밍 잡음을 제거한다. 일반 `run_tp_benchmark` 호출은 기존처럼 실제 경과 시간을 측정하지만, 크로스오버 분석은 주입된 명목 타이머로 hidden-size 모델을 평가한다. 대상 테스트는 정확한 모델 효율과 benefit 플래그를 검증하므로 마이크로초 단위 wall-clock 잡음이 아니라 테스트 이름이 뜻하는 속성을 확인한다.
+
+## 1. 문제
+
+기존 테스트는 `run_crossover_analysis`가 `Instant`로 마이크로초 `spin_wait` 루프를 측정한 뒤 `large.scaling_efficiency >= small.scaling_efficiency`를 비교했다. 부하가 있는 전체 스위트 실행에서는 스케줄러 지연이 2048과 8192 synthetic timing 차이를 압도해 간헐적으로 assertion을 뒤집을 수 있었다. 이슈 스레드는 실제 남은 범위를 이 TP 테스트 하나로 좁혔다. 같은 계열로 처음 언급된 autotune 테스트들은 PR #1096에서 manual timer로 이미 해결되었다.
+
+## 2. 기술 결정
+
+### 2.1 벤치마크 harness 경계에 타이밍 주입
+
+private `BenchmarkTimer` seam이 `wait`와 `measure`를 제공한다. `run_tp_benchmark`는 `RealBenchmarkTimer`를 생성하므로 기존 `Instant`와 `spin_wait` 경로가 유지된다. `run_crossover_analysis`는 `NominalBenchmarkTimer`를 생성하며, 이 타이머는 요청된 duration만큼 synthetic elapsed time을 정확히 전진시킨다.
+
+### 2.2 크로스오버 분석을 결정적으로 유지
+
+크로스오버 분석은 wall-clock 벤치마크가 아니라 model-size 비교다. baseline 및 TP 실행에 명목 simulated duration을 사용하므로 throughput, scaling efficiency, all-reduce overhead, benefit 판정이 호스트 부하와 무관하게 안정적이다.
+
+### 2.3 정확한 모델 출력 검증
+
+대상 e2e 테스트는 이제 2048 hidden-size TP=2 entry의 scaling efficiency가 0.5이고, 8192 hidden-size TP=2 entry의 scaling efficiency가 0.8인지 확인한다. 또한 작은 모델은 break-even이고 큰 모델은 beneficial임을 검증한다. 필요한 entry가 없으면 assertion을 건너뛰지 않고 명시적으로 실패한다.
+
+## 3. 변경 요약
+
+| 항목 | 값 |
+|------|----|
+| 변경 파일 | 2 |
+| Rust 변경량 | 133 insertions, 30 deletions |
+| public API 추가 | 없음 |
+| production timing path | `run_tp_benchmark`에서 유지 |
+| crossover timing path | 결정적 명목 타이머 |
+
+- private real/nominal benchmark timer를 추가했다.
+- `run_tp_benchmark`를 signature 변경 없이 real timer로 경유시켰다.
+- `run_crossover_analysis`를 nominal timer로 경유시키고 해당 동작을 문서화했다.
+- flaky crossover assertion을 정확한 명목 모델 기대값과 benefit 검증으로 교체했다.
+
+## 4. 검증
+
+- `cargo fmt --check`: 통과.
+- `git diff --check -- src/distributed/tensor_parallel/benchmark.rs tests/tp_e2e.rs`: 통과.
+- `cargo test --profile test-fast --test tp_e2e e2e_crossover_larger_models_benefit_more -- --exact --nocapture`: 통과, 1 passed, 35 filtered out.
+- `cargo test --profile test-fast -p mlxcel distributed::tensor_parallel::benchmark::tests::crossover_analysis_basic -- --exact --nocapture`: 통과, matching unit test 1개 통과, 나머지 filtered test는 0 run으로 보고됨.
+- Mutation check: crossover compute scaling을 quadratic에서 linear로 임시 변경했다. exact 대상 테스트가 `small-model scaling efficiency 0.6666666666666666 should match the injected nominal model 0.5`로 실패했고, 복원 후 다시 통과했다.
+- `cargo clippy --profile test-fast --test tp_e2e -- -D warnings`: 통과.
+
+focused local validation은 `/proc/loadavg`가 `12.14 9.86 6.28`을 보고하던 상태에서 실행되었다. 이 auto-implementation unit이 broad cargo, workspace, serial all-test command를 명시적으로 금지했기 때문에 전체 workspace 또는 full-suite loaded-host 실행은 수행하지 않았다.
+
+## 5. 리뷰 결과
+
+| 항목 | 심각도 | 처리 |
+|------|--------|------|
+| 대상 assertion이 마이크로초 호스트 스케줄링에 의존함 | Medium | 크로스오버 분석 timing source를 결정적 주입 명목 시간으로 교체 |
+| 기대 entry가 없으면 테스트가 조용히 통과할 수 있음 | Low | optional `if let` 대신 명시적 `expect` 검사로 교체 |
+| 기대 상수가 caller-configured timing 값으로 오해될 수 있음 | Low | 상수가 hidden-size timing model에서 온다는 주석 추가 |
+
+새로운 보안 문제는 없다. 이 변경은 외부 입력 파싱, I/O, public API, 또는 기존 configured benchmark loop를 넘어서는 unbounded resource use를 추가하지 않는다.
+
+## 6. 남은 제한
+
+- 중앙 병합 전 hosted CI 결과는 GitHub에서 확인해야 한다.
+- hardware/model validation은 주장하지 않는다. 이 경로는 simulated tensor-parallel benchmark이며 실제 모델을 로드하지 않는다.

--- a/src/distributed/tensor_parallel/benchmark.rs
+++ b/src/distributed/tensor_parallel/benchmark.rs
@@ -404,12 +404,67 @@ impl fmt::Display for ScalingAnalysis {
 // Benchmark execution
 // ---------------------------------------------------------------------------
 
+trait BenchmarkTimer {
+    fn wait(&mut self, duration: Duration);
+
+    fn measure<F>(&mut self, body: F) -> Duration
+    where
+        F: FnOnce(&mut Self);
+}
+
+#[derive(Default)]
+struct RealBenchmarkTimer;
+
+impl BenchmarkTimer for RealBenchmarkTimer {
+    fn wait(&mut self, duration: Duration) {
+        spin_wait(duration);
+    }
+
+    fn measure<F>(&mut self, body: F) -> Duration
+    where
+        F: FnOnce(&mut Self),
+    {
+        let start = Instant::now();
+        body(self);
+        start.elapsed()
+    }
+}
+
+#[derive(Default)]
+struct NominalBenchmarkTimer {
+    elapsed: Duration,
+}
+
+impl BenchmarkTimer for NominalBenchmarkTimer {
+    fn wait(&mut self, duration: Duration) {
+        self.elapsed += duration;
+    }
+
+    fn measure<F>(&mut self, body: F) -> Duration
+    where
+        F: FnOnce(&mut Self),
+    {
+        let start = self.elapsed;
+        body(self);
+        self.elapsed - start
+    }
+}
+
 /// Run a single TP benchmark scenario.
 ///
 /// Simulates TP inference with the given configuration by running scheduler
 /// and executor in lockstep, measuring throughput, latency, and all-reduce
 /// overhead using simulated collectives.
 pub fn run_tp_benchmark(config: &TPBenchmarkConfig, tp_size: usize) -> Result<TPBenchmarkResult> {
+    let mut timer = RealBenchmarkTimer;
+    run_tp_benchmark_with_timer(config, tp_size, &mut timer)
+}
+
+fn run_tp_benchmark_with_timer<T: BenchmarkTimer>(
+    config: &TPBenchmarkConfig,
+    tp_size: usize,
+    timer: &mut T,
+) -> Result<TPBenchmarkResult> {
     config.validate()?;
 
     let batch_size = config.batch_sizes.first().copied().unwrap_or(1);
@@ -434,33 +489,33 @@ pub fn run_tp_benchmark(config: &TPBenchmarkConfig, tp_size: usize) -> Result<TP
 
     // Warmup.
     for _ in 0..config.warmup_steps {
-        spin_wait(total_step_time);
+        timer.wait(total_step_time);
     }
 
     // Measure TTFT: time for the first token (prefill of seq_len tokens).
-    let ttft_start = Instant::now();
     // Prefill simulates processing seq_len tokens through the model.
     let prefill_steps = (seq_len + batch_size - 1) / batch_size.max(1);
-    for _ in 0..prefill_steps {
-        spin_wait(total_step_time);
-    }
-    let ttft = ttft_start.elapsed();
+    let ttft = timer.measure(|timer| {
+        for _ in 0..prefill_steps {
+            timer.wait(total_step_time);
+        }
+    });
 
     // Measure decode steps.
-    let decode_start = Instant::now();
     let mut total_ar_time = Duration::ZERO;
     let mut ar_ops = 0u64;
 
-    for _ in 0..config.decode_steps {
-        spin_wait(compute_per_step);
-        if tp_size > 1 {
-            let ar_start = Instant::now();
-            spin_wait(ar_overhead_per_step);
-            total_ar_time += ar_start.elapsed();
-            ar_ops += 2; // attention all-reduce + FFN all-reduce
+    let decode_time = timer.measure(|timer| {
+        for _ in 0..config.decode_steps {
+            timer.wait(compute_per_step);
+            if tp_size > 1 {
+                total_ar_time += timer.measure(|timer| {
+                    timer.wait(ar_overhead_per_step);
+                });
+                ar_ops += 2; // attention all-reduce + FFN all-reduce
+            }
         }
-    }
-    let decode_time = decode_start.elapsed();
+    });
 
     let total_tokens = batch_size as u64 * config.decode_steps as u64;
     let total_time = ttft + decode_time;
@@ -566,11 +621,30 @@ pub fn run_scaling_analysis(config: &TPBenchmarkConfig) -> Result<ScalingAnalysi
 ///
 /// Tests each combination of model hidden size and TP size, comparing
 /// throughput against the single-device baseline.
+/// Uses nominal simulated durations rather than host wall-clock measurements
+/// so model-size crossover decisions stay deterministic under runner load.
 pub fn run_crossover_analysis(
     base_config: &TPBenchmarkConfig,
     model_hidden_sizes: &[usize],
     tp_sizes: &[usize],
 ) -> Result<CrossoverAnalysis> {
+    run_crossover_analysis_with_timer::<NominalBenchmarkTimer>(
+        base_config,
+        model_hidden_sizes,
+        tp_sizes,
+    )
+}
+
+fn run_crossover_analysis_with_timer<T>(
+    base_config: &TPBenchmarkConfig,
+    model_hidden_sizes: &[usize],
+    tp_sizes: &[usize],
+) -> Result<CrossoverAnalysis>
+where
+    T: BenchmarkTimer + Default,
+{
+    base_config.validate()?;
+
     let mut entries = Vec::new();
 
     for &hidden_size in model_hidden_sizes {
@@ -590,8 +664,11 @@ pub fn run_crossover_analysis(
         config.layer_compute_time = compute_time;
         config.allreduce_time = ar_time;
 
-        // Baseline: tp_size=1.
-        let baseline = run_tp_benchmark(&config, 1)?;
+        // Baseline: tp_size=1. Crossover analysis is a model comparison,
+        // so it uses injected nominal time instead of wall-clock measurements.
+        // The general TP benchmark path still uses `RealBenchmarkTimer`.
+        let mut baseline_timer = T::default();
+        let baseline = run_tp_benchmark_with_timer(&config, 1, &mut baseline_timer)?;
 
         for &tp_size in tp_sizes {
             if tp_size == 1 {
@@ -611,7 +688,8 @@ pub fn run_crossover_analysis(
                 continue;
             }
 
-            let result = run_tp_benchmark(&config, tp_size)?;
+            let mut result_timer = T::default();
+            let result = run_tp_benchmark_with_timer(&config, tp_size, &mut result_timer)?;
             let ideal_throughput = baseline.throughput_tok_per_sec * tp_size as f64;
             let scaling_efficiency = if ideal_throughput > 0.0 {
                 result.throughput_tok_per_sec / ideal_throughput

--- a/tests/tp_e2e.rs
+++ b/tests/tp_e2e.rs
@@ -776,22 +776,47 @@ fn e2e_crossover_larger_models_benefit_more() {
 
     let analysis = run_crossover_analysis(&config, &[2048, 8192], &[1, 2]).unwrap();
 
-    // For larger models, TP should provide greater benefit.
-    let small_tp2 = analysis
+    // Crossover analysis is a nominal model comparison, not a wall-clock
+    // benchmark. The harness injects exact simulated durations here so this
+    // assertion verifies the model arithmetic even on loaded CI runners. The
+    // expected efficiencies come from the hidden-size timing model inside
+    // `run_crossover_analysis`: 2048 maps to compute=50us/all-reduce=25us,
+    // and 8192 maps to compute=800us/all-reduce=100us.
+    let small = analysis
         .entries
         .iter()
-        .find(|e| e.model_hidden_size == 2048 && e.tp_size == 2);
-    let large_tp2 = analysis
+        .find(|e| e.model_hidden_size == 2048 && e.tp_size == 2)
+        .expect("2048 hidden-size TP=2 entry should exist");
+    let large = analysis
         .entries
         .iter()
-        .find(|e| e.model_hidden_size == 8192 && e.tp_size == 2);
+        .find(|e| e.model_hidden_size == 8192 && e.tp_size == 2)
+        .expect("8192 hidden-size TP=2 entry should exist");
 
-    if let (Some(small), Some(large)) = (small_tp2, large_tp2) {
-        assert!(
-            large.scaling_efficiency >= small.scaling_efficiency,
-            "larger model should have better TP scaling efficiency"
-        );
-    }
+    let small_expected = 0.5;
+    let large_expected = 0.8;
+    assert!(
+        (small.scaling_efficiency - small_expected).abs() < 1e-12,
+        "small-model scaling efficiency {} should match the injected nominal model {small_expected}",
+        small.scaling_efficiency
+    );
+    assert!(
+        (large.scaling_efficiency - large_expected).abs() < 1e-12,
+        "large-model scaling efficiency {} should match the injected nominal model {large_expected}",
+        large.scaling_efficiency
+    );
+    assert!(
+        large.scaling_efficiency >= small.scaling_efficiency + 0.25,
+        "larger model should have materially better TP scaling efficiency"
+    );
+    assert!(
+        !small.is_beneficial,
+        "2048 hidden-size model should break even, not become beneficial"
+    );
+    assert!(
+        large.is_beneficial,
+        "8192 hidden-size model should be beneficial"
+    );
 }
 
 // ===========================================================================


### PR DESCRIPTION
## Summary

- Route TP crossover analysis through a private nominal timer so model-size crossover decisions do not depend on host scheduling.
- Preserve real `Instant`/`spin_wait` measurement for ordinary `run_tp_benchmark` calls.
- Replace `e2e_crossover_larger_models_benefit_more` with exact nominal-model assertions for 2048 and 8192 hidden-size TP=2 entries plus benefit-flag checks.

## Validation

- `cargo fmt --check`: passed.
- `git diff --check -- src/distributed/tensor_parallel/benchmark.rs tests/tp_e2e.rs`: passed.
- `cargo test --profile test-fast --test tp_e2e e2e_crossover_larger_models_benefit_more -- --exact --nocapture`: passed, 1 passed, 35 filtered out.
- `cargo test --profile test-fast -p mlxcel distributed::tensor_parallel::benchmark::tests::crossover_analysis_basic -- --exact --nocapture`: passed, 1 matching unit test passed, remaining filtered tests reported 0 run.
- Mutation check: temporarily changed the crossover compute model from quadratic hidden-size scaling to linear scaling; the exact target test failed on `small-model scaling efficiency 0.6666666666666666 should match the injected nominal model 0.5`, then passed again after restoring the intended model.
- `cargo clippy --profile test-fast --test tp_e2e -- -D warnings`: passed.

## Technical reports

- `TECHNICAL_REPORTS/1512-deterministic-tp-crossover-20260830.en.md`
- `TECHNICAL_REPORTS/1512-deterministic-tp-crossover-20260830.ko.md`

## Limits

- Full workspace/full-suite loaded-host validation was not run because the wave-runner watchdog for this unit forbids broad cargo, workspace, and serial all-test commands. The focused local validation ran while `/proc/loadavg` reported `12.14 9.86 6.28`.
- Hardware/model validation is not applicable here; this is a simulated tensor-parallel benchmark/test change and no real model path was exercised.

Closes #1184
