### PR TITLE
fix(models): persist recurrent decode state

### DIFF
--- a/TECHNICAL_REPORTS/1513-recurrent-state-lifecycle-20260830.en.md
+++ b/TECHNICAL_REPORTS/1513-recurrent-state-lifecycle-20260830.en.md
@@ -1,0 +1,123 @@
+# Technical Report: PR #1513 - recurrent-state-lifecycle
+
+**Date**: 2026-08-30
+
+**Status**: Completed with synthetic validation limits
+
+**Languages**: Rust
+
+**Risk Level**: High
+
+## Executive Summary
+
+PR #1513 fixes issue #1220 by moving RWKV7, RecurrentGemma, and KimiLinear onto the established model-owned `SequenceState` lifecycle. Before this change, each family recreated its recurrent or mixed recurrent-attention cache inside every `LanguageModel::forward()` call, so a normal greedy decode loop that feeds one token per step lost all prior hidden history after prefill.
+
+The implementation keeps these families non-batched, uses per-`SequenceId` model-owned state for the server scheduler, preserves a single-stream fallback for CLI and benchmark paths, and resets that fallback only before fresh multi-token prefills. Scheduler calls with a `SequenceId` now require an existing prepared state slot and fail closed if the slot is missing. EOS ids are resolved from checkpoint sidecars/config through `read_eos_token_ids()` instead of hardcoded family constants.
+
+Validation in this worker is deterministic and synthetic. It covers Rust compilation, state lifecycle behavior, EOS metadata parsing, formatting, and whitespace checks. It does not qualify real RWKV7, RecurrentGemma, or KimiLinear checkpoints because no pinned checkpoints or hardware target were provided for that run.
+
+## 1. Problem Statement
+
+The affected model families are recurrent or hybrid recurrent-attention architectures:
+
+- RWKV7 stores token-shift, recurrent state, and FFN cache per layer.
+- RecurrentGemma stores RGLRU recurrent state and rotating local-attention cache by layer.
+- KimiLinear stores MLA attention cache and GatedDeltaNet convolution/SSM state by layer.
+
+The generation contract is multi-call: prefill usually runs on the prompt, then each greedy decode step calls the model again with one token. If a family constructs fresh recurrent state inside each forward call, the decode step cannot see prefill history or previous generated tokens. That is a correctness bug, not only a performance issue.
+
+## 2. Change Summary
+
+| Area | Change |
+|------|--------|
+| RWKV7 | Replaced per-forward local cache allocation with `ModelOwnedSequenceState<Rwkv7Cache>`, added prepare/release/forward-by-sequence hooks, fallback reset, model-owned layout, and EOS metadata storage. |
+| RecurrentGemma | Added `ModelOwnedSequenceState<GriffinLayerCache>` over mixed recurrent/attention caches, wired scheduler lifecycle hooks, fallback reset, model-owned layout, and EOS metadata storage. |
+| KimiLinear | Added `ModelOwnedSequenceState<KimiLinearCache>` over mixed MLA/Delta caches, wired scheduler lifecycle hooks, fallback reset, model-owned layout, and EOS metadata storage. |
+| Shared state helper | Added `with_existing_sequence_state()` so scheduler paths can reject missing prepared state instead of silently using fallback state. |
+| EOS loading | Extended `read_eos_token_ids()` to prefer `generation_config.json`, then `tokenizer_config.json`, then `config.json`; tokenizer `eos_token` strings resolve through `added_tokens_decoder`. |
+| Tests | Added focused deterministic coverage for EOS parsing, sequence-state continuity, per-sequence isolation, release, and missing-state rejection. |
+
+### Statistics
+
+| Item | Value |
+|------|-------|
+| Implementation files changed | 9 |
+| Implementation diff | +819 / -102 |
+| Primary implementation commit | `b1836a2a` `fix(models): persist recurrent decode state` |
+| PR | #1513 |
+| Issue | #1220 |
+
+## 3. Technical Decisions
+
+### 3.1 Use model-owned state instead of external KVCache state
+
+The `LanguageModel` trait exposes homogeneous `KVCache` slices, but these families store heterogeneous recurrent state. RWKV7 has RWKV-specific layer state, RecurrentGemma mixes RGLRU and rotating KV cache, and KimiLinear mixes MLA and Delta caches. Matching the existing Mamba, Mamba2, Jamba, Plamo2, FalconH1, NemotronH, and Qwen3-Next pattern avoids forcing these shapes into incompatible external KV slots.
+
+### 3.2 Keep fallback state for CLI paths, but reset it deliberately
+
+Offline generation paths do not always carry a scheduler `SequenceId`. They now use the model-owned fallback slot. The fallback is reset when a fresh multi-token prefill reaches the model, and it is preserved for one-token decode steps. This keeps the existing single-stream API usable while preventing a new prompt from inheriting old hidden state.
+
+### 3.3 Fail closed for missing scheduler state
+
+The server scheduler allocates sequence state and calls `prepare_sequence_state()` before running prefill or decode. A `forward_with_sequence_id(Some(id), ...)` call that lacks a prepared slot indicates lifecycle corruption. PR #1513 therefore uses the new `with_existing_sequence_state()` helper on scheduler paths, producing a named failure instead of silently falling back to the legacy single-stream slot.
+
+### 3.4 Source EOS from checkpoint metadata
+
+RWKV7 and RecurrentGemma previously returned hardcoded EOS ids, and KimiLinear had the same default constant. The implementation now stores resolved EOS ids on the model. Direct config construction can provide `eos_token_id`; normal directory loads and special weight loads override that with `read_eos_token_ids()` when sidecar metadata is present.
+
+## 4. Correctness Review
+
+- `forward()` no longer creates fresh recurrent caches for the affected families.
+- `make_caches()` resets only the fallback single-stream model-owned state and returns placeholder KV caches for trait compatibility.
+- `prepare_sequence_state()` inserts a fresh per-sequence cache vector.
+- `forward_with_sequence_id(Some(id), ...)` requires the prepared vector and updates it across calls.
+- `release_sequence_state_by_id()` removes the per-sequence vector so cancellation and completion do not leak model-owned state.
+- Cache cardinality is asserted before layer iteration, preventing `zip()` from silently skipping layers on malformed state.
+- Scheduler inspection confirmed allocation still calls `prepare_sequence_state()` and completion/cancellation cleanup calls `release_sequence_state_by_id()`.
+
+## 5. Security Review
+
+No new external process execution, file deletion, credential handling, SQL, network request construction, or web rendering paths were introduced. The new sidecar reader only reads JSON files already inside the selected model directory. Invalid or missing EOS metadata returns an empty list or falls back to the next metadata source; it does not panic on malformed JSON.
+
+The explicit missing-state failure is intentional: silently sharing fallback recurrent state across scheduler sequences would leak request-local generation history between users. Failing closed is safer than generating with corrupted hidden state.
+
+## 6. Performance Review
+
+The change removes repeated recurrent cache allocation from every decode step for RWKV7, RecurrentGemma, and KimiLinear. The persistent model-owned state does not add extra per-token cloning; it moves one vector out of the sequence map, mutates it, and reinserts it. The additional EOS sidecar checks run only during load/config resolution, not in the decode hot path.
+
+The PR does not enable batching for these families. They remain `supports_batching() == false` and advertise `SequenceStateLayout::model_owned(...)`, so the scheduler should continue using single-sequence model-owned execution for them.
+
+## 7. Validation Record
+
+| Check | Result | Notes |
+|-------|--------|-------|
+| `cargo fmt --all --check` | Pass | Formatting check after implementation. |
+| `cargo test --lib model_owned_sequence_state -- --nocapture` | Pass | 13 passed, 7309 filtered; includes new generic and family state-continuity filters. |
+| `cargo test --lib read_eos_token_ids -- --nocapture` | Pass | 6 passed, 7316 filtered; covers generation/tokenizer/config EOS precedence and tokenizer `eos_token` resolution. |
+| `cargo test --lib rwkv7_ -- --nocapture` | Pass | 4 passed, 7318 filtered; covers RWKV7 cache snapshot, EOS parsing, continuity, and missing-state rejection. |
+| `cargo test --lib recurrent_gemma_ -- --nocapture` | Pass | 4 passed, 7318 filtered; covers RecurrentGemma EOS parsing, continuity, missing-state rejection, and existing windowed attention classification. |
+| `cargo test --lib kimi_linear_ -- --nocapture` | Pass | 7 passed, 7315 filtered; covers existing KimiLinear guards plus new EOS parsing, continuity, and missing-state rejection. |
+| `cargo test --lib parse_eos_token_ids -- --nocapture` | Pass | 3 passed, 7319 filtered; covers scalar/array/invalid EOS field parsing. |
+| `git diff --check` | Pass | No whitespace errors. |
+| Static old-pattern grep | Pass | No remaining fresh-per-forward cache allocation or hardcoded `[0]`, `[1]`, `[2]` EOS pattern in the three target model files. |
+
+## 8. Validation Limits
+
+- No real RWKV7 checkpoint generation was run.
+- No real RecurrentGemma checkpoint generation was run.
+- No real KimiLinear checkpoint generation was run.
+- No hardware-specific MLX generation qualification was run.
+- No broad workspace test, broad `cargo test --lib`, broad workspace clippy, serial all-tests, or release build was run, matching the unit constraints.
+
+## 9. Follow-up Actions
+
+- Run a pinned RWKV7 checkpoint through CLI greedy generation and verify multi-token output changes when prior context changes.
+- Run a pinned RecurrentGemma checkpoint through CLI and server single-stream generation, including cancellation cleanup.
+- Run a pinned KimiLinear checkpoint through CLI and server single-stream generation, including two concurrent queued requests to confirm state isolation.
+- If these families later opt into batched decode, add explicit batched routing tests before changing `supports_batching()`.
+
+## Appendix
+
+- Issue: #1220
+- PR: #1513
+- Branch: `fix/issue-1220-recurrent-state-lifecycle`

