### PR TITLE
fix(bench): use binary byte units in KV reports

### DIFF
--- a/TECHNICAL_REPORTS/1514-kv-binary-byte-units-20260830.en.md
+++ b/TECHNICAL_REPORTS/1514-kv-binary-byte-units-20260830.en.md
@@ -1,0 +1,69 @@
+# Technical Report: PR #1514 - KV Binary Byte Units
+
+**Date**: 2026-08-30
+**Status**: Open PR, ready for central merge
+**Languages**: Rust
+**Risk Level**: Low
+
+## Executive Summary
+
+PR #1514 corrects byte-size labels in the KV-transfer benchmark so values divided by powers of 1024 are printed with binary unit names. The change is limited to display strings and exact formatter assertions; benchmark measurement arithmetic, transfer strategy behavior, throughput units, and model execution paths are unchanged.
+
+## 1. Problem Statement
+
+The KV-transfer benchmark rendered byte counts as `GB`, `MB`, and `KB` even though the formatter divided by `1024` at each tier. Those labels describe decimal units, while the calculation was binary. The mismatch affected benchmark report strings and could mislead readers comparing KV cache size and transfer summaries.
+
+The issue thread had no comments, so the issue body was the complete specification. The requested fix was to use `GiB`, `MiB`, and `KiB`, then update the formatter tests.
+
+## 2. Technical Decisions
+
+### 2.1 Fix display labels, not measurements
+
+Only the labels changed. The byte counts, benchmark inputs, compression ratios, timing, and throughput calculations remain untouched. This preserves measurement behavior while making the rendered units match the existing arithmetic.
+
+### 2.2 Cover both byte-size formatters in the benchmark module
+
+The private `format_bytes` helper was the direct issue target. `TransferBenchConfig::total_size_str` used the same 1024-based formatting pattern in the same benchmark module, so it was corrected as the same report-string defect. Throughput remains labelled `MB/s` because it is not a byte-size formatter and was outside this issue's scope.
+
+### 2.3 Replace substring checks with exact assertions
+
+The old tests accepted any string containing `KB`, `MB`, or `GB`, which allowed the wrong labels to pass. The tests now assert exact outputs such as `2.0KiB`, `5.0MiB`, `2.0GiB`, and `256.0 MiB`.
+
+## 3. Change Summary
+
+| Item | Value |
+|------|-------|
+| Files changed | 2 implementation/test files, plus reports |
+| Source/test delta | 11 insertions, 11 deletions |
+| Public API changes | None |
+| Measurement logic changes | None |
+| Hardware/model requirements | None |
+
+- Changed `TransferBenchConfig::total_size_str` labels from `GB`/`MB`/`KB` to `GiB`/`MiB`/`KiB`.
+- Changed the private KV-transfer `format_bytes` helper labels from `GB`/`MB`/`KB` to `GiB`/`MiB`/`KiB`.
+- Updated `bench_config_total_size_str` to assert the exact `256.0 MiB` output.
+- Updated `format_bytes_ranges` to assert exact byte, KiB, MiB, and GiB outputs.
+
+## 4. Validation
+
+- `cargo fmt --check`: passed.
+- `git diff --check -- src/distributed/kv_cache_transfer/benchmark.rs src/distributed/kv_cache_transfer/benchmark_tests.rs`: passed.
+- `cargo test --profile test-fast -p mlxcel distributed::kv_cache_transfer::benchmark::tests::format_bytes_ranges -- --exact --nocapture`: passed, 1 matching test passed, remaining tests filtered out.
+- `cargo test --profile test-fast -p mlxcel distributed::kv_cache_transfer::benchmark::tests::bench_config_total_size_str -- --exact --nocapture`: passed, 1 matching test passed, remaining tests filtered out.
+- `cargo clippy --profile test-fast -p mlxcel --lib -- -D warnings`: passed.
+
+Broad workspace tests were not run because this wave-runner unit forbids broad cargo and workspace commands. Hardware/model validation is not applicable because this PR changes benchmark display strings and formatter assertions only.
+
+## 5. Review Findings
+
+| Finding | Severity | Resolution |
+|---------|----------|------------|
+| 1024-based byte-size values were labelled with decimal unit names | Low | Use binary labels `KiB`, `MiB`, and `GiB` |
+| Formatter tests used substring checks that could miss label drift | Low | Use exact assertions for the relevant formatter outputs |
+
+No security issue was introduced. The change adds no input parsing, I/O, unsafe code, public API surface, concurrency, caching, or resource-management behavior.
+
+## 6. Remaining Limits
+
+- Hosted CI should be read from GitHub before central merge.
+- The PR does not attempt to standardize unrelated throughput labels such as `MB/s`; that unit is outside the byte-size formatter scope.

