### PR TITLE
fix(server): bound response stores by bytes

### DIFF
--- a/TECHNICAL_REPORTS/1519-store-byte-bounds-20260830.en.md
+++ b/TECHNICAL_REPORTS/1519-store-byte-bounds-20260830.en.md
@@ -1,0 +1,62 @@
+# Technical Report: Store Byte Bounds
+
+## Summary
+
+PR #1519 resolves issue #1248 by bounding the in-memory Responses API response store and conversation transcript store by approximate retained bytes as well as entry count and TTL.
+
+The change adds saturating JSON-byte accounting, per-entry size snapshots, running totals and byte-budget configuration for both server binaries. It also replaces the previous map-wide LRU victim scan with a `BTreeSet` LRU index so each live entry owns one bounded metadata node and each eviction removes the oldest entry in O(log n).
+
+## Problem
+
+The prior stores capped only the number of retained entries. Each response entry can retain the complete request input and response object, and each conversation entry can retain a growing transcript, so a small number of large multimodal requests could pin much more memory than the entry-count limit implied.
+
+The response store also selected LRU victims with a linear scan over the full map on each eviction. Under byte pressure one insert can evict multiple entries, making the scan cost repeat while memory pressure is already high.
+
+## Implementation
+
+- Added `ResponsesStoreConfig::max_bytes` and `ConversationStoreConfig::max_bytes` with defaults of 256 MiB and 64 MiB.
+- Added `store_budget::serialized_json_len_saturating`, which counts serialized JSON bytes through a writer and returns `usize::MAX` on serialization failure so accounting fails closed.
+- Added one `LruKey` per live entry and a `BTreeSet` index to both stores, with removal on delete, refresh, replacement, TTL sweep and eviction so stale LRU metadata cannot grow independently.
+- Evicted until both `max_entries` and `max_bytes` are satisfied, including the oversized-single-entry case where the new entry evicts itself.
+- Added `--responses-store-max-bytes` / `MLXCEL_RESPONSES_STORE_MAX_BYTES` and `--conversation-store-max-bytes` / `MLXCEL_CONVERSATION_STORE_MAX_BYTES` to both `mlxcel serve` and `mlxcel-server`.
+- Documented the new byte-budget knobs in `docs/environment-variables.md` and `docs/responses-api.md`.
+
+## Correctness
+
+The stores compute size at insertion or transcript replacement time and maintain a running total with saturating add and subtract. Replacements first remove the old entry, then insert the updated entry, so totals and LRU metadata cannot double-count an id.
+
+Reads refresh access order without advancing the LRU sequence on a miss. TTL sweeps remove both map entries and index keys. A zero byte budget keeps the route/store surface enabled when entry count is nonzero, but retained entries immediately self-evict and retrieval returns a normal miss.
+
+## Security and Resource Bounds
+
+The byte limits reduce the memory retention blast radius for well-formed large inputs, including base64 image data carried inside stored request items. Serialization errors and extreme values are treated as maximum-size entries, causing eviction rather than under-accounting.
+
+Initial `HashMap` allocation is capped even when an operator configures an extreme `max_entries` value, avoiding a large upfront allocation from the capacity knob itself. TTL sweep remains O(n) over live entries, but LRU victim selection is no longer a repeated O(n) scan under byte pressure.
+
+## Validation
+
+- `cargo test --lib responses_store -- --nocapture` passed: 16 tests, including byte-only eviction, simultaneous count and byte pressure, oversized single entry, exact boundary, replacement, access-order refresh, TTL, zero and extreme budgets, and running-total consistency.
+- `cargo test --lib conversation_store -- --nocapture` passed: 13 tests, including the same byte, count, oversized, exact-boundary, update, LRU, TTL, zero/extreme and total-consistency cases for transcripts.
+- `cargo test --lib store_byte_budgets_round_trip_through_into_startup_config -- --nocapture` passed.
+- `cargo test --bin mlxcel serve_store_byte_budget -- --nocapture` passed.
+- `cargo test --bin mlxcel-server store_byte_budget -- --nocapture` passed.
+- `cargo test --bin mlxcel-server settings_cli_mlxcel_server -- --nocapture` passed after rebasing over PR #1518.
+- `cargo test --bin mlxcel settings_cli_mlxcel_serve -- --nocapture` passed after rebasing over PR #1518.
+- `cargo test --bin mlxcel settings_cli_build_startup_input_defaults_off_and_propagates_enablement -- --nocapture` passed after rebasing over PR #1518.
+- `cargo test --lib settings_cli -- --nocapture` passed after rebasing over PR #1518.
+- `cargo test --test llama_compat_manifest manifest_option_claims_hold_on_both_server_binaries -- --nocapture` passed.
+- `python3 scripts/ci/check_llama_compat_manifest.py` passed.
+- `cargo fmt --all --check` passed.
+- `cargo clippy --lib --bin mlxcel --bin mlxcel-server -- -D warnings` passed.
+- `git diff --check` passed.
+- Static scan found no conflict markers or old `min_by`, `min_by_key` or `evict_to_capacity` victim-scan code in the touched stores.
+
+## Skipped Validation
+
+Broad cargo workspace tests, serial all-tests, workspace clippy and cold release builds were intentionally skipped under the wave-runner watchdog guard. No real checkpoint, ffmpeg or hardware qualification was run because this change is confined to in-memory server-store accounting and CLI/config wiring.
+
+## Risk Notes
+
+The byte accounting is approximate by design. It now counts JSON escaping for strings and serialized JSON for response/output structures, but Rust allocation overhead and container internals are not included in the budget.
+
+Conversation updates replace the old transcript accounting with the newly appended transcript. If the updated transcript exceeds the byte limit, it self-evicts; this is the intended fail-closed behavior for over-budget retained state.

--- a/TECHNICAL_REPORTS/1519-store-byte-bounds-20260830.en.md
+++ b/TECHNICAL_REPORTS/1519-store-byte-bounds-20260830.en.md
@@ -40,10 +40,10 @@ Initial `HashMap` allocation is capped even when an operator configures an extre
 - `cargo test --lib store_byte_budgets_round_trip_through_into_startup_config -- --nocapture` passed.
 - `cargo test --bin mlxcel serve_store_byte_budget -- --nocapture` passed.
 - `cargo test --bin mlxcel-server store_byte_budget -- --nocapture` passed.
-- `cargo test --bin mlxcel-server settings_cli_mlxcel_server -- --nocapture` passed after rebasing over PR #1518.
-- `cargo test --bin mlxcel settings_cli_mlxcel_serve -- --nocapture` passed after rebasing over PR #1518.
-- `cargo test --bin mlxcel settings_cli_build_startup_input_defaults_off_and_propagates_enablement -- --nocapture` passed after rebasing over PR #1518.
-- `cargo test --lib settings_cli -- --nocapture` passed after rebasing over PR #1518.
+- `cargo test --bin mlxcel-server settings_cli_mlxcel_server -- --nocapture` passed after preserving runtime-settings PR #1516 while rebasing onto main through PR #1518, the chat-template-cache head.
+- `cargo test --bin mlxcel settings_cli_mlxcel_serve -- --nocapture` passed after preserving runtime-settings PR #1516 while rebasing onto main through PR #1518, the chat-template-cache head.
+- `cargo test --bin mlxcel settings_cli_build_startup_input_defaults_off_and_propagates_enablement -- --nocapture` passed after preserving runtime-settings PR #1516 while rebasing onto main through PR #1518, the chat-template-cache head.
+- `cargo test --lib settings_cli -- --nocapture` passed after preserving runtime-settings PR #1516 while rebasing onto main through PR #1518, the chat-template-cache head.
 - `cargo test --test llama_compat_manifest manifest_option_claims_hold_on_both_server_binaries -- --nocapture` passed.
 - `python3 scripts/ci/check_llama_compat_manifest.py` passed.
 - `cargo fmt --all --check` passed.

