### PR TITLE
fix(audio): share bounded real FFT frontend

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -47,6 +47,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "anes"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b46cbb362ab8752921c97e041f5e366ee6297bd428a31275b9fcf1e380f7299"
+
+[[package]]
 name = "anstream"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -364,6 +370,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc652a48c352aef3ea3aed32080501cf3ef6ed5da78602a020c991775b0aff04"
 
 [[package]]
+name = "cast"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
+
+[[package]]
 name = "castaway"
 version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -422,6 +434,33 @@ dependencies = [
  "num-traits",
  "wasm-bindgen",
  "windows-link",
+]
+
+[[package]]
+name = "ciborium"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42e69ffd6f0917f5c029256a24d0161db17cea3997d185db0d35926308770f0e"
+dependencies = [
+ "ciborium-io",
+ "ciborium-ll",
+ "serde",
+]
+
+[[package]]
+name = "ciborium-io"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05afea1e0a06c9be33d539b876f1ce3692f4afea2cb41f740e7743225ed1c757"
+
+[[package]]
+name = "ciborium-ll"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57663b653d948a338bfb3eeba9bb2fd5fcfaecb9e199e87e1eda4d9e8b240fd9"
+dependencies = [
+ "ciborium-io",
+ "half",
 ]
 
 [[package]]
@@ -630,6 +669,42 @@ dependencies = [
 ]
 
 [[package]]
+name = "criterion"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2b12d017a929603d80db1831cd3a24082f8137ce19c69e6447f54f5fc8d692f"
+dependencies = [
+ "anes",
+ "cast",
+ "ciborium",
+ "clap",
+ "criterion-plot",
+ "is-terminal",
+ "itertools 0.10.5",
+ "num-traits",
+ "once_cell",
+ "oorandom",
+ "plotters",
+ "rayon",
+ "regex",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "tinytemplate",
+ "walkdir",
+]
+
+[[package]]
+name = "criterion-plot"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6b50826342786a51a89e2da3a28f1c32b06e387201bc2d19791f622c673706b1"
+dependencies = [
+ "cast",
+ "itertools 0.10.5",
+]
+
+[[package]]
 name = "critical-section"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -659,6 +734,12 @@ name = "crossbeam-utils"
 version = "0.8.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "61803da095bee82a81bb1a452ecc25d3b2f1416d1897eb86430c6159ef717c17"
+
+[[package]]
+name = "crunchy"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
 
 [[package]]
 name = "crypto-common"
@@ -1277,6 +1358,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "half"
+version = "2.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ea2d84b969582b4b1864a92dc5d27cd2b77b622a8d79306834f1be5ba20d84b"
+dependencies = [
+ "cfg-if",
+ "crunchy",
+ "zerocopy",
+]
+
+[[package]]
 name = "hash32"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1686,10 +1778,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a756c3fac73139e83f14c2d742155dd2b78d3ee56597b419a0579b7bdd6dd78"
 
 [[package]]
