### PR TITLE
fix(server): report b10621 tokens_cached and accept verbose on the native route

### DIFF
--- a/compat/llama-server/b10621/routes.json
+++ b/compat/llama-server/b10621/routes.json
@@ -171,9 +171,8 @@
       "test": "src/server/routes/native_route_tests.rs",
       "notes": "Route separation done: /completion and /completions both reach the native handler and answer the b10621 native object (index, content, tokens, id_slot, stop, model, tokens_predicted, tokens_evaluated, generation_settings, prompt, has_new_line, truncated, stop_type, stopping_word, tokens_cached, timings with cache_n), and the streaming form ends with that same object rather than a [DONE] sentinel. The key set and order were taken from a capture of the pinned binary. #1466 closed the stop-sequence half: `stop` now truncates the emitted text, and stop_type reports \"word\" with the matched string in stopping_word, matching the pinned binary on the same request. #1441 then added `response_fields` projection, the `stream_options` block, the whole `n_predict` value domain including `-1` and the verified `0` prompt-only case, and the real prefill figures on every streaming frame, and corrected two `timings` derivations against the binary. The remaining differences are listed in divergence: the tokens_cached formula and the refused request fields are #1477's remaining work, and the generation_settings omission follows the omitted-rather-than-invented policy GET /props records but cannot lift the entry on its own; the entry stays deferred and is filed under #1477 (moved from #1441 by PR #1478).",
       "divergence": [
-        "`generation_settings` echoes the settings mlxcel actually resolved rather than b10621's full task_params block, so keys mlxcel has no analogue for are absent (#1477).",
-        "`tokens_cached` reports the prompt tokens mlxcel's KV prefix cache supplied for this request, while b10621 reports the slot's cache occupancy after it, which is `tokens_evaluated + tokens_predicted - 1`: a 51-token prompt answered with 4 tokens measured `tokens_cached: 54` on the pinned binary against mlxcel's cache-supplied count (#1477).",
-        "`return_tokens`, `return_progress`, `verbose`, `n_indent`, `t_max_predict_ms` and `n_cmpl` above 1 are refused with a diagnostic rather than honored (#1477)."
+        "`generation_settings` echoes the settings mlxcel actually resolved rather than b10621's full task_params block: 25 of upstream's 49 keys are reported and 24 are absent, all of them owned elsewhere (the sampler stages behind adaptive_target, adaptive_decay, dynatemp_range, dynatemp_exponent, mirostat, mirostat_tau, mirostat_eta, min_keep, n_probs, logit_bias, samplers, grammar, grammar_lazy, grammar_triggers, preserved_tokens, post_sampling_probs and backend_sampling are #1436's, speculative.types is #1433's, and chat_format, reasoning_format, reasoning_in_content, generation_prompt, timings_per_token and lora are surfaces those issues and #1439 own) (#1477).",
+        "`return_tokens`, `return_progress`, `n_indent`, `t_max_predict_ms` and `n_cmpl` above 1 are refused with a diagnostic rather than honored; `verbose` and `tokens_cached` are settled and no longer part of this string (#1477)."
       ],
       "rationale": null,
       "mlxcel": {
@@ -193,9 +192,8 @@
       "test": "src/server/routes/native_route_tests.rs",
       "notes": "Route separation done: /completion and /completions both reach the native handler and answer the b10621 native object (index, content, tokens, id_slot, stop, model, tokens_predicted, tokens_evaluated, generation_settings, prompt, has_new_line, truncated, stop_type, stopping_word, tokens_cached, timings with cache_n), and the streaming form ends with that same object rather than a [DONE] sentinel. The key set and order were taken from a capture of the pinned binary. #1466 closed the stop-sequence half: `stop` now truncates the emitted text, and stop_type reports \"word\" with the matched string in stopping_word, matching the pinned binary on the same request. #1441 then added `response_fields` projection, the `stream_options` block, the whole `n_predict` value domain including `-1` and the verified `0` prompt-only case, and the real prefill figures on every streaming frame, and corrected two `timings` derivations against the binary. The remaining differences are listed in divergence: the tokens_cached formula and the refused request fields are #1477's remaining work, and the generation_settings omission follows the omitted-rather-than-invented policy GET /props records but cannot lift the entry on its own; the entry stays deferred and is filed under #1477 (moved from #1441 by PR #1478).",
       "divergence": [
-        "`generation_settings` echoes the settings mlxcel actually resolved rather than b10621's full task_params block, so keys mlxcel has no analogue for are absent (#1477).",
-        "`tokens_cached` reports the prompt tokens mlxcel's KV prefix cache supplied for this request, while b10621 reports the slot's cache occupancy after it, which is `tokens_evaluated + tokens_predicted - 1`: a 51-token prompt answered with 4 tokens measured `tokens_cached: 54` on the pinned binary against mlxcel's cache-supplied count (#1477).",
-        "`return_tokens`, `return_progress`, `verbose`, `n_indent`, `t_max_predict_ms` and `n_cmpl` above 1 are refused with a diagnostic rather than honored (#1477)."
+        "`generation_settings` echoes the settings mlxcel actually resolved rather than b10621's full task_params block: 25 of upstream's 49 keys are reported and 24 are absent, all of them owned elsewhere (the sampler stages behind adaptive_target, adaptive_decay, dynatemp_range, dynatemp_exponent, mirostat, mirostat_tau, mirostat_eta, min_keep, n_probs, logit_bias, samplers, grammar, grammar_lazy, grammar_triggers, preserved_tokens, post_sampling_probs and backend_sampling are #1436's, speculative.types is #1433's, and chat_format, reasoning_format, reasoning_in_content, generation_prompt, timings_per_token and lora are surfaces those issues and #1439 own) (#1477).",
+        "`return_tokens`, `return_progress`, `n_indent`, `t_max_predict_ms` and `n_cmpl` above 1 are refused with a diagnostic rather than honored; `verbose` and `tokens_cached` are settled and no longer part of this string (#1477)."
       ],
       "rationale": null,
       "mlxcel": {
@@ -564,9 +562,11 @@
       "discovery": "source-schema-declaration",
       "state": "not_applicable",
       "issue": 1477,
-      "test": "src/server/routes/native_route_tests.rs",
-      "notes": "No equivalent: mlxcel serves exactly one completion per request, so there is no path that could return b10621's array of results. `n_cmpl` (and its `n` alias) is accepted at 1, the inert value, and any higher value is refused with a 400 naming the field and telling the caller to send one request per completion.",
-      "divergence": [],
+      "test": "src/server/routes/native_route_tests.rs::unsupported_native_fields_are_refused_with_a_diagnostic",
+      "notes": "Declared and refused above 1 with a diagnostic naming the field. Upstream's schema limit is 1 <= value <= params_base.n_parallel and it REFUSES rather than clamps, so at one slot mlxcel's refusal is the same answer b10621 gives: the pinned binary with -np 1 answers `Field 'n_cmpl': Value must be between 1 <= value <= 1, but got 2`. With more slots upstream returns a JSON array of result objects each carrying its own index, and mlxcel serves one completion per request with no path that returns an array; shipping a partial array shape would be worse than the refusal (#1477).",
+      "divergence": [
+        "above 1 the field is refused; b10621 with more than one slot returns a JSON array of result objects, which mlxcel has no path to produce"
+      ],
       "rationale": null,
       "mlxcel": {
         "field": "n_cmpl"
@@ -583,9 +583,11 @@
       "discovery": "source-schema-declaration",
       "state": "not_applicable",
       "issue": 1477,
-      "test": "src/server/routes/native_route_tests.rs",
-      "notes": "No equivalent: mlxcel has no minimum-indentation stop rule for fill-in-the-middle completions. Accepted at 0, the inert value, and refused with a 400 naming the field otherwise.",
-      "divergence": [],
+      "test": "src/server/routes/native_route_tests.rs::unsupported_native_fields_are_refused_with_a_diagnostic",
+      "notes": "Declared and refused above 0. Upstream's rule (server-context.cpp): once a newline has been generated, the whitespace run at the last newline is measured each step, and if content follows it and the run is shorter than n_indent the slot stops with STOP_TYPE_LIMIT and the last line is erased from the generated text. Measured on the pinned binary: `def f():\\n    return 1\\n` with n_indent 4 stops after 3 tokens with stop_type limit, and an 8-space body stops at 26 tokens with n_indent 8 against 30 with n_indent 0. mlxcel's only per-request stop machinery is the stop-string matcher on the sequence, and adding an indentation rule means a second per-token stop guard plus the trailing-line erase (#1477).",
+      "divergence": [
+        "the field is refused above 0; b10621 stops the completion when a generated line's indentation falls below it, reported as stop_type limit"
+      ],
       "rationale": null,
       "mlxcel": {
         "field": "n_indent"
@@ -643,9 +645,11 @@
       "discovery": "source-schema-declaration",
       "state": "not_applicable",
       "issue": 1477,
-      "test": "src/server/routes/native_route_tests.rs",
-      "notes": "No equivalent: the mlxcel scheduler emits no prompt-processing progress events on this path, so there is nothing to attach to a stream frame. Accepted at false, the inert value, and refused with a 400 naming the field otherwise.",
-      "divergence": [],
+      "test": "src/server/routes/native_route_tests.rs::unsupported_native_fields_are_refused_with_a_diagnostic",
+      "notes": "Declared and refused when true. The scheduler emits exactly one GenerateEvent::Prefill per request, at the first stamped token, which supplies total, cache and time_ms but only the terminal processed == total. Re-measured against the pinned binary for #1477: upstream emits one empty-content frame per prefill chunk ahead of the first content frame, and with -b 64 on a 321-token prompt the processed values were 0, 64, 128, 192, 256, 320, 321 against total 321. mlxcel schedules chunked prefill at --prefill-chunk-size, so the shape maps directly; what is missing is a per-chunk progress event and its route mapping (#1477).",
+      "divergence": [
+        "the field is refused when true; b10621 emits one `prompt_progress` frame per prefill chunk ahead of the first content frame"
+      ],
       "rationale": null,
       "mlxcel": {
         "field": "return_progress"
@@ -662,9 +666,11 @@
       "discovery": "source-schema-declaration",
       "state": "not_applicable",
       "issue": 1477,
-      "test": "src/server/routes/native_route_tests.rs",
-      "notes": "No equivalent on this path: mlxcel's streaming decoder emits detokenized text and does not surface the raw token ids to the native route. Accepted at false, the inert value, and refused with a 400 naming the field and pointing at POST /tokenize otherwise.",
-      "divergence": [],
+      "test": "src/server/routes/native_route_tests.rs::unsupported_native_fields_are_refused_with_a_diagnostic",
+      "notes": "Declared and refused when true. The generated ids exist on the sequence (SequenceInfo::generated_tokens) but nothing carries them out: GenerationResult has no id vector and the native streaming callback is FnMut(String, Option<TokenLogprobData>), whose token_id is populated only when logprobs were requested. Re-measured against the pinned binary for #1477: the non-streaming `tokens` array is gated on the field, while STREAMING frames carry a per-frame `tokens` array unconditionally, with and without it, and the final streaming frame carries `tokens: []` in both cases. Honoring the field therefore means an opt-in id channel for the non-streaming half AND an unconditional per-frame id on the streaming half (#1477).",
+      "divergence": [
+        "the field is refused when true; b10621 fills the top-level `tokens` array with the generated ids, and its streaming frames carry per-frame ids unconditionally"
+      ],
       "rationale": null,
       "mlxcel": {
         "field": "return_tokens"
@@ -738,9 +744,11 @@
       "discovery": "source-schema-declaration",
       "state": "not_applicable",
       "issue": 1477,
-      "test": "src/server/routes/native_route_tests.rs",
-      "notes": "No per-request equivalent: mlxcel bounds a stalled decode with the server-wide --decode-timeout / MLXCEL_DECODE_TIMEOUT watchdog, which cannot be narrowed per request. Accepted at -1 or 0, the inert values, and refused with a 400 naming the field and the alternative otherwise.",
-      "divergence": [],
+      "test": "src/server/routes/native_route_tests.rs::unsupported_native_fields_are_refused_with_a_diagnostic",
+      "notes": "Declared and refused above 0. Upstream's rule (server-context.cpp): the deadline is checked only when the emitted piece contains a newline, and if t_gen_ms() has passed it the slot stops with STOP_TYPE_LIMIT. Measured on the pinned binary: t_max_predict_ms 50 on an n_predict 200 request stopped at 16 tokens with stop_type limit and truncated false. mlxcel bounds a stalled decode with the server-wide --decode-timeout / MLXCEL_DECODE_TIMEOUT watchdog, which cannot be narrowed per request, and honoring this needs a per-sequence deadline evaluated in the decode loop under upstream's newline condition (#1477).",
+      "divergence": [
+        "the field is refused above 0; b10621 bounds the prediction phase per request from the first token, firing only after a newline has been generated"
+      ],
       "rationale": null,
       "mlxcel": {
         "field": "t_max_predict_ms"
@@ -774,10 +782,10 @@
       "field_type": "bool",
       "description": "Include __verbose field in the response with additional debug information",
       "discovery": "source-schema-declaration",
-      "state": "not_applicable",
+      "state": "supported",
       "issue": 1477,
-      "test": "src/server/routes/native_route_tests.rs",
-      "notes": "No equivalent: mlxcel has no __verbose debug block. Accepted at false, the inert value, and refused with a 400 naming the field and pointing at GET /slots and GET /metrics otherwise.",
+      "test": "src/server/routes/native_route_tests.rs::verbose_is_accepted_and_changes_nothing",
+      "notes": "Accepted and inert, which is exactly what b10621 does on this route. Upstream writes its __verbose debug block only from the OAI-compat response builders (server-task.cpp lines 404, 452, 521 and 1098, each inside a to_json_oaicompat* function); the native completion object IS to_json_non_oaicompat(), so the field changes nothing there. Measured against the pinned binary: the top-level key set of a request with verbose true is identical to the same request without it. Before #1477 mlxcel refused the field with a 400, which was the divergence.",
       "divergence": [],
       "rationale": null,
       "mlxcel": {

--- a/docs/llama-server-compat.md
+++ b/docs/llama-server-compat.md
@@ -84,7 +84,11 @@ The native completion object carries `index`, `content`, `tokens`, `id_slot`, `s
 
 **A client that was pointing at `/completions` or `/embeddings` and parsing the OpenAI shape must move to `/v1/completions` or `/v1/embeddings`.** Those two paths are unchanged and stay OpenAI compatible.
 
-Native request fields mlxcel has no equivalent for are now refused with a 400 naming the field and the alternative, instead of being accepted and ignored: `n_cmpl` (and its `n` alias) above 1, `n_indent`, `t_max_predict_ms`, `return_progress`, `verbose` and `return_tokens`. Each is still accepted at its inert value, so a client that sends the whole schema at its defaults is not turned away.
+Native request fields mlxcel has no equivalent for are refused with a 400 naming the field and the alternative, instead of being accepted and ignored: `n_cmpl` (and its `n` alias) above 1, `n_indent`, `t_max_predict_ms`, `return_progress` and `return_tokens`. Each is still accepted at its inert value, so a client that sends the whole schema at its defaults is not turned away.
+
+`verbose` left that list in #1477, on evidence rather than on effort: b10621 writes its `__verbose` debug block only from the OAI-compat response builders (`server-task.cpp`), and the native completion object IS `to_json_non_oaicompat()`, so `verbose: true` changes nothing upstream either. Measured against the pinned binary, the top-level key set with the field set is identical to the key set without it. mlxcel now accepts it and ignores it, which is what upstream does; refusing it was the divergence.
+
+`tokens_cached` also changed meaning in #1477 and is a **breaking change for a client that read it as a cache-hit figure**. b10621 reports the slot's cache occupancy after the request, which is `tokens_evaluated + tokens_predicted - 1` (saturating), not what the prefix cache supplied for it. Six measurements against the pinned binary agree, including the `n_predict: 0` prompt-only case, which upstream still answers with `tokens_predicted: 1`, and a fully cache-hit request, where the figure is unchanged by the hit. The cache-supplied count is `timings.cache_n`, which is unchanged and is what `timings.prompt_n` is derived from; a client that wants the hit size should read `cache_n`.
 
 Four more native fields moved from ignored to honored on the same routes, each checked against the pinned binary rather than against the schema's descriptions, which are wrong about two of them:
 

--- a/src/server/routes/native_completion.rs
+++ b/src/server/routes/native_completion.rs
@@ -357,7 +357,19 @@ fn build_native_response(
         truncated: matches!(outcome.stop_kind, StopKind::ContextExhausted),
         stop_type,
         stopping_word,
-        tokens_cached: outcome.cached_tokens,
+        // b10621 reports the SLOT's cache occupancy after the request, not
+        // what the prefix cache supplied for it (#1477). Six independent
+        // measurements against the pinned binary agree on
+        // `tokens_evaluated + tokens_predicted - 1`, including the
+        // `n_predict: 0` prompt-only case (which upstream still answers with
+        // `tokens_predicted: 1`) and a fully cache-hit request, where the
+        // figure is unchanged by the hit. `timings.cache_n` below stays the
+        // cache-supplied count, which is a different quantity and is what
+        // `prompt_n` is derived from.
+        tokens_cached: outcome
+            .tokens_evaluated
+            .saturating_add(outcome.tokens_predicted)
+            .saturating_sub(1),
         timings: NativeTimings::new(
             outcome.cached_tokens,
             outcome.tokens_evaluated,
@@ -744,13 +756,6 @@ fn reject_unsupported_native_fields(request: &NativeCompletionRequest) -> Option
         return refuse(
             "return_progress is not supported on /completion; the mlxcel scheduler emits no \
              prompt-processing progress events on this path"
-                .to_string(),
-        );
-    }
-    if request.verbose.unwrap_or(false) {
-        return refuse(
-            "verbose is not supported on /completion; mlxcel has no __verbose debug block. \
-             Use GET /slots and GET /metrics for per-request observability"
                 .to_string(),
         );
     }

--- a/src/server/routes/native_route_tests.rs
+++ b/src/server/routes/native_route_tests.rs
@@ -225,10 +225,6 @@ async fn unsupported_native_fields_are_refused_with_a_diagnostic() {
             serde_json::json!({"prompt": "hi", "return_progress": true}),
         ),
         (
-            "verbose",
-            serde_json::json!({"prompt": "hi", "verbose": true}),
-        ),
-        (
             "return_tokens",
             serde_json::json!({"prompt": "hi", "return_tokens": true}),
         ),
@@ -245,6 +241,92 @@ async fn unsupported_native_fields_are_refused_with_a_diagnostic() {
             "the diagnostic must name {field}, got {message:?}"
         );
     }
+}
+
+/// `tokens_cached` is b10621's SLOT cache occupancy after the request, not
+/// what the prefix cache supplied for it (#1477).
+///
+/// Six independent measurements against the pinned binary agree on
+/// `tokens_evaluated + tokens_predicted - 1`: 5+8-1=12 on a limit stop,
+/// 5+1-1=5 on the `n_predict: 0` prompt-only case (upstream still answers it
+/// with `tokens_predicted: 1`), 8+24-1=31 and 11+40-1=50 on longer runs,
+/// 5+200-1=204, and 15+4-1=18 on a fully cache-hit request, where the figure
+/// is unchanged by the hit. `timings.cache_n` stays the cache-supplied count,
+/// which is the different quantity `prompt_n` is derived from, so this test
+/// pins both at once.
+#[tokio::test]
+async fn tokens_cached_reports_the_upstream_slot_occupancy_formula() {
+    let (status, body) = post(
+        "/completion",
+        serde_json::json!({"prompt": "hello there", "n_predict": 4}),
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK, "{body}");
+
+    let evaluated = body["tokens_evaluated"].as_u64().expect("tokens_evaluated");
+    let predicted = body["tokens_predicted"].as_u64().expect("tokens_predicted");
+    let cached = body["tokens_cached"].as_u64().expect("tokens_cached");
+    assert_eq!(
+        cached,
+        (evaluated + predicted).saturating_sub(1),
+        "tokens_cached must be tokens_evaluated + tokens_predicted - 1 (saturating), got \
+         {cached} from {evaluated} + {predicted}"
+    );
+    assert_eq!(
+        body["timings"]["cache_n"].as_u64(),
+        Some(0),
+        "cache_n is the cache-supplied prompt count and is a different quantity"
+    );
+    assert_eq!(
+        body["timings"]["prompt_n"].as_u64(),
+        Some(evaluated),
+        "prompt_n stays tokens_evaluated - cache_n"
+    );
+}
+
+/// b10621 accepts `verbose` on the native route and ignores it (#1477).
+///
+/// Upstream writes its `__verbose` debug block only from the OAI-compat
+/// response builders; the native `/completion` object IS
+/// `to_json_non_oaicompat()`, so the field changes nothing there. Measured
+/// against the pinned binary, the top-level key set with `verbose: true` is
+/// identical to the key set without it. mlxcel used to refuse the field with
+/// a 400, which was the divergence; it now matches upstream by accepting it
+/// and changing nothing.
+#[tokio::test]
+async fn verbose_is_accepted_and_changes_nothing() {
+    let (with_status, with_body) = post(
+        "/completion",
+        serde_json::json!({"prompt": "hello", "n_predict": 4, "verbose": true}),
+    )
+    .await;
+    assert_eq!(with_status, StatusCode::OK, "{with_body}");
+    let (without_status, without_body) = post(
+        "/completion",
+        serde_json::json!({"prompt": "hello", "n_predict": 4}),
+    )
+    .await;
+    assert_eq!(without_status, StatusCode::OK, "{without_body}");
+
+    let keys = |v: &serde_json::Value| {
+        let mut k: Vec<String> = v
+            .as_object()
+            .expect("the native response is an object")
+            .keys()
+            .cloned()
+            .collect();
+        k.sort();
+        k
+    };
+    assert_eq!(
+        keys(&with_body),
+        keys(&without_body),
+        "verbose must not add or remove a key, as it does not upstream"
+    );
+    assert!(
+        with_body.get("__verbose").is_none(),
+        "the native route has no __verbose block upstream and must not invent one"
+    );
 }
 
 #[tokio::test]

--- a/src/server/types/request.rs
+++ b/src/server/types/request.rs
@@ -1257,7 +1257,14 @@ pub struct NativeCompletionRequest {
     /// Include prompt-processing progress events in stream mode. mlxcel's
     /// scheduler emits no prefill progress events on this path.
     pub return_progress: Option<bool>,
-    /// Include an `__verbose` debug block in the response.
+    /// llama-server b10621 `verbose`, accepted and inert on this route.
+    ///
+    /// Upstream writes its `__verbose` debug block only from the OAI-compat
+    /// response builders (`server-task.cpp`); the native `/completion` object
+    /// IS `to_json_non_oaicompat()`, so `verbose: true` changes nothing there.
+    /// Verified against the pinned binary: the top-level key set with the
+    /// field set is identical to the key set without it. mlxcel therefore
+    /// accepts it and ignores it, which is exactly what upstream does (#1477).
     pub verbose: Option<bool>,
     /// Return the raw generated token ids in the `tokens` field.
     pub return_tokens: Option<bool>,


### PR DESCRIPTION
## Summary

Settles two of the four divergences on `POST /completion` and `POST /completions`, both against the pinned b10621 binary rather than by argument, and rewrites the manifest entries for the rest with fresh measurement. **This pull request carries no closing keyword**: issue 1477 keeps the four request fields that are still refused and stays open, deliberately.

Two premises in that issue's body were wrong and are corrected in place, with the captures recorded in a comment on it. Implementing against them would have produced a `__verbose` block mlxcel invented and a JSON array behind a limit upstream refuses.

## What changed

- **`tokens_cached` is b10621's slot cache occupancy.** It reported the prompt tokens mlxcel's prefix cache supplied for the request; upstream reports the slot's occupancy after it, which six independent measurements agree is `tokens_evaluated + tokens_predicted - 1`. The subtraction saturates. `timings.cache_n` keeps the cache-supplied count, which is the different quantity `timings.prompt_n` is derived from and which PR #1476 verified against the binary; conflating them would have broken `prompt_n` silently. **Breaking for a client that read `tokens_cached` as a cache-hit figure**, with the migration in `docs/llama-server-compat.md`.
- **`verbose` is accepted and inert, as upstream is.** `__verbose` is written only from the OAI-compat response builders (`server-task.cpp` lines 404, 452, 521 and 1098, each inside a `to_json_oaicompat*`) and the native completion object IS `to_json_non_oaicompat()`. Captured against the pinned binary, a request with `verbose: true` returns exactly the key set of the same request without it. Refusing it was the divergence; `field:verbose` becomes `supported`.
- **The remaining entries are restated against measurement, not carried forward.** `field:n_cmpl` records that upstream's schema limit refuses rather than clamps and is bounded by the server's own slot count, so at one slot mlxcel's refusal is byte-equivalent to b10621's. `field:return_tokens` records the re-measurement the issue asked for: streaming frames carry per-frame ids unconditionally, with and without the field, and the final streaming frame carries `tokens: []` in both cases, so honoring it means an opt-in channel for the non-streaming half and an unconditional per-frame id for the streaming half. `field:return_progress`, `field:n_indent` and `field:t_max_predict_ms` each carry upstream's rule with the line in `server-context.cpp` and the number that pins it.
- **The `generation_settings` divergence is re-measured**: 25 of upstream's 49 keys are reported and the 24 absent ones are named with the issue that owns each (#1436 for the sampler stages, #1433 for `speculative.types`, #1439 and those two for the rest).

## Validation

Head to head against the pinned binary (build 10621, commit `c1d0e7a00`) serving `ggml-org/Qwen3-0.6B-GGUF`, mlxcel serving `qwen3-0.6b-4bit` at `--ctx-size 4096 --parallel 1`, same request body to both.

| case | binary | `tokens_evaluated` | `tokens_predicted` | `tokens_cached` | `e+p-1` | `cache_n` | `prompt_n` |
|---|---|---|---|---|---|---|---|
| limit stop, `n_predict 8` | b10621 | 5 | 8 | 12 | 12 | 0 | 5 |
| limit stop, `n_predict 8` | mlxcel | 5 | 8 | 12 | 12 | 0 | 5 |
| prompt only, `n_predict 0` | b10621 | 5 | 1 | 5 | 5 | 0 | 5 |
| prompt only, `n_predict 0` | mlxcel | 5 | 1 | 5 | 5 | 0 | 5 |
| longer run, `n_predict 24` | b10621 | 8 | 24 | 31 | 31 | 0 | 8 |
| longer run, `n_predict 24` | mlxcel | 8 | 24 | 31 | 31 | 0 | 8 |
| `verbose: true` | b10621 | 1 | 4 | 4 | 4 | 0 | 1 |
| `verbose: true` | mlxcel | 1 | 4 | 4 | 4 | 0 | 1 |

The `n_predict: 0` row is the underflow case the issue asked to measure before choosing a formula: upstream answers it with `tokens_predicted: 1`, so `5 + 1 - 1 = 5` and the saturating subtraction never fires in practice. The `verbose: true` row is the control for that change: the same request, the same numbers, and the key set unchanged.

Two further captures behind the restated entries, from the same session: `tokens_cached` also held at `15 + 4 - 1 = 18` on a fully cache-hit request (`cache_n` 14, `prompt_n` 1), so the figure is independent of the hit; and with `-b 64` on a 321-token prompt, `return_progress` emitted `processed` 0, 64, 128, 192, 256, 320, 321 against `total: 321`, one frame per prefill chunk, which maps directly onto mlxcel's own chunked prefill when that work is done.

## What remains on issue 1477

`return_tokens`, `return_progress`, `n_indent` and `t_max_predict_ms` are still refused, and each manifest entry now names the upstream rule, the source line, and the measurement rather than a general "no equivalent". `return_tokens` needs an opt-in id channel out of the scheduler plus unconditional per-frame ids on the streaming path; `return_progress` needs a per-chunk progress event mapped onto `PromptProgress`; the two stop rules need a second per-token guard on the sequence with upstream's newline and indentation conditions. `n_cmpl` above 1 stays `not_applicable`: shipping a partial array shape would be worse than the refusal, which at one slot is already what upstream answers.

## Test plan

- [x] `cargo fmt --all -- --check` and `cargo clippy --profile test-fast --features metal,accelerate --lib --tests --bins -- -D warnings`
- [x] `cargo test --profile test-fast --features metal,accelerate --lib server::` (2653)
- [x] `cargo test --profile test-fast --features metal,accelerate --test llama_compat_manifest` (4)
- [x] `python3 scripts/ci/check_llama_compat_manifest.py`
- [x] The head-to-head table above against the pinned binary

Tracked on issue 1477, which stays open.