--- a/TECHNICAL_REPORTS/1519-store-byte-bounds-20260830.ko.md
+++ b/TECHNICAL_REPORTS/1519-store-byte-bounds-20260830.ko.md
@@ -1,0 +1,62 @@
+# 기술 보고서: 저장소 바이트 상한
+
+## 요약
+
+PR #1519는 Responses API의 인메모리 응답 저장소와 대화 transcript 저장소가 엔트리 수와 TTL뿐 아니라 근사 retained byte 기준으로도 제한되도록 하여 이슈 #1248을 해결한다.
+
+이 변경은 saturating JSON byte 계수, 엔트리별 크기 스냅샷, running total, 두 서버 바이너리의 byte budget 설정을 추가한다. 또한 기존의 map 전체 LRU victim 선형 스캔을 `BTreeSet` LRU 인덱스로 교체하여 live entry 하나가 bounded metadata node 하나만 보유하고 eviction마다 가장 오래된 엔트리를 O(log n)에 제거한다.
+
+## 문제
+
+기존 저장소는 보존 엔트리 수만 제한했다. 응답 엔트리는 전체 요청 입력과 응답 객체를 보관할 수 있고 대화 엔트리는 계속 커지는 transcript를 보관할 수 있으므로, 적은 수의 큰 multimodal 요청만으로도 엔트리 수 제한이 암시하는 것보다 훨씬 큰 메모리를 고정할 수 있었다.
+
+응답 저장소는 eviction마다 전체 map을 선형 스캔하여 LRU victim을 골랐다. Byte pressure 상황에서는 한 번의 insert가 여러 엔트리를 evict할 수 있으므로, 이미 메모리 압력이 높은 상황에서 scan cost가 반복될 수 있었다.
+
+## 구현
+
+- `ResponsesStoreConfig::max_bytes`와 `ConversationStoreConfig::max_bytes`를 추가하고 기본값을 각각 256 MiB와 64 MiB로 설정했다.
+- Writer를 통해 serialized JSON byte를 세고 serialization 실패 시 `usize::MAX`를 반환하는 `store_budget::serialized_json_len_saturating`을 추가하여 accounting이 fail closed되도록 했다.
+- 두 저장소에 live entry별 `LruKey` 하나와 `BTreeSet` 인덱스를 추가하고, delete, refresh, replacement, TTL sweep, eviction에서 함께 제거하여 stale LRU metadata가 map과 별도로 증가하지 않도록 했다.
+- `max_entries`와 `max_bytes`가 모두 만족될 때까지 eviction하도록 했으며, oversized single entry는 삽입 직후 자기 자신을 evict한다.
+- `mlxcel serve`와 `mlxcel-server`에 `--responses-store-max-bytes` / `MLXCEL_RESPONSES_STORE_MAX_BYTES`, `--conversation-store-max-bytes` / `MLXCEL_CONVERSATION_STORE_MAX_BYTES`를 추가했다.
+- `docs/environment-variables.md`와 `docs/responses-api.md`에 새 byte-budget knob를 문서화했다.
+
+## 정합성
+
+저장소는 삽입 또는 transcript replacement 시점에 크기를 계산하고 saturating add/subtract로 running total을 유지한다. Replacement는 기존 엔트리를 먼저 제거한 뒤 갱신된 엔트리를 삽입하므로 total과 LRU metadata가 같은 id를 중복 계산하지 않는다.
+
+읽기는 접근 순서를 갱신하되 miss에서는 LRU sequence를 증가시키지 않는다. TTL sweep은 map entry와 index key를 함께 제거한다. Byte budget이 0이면 entry count가 0이 아닌 경우 route/store surface는 유지되지만 저장 엔트리는 즉시 자기 자신을 evict하고 조회는 일반 miss로 끝난다.
+
+## 보안 및 리소스 경계
+
+Byte limit은 stored request item 안의 base64 image data를 포함한 well-formed large input이 TTL window 동안 과도한 메모리를 고정하는 blast radius를 줄인다. Serialization 오류와 extreme value는 maximum-size entry로 취급되어 under-accounting 대신 eviction을 유도한다.
+
+운영자가 극단적인 `max_entries` 값을 설정해도 초기 `HashMap` capacity는 제한되어 capacity knob 자체로 큰 upfront allocation이 발생하지 않는다. TTL sweep은 live entry에 대해 O(n)으로 남아 있지만, LRU victim selection은 byte pressure 상황에서 반복되는 O(n) scan이 아니다.
+
+## 검증
+
+- `cargo test --lib responses_store -- --nocapture` 통과: 16개 테스트, byte-only eviction, count와 byte 동시 pressure, oversized single entry, exact boundary, replacement, access-order refresh, TTL, zero/extreme budgets, running-total consistency 포함.
+- `cargo test --lib conversation_store -- --nocapture` 통과: 13개 테스트, transcript에 대한 byte, count, oversized, exact-boundary, update, LRU, TTL, zero/extreme, total-consistency 사례 포함.
+- `cargo test --lib store_byte_budgets_round_trip_through_into_startup_config -- --nocapture` 통과.
+- `cargo test --bin mlxcel serve_store_byte_budget -- --nocapture` 통과.
+- `cargo test --bin mlxcel-server store_byte_budget -- --nocapture` 통과.
+- `cargo test --bin mlxcel-server settings_cli_mlxcel_server -- --nocapture` 통과, PR #1518 위로 rebase한 뒤 확인.
+- `cargo test --bin mlxcel settings_cli_mlxcel_serve -- --nocapture` 통과, PR #1518 위로 rebase한 뒤 확인.
+- `cargo test --bin mlxcel settings_cli_build_startup_input_defaults_off_and_propagates_enablement -- --nocapture` 통과, PR #1518 위로 rebase한 뒤 확인.
+- `cargo test --lib settings_cli -- --nocapture` 통과, PR #1518 위로 rebase한 뒤 확인.
+- `cargo test --test llama_compat_manifest manifest_option_claims_hold_on_both_server_binaries -- --nocapture` 통과.
+- `python3 scripts/ci/check_llama_compat_manifest.py` 통과.
+- `cargo fmt --all --check` 통과.
+- `cargo clippy --lib --bin mlxcel --bin mlxcel-server -- -D warnings` 통과.
+- `git diff --check` 통과.
+- Static scan에서 touched store 파일에 conflict marker나 기존 `min_by`, `min_by_key`, `evict_to_capacity` victim-scan code가 남아 있지 않음을 확인했다.
+
+## 생략한 검증
+
+Wave-runner watchdog guard에 따라 broad cargo workspace tests, serial all-tests, workspace clippy, cold release build는 실행하지 않았다. 이 변경은 인메모리 server-store accounting과 CLI/config wiring에 한정되므로 real checkpoint, ffmpeg, hardware qualification은 실행하지 않았다.
+
+## 위험 사항
+
+Byte accounting은 의도적으로 approximate이다. 문자열 JSON escaping과 response/output structure의 serialized JSON은 계수하지만, Rust allocation overhead와 container internal overhead는 budget에 포함하지 않는다.
+
+대화 update는 기존 transcript accounting을 제거한 뒤 append된 새 transcript로 교체한다. 갱신된 transcript가 byte limit을 초과하면 자기 자신을 evict하며, 이는 over-budget retained state에 대한 의도된 fail-closed 동작이다.

--- a/TECHNICAL_REPORTS/1519-store-byte-bounds-20260830.ko.md
+++ b/TECHNICAL_REPORTS/1519-store-byte-bounds-20260830.ko.md
@@ -40,10 +40,10 @@ Byte limit은 stored request item 안의 base64 image data를 포함한 well-for
 - `cargo test --lib store_byte_budgets_round_trip_through_into_startup_config -- --nocapture` 통과.
 - `cargo test --bin mlxcel serve_store_byte_budget -- --nocapture` 통과.
 - `cargo test --bin mlxcel-server store_byte_budget -- --nocapture` 통과.
-- `cargo test --bin mlxcel-server settings_cli_mlxcel_server -- --nocapture` 통과, PR #1518 위로 rebase한 뒤 확인.
-- `cargo test --bin mlxcel settings_cli_mlxcel_serve -- --nocapture` 통과, PR #1518 위로 rebase한 뒤 확인.
-- `cargo test --bin mlxcel settings_cli_build_startup_input_defaults_off_and_propagates_enablement -- --nocapture` 통과, PR #1518 위로 rebase한 뒤 확인.
-- `cargo test --lib settings_cli -- --nocapture` 통과, PR #1518 위로 rebase한 뒤 확인.
+- `cargo test --bin mlxcel-server settings_cli_mlxcel_server -- --nocapture` 통과, runtime-settings PR #1516을 보존하면서 chat-template-cache head인 PR #1518까지 포함한 main 위로 rebase한 뒤 확인.
+- `cargo test --bin mlxcel settings_cli_mlxcel_serve -- --nocapture` 통과, runtime-settings PR #1516을 보존하면서 chat-template-cache head인 PR #1518까지 포함한 main 위로 rebase한 뒤 확인.
+- `cargo test --bin mlxcel settings_cli_build_startup_input_defaults_off_and_propagates_enablement -- --nocapture` 통과, runtime-settings PR #1516을 보존하면서 chat-template-cache head인 PR #1518까지 포함한 main 위로 rebase한 뒤 확인.
+- `cargo test --lib settings_cli -- --nocapture` 통과, runtime-settings PR #1516을 보존하면서 chat-template-cache head인 PR #1518까지 포함한 main 위로 rebase한 뒤 확인.
 - `cargo test --test llama_compat_manifest manifest_option_claims_hold_on_both_server_binaries -- --nocapture` 통과.
 - `python3 scripts/ci/check_llama_compat_manifest.py` 통과.
 - `cargo fmt --all --check` 통과.

--- a/docs/environment-variables.md
+++ b/docs/environment-variables.md
@@ -210,6 +210,8 @@ These variables are applied when the corresponding CLI flag is absent.
 | `MLXCEL_PROMPT_CACHE_SNAPSHOT_MAX_ENTRIES` | unsigned integer | `4096` | `--prompt-cache-snapshot-max-entries` |
 | `MLXCEL_PROMPT_CACHE_SNAPSHOT_TTL` | unsigned integer seconds | `7200` | `--prompt-cache-snapshot-ttl` |
 | `MLXCEL_ENABLE_VLM_PREFIX_CACHE` | boolean | `false` | `--enable-vlm-prefix-cache` |
+| `MLXCEL_RESPONSES_STORE_MAX_BYTES` | unsigned integer bytes | `268435456` | `--responses-store-max-bytes` |
+| `MLXCEL_CONVERSATION_STORE_MAX_BYTES` | unsigned integer bytes | `67108864` | `--conversation-store-max-bytes` |
 | `APC_ENABLED` | boolean | `true` | `--apc-enabled` |
 | `APC_BLOCK_SIZE` | unsigned integer tokens | `16` | `--apc-block-size` |
 | `APC_NUM_BLOCKS` | unsigned integer | derived from max entries | `--apc-num-blocks` |
@@ -238,6 +240,12 @@ supersede from capacity thrash.
 
 `MLXCEL_ENABLE_VLM_PREFIX_CACHE` opts same-image multimodal follow-up turns into
 prompt-prefix sharing while leaving text-only prompt-cache behavior unchanged.
+
+`MLXCEL_RESPONSES_STORE_MAX_BYTES` and
+`MLXCEL_CONVERSATION_STORE_MAX_BYTES` bound the approximate retained JSON bytes
+for `/v1/responses` response history and conversation transcripts. The entry
+count and TTL limits still apply. A value of `0` leaves the route surface
+enabled but makes newly stored entries immediately evict themselves.
 
 The three `SNAPSHOT` variables budget a separate store: whole recurrent-state
 snapshots for SSM and linear-attention families, which cannot share KV blocks

--- a/docs/responses-api.md
+++ b/docs/responses-api.md
@@ -202,13 +202,16 @@ Phase 1 emits events such as:
 
 ## Response and conversation stores
 
-The stores are in memory and are bounded by entry count and TTL.
+The stores are in memory and are bounded by entry count, approximate retained
+JSON bytes, and TTL.
 
 | Flag | Default | Env var | Notes |
 |------|---------|---------|-------|
 | `--responses-store-max-entries` | `1024` | `LLAMA_ARG_RESPONSES_STORE_MAX_ENTRIES` | `0` disables response persistence. |
+| `--responses-store-max-bytes` | `268435456` | `MLXCEL_RESPONSES_STORE_MAX_BYTES` | Approximate retained-byte budget; `0` keeps the route enabled but immediately evicts stored responses. |
 | `--responses-store-ttl-secs` | `3600` | `LLAMA_ARG_RESPONSES_STORE_TTL_SECS` | `0` disables TTL. |
 | `--conversation-store-max-entries` | `256` | `LLAMA_ARG_CONVERSATION_STORE_MAX_ENTRIES` | `0` disables conversations. |
+| `--conversation-store-max-bytes` | `67108864` | `MLXCEL_CONVERSATION_STORE_MAX_BYTES` | Approximate retained-byte budget; `0` keeps the route enabled but immediately evicts transcripts. |
 | `--conversation-store-ttl-secs` | `3600` | `LLAMA_ARG_CONVERSATION_STORE_TTL_SECS` | `0` disables TTL. |
 
 When response storage is disabled, retrieve/delete/cancel-by-id and