+name = "is-terminal"
+version = "0.4.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
+dependencies = [
+ "hermit-abi",
+ "libc",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "is_terminal_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
+
+[[package]]
+name = "itertools"
+version = "0.10.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0fd2260e829bddf4cb6ea802289de2f86d6a7a690192fbe91b3f46e0f2c8473"
+dependencies = [
+ "either",
+]
 
 [[package]]
 name = "itertools"
@@ -1938,6 +2050,7 @@ dependencies = [
  "bytes",
  "chrono",
  "clap",
+ "criterion",
  "ctor",
  "dirs",
  "fancy-regex 0.17.0",
@@ -2221,6 +2334,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "oorandom"
+version = "11.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6790f58c7ff633d8771f42965289203411a5e5c68388703c06e14f24770b41e"
+
+[[package]]
 name = "openssl"
 version = "0.10.81"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2368,6 +2487,34 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f6b464fbc74e149a392436b17d523f769e057cb6877f6a5c4618bc6f11800548"
 
 [[package]]
+name = "plotters"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5aeb6f403d7a4911efb1e33402027fc44f29b5bf6def3effcc22d7bb75f2b747"
+dependencies = [
+ "num-traits",
+ "plotters-backend",
+ "plotters-svg",
+ "wasm-bindgen",
+ "web-sys",
+]
+
+[[package]]
+name = "plotters-backend"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df42e13c12958a16b3f7f4386b9ab1f3e7933914ecea48da7139435263a4172a"
+
+[[package]]
+name = "plotters-svg"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "51bae2ac328883f7acdfea3d66a7c35751187f870bc81f94563733a154d7a670"
+dependencies = [
+ "plotters-backend",
+]
+
+[[package]]
 name = "png"
 version = "0.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2449,7 +2596,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b570b25f7617e43d59005d0990ccb79e950a423952cea19671b7a876da390adf"
 dependencies = [
  "anyhow",
- "itertools",
+ "itertools 0.14.0",
  "proc-macro2",
  "quote",
  "syn 2.0.119",
@@ -2626,7 +2773,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2964d0cf57a3e7a06e8183d14a8b527195c706b7983549cd5462d5aa3747438f"
 dependencies = [
  "either",
- "itertools",
+ "itertools 0.14.0",
  "rayon",
 ]
 
@@ -2914,6 +3061,15 @@ dependencies = [
  "hashbrown 0.16.1",
  "serde",
  "serde_json",
+]
+
+[[package]]
+name = "same-file"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
+dependencies = [
+ "winapi-util",
 ]
 
 [[package]]
@@ -3391,6 +3547,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "tinytemplate"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be4d6b5f19ff7664e8c98d03e2139cb510db9b0a60b55f8e8709b689d939b6bc"
+dependencies = [
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "tinyvec"
 version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3419,7 +3585,7 @@ dependencies = [
  "esaxx-rs",
  "fancy-regex 0.14.0",
  "getrandom 0.3.4",
- "itertools",
+ "itertools 0.14.0",
  "log",
  "macro_rules_attribute",
  "monostate",
@@ -3452,7 +3618,7 @@ dependencies = [
  "esaxx-rs",
  "getrandom 0.3.4",
  "indicatif",
- "itertools",
+ "itertools 0.14.0",
  "log",
  "macro_rules_attribute",
  "monostate",
@@ -3928,6 +4094,16 @@ name = "version_check"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
+
+[[package]]
+name = "walkdir"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29790946404f91d9c5d06f9874efddea1dc06c5efe94541a7d6863108e3a5e4b"
+dependencies = [
+ "same-file",
+ "winapi-util",
+]
 
 [[package]]
 name = "want"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -345,6 +345,11 @@ rcgen = { version = "0.13", default-features = false, features = ["crypto", "pem
 # `BodyExt::collect` for the read-budget body tests (#1432). Already in the
 # graph through axum and hyper-util.
 http-body-util = "0.1"
+criterion = "0.5"
+
+[[bench]]
+name = "audio_fft"
+harness = false
 
 [[test]]
 name = "distributed_integration"

--- a/TECHNICAL_REPORTS/1517-shared-audio-fft-20260830.en.md
+++ b/TECHNICAL_REPORTS/1517-shared-audio-fft-20260830.en.md
@@ -1,0 +1,136 @@
+# Technical Report: PR #1517 - shared-audio-fft
+
+**Date**: 2026-08-30
+
+**Status**: Completed with benchmark and real-hardware validation limits
+
+**Languages**: Rust
+
+**Risk Level**: Medium
+
+## Executive Summary
+
+PR #1517 fixes issue #1224 by replacing duplicated audio-spectrum transforms with one shared bounded real FFT implementation. The previous code had a Gemma4/Whisper host-side DFT helper, a separate Nemotron DFT copy, and a Gemma3n-specific radix-2 FFT copy. That duplicated the most expensive part of log-mel feature extraction and made cardinality, malformed input handling, and future fixes inconsistent across audio frontends.
+
+The new helper lives in `src/audio/fft.rs`. It computes exact-grid real magnitude spectra for all currently used frame sizes: Whisper's non-power-of-two 400-sample grid uses Bluestein convolution, while 512- and 1024-sample power-of-two grids use radix-2 FFT. Callers request the output bin count they need, and the helper preserves that cardinality for normal and empty input while failing closed for oversized transform sizes.
+
+Validation covered shared FFT unit tests, Whisper, Gemma4, Gemma3n, Nemotron-Omni, formatting, clippy, whitespace checks, stale-marker scans, benchmark target compilation, and an optimized standalone microprobe. No real checkpoint, ffmpeg, or hardware-backed audio inference was run in this implementation pass.
+
+## 1. Problem Statement
+
+Audio feature extraction repeatedly computes one-sided magnitude spectra before applying mel filters. Before this PR, the same responsibility existed in three forms:
+
+- Gemma4 and Whisper used a naïve DFT loop that was O(N*K) per frame.
+- Nemotron-Omni carried a second copy of the same DFT pattern.
+- Gemma3n carried a specialized 1024-point radix-2 FFT helper that only served that frontend.
+
+This was a correctness and maintenance risk as well as a performance issue. Each copy had to independently preserve bin cardinality, empty-frame behavior, normalization assumptions, and malformed configuration bounds. The issue asked for one shared implementation that safely supports actual frame sizes, including non-power-of-two input.
+
+## 2. Change Summary
+
+| Area | Change |
+|------|--------|
+| Shared FFT | Added `src/audio/fft.rs` with a bounded host-side real FFT helper, radix-2 support, Bluestein support for non-power-of-two exact grids, cardinality tests, and oversized-input fail-closed behavior. |
+| Whisper | Replaced the shared DFT import with the new FFT helper while preserving 400-point DFT-grid semantics and existing mel output fixtures. |
+| Gemma4 | Replaced the old local DFT helper with the shared helper and preserved existing golden log-mel tests. |
+| Gemma3n | Removed the private 1024-point FFT copy and routed feature extraction through the shared helper while reusing a per-clip frame buffer. |
+| Nemotron-Omni | Removed the copied DFT path, routed through the shared helper, and added spectrum-config guards for invalid or oversized metadata. |
+| Benchmarks | Added `benches/audio_fft.rs`, a Criterion target comparing the old DFT baseline against the shared FFT for 400, 512, and 1024 sample frames. |
+| Review fix | Added checked arithmetic around Nemotron padded-waveform and output-buffer sizing so extreme inputs fall back to the existing single zero-mel frame shape instead of relying on unchecked allocation math. |
+
+### Statistics
+
+| Item | Value |
+|------|-------|
+| Implementation files changed | 9 |
+| Report files changed | 2 |
+| Primary implementation commit | `7da16bee` `fix(audio): share bounded real FFT frontend` |
+| Review-fix commit | `890dbf75` `fix(audio): bound Nemotron FFT allocation math` |
+| PR | #1517 |
+| Issue | #1224 |
+
+## 3. Technical Decisions
+
+### 3.1 Preserve exact DFT grids instead of silently remapping non-power-of-two frames
+
+Whisper uses a 400-sample FFT length. Zero-padding that input to 512 and returning 512-grid bins would move spectral frequencies and risk golden fixture drift. The shared helper therefore uses Bluestein convolution for non-power-of-two lengths. This computes the same DFT grid as the direct transform while still using a radix-2 convolution internally.
+
+### 3.2 Make bin cardinality a caller contract
+
+The helper accepts the requested number of output bins. For valid input it computes as many real FFT bins as exist and zero-fills any extra positive-frequency bins. Empty input returns exactly the requested number of zeros. Requests above the bounded maximum return an empty vector instead of allocating unbounded memory. This keeps caller-visible shapes deterministic.
+
+### 3.3 Bound host-side allocation before transform setup
+
+`MAX_REAL_FFT_LEN` is set to 131072 samples, matching the largest expected configured audio frontend budget in this code path. Inputs above that bound return a fail-closed result before transform scratch allocation. Nemotron config loading also clamps invalid `n_fft`, `hop_length`, mel-bin count, and non-finite preemphasis values to safe defaults.
+
+### 3.4 Keep normalization in the mel frontends
+
+The shared helper returns magnitudes only. Each frontend retains its existing downstream power, mel-filter, log, clamp, or normalization logic. This limits semantic drift and lets existing golden tests detect unintended changes at the feature level.
+
+## 4. Correctness Review
+
+- The shared helper covers power-of-two and non-power-of-two frame sizes used by current audio frontends.
+- Unit tests compare the helper against a direct DFT baseline for 400, 512, and 1024 sample frames.
+- Output-bin cardinality is tested directly for normal and empty input.
+- Oversized input and oversized bin-count requests fail closed without large transform allocation.
+- Whisper, Gemma4, Gemma3n, and Nemotron-Omni route through the same helper.
+- Static stale-marker scans found no remaining targeted DFT helper names, Gemma3n-specific FFT helper, or obsolete TODO markers in the touched audio paths.
+- A final review pass found unchecked Nemotron arithmetic around padded waveform and feature output sizing; the follow-up commit added checked addition and multiplication before allocation.
+
+## 5. Security Review
+
+The PR does not add file deletion, shell execution, network access, credential handling, SQL, deserialization of untrusted executable content, or web rendering paths. The main security-relevant concern is resource exhaustion through malformed audio metadata or extreme inputs.
+
+The implementation addresses that risk by bounding FFT length, bounding requested FFT bins, sanitizing Nemotron spectrum config, and checking Nemotron allocation arithmetic before allocating padded waveform or feature buffers. Unsupported or extreme shapes fail closed to deterministic zero-output behavior rather than attempting unbounded allocation.
+
+## 6. Performance Review
+
+The old DFT paths were O(N*K) per frame. The shared helper changes 512- and 1024-point paths to O(N log N) radix-2 FFT and changes the 400-point path to Bluestein convolution over a bounded radix-2 convolution size. Gemma3n also avoids recreating its frame scratch buffer for every frame by reusing a per-clip buffer.
+
+The Criterion benchmark target compiles, but the full optimized Criterion run did not complete within the bounded execution window because the cold bench-profile root-crate build was still running. A standalone optimized microprobe against the exact shared helper showed the expected speedup and numerical agreement:
+
+| Frame length | DFT time | FFT time | Speedup | Max abs error |
+|--------------|----------|----------|---------|---------------|
+| 400 | 824565 ns | 34815 ns | 23.7x | 7.034e-13 |
+| 512 | 1062967 ns | 4806 ns | 221.2x | 5.776e-13 |
+| 1024 | 4153601 ns | 10649 ns | 390.0x | 2.863e-12 |
+
+These numbers are microprobe evidence, not a substitute for retained Criterion artifacts or real checkpoint throughput measurement.
+
+## 7. Validation Record
+
+| Check | Result | Notes |
+|-------|--------|-------|
+| `cargo fmt --all --check` | Pass | Formatting check after implementation and review fix. |
+| `cargo test --lib audio::fft:: -- --nocapture` | Pass | 4 passed, 7326 filtered; covers DFT agreement, cardinality, empty input, and oversized fail-closed behavior. |
+| `cargo test --lib audio::feature_extractor::tests:: -- --nocapture` | Pass | 8 passed; covers Gemma4 audio frontend golden behavior including log-mel fixtures. |
+| `cargo test --lib audio::gemma3n::feature_extractor::tests:: -- --nocapture` | Pass | 8 passed; covers Gemma3n deterministic and fixture behavior after removing the private FFT copy. |
+| `cargo test --lib whisper_mel -- --nocapture` | Pass | 13 passed; covers Whisper mel output compatibility after switching the 400-point path to Bluestein-backed exact-grid FFT. |
+| `cargo test --lib nemotron_h_nano_omni::feature_extractor -- --nocapture` | Pass | 5 passed; includes malformed spectrum config fallback. |
+| `cargo test --lib deterministic_waveform_matches_pinned_speechlib_features -- --nocapture` | Pass | The selector exists under Phi4MM on current main, not under Nemotron; the named available selector passed. |
+| `cargo test --bench audio_fft --no-run` | Pass | Confirms the Criterion benchmark target compiles. |
+| `cargo clippy --lib --bench audio_fft -- -D warnings` | Pass | Focused lint gate after implementation and review fix. |
+| `git diff --check` | Pass | No whitespace errors. |
+| Static stale-marker scan | Pass | No targeted old DFT helper or obsolete TODO markers remained in `src/audio` and `benches/audio_fft.rs`. |
+| `cargo bench --bench audio_fft` | Bounded stop | Attempted twice; stopped during cold bench-profile root-crate compilation after bounded polling. |
+| Standalone optimized microprobe | Pass | Shows 23.7x, 221.2x, and 390.0x speedups with max absolute error below 3e-12 for 400, 512, and 1024 sample frames. |
+
+## 8. Validation Limits
+
+- No real Whisper, Gemma4, Gemma3n, or Nemotron-Omni checkpoint inference was run.
+- No ffmpeg-backed media ingestion path was run.
+- No hardware-specific MLX or GPU qualification was run.
+- No broad workspace test, broad `cargo test --lib`, broad workspace clippy, serial all-tests, or release build was run, matching the unit constraints.
+- The issue referenced a Nemotron test named `deterministic_waveform_matches_pinned_speechlib_features`, but current main has that exact selector under Phi4MM.
+
+## 9. Follow-up Actions
+
+- Run the retained Criterion benchmark on a warmed bench-profile build and archive the timing artifacts.
+- Run real checkpoint audio feature extraction for Whisper, Gemma4, Gemma3n, and Nemotron-Omni on available target hardware.
+- Add a frontend-level oversized-input integration test if a future media ingestion API exposes user-controlled frame sizing directly.
+
+## Appendix
+
+- Issue: #1224
+- PR: #1517
+- Branch: `fix/issue-1224-shared-audio-fft`

--- a/TECHNICAL_REPORTS/1517-shared-audio-fft-20260830.ko.md
+++ b/TECHNICAL_REPORTS/1517-shared-audio-fft-20260830.ko.md
@@ -1,0 +1,136 @@
+# 기술 보고서: PR #1517 - shared-audio-fft
+
+**작성일**: 2026-08-30
+
+**상태**: Benchmark 및 real-hardware validation 한계가 있는 구현 완료
+
+**언어**: Rust
+
+**위험도**: Medium
+
+## 요약
+
+PR #1517은 issue #1224를 해결하기 위해 중복된 audio spectrum transform을 하나의 shared bounded real FFT 구현으로 교체한다. 기존 코드는 Gemma4/Whisper용 host-side DFT helper, 별도 Nemotron DFT copy, Gemma3n 전용 radix-2 FFT copy를 가지고 있었다. 이 중복은 log-mel feature extraction에서 가장 비용이 큰 부분을 반복 구현하게 만들고, cardinality, malformed input 처리, 향후 수정의 일관성을 약하게 만들었다.
+
+새 helper는 `src/audio/fft.rs`에 있다. 현재 사용되는 모든 frame size에 대해 exact-grid real magnitude spectrum을 계산한다. Whisper의 non-power-of-two 400-sample grid는 Bluestein convolution을 사용하고, 512 및 1024 sample power-of-two grid는 radix-2 FFT를 사용한다. Caller는 필요한 output bin 수를 요청하며, helper는 normal/empty input에서 그 cardinality를 보존하고 oversized transform size는 fail closed한다.
+
+검증은 shared FFT unit test, Whisper, Gemma4, Gemma3n, Nemotron-Omni, formatting, clippy, whitespace check, stale-marker scan, benchmark target compilation, optimized standalone microprobe를 포함했다. 이번 구현 pass에서는 real checkpoint, ffmpeg, hardware-backed audio inference를 실행하지 않았다.
+
+## 1. 문제 정의
+
+Audio feature extraction은 mel filter 적용 전에 one-sided magnitude spectrum을 반복적으로 계산한다. 이번 PR 전에는 같은 책임이 세 가지 형태로 존재했다.
+
+- Gemma4와 Whisper는 frame마다 O(N*K)인 naïve DFT loop를 사용했다.
+- Nemotron-Omni는 같은 DFT pattern의 두 번째 copy를 가지고 있었다.
+- Gemma3n은 해당 frontend 전용 1024-point radix-2 FFT helper를 가지고 있었다.
+
+이는 performance issue일 뿐 아니라 correctness 및 maintenance risk였다. 각 copy가 bin cardinality, empty-frame behavior, normalization assumption, malformed configuration bound를 따로 보존해야 했기 때문이다. Issue는 실제 frame size를 안전하게 지원하는 하나의 shared implementation을 요구했으며, non-power-of-two input도 포함한다.
+
+## 2. 변경 요약
+
+| 영역 | 변경 |
+|------|------|
+| Shared FFT | Bounded host-side real FFT helper, radix-2 support, non-power-of-two exact grid용 Bluestein support, cardinality test, oversized-input fail-closed behavior를 `src/audio/fft.rs`에 추가했다. |
+| Whisper | Shared DFT import를 새 FFT helper로 교체하면서 400-point DFT-grid semantics와 기존 mel output fixture를 보존했다. |
+| Gemma4 | 기존 local DFT helper를 shared helper로 교체하고 golden log-mel test를 보존했다. |
+| Gemma3n | Private 1024-point FFT copy를 제거하고 shared helper로 라우팅했으며, per-clip frame buffer를 재사용하게 했다. |
+| Nemotron-Omni | Copied DFT path를 제거하고 shared helper를 사용하게 했으며, invalid 또는 oversized metadata에 대한 spectrum-config guard를 추가했다. |
+| Benchmarks | 400, 512, 1024 sample frame에서 기존 DFT baseline과 shared FFT를 비교하는 Criterion target `benches/audio_fft.rs`를 추가했다. |
+| Review fix | Extreme input이 unchecked allocation math에 의존하지 않고 기존 single zero-mel frame shape로 fallback하도록 Nemotron padded-waveform 및 output-buffer sizing에 checked arithmetic을 추가했다. |
+
+### 통계
+
+| 항목 | 값 |
+|------|----|
+| 구현 변경 파일 수 | 9 |
+| 보고서 변경 파일 수 | 2 |
+| 주요 구현 커밋 | `7da16bee` `fix(audio): share bounded real FFT frontend` |
+| Review-fix 커밋 | `890dbf75` `fix(audio): bound Nemotron FFT allocation math` |
+| PR | #1517 |
+| Issue | #1224 |
+
+## 3. 기술적 선택
+
+### 3.1 Non-power-of-two frame을 silent remap하지 않고 exact DFT grid 보존
+
+Whisper는 400-sample FFT length를 사용한다. 이 input을 512로 zero-padding한 뒤 512-grid bin을 반환하면 spectral frequency가 이동하고 golden fixture drift가 생길 수 있다. 따라서 shared helper는 non-power-of-two length에 Bluestein convolution을 사용한다. 내부적으로는 radix-2 convolution을 사용하지만, caller에게는 direct transform과 같은 DFT grid를 제공한다.
+
+### 3.2 Bin cardinality를 caller contract로 명시
+
+Helper는 요청된 output bin 수를 입력받는다. Valid input에서는 존재하는 real FFT bin을 계산하고, 추가 positive-frequency bin은 zero-fill한다. Empty input은 요청된 수만큼의 zero vector를 반환한다. Bounded maximum을 넘는 요청은 unbounded memory allocation 대신 empty vector를 반환한다. 이로써 caller-visible shape가 결정적으로 유지된다.
+
+### 3.3 Transform setup 전에 host-side allocation bound 적용
+
+`MAX_REAL_FFT_LEN`은 131072 sample로 설정했다. 이는 이 code path에서 예상되는 가장 큰 configured audio frontend budget과 맞는다. 이 bound를 넘는 input은 transform scratch allocation 전에 fail-closed result를 반환한다. Nemotron config loading도 invalid `n_fft`, `hop_length`, mel-bin count, non-finite preemphasis 값을 safe default로 clamp한다.
+
+### 3.4 Normalization은 각 mel frontend에 유지
+
+Shared helper는 magnitude만 반환한다. 각 frontend의 downstream power, mel-filter, log, clamp, normalization logic은 기존 위치에 남겨 두었다. 이렇게 semantic drift를 제한하고, 기존 golden test가 feature level에서 의도하지 않은 변경을 잡을 수 있게 했다.
+
+## 4. Correctness review
+
+- Shared helper는 현재 audio frontend가 사용하는 power-of-two 및 non-power-of-two frame size를 모두 다룬다.
+- Unit test는 400, 512, 1024 sample frame에서 direct DFT baseline과 shared helper를 비교한다.
+- Output-bin cardinality는 normal input과 empty input에 대해 직접 테스트한다.
+- Oversized input과 oversized bin-count request는 대형 transform allocation 없이 fail closed한다.
+- Whisper, Gemma4, Gemma3n, Nemotron-Omni가 같은 helper를 사용한다.
+- Static stale-marker scan에서 touched audio path에 기존 target DFT helper name, Gemma3n-specific FFT helper, obsolete TODO marker가 남아 있지 않음을 확인했다.
+- 최종 review pass에서 Nemotron padded waveform 및 feature output sizing 주변 unchecked arithmetic을 발견했고, 후속 commit에서 allocation 전 checked addition/multiplication을 추가했다.
+
+## 5. Security review
+
+이 PR은 file deletion, shell execution, network access, credential handling, SQL, untrusted executable content deserialization, web rendering path를 추가하지 않는다. 주요 security-relevant concern은 malformed audio metadata 또는 extreme input을 통한 resource exhaustion이다.
+
+구현은 FFT length bound, requested FFT bin bound, Nemotron spectrum config sanitization, Nemotron allocation arithmetic check로 이 risk를 줄인다. Unsupported 또는 extreme shape는 unbounded allocation을 시도하지 않고 deterministic zero-output behavior로 fail closed한다.
+
+## 6. Performance review
+
+기존 DFT path는 frame마다 O(N*K)였다. Shared helper는 512 및 1024 point path를 O(N log N) radix-2 FFT로 바꾸고, 400 point path를 bounded radix-2 convolution size 위의 Bluestein convolution으로 바꾼다. Gemma3n은 frame마다 scratch buffer를 새로 만들지 않고 per-clip buffer를 재사용한다.
+
+Criterion benchmark target은 compile된다. 다만 full optimized Criterion run은 cold bench-profile root-crate build가 bounded execution window 안에 끝나지 않아 완료하지 못했다. Exact shared helper를 대상으로 한 standalone optimized microprobe는 기대한 speedup과 numerical agreement를 보여주었다.
+
+| Frame length | DFT time | FFT time | Speedup | Max abs error |
+|--------------|----------|----------|---------|---------------|
+| 400 | 824565 ns | 34815 ns | 23.7x | 7.034e-13 |
+| 512 | 1062967 ns | 4806 ns | 221.2x | 5.776e-13 |
+| 1024 | 4153601 ns | 10649 ns | 390.0x | 2.863e-12 |
+
+이 숫자는 microprobe evidence이며, Criterion artifact 또는 real checkpoint throughput measurement를 대체하지 않는다.
+
+## 7. Validation record
+
+| Check | 결과 | Notes |
+|-------|------|-------|
+| `cargo fmt --all --check` | Pass | 구현 및 review fix 이후 formatting check. |
+| `cargo test --lib audio::fft:: -- --nocapture` | Pass | 4 passed, 7326 filtered. DFT agreement, cardinality, empty input, oversized fail-closed behavior 검증. |
+| `cargo test --lib audio::feature_extractor::tests:: -- --nocapture` | Pass | 8 passed. Gemma4 audio frontend golden behavior와 log-mel fixture 검증. |
+| `cargo test --lib audio::gemma3n::feature_extractor::tests:: -- --nocapture` | Pass | 8 passed. Private FFT copy 제거 이후 Gemma3n deterministic 및 fixture behavior 검증. |
+| `cargo test --lib whisper_mel -- --nocapture` | Pass | 13 passed. 400-point path를 Bluestein-backed exact-grid FFT로 바꾼 뒤 Whisper mel output compatibility 검증. |
+| `cargo test --lib nemotron_h_nano_omni::feature_extractor -- --nocapture` | Pass | 5 passed. Malformed spectrum config fallback 포함. |
+| `cargo test --lib deterministic_waveform_matches_pinned_speechlib_features -- --nocapture` | Pass | Current main에서 이 selector는 Nemotron이 아니라 Phi4MM 아래에 있으며, 사용 가능한 named selector가 통과했다. |
+| `cargo test --bench audio_fft --no-run` | Pass | Criterion benchmark target compile 확인. |
+| `cargo clippy --lib --bench audio_fft -- -D warnings` | Pass | 구현 및 review fix 이후 focused lint gate. |
+| `git diff --check` | Pass | Whitespace error 없음. |
+| Static stale-marker scan | Pass | `src/audio` 및 `benches/audio_fft.rs`에 target old DFT helper나 obsolete TODO marker가 남아 있지 않음. |
+| `cargo bench --bench audio_fft` | Bounded stop | 두 번 시도했으나 cold bench-profile root-crate compilation 중 bounded polling 후 중단. |
+| Standalone optimized microprobe | Pass | 400, 512, 1024 sample frame에서 max absolute error 3e-12 미만과 23.7x, 221.2x, 390.0x speedup 확인. |
+
+## 8. Validation limits
+
+- 실제 Whisper, Gemma4, Gemma3n, Nemotron-Omni checkpoint inference는 실행하지 않았다.
+- ffmpeg-backed media ingestion path는 실행하지 않았다.
+- Hardware-specific MLX 또는 GPU qualification은 실행하지 않았다.
+- Unit constraint에 따라 broad workspace test, broad `cargo test --lib`, broad workspace clippy, serial all-tests, release build는 실행하지 않았다.
+- Issue가 언급한 `deterministic_waveform_matches_pinned_speechlib_features`라는 Nemotron test는 current main에서 정확히 같은 selector가 Phi4MM 아래에 있다.
+
+## 9. 후속 작업
+
+- Warmed bench-profile build에서 retained Criterion benchmark를 실행하고 timing artifact를 보관한다.
+- Target hardware에서 Whisper, Gemma4, Gemma3n, Nemotron-Omni real checkpoint audio feature extraction을 실행한다.
+- 향후 media ingestion API가 user-controlled frame sizing을 직접 노출한다면 frontend-level oversized-input integration test를 추가한다.
+
+## Appendix
+
+- Issue: #1224
+- PR: #1517
+- Branch: `fix/issue-1224-shared-audio-fft`

--- a/benches/audio_fft.rs
+++ b/benches/audio_fft.rs
@@ -1,0 +1,62 @@
+use std::f64::consts::PI;
+use std::time::Duration;
+
+use criterion::{Criterion, Throughput, black_box, criterion_group, criterion_main};
+
+#[allow(dead_code)]
+#[path = "../src/audio/fft.rs"]
+mod fft;
+
+fn deterministic_frame(len: usize) -> Vec<f64> {
+    (0..len)
+        .map(|index| {
+            let t = index as f64 / len as f64;
+            0.3 * (2.0 * PI * 3.0 * t).sin()
+                + 0.2 * (2.0 * PI * 17.0 * t).cos()
+                + 0.05 * (2.0 * PI * 61.0 * t).sin()
+        })
+        .collect()
+}
+
+fn dft_magnitude(input: &[f64], num_bins: usize) -> Vec<f64> {
+    let n = input.len();
+    let mut magnitudes = Vec::with_capacity(num_bins);
+    for k in 0..num_bins {
+        let mut re = 0.0f64;
+        let mut im = 0.0f64;
+        for (t, &sample) in input.iter().enumerate() {
+            let angle = -2.0 * PI * k as f64 * t as f64 / n as f64;
+            re += sample * angle.cos();
+            im += sample * angle.sin();
+        }
+        magnitudes.push(re.hypot(im));
+    }
+    magnitudes
+}
+
+fn bench_audio_real_fft(c: &mut Criterion) {
+    let mut group = c.benchmark_group("audio_real_fft_magnitude");
+    group.sample_size(10);
+    for len in [400usize, 512, 1024] {
+        let input = deterministic_frame(len);
+        let bins = len / 2 + 1;
+        group.throughput(Throughput::Elements(len as u64));
+        group.bench_function(format!("dft_len_{len}"), |b| {
+            b.iter(|| dft_magnitude(black_box(&input), black_box(bins)))
+        });
+        group.bench_function(format!("fft_len_{len}"), |b| {
+            b.iter(|| fft::real_fft_magnitude(black_box(&input), black_box(bins)))
+        });
+    }
+    group.finish();
+}
+
+criterion_group! {
+    name = benches;
+    config = Criterion::default()
+        .sample_size(10)
+        .warm_up_time(Duration::from_millis(100))
+        .measurement_time(Duration::from_millis(300));
+    targets = bench_audio_real_fft
+}
+criterion_main!(benches);

--- a/src/audio/feature_extractor.rs
+++ b/src/audio/feature_extractor.rs
@@ -24,6 +24,8 @@
 
 use std::f64::consts::PI;
 
+use super::fft::real_fft_magnitude;
+
 /// Mel filter bank matrix: `[num_frequency_bins, num_mel_filters]`.
 fn mel_filter_bank(
     num_frequency_bins: usize,
@@ -350,7 +352,7 @@ impl AudioFeatureExtractor {
                 *item = 0.0;
             }
 
-            // Real FFT (using naive DFT for correctness; can optimize later)
+            // Real FFT magnitude on the configured FFT grid.
             let magnitude = real_fft_magnitude(&fft_input, num_freq_bins);
 
             // Mel filterbank application
@@ -403,27 +405,6 @@ impl AudioFeatureExtractor {
     pub fn feature_size(&self) -> usize {
         self.feature_size
     }
-}
-
-/// Compute magnitude of real-valued FFT using simple DFT.
-/// Returns `[num_freq_bins]` magnitudes.
-///
-/// Shared with the Whisper log-mel front-end in [`super::whisper_mel`], which
-/// squares the result to obtain the power spectrum.
-pub(crate) fn real_fft_magnitude(input: &[f64], num_bins: usize) -> Vec<f64> {
-    let n = input.len();
-    let mut magnitudes = Vec::with_capacity(num_bins);
-    for k in 0..num_bins {
-        let mut re = 0.0f64;
-        let mut im = 0.0f64;
-        for (t, &sample) in input.iter().enumerate() {
-            let angle = -2.0 * PI * k as f64 * t as f64 / n as f64;
-            re += sample * angle.cos();
-            im += sample * angle.sin();
-        }
-        magnitudes.push((re * re + im * im).sqrt());
-    }
-    magnitudes
 }
 
 /// Compute the number of audio soft tokens for a waveform of given duration.

--- a/src/audio/fft.rs
+++ b/src/audio/fft.rs
@@ -1,0 +1,265 @@
+// Copyright 2025-2026 Lablup Inc. and Jeongkyu Shin
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Bounded host-side FFT primitives for audio feature extraction.
+//!
+//! The audio frontends all need real-input magnitude spectra, but their frame
+//! sizes are not identical: Whisper uses a 400-point transform while Gemma 4,
+//! Nemotron-Omni, and Gemma3n use power-of-two `n_fft` values. Zero-padding the
+//! 400-point Whisper frame to 512 would change the retained bin frequencies, so
+//! this helper computes the exact requested DFT grid with Bluestein's algorithm
+//! for non-power-of-two lengths and the same radix-2 kernel for power-of-two
+//! lengths.
+
+use std::f64::consts::PI;
+
+/// Largest FFT size accepted by the shared host audio helper.
+///
+/// Gemma 4's config guard permits a 65,536-sample frame and optional 2x FFT
+/// overdrive, so 131,072 is the largest valid in-tree caller today. Larger
+/// values are treated as malformed metadata and fail closed before allocating
+/// transform scratch.
+pub(crate) const MAX_REAL_FFT_LEN: usize = 1 << 17;
+const MAX_REAL_FFT_BINS: usize = MAX_REAL_FFT_LEN / 2 + 1;
+
+#[derive(Clone, Copy, Debug, Default)]
+struct Complex {
+    re: f64,
+    im: f64,
+}
+
+impl Complex {
+    fn new(re: f64, im: f64) -> Self {
+        Self { re, im }
+    }
+
+    fn mul(self, rhs: Self) -> Self {
+        Self {
+            re: self.re * rhs.re - self.im * rhs.im,
+            im: self.re * rhs.im + self.im * rhs.re,
+        }
+    }
+
+    fn hypot(self) -> f64 {
+        self.re.hypot(self.im)
+    }
+}
+
+/// Compute real-input FFT magnitudes on the input's own DFT grid.
+///
+/// Returns exactly `num_bins` values for all valid in-tree callers. If the
+/// caller asks for more positive-frequency bins than the input has, the extra
+/// bins are zero-filled instead of panicking. Oversized requests return an empty
+/// vector before allocating, so malformed metadata cannot drive an unbounded
+/// preprocessing allocation.
+pub(crate) fn real_fft_magnitude(input: &[f64], num_bins: usize) -> Vec<f64> {
+    if num_bins == 0 {
+        return Vec::new();
+    }
+    if num_bins > MAX_REAL_FFT_BINS {
+        return Vec::new();
+    }
+
+    let n = input.len();
+    let mut magnitudes = vec![0.0f64; num_bins];
+    if n == 0 || n > MAX_REAL_FFT_LEN {
+        return magnitudes;
+    }
+
+    let usable_bins = num_bins.min(n / 2 + 1);
+    if n.is_power_of_two() {
+        fill_radix2_real_magnitudes(input, usable_bins, &mut magnitudes);
+    } else {
+        fill_bluestein_real_magnitudes(input, usable_bins, &mut magnitudes);
+    }
+    magnitudes
+}
+
+fn fill_radix2_real_magnitudes(input: &[f64], usable_bins: usize, magnitudes: &mut [f64]) {
+    let mut values: Vec<Complex> = input
+        .iter()
+        .map(|&sample| Complex::new(sample, 0.0))
+        .collect();
+    fft_radix2(&mut values, false);
+    for (index, slot) in magnitudes.iter_mut().take(usable_bins).enumerate() {
+        *slot = values[index].hypot();
+    }
+}
+
+fn fill_bluestein_real_magnitudes(input: &[f64], usable_bins: usize, magnitudes: &mut [f64]) {
+    let n = input.len();
+    let convolution_len = (2 * n - 1).next_power_of_two();
+    let mut signal = vec![Complex::default(); convolution_len];
+    let mut chirp = vec![Complex::default(); convolution_len];
+
+    for (index, &sample) in input.iter().enumerate() {
+        let angle = chirp_angle(index, n);
+        let forward_chirp = Complex::new(angle.cos(), -angle.sin());
+        let inverse_chirp = Complex::new(angle.cos(), angle.sin());
+        signal[index] = Complex::new(sample, 0.0).mul(forward_chirp);
+        chirp[index] = inverse_chirp;
+        if index != 0 {
+            chirp[convolution_len - index] = inverse_chirp;
+        }
+    }
+
+    fft_radix2(&mut signal, false);
+    fft_radix2(&mut chirp, false);
+    for (lhs, rhs) in signal.iter_mut().zip(chirp) {
+        *lhs = lhs.mul(rhs);
+    }
+    fft_radix2(&mut signal, true);
+
+    for (index, slot) in magnitudes.iter_mut().take(usable_bins).enumerate() {
+        let angle = -chirp_angle(index, n);
+        let correction = Complex::new(angle.cos(), angle.sin());
+        *slot = signal[index].mul(correction).hypot();
+    }
+}
+
+fn chirp_angle(index: usize, n: usize) -> f64 {
+    PI * (index as f64) * (index as f64) / n as f64
+}
+
+fn fft_radix2(values: &mut [Complex], inverse: bool) {
+    let n = values.len();
+    debug_assert!(n.is_power_of_two());
+    if n <= 1 {
+        return;
+    }
+
+    let mut reversed = 0usize;
+    for index in 1..n {
+        let mut bit = n >> 1;
+        while reversed & bit != 0 {
+            reversed ^= bit;
+            bit >>= 1;
+        }
+        reversed ^= bit;
+        if index < reversed {
+            values.swap(index, reversed);
+        }
+    }
+
+    let mut width = 2usize;
+    while width <= n {
+        let half = width / 2;
+        let angle = if inverse {
+            2.0 * PI / width as f64
+        } else {
+            -2.0 * PI / width as f64
+        };
+        let step = Complex::new(angle.cos(), angle.sin());
+        for start in (0..n).step_by(width) {
+            let mut twiddle = Complex::new(1.0, 0.0);
+            for offset in 0..half {
+                let left = start + offset;
+                let right = left + half;
+                let product = twiddle.mul(values[right]);
+                let left_value = values[left];
+                values[left] = Complex::new(left_value.re + product.re, left_value.im + product.im);
+                values[right] =
+                    Complex::new(left_value.re - product.re, left_value.im - product.im);
+                twiddle = twiddle.mul(step);
+            }
+        }
+        width <<= 1;
+    }
+
+    if inverse {
+        let scale = 1.0 / n as f64;
+        for value in values {
+            value.re *= scale;
+            value.im *= scale;
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn naive_dft_magnitude(input: &[f64], num_bins: usize) -> Vec<f64> {
+        let n = input.len();
+        let mut magnitudes = vec![0.0; num_bins];
+        if n == 0 {
+            return magnitudes;
+        }
+        for (k, slot) in magnitudes
+            .iter_mut()
+            .enumerate()
+            .take(num_bins.min(n / 2 + 1))
+        {
+            let mut re = 0.0f64;
+            let mut im = 0.0f64;
+            for (t, &sample) in input.iter().enumerate() {
+                let angle = -2.0 * PI * k as f64 * t as f64 / n as f64;
+                re += sample * angle.cos();
+                im += sample * angle.sin();
+            }
+            *slot = re.hypot(im);
+        }
+        magnitudes
+    }
+
+    fn deterministic_frame(len: usize) -> Vec<f64> {
+        (0..len)
+            .map(|index| {
+                let t = index as f64 / len as f64;
+                0.3 * (2.0 * PI * 3.0 * t).sin()
+                    + 0.2 * (2.0 * PI * 17.0 * t).cos()
+                    + 0.05 * (2.0 * PI * 61.0 * t).sin()
+            })
+            .collect()
+    }
+
+    #[test]
+    fn matches_dft_for_actual_audio_frame_sizes() {
+        for len in [400, 512, 1024] {
+            let input = deterministic_frame(len);
+            let bins = len / 2 + 1;
+            let expected = naive_dft_magnitude(&input, bins);
+            let actual = real_fft_magnitude(&input, bins);
+            assert_eq!(actual.len(), bins);
+            for (bin, (&actual, &expected)) in actual.iter().zip(&expected).enumerate() {
+                let tolerance = 1e-8f64.max(expected.abs() * 1e-10);
+                assert!(
+                    (actual - expected).abs() <= tolerance,
+                    "len={len} bin={bin} actual={actual} expected={expected}"
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn preserves_requested_cardinality_and_zero_fills_extra_bins() {
+        let actual = real_fft_magnitude(&[1.0, -1.0, 1.0, -1.0], 5);
+        assert_eq!(actual.len(), 5);
+        assert_eq!(actual[3], 0.0);
+        assert_eq!(actual[4], 0.0);
+    }
+
+    #[test]
+    fn empty_input_returns_zero_magnitudes_with_requested_cardinality() {
+        assert_eq!(real_fft_magnitude(&[], 3), vec![0.0, 0.0, 0.0]);
+        assert!(real_fft_magnitude(&[], 0).is_empty());
+    }
+
+    #[test]
+    fn oversized_input_fails_closed_without_transform_scratch() {
+        let input = vec![1.0; MAX_REAL_FFT_LEN + 1];
+        assert_eq!(real_fft_magnitude(&input, 3), vec![0.0, 0.0, 0.0]);
+        assert!(real_fft_magnitude(&[1.0], MAX_REAL_FFT_BINS + 1).is_empty());
+    }
+}

--- a/src/audio/gemma3n/feature_extractor.rs
+++ b/src/audio/gemma3n/feature_extractor.rs
@@ -16,7 +16,7 @@
 
 use std::f64::consts::PI;
 
-use crate::audio::{AudioCancellation, AudioPreprocessCheckpoint};
+use crate::audio::{AudioCancellation, AudioPreprocessCheckpoint, fft::real_fft_magnitude};
 
 pub const GEMMA3N_SAMPLE_RATE: u32 = 16_000;
 pub const GEMMA3N_MAX_SAMPLES: usize = 480_000;
@@ -115,6 +115,7 @@ impl Gemma3nAudioFeatureExtractor {
             let left_padding = padded_len - effective_len;
             waveform[left_padding..left_padding + effective_len]
                 .copy_from_slice(&clip[..effective_len]);
+            let mut fft_input = vec![0.0f64; FFT_LENGTH];
 
             for frame_index in 0..frames {
                 if frame_index % 8 == 0 {
@@ -122,7 +123,6 @@ impl Gemma3nAudioFeatureExtractor {
                 }
                 let start = frame_index * HOP_LENGTH;
                 let unfolded = &waveform[start..start + FRAME_LENGTH + 1];
-                let mut fft_input = vec![0.0f64; FFT_LENGTH];
                 fft_input[0] = (unfolded[0] * 0.03 * self.window[0]) as f64;
                 for i in 1..FRAME_LENGTH {
                     let emphasized = unfolded[i] - 0.97 * unfolded[i - 1];
@@ -133,7 +133,7 @@ impl Gemma3nAudioFeatureExtractor {
                     valid_mask.push(start >= left_padding && start < left_padding + effective_len);
                     continue;
                 }
-                let magnitude = real_fft_magnitude_1024(&fft_input);
+                let magnitude = real_fft_magnitude(&fft_input, FFT_LENGTH / 2 + 1);
                 for mel in 0..FEATURE_SIZE {
                     let mut value = 0.0f64;
                     for (bin, magnitude) in magnitude.iter().enumerate() {
@@ -164,65 +164,6 @@ fn check_feature_cancelled(cancelled: &dyn AudioCancellation) -> Result<(), Stri
     } else {
         Ok(())
     }
-}
-
-/// Compute the positive-frequency magnitude spectrum for the fixed 1024-point
-/// Gemma 3n transform. The in-tree generic audio helper intentionally uses a
-/// direct DFT, which is useful for small reference transforms but makes a
-/// 30-second Gemma 3n clip prohibitively expensive. This radix-2 FFT preserves
-/// the reference math while keeping frontend preprocessing practical.
-fn real_fft_magnitude_1024(input: &[f64]) -> Vec<f64> {
-    debug_assert_eq!(input.len(), FFT_LENGTH);
-    let mut real = input.to_vec();
-    let mut imaginary = vec![0.0f64; FFT_LENGTH];
-
-    let mut reversed = 0usize;
-    for index in 1..FFT_LENGTH {
-        let mut bit = FFT_LENGTH >> 1;
-        while reversed & bit != 0 {
-            reversed ^= bit;
-            bit >>= 1;
-        }
-        reversed ^= bit;
-        if index < reversed {
-            real.swap(index, reversed);
-            imaginary.swap(index, reversed);
-        }
-    }
-
-    let mut width = 2usize;
-    while width <= FFT_LENGTH {
-        let half = width / 2;
-        let angle = -2.0 * PI / width as f64;
-        let step_real = angle.cos();
-        let step_imaginary = angle.sin();
-        for start in (0..FFT_LENGTH).step_by(width) {
-            let mut twiddle_real = 1.0f64;
-            let mut twiddle_imaginary = 0.0f64;
-            for offset in 0..half {
-                let right = start + offset + half;
-                let product_real =
-                    twiddle_real * real[right] - twiddle_imaginary * imaginary[right];
-                let product_imaginary =
-                    twiddle_real * imaginary[right] + twiddle_imaginary * real[right];
-                let left = start + offset;
-                let left_real = real[left];
-                let left_imaginary = imaginary[left];
-                real[left] = left_real + product_real;
-                imaginary[left] = left_imaginary + product_imaginary;
-                real[right] = left_real - product_real;
-                imaginary[right] = left_imaginary - product_imaginary;
-                let next_real = twiddle_real * step_real - twiddle_imaginary * step_imaginary;
-                twiddle_imaginary = twiddle_real * step_imaginary + twiddle_imaginary * step_real;
-                twiddle_real = next_real;
-            }
-        }
-        width *= 2;
-    }
-
-    (0..=FFT_LENGTH / 2)
-        .map(|index| real[index].hypot(imaginary[index]))
-        .collect()
 }
 
 fn mel_filter_bank() -> Vec<f32> {

--- a/src/audio/mod.rs
+++ b/src/audio/mod.rs
@@ -30,6 +30,7 @@ mod attention;
 pub mod config;
 pub mod encoder;
 pub mod feature_extractor;
+pub(crate) mod fft;
 pub mod gemma3n;
 pub mod nemotron_h_nano_omni;
 pub mod phi4mm;

--- a/src/audio/nemotron_h_nano_omni/feature_extractor.rs
+++ b/src/audio/nemotron_h_nano_omni/feature_extractor.rs
@@ -37,12 +37,14 @@
 //! - Per-clip normalization (zero mean, unit std) over valid frames.
 //!
 //! Used by: Nemotron H Nano Omni VLM (audio modality)
-//!
-//! TODO: extract a shared FFT helper with `crate::audio::feature_extractor`.
 
 use std::f64::consts::PI;
 
+use crate::audio::fft::{MAX_REAL_FFT_LEN, real_fft_magnitude};
+
 use super::config::NemotronOmniAudioConfig;
+
+const MAX_NEMOTRON_MEL_BINS: usize = 4096;
 
 /// Output of one extractor invocation.
 #[derive(Debug)]
@@ -79,15 +81,46 @@ pub struct NemotronOmniFeatureExtractor {
 
 impl NemotronOmniFeatureExtractor {
     pub fn new(config: &NemotronOmniAudioConfig) -> Self {
-        let window = build_centered_hann_window(config.win_length, config.n_fft);
-        let mel_filters =
-            slaney_mel_filterbank(config.sampling_rate, config.n_fft, config.num_mel_bins);
+        let defaults = NemotronOmniAudioConfig::default();
+        let sampling_rate = if config.sampling_rate == 0 {
+            defaults.sampling_rate
+        } else {
+            config.sampling_rate
+        };
+        let hop_length = if config.hop_length == 0 || config.hop_length > MAX_REAL_FFT_LEN {
+            defaults.hop_length
+        } else {
+            config.hop_length
+        };
+        let n_fft = if (1..=MAX_REAL_FFT_LEN).contains(&config.n_fft) {
+            config.n_fft
+        } else {
+            defaults.n_fft
+        };
+        let win_length = if (1..=n_fft).contains(&config.win_length) {
+            config.win_length
+        } else {
+            defaults.win_length.min(n_fft)
+        };
+        let num_mel_bins = if (1..=MAX_NEMOTRON_MEL_BINS).contains(&config.num_mel_bins) {
+            config.num_mel_bins
+        } else {
+            defaults.num_mel_bins
+        };
+        let preemphasis = if config.preemphasis.is_finite() {
+            config.preemphasis
+        } else {
+            defaults.preemphasis
+        };
+
+        let window = build_centered_hann_window(win_length, n_fft);
+        let mel_filters = slaney_mel_filterbank(sampling_rate, n_fft, num_mel_bins);
         Self {
-            sampling_rate: config.sampling_rate,
-            hop_length: config.hop_length,
-            n_fft: config.n_fft,
-            num_mel_bins: config.num_mel_bins,
-            preemphasis: config.preemphasis,
+            sampling_rate,
+            hop_length,
+            n_fft,
+            num_mel_bins,
+            preemphasis,
             window,
             mel_filters,
         }
@@ -151,13 +184,12 @@ impl NemotronOmniFeatureExtractor {
             }
             let magnitude = real_fft_magnitude(&fft_buf, num_freq_bins);
             // Power spectrogram = |X|^2.
-            let power: Vec<f64> = magnitude.iter().map(|m| m * m).collect();
             // Mel filterbank: features[mel] = sum_freq filters[mel, freq] * power[freq]
             for mel_idx in 0..self.num_mel_bins {
                 let mut acc = 0.0f64;
                 let row = &self.mel_filters[mel_idx * num_freq_bins..(mel_idx + 1) * num_freq_bins];
-                for (freq_idx, &p) in power.iter().enumerate() {
-                    acc += row[freq_idx] as f64 * p;
+                for (freq_idx, &magnitude) in magnitude.iter().enumerate() {
+                    acc += row[freq_idx] as f64 * magnitude * magnitude;
                 }
                 let log_mel = (acc + mel_floor).ln() as f32;
                 features[frame_idx * self.num_mel_bins + mel_idx] = log_mel;
@@ -349,27 +381,6 @@ fn slaney_mel_to_hz(mel: f64) -> f64 {
     }
 }
 
-/// Naive real-FFT magnitude. `input` must have length `n_fft`. Returns
-/// `num_bins` complex magnitudes.
-///
-/// O(N²) is acceptable here because audio inference is offline and the
-/// per-clip FFT count is small. The Gemma 4 path uses the same approach.
-fn real_fft_magnitude(input: &[f64], num_bins: usize) -> Vec<f64> {
-    let n = input.len();
-    let mut magnitudes = Vec::with_capacity(num_bins);
-    for k in 0..num_bins {
-        let mut re = 0.0f64;
-        let mut im = 0.0f64;
-        for (t, &sample) in input.iter().enumerate() {
-            let angle = -2.0 * PI * k as f64 * t as f64 / n as f64;
-            re += sample * angle.cos();
-            im += sample * angle.sin();
-        }
-        magnitudes.push((re * re + im * im).sqrt());
-    }
-    magnitudes
-}
-
 /// In-place per-clip mean/variance normalization over the valid frame
 /// range. Mirrors upstream's
 /// `mel = ((mel - mean) / (sqrt(variance) + 1e-5)) * mask`.
@@ -512,5 +523,28 @@ mod tests {
         for &m in &mean {
             assert!(m.abs() < 1e-3, "mean {m} not close to zero");
         }
+    }
+
+    #[test]
+    fn malformed_spectrum_config_falls_back_to_bounded_defaults() {
+        let mut cfg = make_config();
+        cfg.sampling_rate = 0;
+        cfg.hop_length = 0;
+        cfg.n_fft = MAX_REAL_FFT_LEN + 1;
+        cfg.win_length = MAX_REAL_FFT_LEN + 1;
+        cfg.num_mel_bins = usize::MAX;
+        cfg.preemphasis = f32::NAN;
+
+        let extractor = NemotronOmniFeatureExtractor::new(&cfg);
+        assert_eq!(extractor.sampling_rate(), 16_000);
+        assert_eq!(extractor.hop_length(), 160);
+        assert_eq!(extractor.n_fft, 512);
+        assert_eq!(extractor.num_mel_bins(), 128);
+        assert_eq!(extractor.preemphasis, 0.97);
+
+        let tone = generate_tone(440.0, 0.1, extractor.sampling_rate());
+        let (features, frames) = extractor.extract_clip(&tone);
+        assert_eq!(features.len(), frames * extractor.num_mel_bins());
+        assert!(features.iter().all(|value| value.is_finite()));
     }
 }

--- a/src/audio/nemotron_h_nano_omni/feature_extractor.rs
+++ b/src/audio/nemotron_h_nano_omni/feature_extractor.rs
@@ -150,7 +150,9 @@ impl NemotronOmniFeatureExtractor {
 
         // STFT with `pad_mode="constant"`: pad waveform with `n_fft / 2`
         // zeros on each side and frame at hop_length stride.
-        let padded_len = waveform.len() + 2 * half_window;
+        let Some(padded_len) = waveform.len().checked_add(2 * half_window) else {
+            return (vec![0.0; self.num_mel_bins], 1);
+        };
         let num_frames = padded_len / self.hop_length;
         if num_frames == 0 {
             // Edge case: extremely short clip. Match upstream's
@@ -167,7 +169,10 @@ impl NemotronOmniFeatureExtractor {
         padded[half_window..half_window + preemphasized.len()].copy_from_slice(&preemphasized);
 
         let mut fft_buf = vec![0.0f64; self.n_fft];
-        let mut features = vec![0.0f32; num_frames * self.num_mel_bins];
+        let Some(feature_len) = num_frames.checked_mul(self.num_mel_bins) else {
+            return (vec![0.0; self.num_mel_bins], 1);
+        };
+        let mut features = vec![0.0f32; feature_len];
 
         for frame_idx in 0..num_frames {
             let start = frame_idx * self.hop_length;

--- a/src/audio/whisper_mel.rs
+++ b/src/audio/whisper_mel.rs
@@ -18,7 +18,7 @@
 //! sibling [`super::feature_extractor`] module. The two differ in their
 //! normalization and mel scale, so this file only adds the recognizer-specific
 //! parameters and reuses the shared DSP primitive
-//! ([`super::feature_extractor::real_fft_magnitude`]) for the per-frame
+//! ([`super::fft::real_fft_magnitude`]) for the per-frame
 //! transform.
 //!
 //! Pipeline (16 kHz mono input):
@@ -31,7 +31,7 @@
 
 use std::f64::consts::PI;
 
-use super::feature_extractor::real_fft_magnitude;
+use super::fft::real_fft_magnitude;
 
 /// Native sample rate the encoder expects.
 pub const WHISPER_SAMPLE_RATE: u32 = 16_000;
@@ -221,7 +221,7 @@ pub fn log_mel_spectrogram(audio: &[f32], n_mels: usize) -> (Vec<f32>, usize) {
         for i in 0..WHISPER_N_FFT {
             frame_buf[i] = (padded[start + i] * window[i]) as f64;
         }
-        // Power spectrum: square the shared DFT magnitude.
+        // Power spectrum: square the shared FFT magnitude.
         let mag = real_fft_magnitude(&frame_buf, n_freqs);
         for mel in 0..n_mels {
             let mut acc = 0.0f64;


### PR DESCRIPTION
## Summary

Replace the per-frame naïve DFT audio spectrum implementations with one shared bounded real FFT helper. The helper uses radix-2 FFT for power-of-two audio frame sizes and Bluestein convolution for Whisper's 400-point transform so non-power-of-two frames keep their exact DFT bin grid instead of being remapped by external zero-padding.

## What changed

- Added `src/audio/fft.rs` with exact-grid real magnitude spectra, requested-bin cardinality tests, empty-input handling, and fail-closed oversized-input bounds.
- Routed Whisper, Gemma4, Nemotron-Omni, and Gemma3n audio feature extraction through the shared helper, deleting the Gemma4/shared DFT copy, the Nemotron DFT copy, and the Gemma3n-only FFT copy.
- Added Nemotron spectrum-config guards for zero or oversized `n_fft`, zero `hop_length`, oversized mel-bin counts, non-finite preemphasis, and checked padded-waveform/output-buffer arithmetic so malformed metadata cannot drive unbounded FFT/filterbank allocations.
- Added `benches/audio_fft.rs`, a Criterion benchmark target that compares the old DFT baseline against the shared FFT for 400, 512, and 1024 sample frames.
- Added bilingual technical reports: `TECHNICAL_REPORTS/1517-shared-audio-fft-20260830.en.md` and `TECHNICAL_REPORTS/1517-shared-audio-fft-20260830.ko.md`.

## Validation

- [x] `cargo fmt --all --check`
- [x] `cargo test --lib audio::fft:: -- --nocapture`
- [x] `cargo test --lib audio::feature_extractor::tests:: -- --nocapture`
- [x] `cargo test --lib audio::gemma3n::feature_extractor::tests:: -- --nocapture`
- [x] `cargo test --lib whisper_mel -- --nocapture`
- [x] `cargo test --lib nemotron_h_nano_omni::feature_extractor -- --nocapture`
- [x] `cargo test --lib deterministic_waveform_matches_pinned_speechlib_features -- --nocapture`
- [x] `cargo test --bench audio_fft --no-run`
- [x] `cargo clippy --lib --bench audio_fft -- -D warnings`
- [x] `git diff --check`
- [x] Static stale-marker scan found no remaining target DFT/TODO markers.

## Benchmark notes

- Standalone `rustc -O` microprobe against the exact shared helper measured DFT vs FFT at 400, 512, and 1024 samples: 400-point 23.7x faster with max_abs 7.034e-13, 512-point 221.2x faster with max_abs 5.776e-13, and 1024-point 390.0x faster with max_abs 2.863e-12.
- `cargo bench --bench audio_fft` was attempted twice but stopped during bench-profile compilation after bounded polling to avoid waiting silently on a cold optimized root-crate build; the Criterion target itself compiles with `cargo test --bench audio_fft --no-run`.

## Limits

- No real checkpoint, ffmpeg, or hardware-backed audio inference was run in this implementation pass.
- The issue mentions a Nemotron test named `deterministic_waveform_matches_pinned_speechlib_features`, but current `origin/main` has that exact test name under Phi4MM, not Nemotron; the available named selector was run and passed.

Closes #1224