--- a/TECHNICAL_REPORTS/1513-recurrent-state-lifecycle-20260830.ko.md
+++ b/TECHNICAL_REPORTS/1513-recurrent-state-lifecycle-20260830.ko.md
@@ -1,0 +1,123 @@
+# 기술 보고서: PR #1513 - recurrent-state-lifecycle
+
+**작성일**: 2026-08-30
+
+**상태**: Synthetic validation 한계가 있는 구현 완료
+
+**언어**: Rust
+
+**위험도**: High
+
+## 요약
+
+PR #1513은 issue #1220을 해결하기 위해 RWKV7, RecurrentGemma, KimiLinear를 기존 model-owned `SequenceState` lifecycle에 연결한다. 기존 구현은 각 `LanguageModel::forward()` 호출 안에서 recurrent 또는 mixed recurrent-attention cache를 새로 만들었기 때문에, prompt prefill 이후 한 token씩 호출되는 일반 greedy decode loop에서 이전 hidden history가 사라졌다.
+
+이번 변경은 세 family를 계속 non-batched로 유지하고, server scheduler 경로에서는 per-`SequenceId` model-owned state를 사용한다. CLI와 benchmark 같은 single-stream 경로는 fallback slot을 사용하되, 새 multi-token prefill 직전에만 reset한다. Scheduler가 `SequenceId`를 넘겼는데 준비된 state slot이 없으면 fallback state를 조용히 쓰지 않고 fail closed한다. EOS id도 hardcoded family constant가 아니라 `read_eos_token_ids()`를 통해 checkpoint sidecar/config에서 읽는다.
+
+이 worker에서 수행한 검증은 deterministic/synthetic 범위다. Rust compilation, state lifecycle behavior, EOS metadata parsing, formatting, whitespace check를 확인했다. 그러나 pinned checkpoint와 hardware target이 제공되지 않았으므로 실제 RWKV7, RecurrentGemma, KimiLinear checkpoint generation은 검증하지 않았다.
+
+## 1. 문제 정의
+
+영향을 받는 model family는 recurrent 또는 hybrid recurrent-attention architecture다.
+
+- RWKV7은 layer별 token-shift, recurrent state, FFN cache를 저장한다.
+- RecurrentGemma는 layer별 RGLRU recurrent state와 rotating local-attention cache를 저장한다.
+- KimiLinear는 layer별 MLA attention cache와 GatedDeltaNet convolution/SSM state를 저장한다.
+
+Generation contract는 여러 번의 호출로 구성된다. 보통 prompt prefill을 먼저 실행하고, 이후 greedy decode step마다 token 하나로 model을 다시 호출한다. 이때 forward call 안에서 recurrent state를 매번 새로 만들면 decode step은 prefill history나 이전 generated token을 볼 수 없다. 이는 성능 문제가 아니라 correctness bug다.
+
+## 2. 변경 요약
+
+| 영역 | 변경 |
+|------|------|
+| RWKV7 | Per-forward local cache allocation을 `ModelOwnedSequenceState<Rwkv7Cache>`로 교체하고, prepare/release/forward-by-sequence hook, fallback reset, model-owned layout, EOS metadata 저장을 추가했다. |
+| RecurrentGemma | Mixed recurrent/attention cache를 위한 `ModelOwnedSequenceState<GriffinLayerCache>`를 추가하고 scheduler lifecycle hook, fallback reset, model-owned layout, EOS metadata 저장을 연결했다. |
+| KimiLinear | Mixed MLA/Delta cache를 위한 `ModelOwnedSequenceState<KimiLinearCache>`를 추가하고 scheduler lifecycle hook, fallback reset, model-owned layout, EOS metadata 저장을 연결했다. |
+| Shared state helper | Scheduler path가 prepared state 누락을 fallback state로 숨기지 않도록 `with_existing_sequence_state()`를 추가했다. |
+| EOS loading | `read_eos_token_ids()`가 `generation_config.json`, `tokenizer_config.json`, `config.json` 순서로 EOS를 읽도록 확장했다. Tokenizer의 `eos_token` string은 `added_tokens_decoder`로 id를 찾는다. |
+| Tests | EOS parsing, sequence-state continuity, per-sequence isolation, release, missing-state rejection에 대한 focused deterministic coverage를 추가했다. |
+
+### 통계
+
+| 항목 | 값 |
+|------|----|
+| 구현 변경 파일 수 | 9 |
+| 구현 diff | +819 / -102 |
+| 주요 구현 커밋 | `b1836a2a` `fix(models): persist recurrent decode state` |
+| PR | #1513 |
+| Issue | #1220 |
+
+## 3. 기술적 선택
+
+### 3.1 External KVCache state 대신 model-owned state 사용
+
+`LanguageModel` trait는 homogeneous `KVCache` slice를 제공하지만, 이 family들의 state는 heterogeneous recurrent state다. RWKV7은 RWKV-specific layer state, RecurrentGemma는 RGLRU와 rotating KV cache, KimiLinear는 MLA와 Delta cache를 섞어 쓴다. 기존 Mamba, Mamba2, Jamba, Plamo2, FalconH1, NemotronH, Qwen3-Next와 같은 pattern을 사용하면 incompatible external KV slot에 억지로 맞추지 않아도 된다.
+
+### 3.2 CLI path용 fallback state는 유지하되 명시적으로 reset
+
+Offline generation path는 항상 scheduler `SequenceId`를 갖고 있지 않다. 이 경로는 model-owned fallback slot을 사용한다. Fallback은 fresh multi-token prefill이 들어올 때 reset되고, one-token decode step에서는 유지된다. 따라서 기존 single-stream API를 보존하면서 새 prompt가 이전 hidden state를 물려받는 문제를 막는다.
+
+### 3.3 Missing scheduler state는 fail closed
+
+Server scheduler는 sequence state를 allocate한 뒤 prefill/decode 전에 `prepare_sequence_state()`를 호출한다. `forward_with_sequence_id(Some(id), ...)` 호출 시 prepared slot이 없다면 lifecycle corruption이다. PR #1513은 scheduler path에서 새 `with_existing_sequence_state()` helper를 사용해 legacy single-stream fallback slot으로 조용히 떨어지지 않게 했다.
+
+### 3.4 EOS는 checkpoint metadata에서 읽기
+
+RWKV7, RecurrentGemma, KimiLinear는 hardcoded EOS id를 반환하고 있었다. 이제 model은 resolved EOS id를 저장한다. Direct config construction은 `eos_token_id`를 사용할 수 있고, 일반 directory load와 special weight load는 sidecar metadata가 있으면 `read_eos_token_ids()` 값으로 덮어쓴다.
+
+## 4. Correctness review
+
+- 영향 family의 `forward()`는 더 이상 fresh recurrent cache를 만들지 않는다.
+- `make_caches()`는 fallback single-stream model-owned state만 reset하고 trait compatibility용 placeholder KV cache를 반환한다.
+- `prepare_sequence_state()`는 fresh per-sequence cache vector를 넣는다.
+- `forward_with_sequence_id(Some(id), ...)`는 prepared vector를 요구하고 호출 사이에 state를 갱신한다.
+- `release_sequence_state_by_id()`는 per-sequence vector를 제거하므로 cancellation/completion 후 model-owned state가 남지 않는다.
+- Layer/cache `zip()` 전에 cache cardinality를 assert해 malformed state가 layer 일부를 조용히 skip하지 못하게 했다.
+- Scheduler inspection에서 allocation이 여전히 `prepare_sequence_state()`를 호출하고 completion/cancellation cleanup이 `release_sequence_state_by_id()`를 호출하는 것을 확인했다.
+
+## 5. Security review
+
+새 외부 process 실행, file deletion, credential handling, SQL, network request construction, web rendering 경로는 추가하지 않았다. 새 sidecar reader는 선택된 model directory 내부의 JSON file만 읽는다. EOS metadata가 없거나 malformed JSON이면 panic하지 않고 empty list를 반환하거나 다음 metadata source로 fallback한다.
+
+명시적인 missing-state failure는 의도된 동작이다. Scheduler sequence 사이에서 fallback recurrent state를 공유하면 request-local generation history가 사용자 간에 섞일 수 있다. Corrupted hidden state로 generation을 계속하는 것보다 fail closed가 안전하다.
+
+## 6. Performance review
+
+이번 변경은 RWKV7, RecurrentGemma, KimiLinear에서 decode step마다 recurrent cache를 반복 allocation하던 문제를 제거한다. Persistent model-owned state는 token마다 clone을 추가하지 않는다. Sequence map에서 vector 하나를 빼서 mutate한 뒤 다시 넣는다. EOS sidecar check는 load/config resolution 시점에만 실행되며 decode hot path에는 없다.
+
+이 PR은 세 family의 batching을 enable하지 않는다. `supports_batching() == false`를 유지하고 `SequenceStateLayout::model_owned(...)`를 광고하므로 scheduler는 계속 single-sequence model-owned execution을 사용해야 한다.
+
+## 7. Validation record
+
+| Check | 결과 | Notes |
+|-------|------|-------|
+| `cargo fmt --all --check` | Pass | 구현 후 formatting check. |
+| `cargo test --lib model_owned_sequence_state -- --nocapture` | Pass | 13 passed, 7309 filtered. 새 generic/family state-continuity filter 포함. |
+| `cargo test --lib read_eos_token_ids -- --nocapture` | Pass | 6 passed, 7316 filtered. generation/tokenizer/config EOS precedence와 tokenizer `eos_token` resolution 검증. |
+| `cargo test --lib rwkv7_ -- --nocapture` | Pass | 4 passed, 7318 filtered. RWKV7 cache snapshot, EOS parsing, continuity, missing-state rejection 검증. |
+| `cargo test --lib recurrent_gemma_ -- --nocapture` | Pass | 4 passed, 7318 filtered. RecurrentGemma EOS parsing, continuity, missing-state rejection, 기존 windowed attention classification 검증. |
+| `cargo test --lib kimi_linear_ -- --nocapture` | Pass | 7 passed, 7315 filtered. 기존 KimiLinear guard와 새 EOS parsing, continuity, missing-state rejection 검증. |
+| `cargo test --lib parse_eos_token_ids -- --nocapture` | Pass | 3 passed, 7319 filtered. Scalar/array/invalid EOS field parsing 검증. |
+| `git diff --check` | Pass | Whitespace error 없음. |
+| Static old-pattern grep | Pass | 세 target model file에 fresh-per-forward cache allocation과 hardcoded `[0]`, `[1]`, `[2]` EOS pattern이 남아 있지 않음. |
+
+## 8. Validation limits
+
+- 실제 RWKV7 checkpoint generation은 실행하지 않았다.
+- 실제 RecurrentGemma checkpoint generation은 실행하지 않았다.
+- 실제 KimiLinear checkpoint generation은 실행하지 않았다.
+- Hardware-specific MLX generation qualification은 실행하지 않았다.
+- Unit constraint에 따라 broad workspace test, broad `cargo test --lib`, broad workspace clippy, serial all-tests, release build는 실행하지 않았다.
+
+## 9. 후속 작업
+
+- Pinned RWKV7 checkpoint로 CLI greedy generation을 실행하고 prior context 변경에 따라 multi-token output이 달라지는지 확인한다.
+- Pinned RecurrentGemma checkpoint로 CLI/server single-stream generation과 cancellation cleanup을 확인한다.
+- Pinned KimiLinear checkpoint로 CLI/server single-stream generation과 두 개 concurrent queued request의 state isolation을 확인한다.
+- 이 family들이 나중에 batched decode에 opt-in한다면 `supports_batching()` 변경 전에 명시적인 batched routing test를 추가한다.
+
+## Appendix
+
+- Issue: #1220
+- PR: #1513
+- Branch: `fix/issue-1220-recurrent-state-lifecycle`