--- a/TECHNICAL_REPORTS/1514-kv-binary-byte-units-20260830.ko.md
+++ b/TECHNICAL_REPORTS/1514-kv-binary-byte-units-20260830.ko.md
@@ -1,0 +1,69 @@
+# 기술 보고서: PR #1514 - KV Binary Byte Units
+
+**작성일**: 2026-08-30
+**상태**: 열린 PR, 중앙 병합 준비 완료
+**언어**: Rust
+**위험도**: Low
+
+## 요약
+
+PR #1514는 KV-transfer benchmark에서 1024 단위로 나눈 byte-size 값이 binary unit 이름으로 표시되도록 수정한다. 변경 범위는 display string과 정확한 formatter assertion으로 제한되며, benchmark measurement arithmetic, transfer strategy behavior, throughput unit, model execution path는 변경하지 않았다.
+
+## 1. 문제 정의
+
+KV-transfer benchmark는 byte count를 각 tier에서 `1024`로 나누면서도 결과를 `GB`, `MB`, `KB`로 표시했다. 이 label은 decimal unit을 뜻하지만 계산은 binary 기준이었다. 이 불일치는 benchmark report string에 영향을 주며, KV cache size와 transfer summary를 읽는 사람이 단위를 잘못 해석할 수 있다.
+
+이슈 스레드에는 comment가 없었으므로 issue body가 전체 specification이었다. 요청된 수정은 label을 `GiB`, `MiB`, `KiB`로 바꾸고 formatter test를 업데이트하는 것이었다.
+
+## 2. 기술적 선택과 그 이유
+
+### 2.1 Measurement가 아니라 display label만 수정
+
+변경은 label에만 적용했다. Byte count, benchmark input, compression ratio, timing, throughput calculation은 그대로 유지했다. 이렇게 하면 measurement behavior는 보존하면서 rendering unit만 기존 arithmetic과 맞출 수 있다.
+
+### 2.2 Benchmark module 안의 두 byte-size formatter를 함께 정리
+
+private `format_bytes` helper가 issue의 직접 대상이었다. 같은 benchmark module의 `TransferBenchConfig::total_size_str`도 동일하게 1024 기반 formatting pattern을 사용했으므로 같은 report-string defect로 수정했다. `MB/s` throughput label은 byte-size formatter가 아니며 이 이슈 범위 밖이므로 유지했다.
+
+### 2.3 Substring check를 exact assertion으로 교체
+
+기존 테스트는 `KB`, `MB`, `GB`가 포함되어 있으면 통과했기 때문에 잘못된 label을 놓칠 수 있었다. 이제 테스트는 `2.0KiB`, `5.0MiB`, `2.0GiB`, `256.0 MiB` 같은 정확한 output을 assertion한다.
+
+## 3. 변경 요약
+
+| 항목 | 값 |
+|------|----|
+| 변경 파일 | implementation/test 2개 및 reports |
+| source/test delta | 11 insertions, 11 deletions |
+| Public API 변경 | 없음 |
+| Measurement logic 변경 | 없음 |
+| Hardware/model requirement | 없음 |
+
+- `TransferBenchConfig::total_size_str` label을 `GB`/`MB`/`KB`에서 `GiB`/`MiB`/`KiB`로 변경했다.
+- private KV-transfer `format_bytes` helper label을 `GB`/`MB`/`KB`에서 `GiB`/`MiB`/`KiB`로 변경했다.
+- `bench_config_total_size_str`가 정확한 `256.0 MiB` output을 assertion하도록 수정했다.
+- `format_bytes_ranges`가 byte, KiB, MiB, GiB output을 정확히 assertion하도록 수정했다.
+
+## 4. 검증
+
+- `cargo fmt --check`: 통과.
+- `git diff --check -- src/distributed/kv_cache_transfer/benchmark.rs src/distributed/kv_cache_transfer/benchmark_tests.rs`: 통과.
+- `cargo test --profile test-fast -p mlxcel distributed::kv_cache_transfer::benchmark::tests::format_bytes_ranges -- --exact --nocapture`: 통과, matching test 1개 통과, 나머지 test는 filtered out.
+- `cargo test --profile test-fast -p mlxcel distributed::kv_cache_transfer::benchmark::tests::bench_config_total_size_str -- --exact --nocapture`: 통과, matching test 1개 통과, 나머지 test는 filtered out.
+- `cargo clippy --profile test-fast -p mlxcel --lib -- -D warnings`: 통과.
+
+이 wave-runner unit이 broad cargo와 workspace command를 금지했기 때문에 broad workspace test는 실행하지 않았다. 이 PR은 benchmark display string과 formatter assertion만 변경하므로 hardware/model validation은 해당하지 않는다.
+
+## 5. 리뷰 결과
+
+| 항목 | 심각도 | 처리 |
+|------|--------|------|
+| 1024 기반 byte-size 값이 decimal unit label로 표시됨 | Low | binary label `KiB`, `MiB`, `GiB` 사용 |
+| Formatter test가 substring check라 label drift를 놓칠 수 있음 | Low | 관련 formatter output에 exact assertion 사용 |
+
+새로운 security issue는 없다. 이 변경은 input parsing, I/O, unsafe code, public API surface, concurrency, caching, resource-management behavior를 추가하지 않는다.
+
+## 6. 남은 제한
+
+- 중앙 병합 전 hosted CI 상태는 GitHub에서 확인해야 한다.
+- 이 PR은 `MB/s` 같은 unrelated throughput label을 표준화하지 않는다. 해당 unit은 byte-size formatter 범위 밖이다.