--- a/src/bin/mlx_server.rs
+++ b/src/bin/mlx_server.rs
@@ -957,6 +957,17 @@ struct ServerArgs {
     )]
     responses_store_max_entries: usize,
 
+    /// Approximate byte budget for the OpenAI `/v1/responses` store.
+    /// `0` keeps response storage enabled but immediately evicts every stored
+    /// response. Also reads `MLXCEL_RESPONSES_STORE_MAX_BYTES`.
+    #[arg(
+        long = "responses-store-max-bytes",
+        env = "MLXCEL_RESPONSES_STORE_MAX_BYTES",
+        default_value_t = mlxcel::server::responses_store::DEFAULT_RESPONSES_STORE_MAX_BYTES,
+        value_name = "BYTES"
+    )]
+    responses_store_max_bytes: usize,
+
     /// TTL (seconds) for in-memory Responses-API response
     /// entries. `0` disables TTL.
     /// Also reads `LLAMA_ARG_RESPONSES_STORE_TTL_SECS`.
@@ -978,6 +989,17 @@ struct ServerArgs {
         value_name = "N"
     )]
     conversation_store_max_entries: usize,
+
+    /// Approximate byte budget for conversation transcripts.
+    /// `0` keeps the conversation store enabled but immediately evicts every
+    /// transcript. Also reads `MLXCEL_CONVERSATION_STORE_MAX_BYTES`.
+    #[arg(
+        long = "conversation-store-max-bytes",
+        env = "MLXCEL_CONVERSATION_STORE_MAX_BYTES",
+        default_value_t = mlxcel::server::conversation_store::DEFAULT_CONVERSATION_STORE_MAX_BYTES,
+        value_name = "BYTES"
+    )]
+    conversation_store_max_bytes: usize,
 
     /// TTL (seconds) for conversation transcript entries.
     /// `0` disables TTL.
@@ -2493,12 +2515,13 @@ fn build_startup_input(mut args: ServerArgs) -> anyhow::Result<ServerStartupInpu
         enable_vlm_prefix_cache: args.enable_vlm_prefix_cache,
         // CORS allow-list origins (#244); validated in into_startup_config.
         allowed_origins: args.allowed_origins,
-        // Responses API in-memory store limits. clap reads the
-        // matching `LLAMA_ARG_*` env vars directly via the `env = ...`
-        // attributes on the flags.
+        // Responses API in-memory store limits. clap reads the matching env
+        // vars directly via the `env = ...` attributes on the flags.
         responses_store_max_entries: args.responses_store_max_entries,
+        responses_store_max_bytes: args.responses_store_max_bytes,
         responses_store_ttl_secs: args.responses_store_ttl_secs,
         conversation_store_max_entries: args.conversation_store_max_entries,
+        conversation_store_max_bytes: args.conversation_store_max_bytes,
         conversation_store_ttl_secs: args.conversation_store_ttl_secs,
         // (A4): forward the surgery YAML path. clap reads
         // `MLXCEL_SURGERY` directly via the `env = ...` attribute on
@@ -2639,6 +2662,39 @@ mod tests {
         assert!(enabled.settings, "--settings must propagate through clap");
         let enabled = build_startup_input(enabled).expect("enabled startup input");
         assert!(enabled.settings, "--settings must reach startup input");
+    }
+
+    #[test]
+    fn store_byte_budget_flags_parse() {
+        let args = parse_server_args(&[
+            "mlxcel-server",
+            "-m",
+            "models/foo",
+            "--responses-store-max-bytes",
+            "12345",
+            "--conversation-store-max-bytes",
+            "67890",
+        ]);
+
+        assert_eq!(args.responses_store_max_bytes, 12_345);
+        assert_eq!(args.conversation_store_max_bytes, 67_890);
+    }
+
+    #[test]
+    fn store_byte_budget_envs_parse_when_flags_are_absent() {
+        let _lock = CLI_ENV_LOCK
+            .get_or_init(|| Mutex::new(()))
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        let _env = ScopedEnv::set(&[
+            ("MLXCEL_RESPONSES_STORE_MAX_BYTES", "11111"),
+            ("MLXCEL_CONVERSATION_STORE_MAX_BYTES", "22222"),
+        ]);
+
+        let args = parse_server_args(&["mlxcel-server", "-m", "models/foo"]);
+
+        assert_eq!(args.responses_store_max_bytes, 11_111);
+        assert_eq!(args.conversation_store_max_bytes, 22_222);
     }
 
     #[test]

--- a/src/commands/serve.rs
+++ b/src/commands/serve.rs
@@ -729,12 +729,13 @@ fn build_startup_input(mut args: crate::ServeArgs) -> anyhow::Result<ServerStart
         enable_vlm_prefix_cache: args.enable_vlm_prefix_cache,
         // CORS allow-list origins (#244); validated in into_startup_config.
         allowed_origins: args.allowed_origins,
-        // Responses API in-memory store limits. clap reads the
-        // matching `LLAMA_ARG_*` env vars directly via the `env = ...`
-        // attributes on the flags.
+        // Responses API in-memory store limits. clap reads the matching env
+        // vars directly via the `env = ...` attributes on the flags.
         responses_store_max_entries: args.responses_store_max_entries,
+        responses_store_max_bytes: args.responses_store_max_bytes,
         responses_store_ttl_secs: args.responses_store_ttl_secs,
         conversation_store_max_entries: args.conversation_store_max_entries,
+        conversation_store_max_bytes: args.conversation_store_max_bytes,
         conversation_store_ttl_secs: args.conversation_store_ttl_secs,
         // (A4): forward the surgery YAML path. clap reads
         // `MLXCEL_SURGERY` directly via the `env = ...` attribute on

--- a/src/commands/serve_tests.rs
+++ b/src/commands/serve_tests.rs
@@ -189,8 +189,12 @@ fn sample_args() -> crate::ServeArgs {
         apc_num_blocks: None,
         apc_hash: None,
         responses_store_max_entries: 1024,
+        responses_store_max_bytes:
+            mlxcel::server::responses_store::DEFAULT_RESPONSES_STORE_MAX_BYTES,
         responses_store_ttl_secs: 3600,
         conversation_store_max_entries: 256,
+        conversation_store_max_bytes:
+            mlxcel::server::conversation_store::DEFAULT_CONVERSATION_STORE_MAX_BYTES,
         conversation_store_ttl_secs: 3600,
         // (A4): keep tests on the baseline path by default.
         #[cfg(feature = "surgery")]

--- a/src/main.rs
+++ b/src/main.rs
@@ -1513,6 +1513,17 @@ pub(crate) struct ServeArgs {
     )]
     responses_store_max_entries: usize,
 
+    /// Approximate byte budget for the OpenAI `/v1/responses` store.
+    /// `0` keeps response storage enabled but immediately evicts every stored
+    /// response. Also reads `MLXCEL_RESPONSES_STORE_MAX_BYTES`.
+    #[arg(
+        long = "responses-store-max-bytes",
+        env = "MLXCEL_RESPONSES_STORE_MAX_BYTES",
+        default_value_t = mlxcel::server::responses_store::DEFAULT_RESPONSES_STORE_MAX_BYTES,
+        value_name = "BYTES"
+    )]
+    responses_store_max_bytes: usize,
+
     /// TTL (seconds) for in-memory Responses-API response
     /// entries. `0` disables TTL, entries are evicted only when the
     /// max-entries cap is hit.
@@ -1537,6 +1548,17 @@ pub(crate) struct ServeArgs {
         value_name = "N"
     )]
     conversation_store_max_entries: usize,
+
+    /// Approximate byte budget for conversation transcripts.
+    /// `0` keeps the conversation store enabled but immediately evicts every
+    /// transcript. Also reads `MLXCEL_CONVERSATION_STORE_MAX_BYTES`.
+    #[arg(
+        long = "conversation-store-max-bytes",
+        env = "MLXCEL_CONVERSATION_STORE_MAX_BYTES",
+        default_value_t = mlxcel::server::conversation_store::DEFAULT_CONVERSATION_STORE_MAX_BYTES,
+        value_name = "BYTES"
+    )]
+    conversation_store_max_bytes: usize,
 
     /// TTL (seconds) for conversation transcript entries.
     /// `0` disables TTL.

--- a/src/main_tests.rs
+++ b/src/main_tests.rs
@@ -1159,6 +1159,36 @@ fn parse_serve_args(rest: &[&str]) -> super::ServeArgs {
     }
 }
 