--- a/src/loading/mod.rs
+++ b/src/loading/mod.rs
@@ -94,18 +94,61 @@ fn resolve_model_dir(model_path: &Path) -> PathBuf {
 fn parse_eos_token_ids(config: &serde_json::Value) -> Vec<i32> {
     match config.get("eos_token_id") {
         Some(serde_json::Value::Number(n)) => {
-            if let Some(id) = n.as_i64() {
-                vec![id as i32]
-            } else {
-                Vec::new()
+            if let Some(id) = n.as_i64()
+                && let Ok(id) = i32::try_from(id)
+            {
+                return vec![id];
             }
+            Vec::new()
         }
         Some(serde_json::Value::Array(arr)) => arr
             .iter()
-            .filter_map(|v| v.as_i64().map(|n| n as i32))
+            .filter_map(|v| v.as_i64())
+            .filter_map(|n| i32::try_from(n).ok())
             .collect(),
         _ => Vec::new(),
     }
+}
+
+fn tokenizer_eos_token_content(config: &serde_json::Value) -> Option<&str> {
+    match config.get("eos_token")? {
+        serde_json::Value::String(token) => Some(token.as_str()),
+        serde_json::Value::Object(obj) => obj.get("content")?.as_str(),
+        _ => None,
+    }
+}
+
+fn parse_tokenizer_config_eos_token_ids(config: &serde_json::Value) -> Vec<i32> {
+    let ids = parse_eos_token_ids(config);
+    if !ids.is_empty() {
+        return ids;
+    }
+
+    let Some(eos_token) = tokenizer_eos_token_content(config) else {
+        return Vec::new();
+    };
+    let Some(decoder) = config
+        .get("added_tokens_decoder")
+        .and_then(serde_json::Value::as_object)
+    else {
+        return Vec::new();
+    };
+
+    decoder
+        .iter()
+        .filter_map(|(id, token)| {
+            let content = match token {
+                serde_json::Value::String(content) => Some(content.as_str()),
+                serde_json::Value::Object(obj) => obj.get("content")?.as_str(),
+                _ => None,
+            }?;
+            if content == eos_token {
+                id.parse::<i32>().ok()
+            } else {
+                None
+            }
+        })
+        .collect()
 }
 
 /// Sampling and stop-token defaults read from `generation_config.json`.
@@ -377,12 +420,40 @@ pub fn read_generation_config_defaults(model_dir: &Path) -> GenerationConfigDefa
     parse_generation_config_defaults(&config)
 }
 
-/// Read EOS token IDs from generation_config.json
+/// Read EOS token IDs from the checkpoint sidecars.
 ///
-/// Returns the token IDs from the `eos_token_id` field, which can be either
-/// a single integer or an array of integers. Returns empty vec if not found.
+/// Prefer `generation_config.json` when present, then tokenizer-owned metadata
+/// in `tokenizer_config.json`, then `config.json`. Each `eos_token_id` field
+/// can be either a single integer or an array of integers. Tokenizer configs
+/// that declare only an `eos_token` string are resolved through
+/// `added_tokens_decoder`. Returns an empty vec if not found.
 pub fn read_eos_token_ids(model_dir: &Path) -> Vec<i32> {
-    read_generation_config_defaults(model_dir).eos_token_ids
+    let model_dir = resolve_model_dir(model_dir);
+    let generation_ids = read_generation_config_defaults(&model_dir).eos_token_ids;
+    if !generation_ids.is_empty() {
+        return generation_ids;
+    }
+
+    for (file_name, parser) in [
+        (
+            "tokenizer_config.json",
+            parse_tokenizer_config_eos_token_ids as fn(&serde_json::Value) -> Vec<i32>,
+        ),
+        ("config.json", parse_eos_token_ids),
+    ] {
+        let Ok(content) = std::fs::read_to_string(model_dir.join(file_name)) else {
+            continue;
+        };
+        let Ok(config) = serde_json::from_str::<serde_json::Value>(&content) else {
+            continue;
+        };
+        let ids = parser(&config);
+        if !ids.is_empty() {
+            return ids;
+        }
+    }
+
+    Vec::new()
 }
 
 /// Read the model's context window from `config.json`.
@@ -807,9 +878,10 @@ fn load_model_from_weights(model_path: &Path, weights: &mut WeightMap) -> Result
             weights,
         )?,
         WeightLoadRoute::Special => {
-            try_load_special_model_from_weights(model_type, &config_str, weights)?.ok_or_else(
-                || anyhow::anyhow!("Missing weight loader for model type: {:?}", model_type),
-            )?
+            try_load_special_model_from_weights(model_type, model_path, &config_str, weights)?
+                .ok_or_else(|| {
+                    anyhow::anyhow!("Missing weight loader for model type: {:?}", model_type)
+                })?
         }
         WeightLoadRoute::ConfigBacked => {
             try_load_config_backed_model_from_weights(model_type, &config_str, weights)?

--- a/src/loading/special.rs
+++ b/src/loading/special.rs
@@ -20,6 +20,7 @@
 
 use anyhow::Result;
 use mlxcel_core::weights::WeightMap;
+use std::path::Path;
 
 use crate::LoadedModel;
 use crate::model_metadata;
@@ -104,6 +105,7 @@ pub(crate) fn is_special_weight_model_type(model_type: ModelType) -> bool {
 
 pub(crate) fn try_load_special_model_from_weights(
     model_type: ModelType,
+    model_path: &Path,
     config_str: &str,
     weights: &mut WeightMap,
 ) -> Result<Option<LoadedModel>> {
@@ -206,13 +208,15 @@ pub(crate) fn try_load_special_model_from_weights(
                 models::NemotronNASModel::from_weights,
                 LoadedModel::NemotronNAS
             ),
-            ModelType::RecurrentGemma => load_owned_model_from_config!(
-                config_str,
-                weights,
-                models::recurrent_gemma::GriffinConfig,
-                models::GriffinModel::from_weights,
-                LoadedModel::RecurrentGemma
-            ),
+            ModelType::RecurrentGemma => {
+                let args: models::recurrent_gemma::GriffinConfig =
+                    super::parse_model_config(config_str)?;
+                let owned = copy_weight_map(weights);
+                let mut model = models::GriffinModel::from_weights(args, owned)
+                    .map_err(|err| anyhow::anyhow!("{}", err))?;
+                model.set_eos_token_ids(super::read_eos_token_ids(model_path));
+                LoadedModel::RecurrentGemma(model)
+            }
             _ => unreachable!(
                 "owned-config helper called for non-owned model: {:?}",
                 model_type
@@ -245,8 +249,9 @@ pub(crate) fn try_load_special_model_from_weights(
             let mut owned = copy_weight_map(weights);
             owned = models::KimiLinearModel::sanitize_weights(owned, &args)
                 .map_err(|err| anyhow::anyhow!("{}", err))?;
-            let model = models::KimiLinearModel::from_weights(&owned, &args)
+            let mut model = models::KimiLinearModel::from_weights(&owned, &args)
                 .map_err(|err| anyhow::anyhow!("{}", err))?;
+            model.set_eos_token_ids(super::read_eos_token_ids(model_path));
             LoadedModel::KimiLinear(model)
         }
         SpecialWeightLoaderKind::Longcat => {
@@ -265,8 +270,9 @@ pub(crate) fn try_load_special_model_from_weights(
         }
         SpecialWeightLoaderKind::Rwkv7 => {
             let args: models::rwkv7::Rwkv7Config = super::parse_model_config(config_str)?;
-            let model = models::Rwkv7::from_weights(weights, args)
+            let mut model = models::Rwkv7::from_weights(weights, args)
                 .map_err(|err| anyhow::anyhow!("{}", err))?;
+            model.set_eos_token_ids(super::read_eos_token_ids(model_path));
             LoadedModel::Rwkv7(model)
         }
     }))

--- a/src/loading/tests.rs
+++ b/src/loading/tests.rs
@@ -150,6 +150,73 @@ fn read_eos_token_ids_reads_generation_config() {
 }
 
 #[test]
+fn read_eos_token_ids_falls_back_to_tokenizer_config_ids() {
+    let model_dir = temp_path("tokenizer_config_eos_id");
+    fs::create_dir_all(&model_dir).unwrap();
+    fs::write(
+        model_dir.join("tokenizer_config.json"),
+        r#"{ "eos_token_id": [20, 21] }"#,
+    )
+    .unwrap();
+
+    assert_eq!(read_eos_token_ids(&model_dir), vec![20, 21]);
+
+    fs::remove_dir_all(model_dir).unwrap();
+}
+
+#[test]
+fn read_eos_token_ids_resolves_tokenizer_config_eos_token_content() {
+    let model_dir = temp_path("tokenizer_config_eos_token");
+    fs::create_dir_all(&model_dir).unwrap();
+    fs::write(
+        model_dir.join("tokenizer_config.json"),
+        r#"{
+            "eos_token": { "content": "<|end|>" },
+            "added_tokens_decoder": {
+                "30": { "content": "<|pad|>" },
+                "31": { "content": "<|end|>" }
+            }
+        }"#,
+    )
+    .unwrap();
+
+    assert_eq!(read_eos_token_ids(&model_dir), vec![31]);
+
+    fs::remove_dir_all(model_dir).unwrap();
+}
+
+#[test]
+fn read_eos_token_ids_prefers_generation_config_over_tokenizer_config() {
+    let model_dir = temp_path("generation_precedence");
+    fs::create_dir_all(&model_dir).unwrap();
+    fs::write(
+        model_dir.join("generation_config.json"),
+        r#"{ "eos_token_id": [10, 11] }"#,
+    )
+    .unwrap();
+    fs::write(
+        model_dir.join("tokenizer_config.json"),
+        r#"{ "eos_token_id": [20, 21] }"#,
+    )
+    .unwrap();
+
+    assert_eq!(read_eos_token_ids(&model_dir), vec![10, 11]);
+
+    fs::remove_dir_all(model_dir).unwrap();
+}
+
+#[test]
+fn read_eos_token_ids_falls_back_to_model_config() {
+    let model_dir = temp_path("config_json_eos");
+    fs::create_dir_all(&model_dir).unwrap();
+    fs::write(model_dir.join("config.json"), r#"{ "eos_token_id": 40 }"#).unwrap();
+
+    assert_eq!(read_eos_token_ids(&model_dir), vec![40]);
+
+    fs::remove_dir_all(model_dir).unwrap();
+}
+
+#[test]
 fn resolve_model_dir_uses_parent_for_model_files() {
     let model_dir = temp_path("model_dir");
     fs::create_dir_all(&model_dir).unwrap();

--- a/src/models/kimi_linear.rs
+++ b/src/models/kimi_linear.rs
@@ -25,6 +25,7 @@
 use crate::models::gated_delta::{gated_delta_update, scaled_fast_rms_norm_no_weight};
 use crate::models::switch_layers::SwitchGLU;
 use crate::models::switch_layers::validate_expert_quantization_params;
+use mlxcel_core::cache::{SequenceId, SequenceStateLayout};
 use mlxcel_core::dtype;
 use mlxcel_core::generate::LanguageModel;
 use mlxcel_core::layers::{KVCache, RMSNorm, UnifiedEmbedding, UnifiedLinear};
@@ -33,6 +34,8 @@ use mlxcel_core::weights::WeightMap;
 use mlxcel_core::{MlxArray, UniquePtr, concatenate};
 use serde::Deserialize;
 use std::path::Path;
+
+use super::model_owned::ModelOwnedSequenceState;
 
 // Configuration.
 #[derive(Debug, Clone, Deserialize)]
@@ -99,6 +102,8 @@ pub struct KimiLinearConfig {
     #[serde(default = "default_one_usize")]
     pub topk_group: usize,
     pub quantization: Option<Quantization>,
+    #[serde(default)]
+    pub eos_token_id: Option<serde_json::Value>,
 }
 
 fn default_one_usize() -> usize {
@@ -435,6 +440,19 @@ impl KimiLinearCache {
             KimiLinearCache::Delta(d) => d.offset,
         }
     }
+}
+
+fn make_kimi_caches_from_layers(layers: &[KimiDecoderLayer]) -> Vec<KimiLinearCache> {
+    layers
+        .iter()
+        .map(|layer| {
+            if layer.is_linear {
+                KimiLinearCache::Delta(KimiDeltaCache::new())
+            } else {
+                KimiLinearCache::MLA(KVCache::new())
+            }
+        })
+        .collect()
 }
 
 // KimiMLAAttention - Multi-head Latent Attention.
@@ -1083,6 +1101,8 @@ pub struct KimiLinearModel {
     pub tie_word_embeddings: bool,
     _ssm_layer_idx: usize,
     attn_layer_idx: usize,
+    sequence_state: ModelOwnedSequenceState<KimiLinearCache>,
+    eos_token_ids: Vec<i32>,
 }
 
 impl KimiLinearModel {
@@ -1091,12 +1111,18 @@ impl KimiLinearModel {
         input_ids: &MlxArray,
         caches: &mut [KimiLinearCache],
     ) -> UniquePtr<MlxArray> {
+        assert_eq!(
+            caches.len(),
+            self.layers.len(),
+            "KimiLinear cache cardinality must match layer count"
+        );
+
         let mut h = self.embed_tokens.forward(input_ids);
         let shape = mlxcel_core::array_shape(&h);
         let l = shape[1];
 
         // Create masks
-        let attn_mask = if l > 1 {
+        let attn_mask = if l > 1 && !caches.is_empty() {
             let offset = caches[self.attn_layer_idx].offset();
             Some(create_causal_mask(l, offset))
         } else {
@@ -1121,16 +1147,7 @@ impl KimiLinearModel {
     }
 
     pub fn make_kimi_caches(&self) -> Vec<KimiLinearCache> {
-        self.layers
-            .iter()
-            .map(|l| {
-                if l.is_linear {
-                    KimiLinearCache::Delta(KimiDeltaCache::new())
-                } else {
-                    KimiLinearCache::MLA(KVCache::new())
-                }
-            })
-            .collect()
+        make_kimi_caches_from_layers(&self.layers)
     }
 
     pub fn load<P: AsRef<Path>>(model_dir: P) -> Result<(Self, KimiLinearConfig), String> {
@@ -1162,7 +1179,8 @@ impl KimiLinearModel {
         let weights = Self::sanitize_weights(weights, &config)?;
 
         println!("[KimiLinear] Building model...");
-        let model = Self::from_weights(&weights, &config)?;
+        let mut model = Self::from_weights(&weights, &config)?;
+        model.set_eos_token_ids(crate::loading::read_eos_token_ids(model_dir));
 
         println!("[KimiLinear] Model loaded successfully");
         Ok((model, config))
@@ -1437,6 +1455,9 @@ impl KimiLinearModel {
             .find(|i| !config.is_linear_layer(*i))
             .unwrap_or(0);
 
+        let internal_caches = make_kimi_caches_from_layers(&layers);
+        let eos_token_ids = super::parse_optional_eos_token_ids(&config.eos_token_id);
+
         Ok(Self {
             embed_tokens,
             layers,
@@ -1445,7 +1466,36 @@ impl KimiLinearModel {
             tie_word_embeddings: config.tie_word_embeddings,
             _ssm_layer_idx: ssm_layer_idx,
             attn_layer_idx,
+            sequence_state: ModelOwnedSequenceState::new(internal_caches),
+            eos_token_ids,
         })
+    }
+
+    pub(crate) fn set_eos_token_ids(&mut self, eos_token_ids: Vec<i32>) {
+        if !eos_token_ids.is_empty() {
+            self.eos_token_ids = eos_token_ids;
+        }
+    }
+
+    fn forward_for_sequence(
+        &self,
+        input_ids: &MlxArray,
+        seq_id: Option<SequenceId>,
+    ) -> UniquePtr<MlxArray> {
+        let seq_len = mlxcel_core::array_shape(input_ids)[1];
+        if seq_id.is_none() && seq_len > 1 {
+            self.sequence_state
+                .replace_internal(self.make_kimi_caches());
+        }
+
+        if let Some(seq_id) = seq_id {
+            self.sequence_state
+                .with_existing_sequence_state(seq_id, |internal| self.forward(input_ids, internal))
+                .unwrap_or_else(|err| panic!("KimiLinear {err}"))
+        } else {
+            self.sequence_state
+                .with_sequence_state(None, |internal| self.forward(input_ids, internal))
+        }
     }
 }
 
@@ -1464,12 +1514,14 @@ impl LanguageModel for KimiLinearModel {
     }
 
     fn eos_token_ids(&self) -> Vec<i32> {
-        vec![2] // Default EOS
+        self.eos_token_ids.clone()
     }
 
     fn make_caches(&self) -> Vec<KVCache> {
-        // Return dummy KV caches for trait compatibility
-        // KimiLinear uses mixed cache types (MLA KVCache + DeltaCache) internally
+        self.sequence_state
+            .replace_internal(self.make_kimi_caches());
+        // Return dummy KV caches for trait compatibility; KimiLinear keeps
+        // mixed MLA/Delta state in model-owned slots.
         (0..self.layers.len()).map(|_| KVCache::new()).collect()
     }
 
@@ -1479,9 +1531,35 @@ impl LanguageModel for KimiLinearModel {
         _caches: &mut [KVCache],
         _mask: Option<&MlxArray>,
     ) -> UniquePtr<MlxArray> {
-        // KimiLinear manages its own mixed caches internally
-        let mut caches = self.make_kimi_caches();
-        self.forward(input_ids, &mut caches)
+        self.forward_for_sequence(input_ids, None)
+    }
+
+    fn sequence_state_layout(&self) -> SequenceStateLayout {
+        SequenceStateLayout::model_owned(self.layers.len())
+    }
+
+    fn reset_runtime_state(&self) {
+        self.sequence_state
+            .replace_internal(self.make_kimi_caches());
+    }
+
+    fn prepare_sequence_state(&self, seq_id: SequenceId) {
+        self.sequence_state
+            .prepare_sequence_state(seq_id, self.make_kimi_caches());
+    }
+
+    fn release_sequence_state_by_id(&self, seq_id: SequenceId) {
+        self.sequence_state.release_sequence_state(seq_id);
+    }
+
+    fn forward_with_sequence_id(
+        &self,
+        input_ids: &MlxArray,
+        seq_id: Option<SequenceId>,
+        _caches: &mut [KVCache],
+        _mask: Option<&MlxArray>,
+    ) -> UniquePtr<MlxArray> {
+        self.forward_for_sequence(input_ids, seq_id)
     }
 }
 

--- a/src/models/kimi_linear_tests.rs
+++ b/src/models/kimi_linear_tests.rs
@@ -18,8 +18,13 @@
 //! quantized per-head projection (issue #958), and the rejection of a
 //! `kv_b_proj` plane that carries `.scales` with no `.biases` (issue #1026).
 
-use super::{KimiLinearConfig, KimiLinearModel, LinearAttnConfig, MultiLinear};
+use super::{
+    KimiDeltaCache, KimiLinearCache, KimiLinearConfig, KimiLinearModel, LinearAttnConfig,
+    MultiLinear,
+};
+use crate::models::model_owned::ModelOwnedSequenceState;
 use crate::models::switch_layers::{HOSTILE_QUANT_PARAMS, insert_stacked_quantized_expert_plane};
+use mlxcel_core::cache::SequenceId;
 use mlxcel_core::weights::WeightMap;
 
 /// Honest 4-bit geometry: `packed_in * 32 == bits * num_groups * group_size`
@@ -128,6 +133,7 @@ fn mla_config(kv_lora_rank: usize) -> KimiLinearConfig {
         num_expert_group: 1,
         topk_group: 1,
         quantization: None,
+        eos_token_id: Some(serde_json::json!([50, 51])),
     }
 }
 
@@ -337,4 +343,82 @@ fn kimi_linear_multi_linear_infers_its_quantization_mode_from_the_biases_plane()
         .expect("a non-quantized per-head projection must load with an unset pair");
     assert!(!loaded.is_quantized);
     assert_eq!(loaded.mode, "affine");
+}
+
+fn mixed_kimi_caches() -> Vec<KimiLinearCache> {
+    vec![
+        KimiLinearCache::Delta(KimiDeltaCache::new()),
+        KimiLinearCache::MLA(mlxcel_core::layers::KVCache::new()),
+    ]
+}
+
+#[test]
+fn kimi_linear_eos_token_ids_come_from_config_metadata() {
+    let config = mla_config(16);
+
+    assert_eq!(
+        crate::models::parse_optional_eos_token_ids(&config.eos_token_id),
+        vec![50, 51]
+    );
+}
+
+#[test]
+fn kimi_linear_model_owned_sequence_state_preserves_greedy_decode_cache() {
+    let state = ModelOwnedSequenceState::new(mixed_kimi_caches());
+    let seq = SequenceId::from_raw(1220);
+
+    state.prepare_sequence_state(seq, mixed_kimi_caches());
+    state
+        .with_existing_sequence_state(seq, |caches| match &mut caches[0] {
+            KimiLinearCache::Delta(cache) => {
+                cache.q_conv_state =
+                    Some(mlxcel_core::zeros(&[1, 3, 8], mlxcel_core::dtype::FLOAT32));
+                cache.advance(1);
+            }
+            KimiLinearCache::MLA(_) => panic!("expected Delta cache"),
+        })
+        .expect("prepared KimiLinear sequence must exist");
+
+    state
+        .with_existing_sequence_state(seq, |caches| match &mut caches[0] {
+            KimiLinearCache::Delta(cache) => {
+                assert!(
+                    cache.q_conv_state.is_some(),
+                    "decode must see the cache populated by the previous token"
+                );
+                assert_eq!(cache.offset, 1);
+                cache.ssm_state = Some(mlxcel_core::zeros(
+                    &[1, 2, 4, 8],
+                    mlxcel_core::dtype::FLOAT32,
+                ));
+                cache.advance(1);
+            }
+            KimiLinearCache::MLA(_) => panic!("expected Delta cache"),
+        })
+        .expect("prepared KimiLinear sequence must still exist");
+
+    state
+        .with_existing_sequence_state(seq, |caches| match &caches[0] {
+            KimiLinearCache::Delta(cache) => {
+                assert!(
+                    cache.ssm_state.is_some(),
+                    "cache writes must survive across consecutive greedy steps"
+                );
+                assert_eq!(cache.offset, 2);
+            }
+            KimiLinearCache::MLA(_) => panic!("expected Delta cache"),
+        })
+        .expect("prepared KimiLinear sequence must still exist");
+}
+
+#[test]
+fn kimi_linear_model_owned_sequence_state_refuses_missing_sequence_id() {
+    let state = ModelOwnedSequenceState::new(mixed_kimi_caches());
+    let seq = SequenceId::from_raw(1220);
+
+    let err = state
+        .with_existing_sequence_state(seq, |_| {})
+        .expect_err("unprepared KimiLinear sequence must fail closed");
+
+    assert!(err.contains("missing model-owned sequence state"));
 }

--- a/src/models/mod.rs
+++ b/src/models/mod.rs
@@ -60,6 +60,22 @@ pub mod rope_overrides;
 pub mod rope_utils;
 pub mod switch_layers;
 
+pub(crate) fn parse_optional_eos_token_ids(value: &Option<serde_json::Value>) -> Vec<i32> {
+    match value {
+        Some(serde_json::Value::Number(n)) => n
+            .as_i64()
+            .and_then(|id| i32::try_from(id).ok())
+            .map(|id| vec![id])
+            .unwrap_or_default(),
+        Some(serde_json::Value::Array(arr)) => arr
+            .iter()
+            .filter_map(|v| v.as_i64())
+            .filter_map(|id| i32::try_from(id).ok())
+            .collect(),
+        _ => Vec::new(),
+    }
+}
+
 // Model implementations (mlxcel-core based)
 pub mod afmoe;
 pub mod apertus;

--- a/src/models/model_owned.rs
+++ b/src/models/model_owned.rs
@@ -132,6 +132,20 @@ impl<T> ModelOwnedSequenceState<T> {
         f(&mut internal)
     }
 
+    pub(crate) fn with_existing_sequence_state<R>(
+        &self,
+        seq_id: SequenceId,
+        f: impl FnOnce(&mut [T]) -> R,
+    ) -> Result<R, String> {
+        let mut sequence_state =
+            self.sequences.borrow_mut().remove(&seq_id).ok_or_else(|| {
+                format!("missing model-owned sequence state for sequence {seq_id}")
+            })?;
+        let result = f(&mut sequence_state);
+        self.sequences.borrow_mut().insert(seq_id, sequence_state);
+        Ok(result)
+    }
+
     pub(crate) fn with_batched_sequence_states<R>(
         &self,
         seq_ids: &[SequenceId],
@@ -159,6 +173,11 @@ impl<T> ModelOwnedSequenceState<T> {
 
     pub(crate) fn release_sequence_state(&self, seq_id: SequenceId) {
         self.sequences.borrow_mut().remove(&seq_id);
+    }
+
+    #[cfg(test)]
+    pub(crate) fn has_sequence_state(&self, seq_id: SequenceId) -> bool {
+        self.sequences.borrow().contains_key(&seq_id)
     }
 }
 
@@ -321,4 +340,84 @@ where
     }?;
 
     Ok(Some(attn))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::ModelOwnedSequenceState;
+    use mlxcel_core::cache::SequenceId;
+
+    #[test]
+    fn model_owned_sequence_state_preserves_fallback_between_steps() {
+        let state = ModelOwnedSequenceState::new(vec![0usize]);
+
+        state.with_sequence_state(None, |fallback| fallback[0] += 1);
+        state.with_sequence_state(None, |fallback| fallback[0] += 1);
+
+        let value = state.with_sequence_state(None, |fallback| fallback[0]);
+        assert_eq!(value, 2);
+    }
+
+    #[test]
+    fn model_owned_sequence_state_isolates_prepared_sequences() {
+        let state = ModelOwnedSequenceState::new(vec![0usize]);
+        let seq_a = SequenceId::from_raw(1220);
+        let seq_b = SequenceId::from_raw(1221);
+
+        state.prepare_sequence_state(seq_a, vec![10]);
+        state.prepare_sequence_state(seq_b, vec![20]);
+
+        state
+            .with_existing_sequence_state(seq_a, |a| a[0] += 1)
+            .expect("seq_a exists");
+        state
+            .with_existing_sequence_state(seq_b, |b| b[0] += 2)
+            .expect("seq_b exists");
+
+        assert_eq!(
+            state
+                .with_existing_sequence_state(seq_a, |a| a[0])
+                .expect("seq_a still exists"),
+            11
+        );
+        assert_eq!(
+            state
+                .with_existing_sequence_state(seq_b, |b| b[0])
+                .expect("seq_b still exists"),
+            22
+        );
+    }
+
+    #[test]
+    fn model_owned_sequence_state_refuses_missing_sequence_ids() {
+        let state = ModelOwnedSequenceState::new(vec![0usize]);
+        let seq = SequenceId::from_raw(1220);
+
+        let err = state
+            .with_existing_sequence_state(seq, |slot| slot[0])
+            .expect_err("unprepared sequence must fail closed");
+
+        assert!(
+            err.contains("missing model-owned sequence state for sequence seq-1220"),
+            "unexpected error: {err}"
+        );
+    }
+
+    #[test]
+    fn model_owned_sequence_state_release_drops_prepared_slot() {
+        let state = ModelOwnedSequenceState::new(vec![0usize]);
+        let seq = SequenceId::from_raw(1220);
+
+        state.prepare_sequence_state(seq, vec![1]);
+        assert!(state.has_sequence_state(seq));
+
+        state.release_sequence_state(seq);
+
+        assert!(!state.has_sequence_state(seq));
+        assert!(
+            state
+                .with_existing_sequence_state(seq, |slot| slot[0])
+                .is_err()
+        );
+    }
 }

--- a/src/models/recurrent_gemma.rs
+++ b/src/models/recurrent_gemma.rs
@@ -24,6 +24,7 @@
 // - logits_soft_cap for output softcapping
 // - embeddings_scale_by_sqrt_dim option
 
+use mlxcel_core::cache::{SequenceId, SequenceStateLayout};
 use mlxcel_core::generate::LanguageModel;
 use mlxcel_core::layers::{
     GemmaRMSNorm, KVCache, RotatingKVCache, UnifiedEmbedding, UnifiedLinear,
@@ -33,6 +34,8 @@ use mlxcel_core::weights::WeightMap;
 use mlxcel_core::{MlxArray, UniquePtr, concatenate};
 use serde::Deserialize;
 use std::path::Path;
+
+use super::model_owned::ModelOwnedSequenceState;
 
 // Configuration.
 #[derive(Debug, Clone, Deserialize)]
@@ -77,6 +80,8 @@ pub struct GriffinConfig {
 
     #[serde(default)]
     pub quantization: Option<Quantization>,
+    #[serde(default)]
+    pub eos_token_id: Option<serde_json::Value>,
 }
 
 fn default_rms_norm_eps() -> f32 {
@@ -148,6 +153,19 @@ impl Default for RGLRUCache {
 pub enum GriffinLayerCache {
     Attention(RotatingKVCache),
     Recurrent(RGLRUCache),
+}
+
+fn make_griffin_caches(block_types: &[String], window_size: usize) -> Vec<GriffinLayerCache> {
+    block_types
+        .iter()
+        .map(|t| {
+            if t == "attention" {
+                GriffinLayerCache::Attention(RotatingKVCache::new(window_size as i32))
+            } else {
+                GriffinLayerCache::Recurrent(RGLRUCache::new())
+            }
+        })
+        .collect()
 }
 
 // RNN Scan Operation.
@@ -622,6 +640,11 @@ impl GriffinBackbone {
 
         // Forward through layers
         if let Some(cache_slice) = caches {
+            assert_eq!(
+                cache_slice.len(),
+                self.layers.len(),
+                "RecurrentGemma cache cardinality must match layer count"
+            );
             for (layer, cache) in self.layers.iter().zip(cache_slice.iter_mut()) {
                 h = layer.forward(&h, mask.as_deref(), cache);
             }
@@ -652,6 +675,8 @@ pub struct GriffinModel {
     config: GriffinConfig,
     model: GriffinBackbone,
     lm_head: Option<UnifiedLinear>,
+    sequence_state: ModelOwnedSequenceState<GriffinLayerCache>,
+    eos_token_ids: Vec<i32>,
 }
 
 impl GriffinModel {
@@ -660,19 +685,7 @@ impl GriffinModel {
     }
 
     pub fn make_griffin_caches(&self) -> Vec<GriffinLayerCache> {
-        self.model
-            .block_types
-            .iter()
-            .map(|t| {
-                if t == "attention" {
-                    GriffinLayerCache::Attention(RotatingKVCache::new(
-                        self.config.attention_window_size as i32,
-                    ))
-                } else {
-                    GriffinLayerCache::Recurrent(RGLRUCache::new())
-                }
-            })
-            .collect()
+        make_griffin_caches(&self.model.block_types, self.config.attention_window_size)
     }
 
     pub fn forward_with_caches(
@@ -731,7 +744,8 @@ impl GriffinModel {
 
         // Build model
         println!("[Griffin] Building model...");
-        let model = Self::from_weights(config.clone(), weights)?;
+        let mut model = Self::from_weights(config.clone(), weights)?;
+        model.set_eos_token_ids(crate::loading::read_eos_token_ids(path));
 
         println!("[Griffin] Model loaded successfully");
         Ok((model, config))
@@ -964,6 +978,9 @@ impl GriffinModel {
             None
         };
 
+        let internal_caches = make_griffin_caches(&block_types, config.attention_window_size);
+        let eos_token_ids = super::parse_optional_eos_token_ids(&config.eos_token_id);
+
         let model = GriffinBackbone {
             embed_tokens,
             layers,
@@ -978,7 +995,39 @@ impl GriffinModel {
             config,
             model,
             lm_head,
+            sequence_state: ModelOwnedSequenceState::new(internal_caches),
+            eos_token_ids,
         })
+    }
+
+    pub(crate) fn set_eos_token_ids(&mut self, eos_token_ids: Vec<i32>) {
+        if !eos_token_ids.is_empty() {
+            self.eos_token_ids = eos_token_ids;
+        }
+    }
+
+    fn forward_for_sequence(
+        &self,
+        input: &MlxArray,
+        seq_id: Option<SequenceId>,
+    ) -> UniquePtr<MlxArray> {
+        let seq_len = mlxcel_core::array_shape(input)[1];
+        if seq_id.is_none() && seq_len > 1 {
+            self.sequence_state
+                .replace_internal(self.make_griffin_caches());
+        }
+
+        if let Some(seq_id) = seq_id {
+            self.sequence_state
+                .with_existing_sequence_state(seq_id, |internal| {
+                    self.forward_with_caches(input, Some(internal))
+                })
+                .unwrap_or_else(|err| panic!("RecurrentGemma {err}"))
+        } else {
+            self.sequence_state.with_sequence_state(None, |internal| {
+                self.forward_with_caches(input, Some(internal))
+            })
+        }
     }
 }
 
@@ -990,13 +1039,15 @@ impl LanguageModel for GriffinModel {
         _caches: &mut [KVCache],
         _mask: Option<&MlxArray>,
     ) -> UniquePtr<MlxArray> {
-        // Note: Griffin uses mixed cache types (KVCache + RGLRUCache)
-        // For LanguageModel trait compatibility, we use internal caching
-        self.forward_with_caches(input, None)
+        // Griffin uses model-owned mixed cache types (KVCache + RGLRUCache);
+        // the trait KVCache slice is only a compatibility placeholder.
+        self.forward_for_sequence(input, None)
     }
 
     fn make_caches(&self) -> Vec<KVCache> {
-        // Return KV caches for compatibility - actual usage should use make_griffin_caches()
+        self.sequence_state
+            .replace_internal(self.make_griffin_caches());
+        // Return dummy KV caches for compatibility; actual state is model-owned.
         (0..self.config.num_hidden_layers)
             .map(|_| KVCache::new())
             .collect()
@@ -1014,7 +1065,116 @@ impl LanguageModel for GriffinModel {
         false // RecurrentGemma uses internal RGLRUCache state, not compatible with per-sequence KV isolation
     }
 
+    fn sequence_state_layout(&self) -> SequenceStateLayout {
+        SequenceStateLayout::model_owned(self.config.num_hidden_layers)
+    }
+
+    fn reset_runtime_state(&self) {
+        self.sequence_state
+            .replace_internal(self.make_griffin_caches());
+    }
+
+    fn prepare_sequence_state(&self, seq_id: SequenceId) {
+        self.sequence_state
+            .prepare_sequence_state(seq_id, self.make_griffin_caches());
+    }
+
+    fn release_sequence_state_by_id(&self, seq_id: SequenceId) {
+        self.sequence_state.release_sequence_state(seq_id);
+    }
+
+    fn forward_with_sequence_id(
+        &self,
+        input_ids: &MlxArray,
+        seq_id: Option<SequenceId>,
+        _caches: &mut [KVCache],
+        _mask: Option<&MlxArray>,
+    ) -> UniquePtr<MlxArray> {
+        self.forward_for_sequence(input_ids, seq_id)
+    }
+
     fn eos_token_ids(&self) -> Vec<i32> {
-        vec![1] // Gemma EOS token
+        self.eos_token_ids.clone()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{GriffinLayerCache, make_griffin_caches};
+    use crate::models::model_owned::ModelOwnedSequenceState;
+    use mlxcel_core::cache::SequenceId;
+    use mlxcel_core::dtype;
+
+    #[test]
+    fn recurrent_gemma_eos_token_ids_come_from_config_metadata() {
+        let config: super::GriffinConfig = serde_json::from_value(serde_json::json!({
+            "model_type": "recurrent_gemma",
+            "hidden_size": 8,
+            "intermediate_size": 16,
+            "num_hidden_layers": 1,
+            "num_attention_heads": 2,
+            "num_key_value_heads": 1,
+            "vocab_size": 32,
+            "eos_token_id": [20, 21]
+        }))
+        .expect("RecurrentGemma config must parse");
+
+        assert_eq!(
+            crate::models::parse_optional_eos_token_ids(&config.eos_token_id),
+            vec![20, 21]
+        );
+    }
+
+    #[test]
+    fn recurrent_gemma_model_owned_sequence_state_preserves_greedy_decode_cache() {
+        let block_types = vec!["recurrent".to_string(), "attention".to_string()];
+        let state = ModelOwnedSequenceState::new(make_griffin_caches(&block_types, 8));
+        let seq = SequenceId::from_raw(1220);
+
+        state.prepare_sequence_state(seq, make_griffin_caches(&block_types, 8));
+        state
+            .with_existing_sequence_state(seq, |caches| match &mut caches[0] {
+                GriffinLayerCache::Recurrent(cache) => {
+                    cache.conv_cache = Some(mlxcel_core::zeros(&[1, 3, 8], dtype::FLOAT32));
+                }
+                GriffinLayerCache::Attention(_) => panic!("expected recurrent cache"),
+            })
+            .expect("prepared RecurrentGemma sequence must exist");
+
+        state
+            .with_existing_sequence_state(seq, |caches| match &mut caches[0] {
+                GriffinLayerCache::Recurrent(cache) => {
+                    assert!(
+                        cache.conv_cache.is_some(),
+                        "decode must see the cache populated by the previous token"
+                    );
+                    cache.state_cache = Some(mlxcel_core::zeros(&[1, 8], dtype::FLOAT32));
+                }
+                GriffinLayerCache::Attention(_) => panic!("expected recurrent cache"),
+            })
+            .expect("prepared RecurrentGemma sequence must still exist");
+
+        state
+            .with_existing_sequence_state(seq, |caches| match &caches[0] {
+                GriffinLayerCache::Recurrent(cache) => assert!(
+                    cache.state_cache.is_some(),
+                    "cache writes must survive across consecutive greedy steps"
+                ),
+                GriffinLayerCache::Attention(_) => panic!("expected recurrent cache"),
+            })
+            .expect("prepared RecurrentGemma sequence must still exist");
+    }
+
+    #[test]
+    fn recurrent_gemma_model_owned_sequence_state_refuses_missing_sequence_id() {
+        let block_types = vec!["recurrent".to_string()];
+        let state = ModelOwnedSequenceState::new(make_griffin_caches(&block_types, 8));
+        let seq = SequenceId::from_raw(1220);
+
+        let err = state
+            .with_existing_sequence_state(seq, |_| {})
+            .expect_err("unprepared RecurrentGemma sequence must fail closed");
+
+        assert!(err.contains("missing model-owned sequence state"));
     }
 }

--- a/src/models/rwkv7.rs
+++ b/src/models/rwkv7.rs
@@ -15,12 +15,15 @@
 // RWKV7: Recurrent neural network with time mixing and channel mixing
 // Reference: https://github.com/ml-explore/mlx-lm/blob/main/mlx_lm/models/rwkv7.py
 
+use mlxcel_core::cache::{SequenceId, SequenceStateLayout};
 use mlxcel_core::generate::LanguageModel;
-use mlxcel_core::layers::{RMSNorm, UnifiedEmbedding, UnifiedLinear};
+use mlxcel_core::layers::{KVCache, RMSNorm, UnifiedEmbedding, UnifiedLinear};
 use mlxcel_core::weights::WeightMap;
 use mlxcel_core::{MlxArray, UniquePtr};
 use serde::Deserialize;
 use std::path::Path;
+
+use super::model_owned::ModelOwnedSequenceState;
 
 // Configuration.
 #[derive(Debug, Clone, Deserialize)]
@@ -47,6 +50,8 @@ pub struct Rwkv7Config {
     pub tie_word_embeddings: bool,
     #[serde(default)]
     pub quantization: Option<Quantization>,
+    #[serde(default)]
+    pub eos_token_id: Option<serde_json::Value>,
 }
 
 fn default_norm_eps() -> f32 {
@@ -917,29 +922,26 @@ impl Rwkv7Model {
         })
     }
 
-    fn forward(&self, x: &MlxArray, cache: &mut Option<Vec<Rwkv7Cache>>) -> UniquePtr<MlxArray> {
+    fn forward(&self, x: &MlxArray, caches: &mut [Rwkv7Cache]) -> UniquePtr<MlxArray> {
+        assert_eq!(
+            caches.len(),
+            self.layers.len(),
+            "RWKV7 cache cardinality must match layer count"
+        );
+
         let mut h = self.embeddings.forward(x);
 
         let mut v_first: Option<UniquePtr<MlxArray>> = None;
 
-        if let Some(caches) = cache {
-            for (i, layer) in self.layers.iter().enumerate() {
-                let mut layer_cache = Some(&mut caches[i]);
-                let (new_h, new_v_first) = layer.forward(
-                    &h,
-                    v_first.as_ref().map(|v| v.as_ref().unwrap()),
-                    &mut layer_cache,
-                );
-                h = new_h;
-                v_first = Some(new_v_first);
-            }
-        } else {
-            for layer in &self.layers {
-                let (new_h, new_v_first) =
-                    layer.forward(&h, v_first.as_ref().map(|v| v.as_ref().unwrap()), &mut None);
-                h = new_h;
-                v_first = Some(new_v_first);
-            }
+        for (layer, cache) in self.layers.iter().zip(caches.iter_mut()) {
+            let mut layer_cache = Some(cache);
+            let (new_h, new_v_first) = layer.forward(
+                &h,
+                v_first.as_ref().map(|v| v.as_ref().unwrap()),
+                &mut layer_cache,
+            );
+            h = new_h;
+            v_first = Some(new_v_first);
         }
 
         self.norm.forward(&h)
@@ -952,7 +954,8 @@ pub struct Rwkv7 {
     config: Rwkv7Config,
     model: Rwkv7Model,
     lm_head: Option<UnifiedLinear>,
-    rwkv7_cache: Option<Vec<Rwkv7Cache>>,
+    sequence_state: ModelOwnedSequenceState<Rwkv7Cache>,
+    eos_token_ids: Vec<i32>,
 }
 
 impl Rwkv7 {
@@ -970,11 +973,15 @@ impl Rwkv7 {
             None
         };
 
+        let internal_caches = make_rwkv7_cache(config.num_hidden_layers);
+        let eos_token_ids = super::parse_optional_eos_token_ids(&config.eos_token_id);
+
         Ok(Self {
             config,
             model,
             lm_head,
-            rwkv7_cache: None,
+            sequence_state: ModelOwnedSequenceState::new(internal_caches),
+            eos_token_ids,
         })
     }
 
@@ -984,31 +991,43 @@ impl Rwkv7 {
         let config: Rwkv7Config = serde_json::from_str(&config_str)?;
 
         let weights = crate::models::load_text_weights(model_dir, None)?;
-        Ok(Self::from_weights(&weights, config)?)
+        let mut model = Self::from_weights(&weights, config)?;
+        model.set_eos_token_ids(crate::loading::read_eos_token_ids(model_dir));
+        Ok(model)
     }
 
     #[allow(dead_code)]
     fn make_rwkv7_cache(&self) -> Vec<Rwkv7Cache> {
-        (0..self.config.num_hidden_layers)
-            .map(|_| Rwkv7Cache::new())
-            .collect()
+        make_rwkv7_cache(self.config.num_hidden_layers)
     }
-}
 
-impl LanguageModel for Rwkv7 {
-    fn forward(
+    pub(crate) fn set_eos_token_ids(&mut self, eos_token_ids: Vec<i32>) {
+        if !eos_token_ids.is_empty() {
+            self.eos_token_ids = eos_token_ids;
+        }
+    }
+
+    fn forward_for_sequence(
         &self,
         input_ids: &MlxArray,
-        _caches: &mut [mlxcel_core::layers::KVCache],
-        _mask: Option<&MlxArray>,
+        seq_id: Option<SequenceId>,
     ) -> UniquePtr<MlxArray> {
-        // RWKV7 doesn't use standard KV cache, it uses its own Rwkv7Cache
-        // The standard KVCache parameter is ignored
-        // TODO: Properly integrate RWKV7Cache with the generation framework
+        let seq_len = mlxcel_core::array_shape(input_ids)[1];
+        if seq_id.is_none() && seq_len > 1 {
+            self.sequence_state
+                .replace_internal(self.make_rwkv7_cache());
+        }
 
-        // For now, do stateless forward pass
-        let mut cache: Option<Vec<Rwkv7Cache>> = None;
-        let h = self.model.forward(input_ids, &mut cache);
+        let h = if let Some(seq_id) = seq_id {
+            self.sequence_state
+                .with_existing_sequence_state(seq_id, |internal| {
+                    self.model.forward(input_ids, internal)
+                })
+                .unwrap_or_else(|err| panic!("RWKV7 {err}"))
+        } else {
+            self.sequence_state
+                .with_sequence_state(None, |internal| self.model.forward(input_ids, internal))
+        };
 
         if let Some(ref lm_head) = self.lm_head {
             lm_head.forward(&h)
@@ -1016,10 +1035,26 @@ impl LanguageModel for Rwkv7 {
             self.model.embeddings.as_linear(&h)
         }
     }
+}
 
-    fn make_caches(&self) -> Vec<mlxcel_core::layers::KVCache> {
-        // RWKV7 doesn't use standard KV caches, return empty vector
-        Vec::new()
+impl LanguageModel for Rwkv7 {
+    fn forward(
+        &self,
+        input_ids: &MlxArray,
+        _caches: &mut [KVCache],
+        _mask: Option<&MlxArray>,
+    ) -> UniquePtr<MlxArray> {
+        // RWKV7 keeps recurrent state in model-owned per-sequence slots; the
+        // standard KVCache slice is only a scheduler compatibility placeholder.
+        self.forward_for_sequence(input_ids, None)
+    }
+
+    fn make_caches(&self) -> Vec<KVCache> {
+        self.sequence_state
+            .replace_internal(self.make_rwkv7_cache());
+        (0..self.config.num_hidden_layers)
+            .map(|_| KVCache::new())
+            .collect()
     }
 
     fn num_layers(&self) -> usize {
@@ -1034,15 +1069,48 @@ impl LanguageModel for Rwkv7 {
         false // RWKV7 uses internal RNN-like state, not compatible with per-sequence KV isolation
     }
 
-    fn eos_token_ids(&self) -> Vec<i32> {
-        // Default EOS token ID, should be loaded from tokenizer config
-        vec![0]
+    fn sequence_state_layout(&self) -> SequenceStateLayout {
+        SequenceStateLayout::model_owned(self.config.num_hidden_layers)
     }
+
+    fn reset_runtime_state(&self) {
+        self.sequence_state
+            .replace_internal(self.make_rwkv7_cache());
+    }
+
+    fn prepare_sequence_state(&self, seq_id: SequenceId) {
+        self.sequence_state
+            .prepare_sequence_state(seq_id, self.make_rwkv7_cache());
+    }
+
+    fn release_sequence_state_by_id(&self, seq_id: SequenceId) {
+        self.sequence_state.release_sequence_state(seq_id);
+    }
+
+    fn forward_with_sequence_id(
+        &self,
+        input_ids: &MlxArray,
+        seq_id: Option<SequenceId>,
+        _caches: &mut [KVCache],
+        _mask: Option<&MlxArray>,
+    ) -> UniquePtr<MlxArray> {
+        self.forward_for_sequence(input_ids, seq_id)
+    }
+
+    fn eos_token_ids(&self) -> Vec<i32> {
+        self.eos_token_ids.clone()
+    }
+}
+
+fn make_rwkv7_cache(num_hidden_layers: usize) -> Vec<Rwkv7Cache> {
+    (0..num_hidden_layers).map(|_| Rwkv7Cache::new()).collect()
 }
 
 #[cfg(test)]
 mod tests {
-    use super::Rwkv7Cache;
+    use super::{Rwkv7Cache, make_rwkv7_cache};
+    use crate::models::model_owned::ModelOwnedSequenceState;
+    use mlxcel_core::cache::SequenceId;
     use mlxcel_core::{dtype, generate::ModelStateSnapshot};
 
     #[test]
@@ -1076,5 +1144,72 @@ mod tests {
         assert_eq!(mlxcel_core::array_shape(token_shift), vec![1, 8]);
         assert_eq!(mlxcel_core::array_shape(state), vec![1, 2, 4, 8]);
         assert_eq!(mlxcel_core::array_shape(ffn), vec![1, 8]);
+    }
+
+    #[test]
+    fn rwkv7_eos_token_ids_come_from_config_metadata() {
+        let config: super::Rwkv7Config = serde_json::from_value(serde_json::json!({
+            "model_type": "rwkv7",
+            "vocab_size": 16,
+            "hidden_size": 8,
+            "intermediate_size": 16,
+            "head_dim": 4,
+            "num_hidden_layers": 1,
+            "a_low_rank_dim": 2,
+            "v_low_rank_dim": 2,
+            "gate_low_rank_dim": 2,
+            "decay_low_rank_dim": 2,
+            "eos_token_id": [10, 11]
+        }))
+        .expect("RWKV7 config must parse");
+
+        assert_eq!(
+            crate::models::parse_optional_eos_token_ids(&config.eos_token_id),
+            vec![10, 11]
+        );
+    }
+
+    #[test]
+    fn rwkv7_model_owned_sequence_state_preserves_greedy_decode_cache() {
+        let state = ModelOwnedSequenceState::new(make_rwkv7_cache(2));
+        let seq = SequenceId::from_raw(1220);
+
+        state.prepare_sequence_state(seq, make_rwkv7_cache(2));
+        state
+            .with_existing_sequence_state(seq, |caches| {
+                caches[0].token_shift_cache = Some(mlxcel_core::zeros(&[1, 8], dtype::FLOAT32));
+            })
+            .expect("prepared RWKV7 sequence must exist");
+
+        state
+            .with_existing_sequence_state(seq, |caches| {
+                assert!(
+                    caches[0].token_shift_cache.is_some(),
+                    "decode must see the cache populated by the previous token"
+                );
+                caches[1].ffn_cache = Some(mlxcel_core::zeros(&[1, 8], dtype::FLOAT32));
+            })
+            .expect("prepared RWKV7 sequence must still exist");
+
+        state
+            .with_existing_sequence_state(seq, |caches| {
+                assert!(
+                    caches[1].ffn_cache.is_some(),
+                    "cache writes must survive across consecutive greedy steps"
+                );
+            })
+            .expect("prepared RWKV7 sequence must still exist");
+    }
+
+    #[test]
+    fn rwkv7_model_owned_sequence_state_refuses_missing_sequence_id() {
+        let state = ModelOwnedSequenceState::new(make_rwkv7_cache(1));
+        let seq = SequenceId::from_raw(1220);
+
+        let err = state
+            .with_existing_sequence_state(seq, |_| {})
+            .expect_err("unprepared RWKV7 sequence must fail closed");
+
+        assert!(err.contains("missing model-owned sequence state"));
     }
 }


### PR DESCRIPTION
## Summary

Fixes #1220.

- Route RWKV7, RecurrentGemma, and KimiLinear through model-owned per-sequence recurrent state instead of rebuilding caches inside every decode step.
- Reset the legacy single-stream fallback only for fresh multi-token prefills, and require prepared scheduler `SequenceId` slots on the scheduler path.
- Resolve EOS ids from checkpoint sidecars/config via `read_eos_token_ids()` instead of hardcoded family constants.
- Add deterministic regression coverage for EOS metadata fallback, model-owned state continuity, release, isolation, and missing-sequence fail-closed behavior.

## Validation

- `cargo fmt --all --check`
- `cargo test --lib model_owned_sequence_state -- --nocapture`
- `cargo test --lib read_eos_token_ids -- --nocapture`
- `cargo test --lib rwkv7_ -- --nocapture`
- `cargo test --lib recurrent_gemma_ -- --nocapture`
- `cargo test --lib kimi_linear_ -- --nocapture`
- `cargo test --lib parse_eos_token_ids -- --nocapture`
- `git diff --check`

## Not run

- Real RWKV7, RecurrentGemma, and KimiLinear checkpoint generation was not run in this worker because no pinned checkpoints or MLX hardware qualification target were provided.

## Technical reports

- `TECHNICAL_REPORTS/1513-recurrent-state-lifecycle-20260830.en.md`
- `TECHNICAL_REPORTS/1513-recurrent-state-lifecycle-20260830.ko.md`