--- a/src/distributed/kv_cache_transfer/benchmark.rs
+++ b/src/distributed/kv_cache_transfer/benchmark.rs
@@ -109,11 +109,11 @@ impl TransferBenchConfig {
     pub fn total_size_str(&self) -> String {
         let bytes = self.total_bytes();
         if bytes >= 1024 * 1024 * 1024 {
-            format!("{:.1} GB", bytes as f64 / (1024.0 * 1024.0 * 1024.0))
+            format!("{:.1} GiB", bytes as f64 / (1024.0 * 1024.0 * 1024.0))
         } else if bytes >= 1024 * 1024 {
-            format!("{:.1} MB", bytes as f64 / (1024.0 * 1024.0))
+            format!("{:.1} MiB", bytes as f64 / (1024.0 * 1024.0))
         } else {
-            format!("{:.1} KB", bytes as f64 / 1024.0)
+            format!("{:.1} KiB", bytes as f64 / 1024.0)
         }
     }
 }
@@ -340,11 +340,11 @@ fn mean_duration(durations: &[Duration]) -> Duration {
 
 fn format_bytes(bytes: usize) -> String {
     if bytes >= 1024 * 1024 * 1024 {
-        format!("{:.1}GB", bytes as f64 / (1024.0 * 1024.0 * 1024.0))
+        format!("{:.1}GiB", bytes as f64 / (1024.0 * 1024.0 * 1024.0))
     } else if bytes >= 1024 * 1024 {
-        format!("{:.1}MB", bytes as f64 / (1024.0 * 1024.0))
+        format!("{:.1}MiB", bytes as f64 / (1024.0 * 1024.0))
     } else if bytes >= 1024 {
-        format!("{:.1}KB", bytes as f64 / 1024.0)
+        format!("{:.1}KiB", bytes as f64 / 1024.0)
     } else {
         format!("{bytes}B")
     }

--- a/src/distributed/kv_cache_transfer/benchmark_tests.rs
+++ b/src/distributed/kv_cache_transfer/benchmark_tests.rs
@@ -51,7 +51,7 @@ fn bench_config_total_bytes() {
 fn bench_config_total_size_str() {
     let config = TransferBenchConfig::for_model(32, 8, 128, 2048);
     let size = config.total_size_str();
-    assert!(size.contains("MB") || size.contains("GB"));
+    assert_eq!(size, "256.0 MiB");
 }
 
 // --- generate_synthetic_entries ---
@@ -152,8 +152,8 @@ fn benchmark_result_summary_format() {
 
 #[test]
 fn format_bytes_ranges() {
-    assert!(format_bytes(500).contains("B"));
-    assert!(format_bytes(2048).contains("KB"));
-    assert!(format_bytes(5 * 1024 * 1024).contains("MB"));
-    assert!(format_bytes(2 * 1024 * 1024 * 1024).contains("GB"));
+    assert_eq!(format_bytes(500), "500B");
+    assert_eq!(format_bytes(2048), "2.0KiB");
+    assert_eq!(format_bytes(5 * 1024 * 1024), "5.0MiB");
+    assert_eq!(format_bytes(2 * 1024 * 1024 * 1024), "2.0GiB");
 }


### PR DESCRIPTION
## Summary

- Rename KV-transfer benchmark byte-size labels from decimal `GB`/`MB`/`KB` to binary `GiB`/`MiB`/`KiB` where the arithmetic divides by powers of 1024.
- Tighten benchmark formatter tests from substring checks to exact expected strings for `total_size_str` and `format_bytes_ranges`.

## Validation

- `cargo fmt --check`: passed.
- `git diff --check -- src/distributed/kv_cache_transfer/benchmark.rs src/distributed/kv_cache_transfer/benchmark_tests.rs`: passed.
- `cargo test --profile test-fast -p mlxcel distributed::kv_cache_transfer::benchmark::tests::format_bytes_ranges -- --exact --nocapture`: passed, 1 matching test passed, remaining tests filtered out.
- `cargo test --profile test-fast -p mlxcel distributed::kv_cache_transfer::benchmark::tests::bench_config_total_size_str -- --exact --nocapture`: passed, 1 matching test passed, remaining tests filtered out.
- `cargo clippy --profile test-fast -p mlxcel --lib -- -D warnings`: passed.

## Technical reports

- `TECHNICAL_REPORTS/1514-kv-binary-byte-units-20260830.en.md`
- `TECHNICAL_REPORTS/1514-kv-binary-byte-units-20260830.ko.md`

## Review notes

- Scope is limited to report-string labels and exact formatter assertions; benchmark measurement arithmetic, transfer strategy logic, throughput units, and real model paths are unchanged.
- No hardware/model validation is applicable because this PR only changes benchmark display strings and unit tests.

Closes #1221