+#[test]
+fn serve_store_byte_budget_flags_parse() {
+    let args = parse_serve_args(&[
+        "--responses-store-max-bytes",
+        "12345",
+        "--conversation-store-max-bytes",
+        "67890",
+    ]);
+
+    assert_eq!(args.responses_store_max_bytes, 12_345);
+    assert_eq!(args.conversation_store_max_bytes, 67_890);
+}
+
+#[test]
+fn serve_store_byte_budget_envs_parse_when_flags_are_absent() {
+    let _lock = CLI_ENV_LOCK
+        .get_or_init(|| Mutex::new(()))
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner());
+    let _env = ScopedEnv::set(&[
+        ("MLXCEL_RESPONSES_STORE_MAX_BYTES", "11111"),
+        ("MLXCEL_CONVERSATION_STORE_MAX_BYTES", "22222"),
+    ]);
+
+    let args = parse_serve_args(&[]);
+
+    assert_eq!(args.responses_store_max_bytes, 11_111);
+    assert_eq!(args.conversation_store_max_bytes, 22_222);
+}
+
 /// The clap error from `mlxcel serve -m models/foo <rest...>`, which must fail.
 fn serve_parse_error(rest: &[&str], expectation: &str) -> clap::Error {
     Cli::try_parse_from(serve_argv(rest)).expect_err(expectation)

--- a/src/server/cli_input.rs
+++ b/src/server/cli_input.rs
@@ -521,11 +521,17 @@ pub struct ServerStartupInput {
     /// `--responses-store-max-entries` value (`0` disables
     /// the OpenAI Responses API response store entirely).
     pub responses_store_max_entries: usize,
+    /// `--responses-store-max-bytes` value (`0` immediately evicts stored
+    /// responses while leaving the route surface enabled).
+    pub responses_store_max_bytes: usize,
     /// `--responses-store-ttl-secs` value (`0` disables TTL).
     pub responses_store_ttl_secs: u64,
     /// `--conversation-store-max-entries` value (`0` disables
     /// the OpenAI Responses API conversation transcript store entirely).
     pub conversation_store_max_entries: usize,
+    /// `--conversation-store-max-bytes` value (`0` immediately evicts
+    /// transcripts while leaving the route surface enabled).
+    pub conversation_store_max_bytes: usize,
     /// `--conversation-store-ttl-secs` value (`0` disables TTL).
     pub conversation_store_ttl_secs: u64,
 
@@ -1059,8 +1065,10 @@ impl ServerStartupInput {
             cors_policy,
             // forward the Responses-API store limits.
             responses_store_max_entries: self.responses_store_max_entries,
+            responses_store_max_bytes: self.responses_store_max_bytes,
             responses_store_ttl_secs: self.responses_store_ttl_secs,
             conversation_store_max_entries: self.conversation_store_max_entries,
+            conversation_store_max_bytes: self.conversation_store_max_bytes,
             conversation_store_ttl_secs: self.conversation_store_ttl_secs,
             // (A4): forward the surgery YAML path verbatim.
             // start_server() parses the YAML and installs the pipeline

--- a/src/server/cli_input_tests.rs
+++ b/src/server/cli_input_tests.rs
@@ -204,8 +204,12 @@ fn sample_input() -> ServerStartupInput {
         allowed_origins: Vec::new(),
         // Responses API store defaults.
         responses_store_max_entries: 1024,
+        responses_store_max_bytes:
+            crate::server::responses_store::DEFAULT_RESPONSES_STORE_MAX_BYTES,
         responses_store_ttl_secs: 3600,
         conversation_store_max_entries: 256,
+        conversation_store_max_bytes:
+            crate::server::conversation_store::DEFAULT_CONVERSATION_STORE_MAX_BYTES,
         conversation_store_ttl_secs: 3600,
         // (A4): default to None for baseline-path tests.
         #[cfg(feature = "surgery")]
@@ -767,6 +771,18 @@ fn prompt_cache_defaults_round_trip_through_into_startup_config() {
         startup.prompt_cache.min_prefix_tokens,
         expected.min_prefix_tokens
     );
+}
+
+#[test]
+fn store_byte_budgets_round_trip_through_into_startup_config() {
+    let mut input = sample_input();
+    input.responses_store_max_bytes = 12_345;
+    input.conversation_store_max_bytes = 67_890;
+
+    let startup = input.into_startup_config().expect("valid input");
+
+    assert_eq!(startup.responses_store_max_bytes, 12_345);
+    assert_eq!(startup.conversation_store_max_bytes, 67_890);
 }
 
 /// CLI-supplied capacity is propagated.

--- a/src/server/conversation_store.rs
+++ b/src/server/conversation_store.rs
@@ -21,12 +21,19 @@
 //! [`crate::server::responses_store`] — same TTL/LRU semantics, separate
 //! capacity knobs.
 
-use std::collections::HashMap;
+use std::collections::{BTreeSet, HashMap};
 use std::sync::RwLock;
 use std::time::{Duration, Instant};
 
+use crate::server::responses_store::response_input_item_size_bytes;
+use crate::server::store_budget::{LruKey, serialized_json_len_saturating};
 use crate::server::types::responses_request::ResponseInputItem;
 use crate::server::types::responses_response::ResponseOutputItem;
+
+/// Default approximate retained-byte budget for conversation transcripts.
+pub const DEFAULT_CONVERSATION_STORE_MAX_BYTES: usize = 64 * 1024 * 1024;
+
+const INITIAL_HASH_CAPACITY_LIMIT: usize = 4096;
 
 /// One entry in a conversation transcript.
 #[derive(Debug, Clone)]
@@ -46,12 +53,34 @@ struct Entry {
     transcript: ConversationTranscript,
     inserted_at: Instant,
     last_accessed: Instant,
+    size_bytes: usize,
+    lru_key: LruKey,
+}
+
+#[derive(Debug)]
+struct StoreState {
+    entries: HashMap<String, Entry>,
+    lru: BTreeSet<LruKey>,
+    total_bytes: usize,
+    next_sequence: u64,
+}
+
+impl StoreState {
+    fn with_capacity(max_entries: usize) -> Self {
+        Self {
+            entries: HashMap::with_capacity(max_entries.min(INITIAL_HASH_CAPACITY_LIMIT)),
+            lru: BTreeSet::new(),
+            total_bytes: 0,
+            next_sequence: 0,
+        }
+    }
 }
 
 /// Configuration for [`ConversationStore`].
 #[derive(Debug, Clone)]
 pub struct ConversationStoreConfig {
     pub max_entries: usize,
+    pub max_bytes: usize,
     pub ttl: Duration,
 }
 
@@ -59,6 +88,7 @@ impl Default for ConversationStoreConfig {
     fn default() -> Self {
         Self {
             max_entries: 256,
+            max_bytes: DEFAULT_CONVERSATION_STORE_MAX_BYTES,
             ttl: Duration::from_secs(3600),
         }
     }
@@ -66,14 +96,14 @@ impl Default for ConversationStoreConfig {
 
 /// Thread-safe conversation store with TTL and LRU eviction.
 pub struct ConversationStore {
-    inner: RwLock<HashMap<String, Entry>>,
+    inner: RwLock<StoreState>,
     config: ConversationStoreConfig,
 }
 
 impl ConversationStore {
     pub fn new(config: ConversationStoreConfig) -> Self {
         Self {
-            inner: RwLock::new(HashMap::with_capacity(config.max_entries)),
+            inner: RwLock::new(StoreState::with_capacity(config.max_entries)),
             config,
         }
     }
@@ -81,11 +111,17 @@ impl ConversationStore {
     /// Snapshot of the transcript. Refreshes the LRU stamp.
     pub fn get(&self, id: &str) -> Option<ConversationTranscript> {
         let now = Instant::now();
-        let mut map = self.write_guard();
-        Self::sweep_expired(&mut map, &self.config, now);
-        let entry = map.get_mut(id)?;
+        let mut state = self.write_guard();
+        Self::sweep_expired(&mut state, &self.config, now);
+        let old_lru_key = state.entries.get(id)?.lru_key.clone();
+        state.lru.remove(&old_lru_key);
+        let lru_key = Self::next_lru_key(&mut state, id, now);
+        let entry = state.entries.get_mut(id)?;
         entry.last_accessed = now;
-        Some(entry.transcript.clone())
+        entry.lru_key = lru_key.clone();
+        let transcript = entry.transcript.clone();
+        state.lru.insert(lru_key);
+        Some(transcript)
     }
 
     /// Append items to a conversation transcript, creating it if needed.
@@ -94,33 +130,38 @@ impl ConversationStore {
             return;
         }
         let now = Instant::now();
-        let mut map = self.write_guard();
-        Self::sweep_expired(&mut map, &self.config, now);
-        if !map.contains_key(id) {
-            Self::evict_to_capacity(&mut map, self.config.max_entries.saturating_sub(1));
-            map.insert(
-                id.to_string(),
-                Entry {
-                    transcript: ConversationTranscript::default(),
-                    inserted_at: now,
-                    last_accessed: now,
-                },
-            );
-        }
-        let entry = map.get_mut(id).expect("inserted above");
+        let mut state = self.write_guard();
+        Self::sweep_expired(&mut state, &self.config, now);
+        let mut entry = Self::remove_entry(&mut state, id).unwrap_or_else(|| Entry {
+            transcript: ConversationTranscript::default(),
+            inserted_at: now,
+            last_accessed: now,
+            size_bytes: 0,
+            lru_key: LruKey {
+                last_accessed: now,
+                sequence: 0,
+                id: id.to_string(),
+            },
+        });
         entry.transcript.items.extend(items);
         entry.last_accessed = now;
+        entry.size_bytes = Self::transcript_size_bytes(id, &entry.transcript);
+        entry.lru_key = Self::next_lru_key(&mut state, id, now);
+        state.total_bytes = state.total_bytes.saturating_add(entry.size_bytes);
+        state.lru.insert(entry.lru_key.clone());
+        state.entries.insert(id.to_string(), entry);
+        Self::evict_to_limits(&mut state, &self.config);
     }
 
     pub fn remove(&self, id: &str) -> Option<ConversationTranscript> {
-        let mut map = self.write_guard();
-        map.remove(id).map(|e| e.transcript)
+        let mut state = self.write_guard();
+        Self::remove_entry(&mut state, id).map(|e| e.transcript)
     }
 
     pub fn len(&self) -> usize {
         match self.inner.read() {
-            Ok(g) => g.len(),
-            Err(poisoned) => poisoned.into_inner().len(),
+            Ok(g) => g.entries.len(),
+            Err(poisoned) => poisoned.into_inner().entries.len(),
         }
     }
 
@@ -128,43 +169,74 @@ impl ConversationStore {
         self.len() == 0
     }
 
-    fn write_guard(&self) -> std::sync::RwLockWriteGuard<'_, HashMap<String, Entry>> {
+    /// Approximate retained bytes currently accounted by the store.
+    pub fn approximate_total_bytes(&self) -> usize {
+        match self.inner.read() {
+            Ok(g) => g.total_bytes,
+            Err(poisoned) => poisoned.into_inner().total_bytes,
+        }
+    }
+
+    fn write_guard(&self) -> std::sync::RwLockWriteGuard<'_, StoreState> {
         match self.inner.write() {
             Ok(g) => g,
             Err(poisoned) => poisoned.into_inner(),
         }
     }
 
-    fn sweep_expired(
-        map: &mut HashMap<String, Entry>,
-        config: &ConversationStoreConfig,
-        now: Instant,
-    ) {
+    fn sweep_expired(state: &mut StoreState, config: &ConversationStoreConfig, now: Instant) {
         let ttl = config.ttl;
-        map.retain(|_, entry| now.saturating_duration_since(entry.inserted_at) < ttl);
+        let expired: Vec<String> = state
+            .entries
+            .iter()
+            .filter(|(_, entry)| now.saturating_duration_since(entry.inserted_at) >= ttl)
+            .map(|(id, _)| id.clone())
+            .collect();
+        for id in expired {
+            Self::remove_entry(state, &id);
+        }
     }
 
-    fn evict_to_capacity(map: &mut HashMap<String, Entry>, target_size: usize) {
-        while map.len() > target_size {
-            // The key component makes the comparator a TOTAL order: `map`
-            // iterates in `HashMap` order, which `RandomState` randomizes
-            // per instance, and without this tie-break two entries sharing
-            // `last_accessed` would resolve to whichever one hash order
-            // placed first. Comparator form avoids cloning the key that
-            // `min_by_key` would need to fold it into a tuple.
-            let Some(victim) = map
-                .iter()
-                .min_by(|(key_a, a), (key_b, b)| {
-                    a.last_accessed
-                        .cmp(&b.last_accessed)
-                        .then_with(|| key_a.cmp(key_b))
-                })
-                .map(|(k, _)| k.clone())
-            else {
+    fn evict_to_limits(state: &mut StoreState, config: &ConversationStoreConfig) {
+        while state.entries.len() > config.max_entries || state.total_bytes > config.max_bytes {
+            let Some(victim) = state.lru.iter().next().cloned().map(|key| key.id) else {
                 break;
             };
-            map.remove(&victim);
+            Self::remove_entry(state, &victim);
         }
+    }
+
+    fn remove_entry(state: &mut StoreState, id: &str) -> Option<Entry> {
+        let entry = state.entries.remove(id)?;
+        state.lru.remove(&entry.lru_key);
+        state.total_bytes = state.total_bytes.saturating_sub(entry.size_bytes);
+        Some(entry)
+    }
+
+    fn next_lru_key(state: &mut StoreState, id: &str, now: Instant) -> LruKey {
+        let sequence = state.next_sequence;
+        state.next_sequence = state.next_sequence.wrapping_add(1);
+        LruKey {
+            last_accessed: now,
+            sequence,
+            id: id.to_string(),
+        }
+    }
+
+    fn transcript_size_bytes(id: &str, transcript: &ConversationTranscript) -> usize {
+        id.len()
+            .saturating_add(transcript.items.iter().fold(2usize, |bytes, item| {
+                bytes
+                    .saturating_add(conversation_item_size_bytes(item))
+                    .saturating_add(1)
+            }))
+    }
+}
+
+fn conversation_item_size_bytes(item: &ConversationItem) -> usize {
+    match item {
+        ConversationItem::Input(input) => response_input_item_size_bytes(input),
+        ConversationItem::Output(output) => serialized_json_len_saturating(output),
     }
 }
 
@@ -179,6 +251,37 @@ mod tests {
             content: ResponseInputContent::Text(text.to_string()),
             name: None,
         }
+    }
+
+    fn config(max_entries: usize, max_bytes: usize) -> ConversationStoreConfig {
+        ConversationStoreConfig {
+            max_entries,
+            max_bytes,
+            ttl: Duration::from_secs(3600),
+        }
+    }
+
+    fn transcript_with(text: &str) -> ConversationTranscript {
+        ConversationTranscript {
+            items: vec![ConversationItem::Input(user_input(text))],
+        }
+    }
+
+    fn transcript_bytes(id: &str, text: &str) -> usize {
+        ConversationStore::transcript_size_bytes(id, &transcript_with(text))
+    }
+
+    fn assert_indexes_consistent(store: &ConversationStore) {
+        let state = store.inner.read().expect("conversation store state lock");
+        let summed = state.entries.values().fold(0usize, |bytes, entry| {
+            assert!(
+                state.lru.contains(&entry.lru_key),
+                "entry missing from LRU index"
+            );
+            bytes.saturating_add(entry.size_bytes)
+        });
+        assert_eq!(state.lru.len(), state.entries.len());
+        assert_eq!(state.total_bytes, summed);
     }
 
     #[test]
@@ -209,6 +312,7 @@ mod tests {
         let store = ConversationStore::new(ConversationStoreConfig {
             max_entries: 8,
             ttl: Duration::from_millis(10),
+            ..ConversationStoreConfig::default()
         });
         store.append("conv_a", vec![ConversationItem::Input(user_input("hi"))]);
         std::thread::sleep(Duration::from_millis(20));
@@ -222,6 +326,7 @@ mod tests {
         let store = ConversationStore::new(ConversationStoreConfig {
             max_entries: 2,
             ttl: Duration::from_secs(3600),
+            ..ConversationStoreConfig::default()
         });
         store.append("a", vec![ConversationItem::Input(user_input("hi"))]);
         store.append("b", vec![ConversationItem::Input(user_input("hi"))]);
@@ -238,5 +343,156 @@ mod tests {
         let store = ConversationStore::new(ConversationStoreConfig::default());
         store.append("conv", vec![]);
         assert_eq!(store.len(), 0);
+    }
+
+    #[test]
+    fn byte_only_eviction_runs_under_entry_cap() {
+        let budget = transcript_bytes("a", &"a".repeat(64))
+            .saturating_add(transcript_bytes("b", &"b".repeat(64)));
+        let store = ConversationStore::new(config(10, budget));
+
+        store.append(
+            "a",
+            vec![ConversationItem::Input(user_input(&"a".repeat(64)))],
+        );
+        store.append(
+            "b",
+            vec![ConversationItem::Input(user_input(&"b".repeat(64)))],
+        );
+        std::thread::sleep(Duration::from_millis(2));
+        let _ = store.get("a");
+        store.append(
+            "c",
+            vec![ConversationItem::Input(user_input(&"c".repeat(64)))],
+        );
+
+        assert!(store.get("a").is_some(), "recently accessed entry remains");
+        assert!(store.get("c").is_some(), "new entry remains");
+        assert!(
+            store.get("b").is_none(),
+            "byte pressure evicts the LRU entry"
+        );
+        assert!(store.approximate_total_bytes() <= budget);
+        assert_indexes_consistent(&store);
+    }
+
+    #[test]
+    fn simultaneous_count_and_byte_pressure_evicts_to_both_limits() {
+        let budget = transcript_bytes("b", &"b".repeat(32))
+            .saturating_add(transcript_bytes("c", &"c".repeat(32)));
+        let store = ConversationStore::new(config(2, budget));
+
+        store.append(
+            "a",
+            vec![ConversationItem::Input(user_input(&"a".repeat(32)))],
+        );
+        store.append(
+            "b",
+            vec![ConversationItem::Input(user_input(&"b".repeat(32)))],
+        );
+        store.append(
+            "c",
+            vec![ConversationItem::Input(user_input(&"c".repeat(32)))],
+        );
+
+        assert_eq!(store.len(), 2);
+        assert!(store.get("a").is_none(), "oldest entry is evicted");
+        assert!(store.get("b").is_some());
+        assert!(store.get("c").is_some());
+        assert!(store.approximate_total_bytes() <= budget);
+        assert_indexes_consistent(&store);
+    }
+
+    #[test]
+    fn oversized_single_conversation_is_not_retained() {
+        let size = transcript_bytes("large", &"x".repeat(256));
+        let store = ConversationStore::new(config(10, size.saturating_sub(1)));
+
+        store.append(
+            "large",
+            vec![ConversationItem::Input(user_input(&"x".repeat(256)))],
+        );
+
+        assert!(store.get("large").is_none());
+        assert_eq!(store.approximate_total_bytes(), 0);
+        assert_indexes_consistent(&store);
+    }
+
+    #[test]
+    fn exact_byte_boundary_is_retained() {
+        let text = "x".repeat(64);
+        let size = transcript_bytes("edge", &text);
+        let store = ConversationStore::new(config(1, size));
+
+        store.append("edge", vec![ConversationItem::Input(user_input(&text))]);
+
+        assert!(store.get("edge").is_some());
+        assert_eq!(store.len(), 1);
+        assert_indexes_consistent(&store);
+    }
+
+    #[test]
+    fn appending_existing_transcript_updates_running_total_and_lru_index() {
+        let first = "first";
+        let second = "second".repeat(32);
+        let combined = ConversationTranscript {
+            items: vec![
+                ConversationItem::Input(user_input(first)),
+                ConversationItem::Input(user_input(&second)),
+            ],
+        };
+        let budget = ConversationStore::transcript_size_bytes("same", &combined);
+        let store = ConversationStore::new(config(4, budget));
+
+        store.append("same", vec![ConversationItem::Input(user_input(first))]);
+        store.append("same", vec![ConversationItem::Input(user_input(&second))]);
+
+        assert_eq!(store.len(), 1);
+        assert_eq!(store.approximate_total_bytes(), budget);
+        assert_eq!(store.get("same").unwrap().items.len(), 2);
+        assert!(store.remove("same").is_some());
+        assert_eq!(store.approximate_total_bytes(), 0);
+        assert_indexes_consistent(&store);
+    }
+
+    #[test]
+    fn zero_byte_budget_keeps_store_enabled_but_retains_nothing() {
+        let store = ConversationStore::new(config(usize::MAX, 0));
+        store.append("a", vec![ConversationItem::Input(user_input("hi"))]);
+
+        assert_eq!(store.len(), 0);
+        assert!(store.get("a").is_none());
+        assert_eq!(store.approximate_total_bytes(), 0);
+        assert_indexes_consistent(&store);
+    }
+
+    #[test]
+    fn extreme_budgets_do_not_overflow_or_preallocate_unbounded_capacity() {
+        let store = ConversationStore::new(config(usize::MAX, usize::MAX));
+        store.append("a", vec![ConversationItem::Input(user_input("small"))]);
+
+        assert_eq!(store.len(), 1);
+        assert!(store.approximate_total_bytes() > 0);
+        assert_indexes_consistent(&store);
+    }
+
+    #[test]
+    fn running_total_stays_consistent_across_remove_and_ttl_sweep() {
+        let store = ConversationStore::new(ConversationStoreConfig {
+            max_entries: 8,
+            max_bytes: DEFAULT_CONVERSATION_STORE_MAX_BYTES,
+            ttl: Duration::from_millis(10),
+        });
+        store.append("a", vec![ConversationItem::Input(user_input("first"))]);
+        store.append("b", vec![ConversationItem::Input(user_input("second"))]);
+        assert!(store.remove("a").is_some());
+        assert_indexes_consistent(&store);
+
+        std::thread::sleep(Duration::from_millis(20));
+        store.append("c", vec![ConversationItem::Input(user_input("third"))]);
+
+        assert!(store.get("b").is_none());
+        assert!(store.get("c").is_some());
+        assert_indexes_consistent(&store);
     }
 }

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -66,6 +66,7 @@ pub mod slots_state;
 pub mod speculative_dispatch;
 mod startup;
 mod state;
+mod store_budget;
 pub(crate) mod stream_session;
 mod streaming;
 pub mod streaming_anthropic;

--- a/src/server/responses_store.rs
+++ b/src/server/responses_store.rs
@@ -15,8 +15,8 @@
 //! In-memory store for OpenAI Responses API objects.
 //!
 //! Phase 1 keeps the store entirely in-process: a synchronous
-//! [`std::sync::RwLock`] guards a `HashMap<id, Entry>` with an LRU eviction
-//! list and a TTL sweep on every insert/lookup. The store is wired into
+//! [`std::sync::RwLock`] guards a `HashMap<id, Entry>` plus an access-ordered
+//! LRU index and a TTL sweep on every insert/lookup. The store is wired into
 //! [`crate::server::state::AppState`] when `store=true` requests are
 //! allowed; persistence across restarts is reserved for Phase 3.
 //!
@@ -27,14 +27,27 @@
 //!   reference `previous_response_id`.
 //! - Delete on `DELETE /v1/responses/:id` and by the LRU/TTL sweep.
 
-use std::collections::HashMap;
+use std::collections::{BTreeSet, HashMap};
 use std::sync::Arc;
 use std::sync::RwLock;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::time::{Duration, Instant};
 
-use crate::server::types::responses_request::ResponseInputItem;
+use crate::server::store_budget::{LruKey, serialized_json_len_saturating};
+use crate::server::types::responses_request::{
+    ResponseInputContent, ResponseInputItem, ResponseInputPart, ResponseInputRole,
+    ResponseToolOutput,
+};
 use crate::server::types::responses_response::ResponseObject;
+
+/// Default approximate retained-byte budget for the in-memory response store.
+///
+/// This keeps the default bounded below the historical "1024 arbitrary
+/// multimodal entries" footprint while leaving room for several max-size image
+/// requests inside the one-hour TTL window.
+pub const DEFAULT_RESPONSES_STORE_MAX_BYTES: usize = 256 * 1024 * 1024;
+
+const INITIAL_HASH_CAPACITY_LIMIT: usize = 4096;
 
 /// Persisted entry. Inputs and outputs are kept separately so the
 /// chain-resolution path can reconstruct the original conversation
@@ -50,12 +63,34 @@ struct Entry {
     payload: StoredResponse,
     inserted_at: Instant,
     last_accessed: Instant,
+    size_bytes: usize,
+    lru_key: LruKey,
+}
+
+#[derive(Debug)]
+struct StoreState {
+    entries: HashMap<String, Entry>,
+    lru: BTreeSet<LruKey>,
+    total_bytes: usize,
+    next_sequence: u64,
+}
+
+impl StoreState {
+    fn with_capacity(max_entries: usize) -> Self {
+        Self {
+            entries: HashMap::with_capacity(max_entries.min(INITIAL_HASH_CAPACITY_LIMIT)),
+            lru: BTreeSet::new(),
+            total_bytes: 0,
+            next_sequence: 0,
+        }
+    }
 }
 
 /// Configuration for [`ResponsesStore`].
 #[derive(Debug, Clone)]
 pub struct ResponsesStoreConfig {
     pub max_entries: usize,
+    pub max_bytes: usize,
     pub ttl: Duration,
 }
 
@@ -63,6 +98,7 @@ impl Default for ResponsesStoreConfig {
     fn default() -> Self {
         Self {
             max_entries: 1024,
+            max_bytes: DEFAULT_RESPONSES_STORE_MAX_BYTES,
             ttl: Duration::from_secs(3600),
         }
     }
@@ -79,7 +115,7 @@ pub type InFlightToken = Arc<AtomicBool>;
 
 /// Thread-safe response store with TTL and LRU eviction.
 pub struct ResponsesStore {
-    inner: RwLock<HashMap<String, Entry>>,
+    inner: RwLock<StoreState>,
     config: ResponsesStoreConfig,
     /// Map of `response_id → cancellation token` for streaming responses
     /// that have not yet completed. The streaming route inserts on
@@ -91,7 +127,7 @@ pub struct ResponsesStore {
 impl ResponsesStore {
     pub fn new(config: ResponsesStoreConfig) -> Self {
         Self {
-            inner: RwLock::new(HashMap::with_capacity(config.max_entries)),
+            inner: RwLock::new(StoreState::with_capacity(config.max_entries)),
             config,
             in_flight: RwLock::new(HashMap::new()),
         }
@@ -154,65 +190,70 @@ impl ResponsesStore {
         self.in_flight.write()
     }
 
-    /// Insert a response. Evicts expired and LRU entries first to keep
-    /// the map size at-or-below `max_entries`. Returns the count of
+    /// Insert a response. Evicts expired and LRU entries to keep both
+    /// entry count and approximate retained bytes under budget. Returns the count of
     /// remaining entries after the insert for tests/telemetry.
     pub fn insert(&self, id: String, payload: StoredResponse) -> usize {
         let now = Instant::now();
-        let mut map = match self.inner.write() {
+        let mut state = match self.inner.write() {
             Ok(g) => g,
             Err(poisoned) => poisoned.into_inner(),
         };
-        Self::sweep_expired(&mut map, &self.config, now);
-        Self::evict_to_capacity(&mut map, self.config.max_entries.saturating_sub(1));
-        map.insert(
+        Self::sweep_expired(&mut state, &self.config, now);
+        Self::remove_entry(&mut state, &id);
+
+        let size_bytes = Self::entry_size_bytes(&id, &payload);
+        let lru_key = Self::next_lru_key(&mut state, &id, now);
+        state.total_bytes = state.total_bytes.saturating_add(size_bytes);
+        state.lru.insert(lru_key.clone());
+        state.entries.insert(
             id,
             Entry {
                 payload,
                 inserted_at: now,
                 last_accessed: now,
+                size_bytes,
+                lru_key,
             },
         );
-        map.len()
+        Self::evict_to_limits(&mut state, &self.config);
+        state.entries.len()
     }
 
     /// Look up a stored response. Refreshes the entry's LRU stamp.
     /// Returns `None` for missing or expired entries.
     pub fn get(&self, id: &str) -> Option<StoredResponse> {
         let now = Instant::now();
-        // First take a read lock to check existence/freshness without
-        // taking the more expensive write lock on every lookup.
-        if let Ok(guard) = self.inner.read()
-            && let Some(entry) = guard.get(id)
-            && now.saturating_duration_since(entry.inserted_at) >= self.config.ttl
-        {
-            // Fall through to the write-lock branch to evict.
-        }
-
-        let mut map = match self.inner.write() {
+        let mut state = match self.inner.write() {
             Ok(g) => g,
             Err(poisoned) => poisoned.into_inner(),
         };
-        Self::sweep_expired(&mut map, &self.config, now);
-        let entry = map.get_mut(id)?;
+        Self::sweep_expired(&mut state, &self.config, now);
+        let old_lru_key = state.entries.get(id)?.lru_key.clone();
+        state.lru.remove(&old_lru_key);
+        let lru_key = Self::next_lru_key(&mut state, id, now);
+        let entry = state.entries.get_mut(id)?;
         entry.last_accessed = now;
-        Some(entry.payload.clone())
+        entry.lru_key = lru_key.clone();
+        let payload = entry.payload.clone();
+        state.lru.insert(lru_key);
+        Some(payload)
     }
 
     /// Remove an entry. Returns the previous value when present.
     pub fn remove(&self, id: &str) -> Option<StoredResponse> {
-        let mut map = match self.inner.write() {
+        let mut state = match self.inner.write() {
             Ok(g) => g,
             Err(poisoned) => poisoned.into_inner(),
         };
-        map.remove(id).map(|e| e.payload)
+        Self::remove_entry(&mut state, id).map(|e| e.payload)
     }
 
     /// Current number of live entries (snapshot).
     pub fn len(&self) -> usize {
         match self.inner.read() {
-            Ok(g) => g.len(),
-            Err(poisoned) => poisoned.into_inner().len(),
+            Ok(g) => g.entries.len(),
+            Err(poisoned) => poisoned.into_inner().entries.len(),
         }
     }
 
@@ -225,44 +266,170 @@ impl ResponsesStore {
         &self.config
     }
 
-    fn sweep_expired(
-        map: &mut HashMap<String, Entry>,
-        config: &ResponsesStoreConfig,
-        now: Instant,
-    ) {
-        let ttl = config.ttl;
-        map.retain(|_, entry| now.saturating_duration_since(entry.inserted_at) < ttl);
-    }
-
-    fn evict_to_capacity(map: &mut HashMap<String, Entry>, target_size: usize) {
-        while map.len() > target_size {
-            // Pick the least-recently-accessed entry. O(n) per eviction;
-            // acceptable for Phase 1's expected store sizes (≤1024). The
-            // key component makes the comparator a TOTAL order: `map`
-            // iterates in `HashMap` order, which `RandomState` randomizes
-            // per instance, and without this tie-break two entries sharing
-            // `last_accessed` would resolve to whichever one hash order
-            // placed first. Comparator form avoids cloning the key that
-            // `min_by_key` would need to fold it into a tuple.
-            let Some(victim) = map
-                .iter()
-                .min_by(|(key_a, a), (key_b, b)| {
-                    a.last_accessed
-                        .cmp(&b.last_accessed)
-                        .then_with(|| key_a.cmp(key_b))
-                })
-                .map(|(k, _)| k.clone())
-            else {
-                break;
-            };
-            map.remove(&victim);
+    /// Approximate retained bytes currently accounted by the store.
+    pub fn approximate_total_bytes(&self) -> usize {
+        match self.inner.read() {
+            Ok(g) => g.total_bytes,
+            Err(poisoned) => poisoned.into_inner().total_bytes,
         }
     }
+
+    fn sweep_expired(state: &mut StoreState, config: &ResponsesStoreConfig, now: Instant) {
+        let ttl = config.ttl;
+        let expired: Vec<String> = state
+            .entries
+            .iter()
+            .filter(|(_, entry)| now.saturating_duration_since(entry.inserted_at) >= ttl)
+            .map(|(id, _)| id.clone())
+            .collect();
+        for id in expired {
+            Self::remove_entry(state, &id);
+        }
+    }
+
+    fn evict_to_limits(state: &mut StoreState, config: &ResponsesStoreConfig) {
+        while state.entries.len() > config.max_entries || state.total_bytes > config.max_bytes {
+            let Some(victim) = state.lru.iter().next().cloned().map(|key| key.id) else {
+                break;
+            };
+            Self::remove_entry(state, &victim);
+        }
+    }
+
+    fn remove_entry(state: &mut StoreState, id: &str) -> Option<Entry> {
+        let entry = state.entries.remove(id)?;
+        state.lru.remove(&entry.lru_key);
+        state.total_bytes = state.total_bytes.saturating_sub(entry.size_bytes);
+        Some(entry)
+    }
+
+    fn next_lru_key(state: &mut StoreState, id: &str, now: Instant) -> LruKey {
+        let sequence = state.next_sequence;
+        state.next_sequence = state.next_sequence.wrapping_add(1);
+        LruKey {
+            last_accessed: now,
+            sequence,
+            id: id.to_string(),
+        }
+    }
+
+    fn entry_size_bytes(id: &str, payload: &StoredResponse) -> usize {
+        id.len()
+            .saturating_add(serialized_json_len_saturating(&payload.response))
+            .saturating_add(input_items_size_bytes(&payload.input_items))
+    }
+}
+
+fn input_items_size_bytes(items: &[ResponseInputItem]) -> usize {
+    items.iter().fold(2usize, |bytes, item| {
+        bytes
+            .saturating_add(response_input_item_size_bytes(item))
+            .saturating_add(1)
+    })
+}
+
+pub(crate) fn response_input_item_size_bytes(item: &ResponseInputItem) -> usize {
+    match item {
+        ResponseInputItem::Message {
+            role,
+            content,
+            name,
+        } => 48usize
+            .saturating_add(response_role_size_bytes(*role))
+            .saturating_add(response_input_content_size_bytes(content))
+            .saturating_add(name.as_deref().map(str_size_bytes).unwrap_or(0)),
+        ResponseInputItem::FunctionCall {
+            call_id,
+            name,
+            arguments,
+        } => 56usize
+            .saturating_add(str_size_bytes(call_id))
+            .saturating_add(str_size_bytes(name))
+            .saturating_add(str_size_bytes(arguments)),
+        ResponseInputItem::FunctionCallOutput { call_id, output } => 56usize
+            .saturating_add(str_size_bytes(call_id))
+            .saturating_add(response_tool_output_size_bytes(output)),
+        ResponseInputItem::Reasoning { content } => content.iter().fold(32usize, |bytes, part| {
+            bytes
+                .saturating_add(str_size_bytes(&part.part_type))
+                .saturating_add(str_size_bytes(&part.text))
+                .saturating_add(16)
+        }),
+    }
+}
+
+fn response_role_size_bytes(role: ResponseInputRole) -> usize {
+    match role {
+        ResponseInputRole::User => 4,
+        ResponseInputRole::Assistant => 9,
+        ResponseInputRole::System => 6,
+        ResponseInputRole::Developer => 9,
+    }
+}
+
+fn response_input_content_size_bytes(content: &ResponseInputContent) -> usize {
+    match content {
+        ResponseInputContent::Text(text) => str_size_bytes(text),
+        ResponseInputContent::Parts(parts) => parts.iter().fold(2usize, |bytes, part| {
+            bytes
+                .saturating_add(response_input_part_size_bytes(part))
+                .saturating_add(1)
+        }),
+    }
+}
+
+fn response_input_part_size_bytes(part: &ResponseInputPart) -> usize {
+    match part {
+        ResponseInputPart::InputText { text } | ResponseInputPart::Text { text } => {
+            32usize.saturating_add(str_size_bytes(text))
+        }
+        ResponseInputPart::InputImage {
+            image_url,
+            detail,
+            file_id,
+        } => 48usize
+            .saturating_add(image_url.as_deref().map(str_size_bytes).unwrap_or(0))
+            .saturating_add(detail.as_deref().map(str_size_bytes).unwrap_or(0))
+            .saturating_add(file_id.as_deref().map(str_size_bytes).unwrap_or(0)),
+        ResponseInputPart::InputFile { raw }
+        | ResponseInputPart::VideoUrl { raw }
+        | ResponseInputPart::InputAudio { raw } => {
+            32usize.saturating_add(serialized_json_len_saturating(raw))
+        }
+        ResponseInputPart::ImageUrl { image_url } => 40usize
+            .saturating_add(str_size_bytes(&image_url.url))
+            .saturating_add(image_url.detail.as_deref().map(str_size_bytes).unwrap_or(0))
+            .saturating_add(
+                image_url
+                    .max_soft_tokens
+                    .map(|value| serialized_json_len_saturating(&value))
+                    .unwrap_or(0),
+            ),
+        ResponseInputPart::Unknown { part_type, raw } => 32usize
+            .saturating_add(str_size_bytes(part_type))
+            .saturating_add(serialized_json_len_saturating(raw)),
+    }
+}
+
+fn response_tool_output_size_bytes(output: &ResponseToolOutput) -> usize {
+    match output {
+        ResponseToolOutput::Text(text) => str_size_bytes(text),
+        ResponseToolOutput::Parts(parts) => parts.iter().fold(2usize, |bytes, part| {
+            bytes
+                .saturating_add(response_input_part_size_bytes(part))
+                .saturating_add(1)
+        }),
+    }
+}
+
+fn str_size_bytes(value: &str) -> usize {
+    serialized_json_len_saturating(value)
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::server::types::responses_request::{ResponseInputContent, ResponseInputRole};
     use crate::server::types::responses_response::{ResponseStatus, ResponseUsage};
 
     fn make_response(id: &str) -> StoredResponse {
@@ -309,6 +476,41 @@ mod tests {
         }
     }
 
+    fn make_response_with_input(id: &str, text: &str) -> StoredResponse {
+        let mut response = make_response(id);
+        response.input_items.push(ResponseInputItem::Message {
+            role: ResponseInputRole::User,
+            content: ResponseInputContent::Text(text.to_string()),
+            name: None,
+        });
+        response
+    }
+
+    fn config(max_entries: usize, max_bytes: usize) -> ResponsesStoreConfig {
+        ResponsesStoreConfig {
+            max_entries,
+            max_bytes,
+            ttl: Duration::from_secs(3600),
+        }
+    }
+
+    fn entry_bytes(id: &str, payload: &StoredResponse) -> usize {
+        ResponsesStore::entry_size_bytes(id, payload)
+    }
+
+    fn assert_indexes_consistent(store: &ResponsesStore) {
+        let state = store.inner.read().expect("store state lock");
+        let summed = state.entries.values().fold(0usize, |bytes, entry| {
+            assert!(
+                state.lru.contains(&entry.lru_key),
+                "entry missing from LRU index"
+            );
+            bytes.saturating_add(entry.size_bytes)
+        });
+        assert_eq!(state.lru.len(), state.entries.len());
+        assert_eq!(state.total_bytes, summed);
+    }
+
     #[test]
     fn insert_then_get_returns_payload() {
         let store = ResponsesStore::new(ResponsesStoreConfig::default());
@@ -331,6 +533,7 @@ mod tests {
         let store = ResponsesStore::new(ResponsesStoreConfig {
             max_entries: 2,
             ttl: Duration::from_secs(3600),
+            ..ResponsesStoreConfig::default()
         });
         store.insert("a".to_string(), make_response("a"));
         store.insert("b".to_string(), make_response("b"));
@@ -348,6 +551,7 @@ mod tests {
         let store = ResponsesStore::new(ResponsesStoreConfig {
             max_entries: 10,
             ttl: Duration::from_millis(10),
+            ..ResponsesStoreConfig::default()
         });
         store.insert("a".to_string(), make_response("a"));
         std::thread::sleep(Duration::from_millis(20));
@@ -393,5 +597,133 @@ mod tests {
             .insert("resp_stream".to_string(), token);
         store.unregister_in_flight("resp_stream");
         assert!(!store.cancel_in_flight("resp_stream"));
+    }
+
+    #[test]
+    fn byte_only_eviction_runs_under_entry_cap() {
+        let a = make_response_with_input("a", &"a".repeat(64));
+        let b = make_response_with_input("b", &"b".repeat(64));
+        let c = make_response_with_input("c", &"c".repeat(64));
+        let budget = entry_bytes("a", &a).saturating_add(entry_bytes("b", &b));
+        let store = ResponsesStore::new(config(10, budget));
+
+        store.insert("a".to_string(), a);
+        store.insert("b".to_string(), b);
+        std::thread::sleep(Duration::from_millis(2));
+        let _ = store.get("a");
+        store.insert("c".to_string(), c);
+
+        assert!(store.get("a").is_some(), "recently accessed entry remains");
+        assert!(store.get("c").is_some(), "new entry remains");
+        assert!(
+            store.get("b").is_none(),
+            "byte pressure evicts the LRU entry"
+        );
+        assert!(store.approximate_total_bytes() <= budget);
+        assert_indexes_consistent(&store);
+    }
+
+    #[test]
+    fn simultaneous_count_and_byte_pressure_evicts_to_both_limits() {
+        let a = make_response_with_input("a", &"a".repeat(32));
+        let b = make_response_with_input("b", &"b".repeat(32));
+        let c = make_response_with_input("c", &"c".repeat(32));
+        let budget = entry_bytes("b", &b).saturating_add(entry_bytes("c", &c));
+        let store = ResponsesStore::new(config(2, budget));
+
+        store.insert("a".to_string(), a);
+        store.insert("b".to_string(), b);
+        store.insert("c".to_string(), c);
+
+        assert_eq!(store.len(), 2);
+        assert!(store.get("a").is_none(), "oldest entry is evicted");
+        assert!(store.get("b").is_some());
+        assert!(store.get("c").is_some());
+        assert!(store.approximate_total_bytes() <= budget);
+        assert_indexes_consistent(&store);
+    }
+
+    #[test]
+    fn oversized_single_response_is_not_retained() {
+        let payload = make_response_with_input("large", &"x".repeat(256));
+        let size = entry_bytes("large", &payload);
+        let store = ResponsesStore::new(config(10, size.saturating_sub(1)));
+
+        assert_eq!(store.insert("large".to_string(), payload), 0);
+
+        assert!(store.get("large").is_none());
+        assert_eq!(store.approximate_total_bytes(), 0);
+        assert_indexes_consistent(&store);
+    }
+
+    #[test]
+    fn exact_byte_boundary_is_retained() {
+        let payload = make_response_with_input("edge", &"x".repeat(64));
+        let size = entry_bytes("edge", &payload);
+        let store = ResponsesStore::new(config(1, size));
+
+        assert_eq!(store.insert("edge".to_string(), payload), 1);
+
+        assert!(store.get("edge").is_some());
+        assert_eq!(store.len(), 1);
+        assert_indexes_consistent(&store);
+    }
+
+    #[test]
+    fn replacement_updates_running_total_and_lru_index() {
+        let small = make_response_with_input("same", "small");
+        let large = make_response_with_input("same", &"x".repeat(128));
+        let large_size = entry_bytes("same", &large);
+        let store = ResponsesStore::new(config(4, large_size));
+
+        store.insert("same".to_string(), small);
+        store.insert("same".to_string(), large);
+
+        assert_eq!(store.len(), 1);
+        assert_eq!(store.approximate_total_bytes(), large_size);
+        assert!(store.remove("same").is_some());
+        assert_eq!(store.approximate_total_bytes(), 0);
+        assert_indexes_consistent(&store);
+    }
+
+    #[test]
+    fn zero_byte_budget_keeps_store_enabled_but_retains_nothing() {
+        let store = ResponsesStore::new(config(usize::MAX, 0));
+        store.insert("a".to_string(), make_response("a"));
+
+        assert_eq!(store.len(), 0);
+        assert!(store.get("a").is_none());
+        assert_eq!(store.approximate_total_bytes(), 0);
+        assert_indexes_consistent(&store);
+    }
+
+    #[test]
+    fn extreme_budgets_do_not_overflow_or_preallocate_unbounded_capacity() {
+        let store = ResponsesStore::new(config(usize::MAX, usize::MAX));
+        store.insert("a".to_string(), make_response_with_input("a", "small"));
+
+        assert_eq!(store.len(), 1);
+        assert!(store.approximate_total_bytes() > 0);
+        assert_indexes_consistent(&store);
+    }
+
+    #[test]
+    fn running_total_stays_consistent_across_remove_and_ttl_sweep() {
+        let store = ResponsesStore::new(ResponsesStoreConfig {
+            max_entries: 8,
+            max_bytes: DEFAULT_RESPONSES_STORE_MAX_BYTES,
+            ttl: Duration::from_millis(10),
+        });
+        store.insert("a".to_string(), make_response_with_input("a", "first"));
+        store.insert("b".to_string(), make_response_with_input("b", "second"));
+        assert!(store.remove("a").is_some());
+        assert_indexes_consistent(&store);
+
+        std::thread::sleep(Duration::from_millis(20));
+        store.insert("c".to_string(), make_response_with_input("c", "third"));
+
+        assert!(store.get("b").is_none());
+        assert!(store.get("c").is_some());
+        assert_indexes_consistent(&store);
     }
 }

--- a/src/server/startup.rs
+++ b/src/server/startup.rs
@@ -472,6 +472,11 @@ pub struct ServerStartupConfig {
     /// and `previous_response_id` return 400. Resolved from
     /// `--responses-store-max-entries` / `LLAMA_ARG_RESPONSES_STORE_MAX_ENTRIES`.
     pub responses_store_max_entries: usize,
+    /// Approximate byte budget for the in-memory response store.
+    /// `0` keeps the store enabled but makes every stored response immediately
+    /// evict itself after insertion. Resolved from
+    /// `--responses-store-max-bytes` / `MLXCEL_RESPONSES_STORE_MAX_BYTES`.
+    pub responses_store_max_bytes: usize,
     /// TTL (seconds) for in-memory response store entries.
     /// `0` disables TTL (entries are evicted only by capacity pressure).
     /// Resolved from `--responses-store-ttl-secs` / `LLAMA_ARG_RESPONSES_STORE_TTL_SECS`.
@@ -480,6 +485,11 @@ pub struct ServerStartupConfig {
     /// `0` disables the store; requests referencing `conversation` still
     /// succeed but operate as if the transcript is empty.
     pub conversation_store_max_entries: usize,
+    /// Approximate byte budget for the in-memory conversation store.
+    /// `0` keeps the store enabled but makes every transcript immediately
+    /// evict itself after append. Resolved from
+    /// `--conversation-store-max-bytes` / `MLXCEL_CONVERSATION_STORE_MAX_BYTES`.
+    pub conversation_store_max_bytes: usize,
     /// TTL (seconds) for conversation transcripts. `0`
     /// disables TTL.
     pub conversation_store_ttl_secs: u64,
@@ -683,8 +693,11 @@ impl Default for ServerStartupConfig {
             // `--kv-cache-budget none`.
             kv_cache_budget: Some(crate::memory_estimate::PagedBudgetDirective::Auto),
             responses_store_max_entries: 1024,
+            responses_store_max_bytes: super::responses_store::DEFAULT_RESPONSES_STORE_MAX_BYTES,
             responses_store_ttl_secs: 3600,
             conversation_store_max_entries: 256,
+            conversation_store_max_bytes:
+                super::conversation_store::DEFAULT_CONVERSATION_STORE_MAX_BYTES,
             conversation_store_ttl_secs: 3600,
             #[cfg(feature = "surgery")]
             surgery_config_path: None,
@@ -2734,6 +2747,7 @@ pub async fn start_server(mut startup: ServerStartupConfig) -> Result<()> {
         Some(Arc::new(super::responses_store::ResponsesStore::new(
             super::responses_store::ResponsesStoreConfig {
                 max_entries: startup.responses_store_max_entries,
+                max_bytes: startup.responses_store_max_bytes,
                 ttl,
             },
         )))
@@ -2749,6 +2763,7 @@ pub async fn start_server(mut startup: ServerStartupConfig) -> Result<()> {
         Some(Arc::new(super::conversation_store::ConversationStore::new(
             super::conversation_store::ConversationStoreConfig {
                 max_entries: startup.conversation_store_max_entries,
+                max_bytes: startup.conversation_store_max_bytes,
                 ttl,
             },
         )))

--- a/src/server/store_budget.rs
+++ b/src/server/store_budget.rs
@@ -1,0 +1,78 @@
+// Copyright 2025-2026 Lablup Inc. and Jeongkyu Shin
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Shared helpers for bounded in-memory server stores.
+
+use std::cmp::Ordering;
+use std::io;
+use std::time::Instant;
+
+use serde::Serialize;
+
+/// Count JSON bytes without allocating a second serialized copy of the value.
+///
+/// The result is intentionally approximate for memory budgeting: it tracks the
+/// wire-size contribution of nested strings and JSON values and uses saturating
+/// arithmetic so malformed or extreme inputs cannot overflow the accounting.
+pub(crate) fn serialized_json_len_saturating<T>(value: &T) -> usize
+where
+    T: Serialize + ?Sized,
+{
+    let mut writer = SaturatingByteCounter::default();
+    match serde_json::to_writer(&mut writer, value) {
+        Ok(()) => writer.bytes,
+        Err(_) => usize::MAX,
+    }
+}
+
+#[derive(Default)]
+struct SaturatingByteCounter {
+    bytes: usize,
+}
+
+impl io::Write for SaturatingByteCounter {
+    fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
+        self.bytes = self.bytes.saturating_add(buf.len());
+        Ok(buf.len())
+    }
+
+    fn flush(&mut self) -> io::Result<()> {
+        Ok(())
+    }
+}
+
+/// Exact LRU index key. Stores keep one of these per live entry and remove it
+/// whenever an entry is deleted or refreshed, so stale metadata cannot grow
+/// independently of the map.
+#[derive(Debug, Clone, Eq, PartialEq)]
+pub(crate) struct LruKey {
+    pub(crate) last_accessed: Instant,
+    pub(crate) sequence: u64,
+    pub(crate) id: String,
+}
+
+impl Ord for LruKey {
+    fn cmp(&self, other: &Self) -> Ordering {
+        self.last_accessed
+            .cmp(&other.last_accessed)
+            .then_with(|| self.sequence.cmp(&other.sequence))
+            .then_with(|| self.id.cmp(&other.id))
+    }
+}
+
+impl PartialOrd for LruKey {
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        Some(self.cmp(other))
+    }
+}


### PR DESCRIPTION
## Summary

- Add approximate retained-byte budgets to the in-memory `/v1/responses` response store and conversation transcript store, with checked/saturating accounting and running totals.
- Replace per-eviction linear victim scans with a `BTreeSet` LRU index so live entries keep one bounded metadata node and eviction removes the oldest entry in O(log n).
- Expose `--responses-store-max-bytes` / `MLXCEL_RESPONSES_STORE_MAX_BYTES` and `--conversation-store-max-bytes` / `MLXCEL_CONVERSATION_STORE_MAX_BYTES` on both server entry points, then document the knobs.
- Preserve the runtime-settings work merged by PR #1516 (`01c20350`) while rebasing onto main through PR #1518 (`972b5f3a`, chat-template-cache head); the only conflict was the colocated `mlxcel-server` test block, and both settings tests plus byte-budget tests are retained.

## Validation

- PASS: `cargo test --lib responses_store -- --nocapture` (16 tests; byte-only eviction, count+byte pressure, oversized single entry, exact boundary, replacement, access-order refresh, TTL, zero/extreme budgets, running total)
- PASS: `cargo test --lib conversation_store -- --nocapture` (13 tests; byte-only eviction, count+byte pressure, oversized single transcript, exact boundary, update/replacement, access-order refresh, TTL, zero/extreme budgets, running total)
- PASS: `cargo test --lib store_byte_budgets_round_trip_through_into_startup_config -- --nocapture`
- PASS: `cargo test --bin mlxcel serve_store_byte_budget -- --nocapture`
- PASS: `cargo test --bin mlxcel-server store_byte_budget -- --nocapture`
- PASS: `cargo test --bin mlxcel-server settings_cli_mlxcel_server -- --nocapture` (preserved runtime-settings PR #1516 while rebasing onto main through PR #1518)
- PASS: `cargo test --bin mlxcel settings_cli_mlxcel_serve -- --nocapture` (preserved runtime-settings PR #1516 while rebasing onto main through PR #1518)
- PASS: `cargo test --bin mlxcel settings_cli_build_startup_input_defaults_off_and_propagates_enablement -- --nocapture` (preserved runtime-settings PR #1516 while rebasing onto main through PR #1518)
- PASS: `cargo test --lib settings_cli -- --nocapture` (preserved runtime-settings PR #1516 while rebasing onto main through PR #1518)
- PASS: `cargo test --test llama_compat_manifest manifest_option_claims_hold_on_both_server_binaries -- --nocapture`
- PASS: `python3 scripts/ci/check_llama_compat_manifest.py`
- PASS: `cargo fmt --all --check`
- PASS: `cargo clippy --lib --bin mlxcel --bin mlxcel-server -- -D warnings`
- PASS: `git diff --check`
- PASS: static scan found no conflict markers or old `min_by` / `min_by_key` / `evict_to_capacity` victim-scan code in the touched stores.

## Hosted Checks

- PASS: cargo-clippy, cargo-deny, cargo-fmt, OpenXLA feature compile, Detect changes, crate versions, cross-repo refs, kernel dtype keys, license/cla, llama-compat manifest.
- SKIP: MLX pin extraction and OpenXLA feature link were skipped by workflow conditions.

## Technical Reports

- `TECHNICAL_REPORTS/1519-store-byte-bounds-20260830.en.md`
- `TECHNICAL_REPORTS/1519-store-byte-bounds-20260830.ko.md`

## Limits

- These validations are deterministic unit/config/static checks. I did not run broad workspace tests, cold release builds, real model checkpoints, ffmpeg, or hardware qualification for this server-memory accounting change.

Closes #1248
