### PR TITLE
feat(server): serve the b10621 assistant prefill and echo, and settle reasoning_in_content

### DIFF
--- a/compat/llama-server/b10621/chat-templates.json
+++ b/compat/llama-server/b10621/chat-templates.json
@@ -182,14 +182,18 @@
       "default": "prefill enabled",
       "description": "whether to prefill the assistant's response if the last message is an assistant message (default: prefill enabled) when this flag is set, if the last message is an assistant message then it will be treated as a full message and not prefilled (env: LLAMA_ARG_PREFILL_ASSISTANT)",
       "discovery": "help-entry-head",
-      "state": "deferred",
+      "state": "by_design",
       "issue": 1470,
-      "test": "tests/llama_chat_template_cli.rs::inert_values_fail_only_for_the_missing_model",
-      "notes": "b10621 prefills by default: a trailing assistant message is a prefix the model continues rather than a complete turn. mlxcel always renders with `add_generation_prompt = true`, so a trailing assistant message is followed by a fresh assistant turn and the model answers instead of continuing. The two therefore differ with no flag passed at all. `--no-prefill-assistant` is inert here (it is what mlxcel already does) and the server says so once at startup; `--prefill-assistant` parses. Implementing the prefill means rendering with `add_generation_prompt = false` for that case, which changes the prompt-cache key as well, so #1470 owns it. Accepted as a hidden compatibility argument: it is a compatibility surface rather than an mlxcel feature, and mlxcel's own `--chat-template`, `--chat-template-file`, `--chat-template-kwargs` and `--reasoning-budget` stay visible in `--help`.",
+      "test": "src/server/chat_request_tests.rs::a_trailing_assistant_message_is_continued_when_prefill_is_on",
+      "notes": "Implemented in #1470 with b10621's own guard: prefill is ON by default, applies when the last message is an assistant message, and two or more trailing assistant messages are refused with upstream's wording (`Cannot have 2 or more assistant messages at the end of the list.`). mlxcel reaches the continued prompt through the template rather than through per-family C++: it renders messages[:-1] with add_generation_prompt = true, which is the family's own assistant-turn opener, and appends the continuation text with no closing tag, so every loaded family continues correctly rather than only the ones upstream has a handler for. The prompt-cache key carries the rendering as a dimension (`template_sig`), because the continued form is a strict prefix of the answered one and an exact-prefix boundary snapshot recorded under one must not be adopted by the other; the boundary render itself is skipped under a prefill for the same reason. b10621's `echo` field selects whether the prefill leads the response, and mlxcel honours it on the chat routes where upstream's own consumer lives. Accepted as a hidden compatibility argument.",
       "divergence": [
-        "b10621 continues a trailing assistant message by default; mlxcel answers it with a fresh turn, whether or not the flag is passed (#1470)."
+        "A trailing assistant message carrying only reasoning and no content is refused unless the chat template primed an open thinking block; b10621 rebuilds the family's own thinking opener in C++ and continues from the reasoning text in every case (#1470)."
       ],
-      "rationale": null,
+      "rationale": {
+        "kind": "policy",
+        "reason": "The open thinking marker is the template's, not mlxcel's: reconstructing it for a family whose generation prompt did not emit one would mean hard-coding a per-family marker table in the request path, which is exactly the per-family C++ this implementation avoids by driving the continuation through the template. Refusing loudly is better than appending reasoning text that the model would read as content.",
+        "revisit_if": "mlxcel grows a template-derived thinking-marker lookup (the tokenizer's inferred markers reach the request path), at which point the reasoning continuation is expressible for every family."
+      },
       "mlxcel": {
         "accepted_spellings": [
           "--prefill-assistant",
@@ -349,11 +353,10 @@
       "state": "deferred",
       "issue": 1470,
       "test": "src/server/routes/chat.rs::reasoning_format_route_tests::each_format_places_the_thoughts_where_b10621_does",
-      "notes": "Chooses where a model's thoughts are reported: `none` leaves them unparsed in `message.content`, `deepseek` puts them in `message.reasoning_content`, `deepseek-legacy` does both, and `auto` detects from the template. mlxcel's pre-#1447 behavior was `deepseek` unconditionally, with no flag to change it, so a client that reads thoughts out of `content` saw an empty answer where llama-server showed the reasoning. All four values are now honoured on the non-streaming and streaming chat paths, on the single-node route and the disaggregated router front alike. The thoughts-preserving content form is rebuilt from the parser's own content plus the extracted reasoning (`tool_calls::parser::content_with_thinking_block`) rather than from the raw text, so it can neither restore the tool-call syntax the parser removed nor lose the Gemma 4 `<|channel>` delimiters the raw-text cleaning pass strips. Interacts with `--skip-chat-parsing`, which turns every parser off and therefore supersedes this flag. The entry is `deferred` rather than `aliased` because the streamed form loses the thinking delimiters, which is the very thing `none` asks for; #1470 owns closing that. Upstream additionally sets `chat_parser_params.reasoning_in_content = stream && legacy` in `tools/server/server-schema.cpp`, whose consumer (`common/chat-parser.cpp`) is outside the pinned source set, so whether a streamed `deepseek-legacy` response carries the thoughts in one field or in both could not be verified from the reference; mlxcel implements the documented help-text shape (both) and #1470 owns confirming it. Accepted as a hidden compatibility argument.",
+      "notes": "Chooses where a model's thoughts are reported: `none` leaves them unparsed in `message.content`, `deepseek` puts them in `message.reasoning_content`, `deepseek-legacy` does both, and `auto` detects from the template. mlxcel's pre-#1447 behavior was `deepseek` unconditionally, with no flag to change it, so a client that reads thoughts out of `content` saw an empty answer where llama-server showed the reasoning. All four values are now honoured on the non-streaming and streaming chat paths, on the single-node route and the disaggregated router front alike. The thoughts-preserving content form is rebuilt from the parser's own content plus the extracted reasoning (`tool_calls::parser::content_with_thinking_block`) rather than from the raw text, so it can neither restore the tool-call syntax the parser removed nor lose the Gemma 4 `<|channel>` delimiters the raw-text cleaning pass strips. Interacts with `--skip-chat-parsing`, which turns every parser off and therefore supersedes this flag. The entry is `deferred` rather than `aliased` because the streamed form loses the thinking delimiters, which is the very thing `none` asks for; #1470 owns closing that. Settled in #1470 against the full b10621 tree: `chat_parser_params.reasoning_in_content` is set in `tools/server/server-schema.cpp` and reported by `params_to_json`, and NO parser reads it (`common/chat.cpp`, `common/chat-peg-parser.cpp` and the auto-parser sources contain no reference). It is a dead field at this commit, so a streamed `deepseek-legacy` response carries the thoughts in BOTH fields exactly as the help text documents, which is what mlxcel implements. Accepted as a hidden compatibility argument.",
       "divergence": [
         "`auto` resolves to `deepseek` rather than being detected from the template: mlxcel's reasoning split uses one marker set for every family it supports, so there is nothing else to detect.",
-        "In a STREAMED response under `none` or `deepseek-legacy` the thinking text reaches `delta.content` but its literal `<think>` / `<|channel>` delimiters do not; the non-streaming `message.content` keeps them (#1470).",
-        "Whether a streamed `deepseek-legacy` response should carry the thoughts in `delta.content` only, rather than in both fields, is unverified: upstream's `reasoning_in_content` consumer is outside the pinned sources (#1470)."
+        "In a STREAMED response under `none` or `deepseek-legacy` the thinking text reaches `delta.content` but its literal `<think>` / `<|channel>` delimiters do not; the non-streaming `message.content` keeps them (#1470)."
       ],
       "rationale": null,
       "mlxcel": {
@@ -532,15 +535,15 @@
       "field_type": "bool",
       "description": "Whether to echo the input tokens in the output",
       "discovery": "source-schema-declaration",
-      "state": "deferred",
+      "state": "supported",
       "issue": 1470,
       "test": "src/server/llama_compat_tests.rs::manifest_native_field_claims_match_native_completion_request",
-      "notes": "b10621's `/completion` can echo the prompt tokens back in the output. mlxcel's returns only the generated text. Unlike the other native fields in this shard, which are `not_applicable` because mlxcel's `/completion` has no chat template or parser to configure, this is a plain completion feature that is simply missing; #1470 owns it.",
-      "divergence": [
-        "Not accepted on `POST /completion`; mlxcel cannot echo the prompt back (#1470)."
-      ],
+      "notes": "Declared in #1470 and inert on this route, which is upstream's behaviour too. b10621's help text describes echoing the input tokens, but the field's only consumer is `task_result_state`, which primes the chat parser so a CONTINUATION's assistant prefill is not re-emitted; `POST /completion` takes a raw prompt, is never a continuation, and therefore never reaches that branch. The chat routes read the same key out of their own body and honour it against the #1470 assistant prefill, which is where it has an effect.",
+      "divergence": [],
       "rationale": null,
-      "mlxcel": null
+      "mlxcel": {
+        "field": "echo"
+      }
     },
     {
       "kind": "native_request_field",

--- a/docs/llama-server-compat.md
+++ b/docs/llama-server-compat.md
@@ -371,7 +371,7 @@ Value-taking options bind their `LLAMA_ARG_*` variable through clap, which passe
 | `deepseek-legacy` | the answer with the `<think>` tags | the thoughts |
 | `auto` (default) | as `deepseek` here | the thoughts |
 
-mlxcel's pre-#1447 behavior was `deepseek` unconditionally. The same placement applies on the disaggregated router front, which serves the same route. The entry stays `deferred` against #1470 for three reasons recorded on it: `auto` resolves to `deepseek` rather than being detected from the template, because mlxcel's reasoning split uses one marker set for every family it supports; in a *streamed* response under `none` or `deepseek-legacy` the thinking text reaches `delta.content` but its literal delimiters do not, because the streaming filter drops them as it matches them; and whether a streamed `deepseek-legacy` response should carry the thoughts in one field or both is unverified, because upstream's `reasoning_in_content` consumer sits outside the pinned source set.
+mlxcel's pre-#1447 behavior was `deepseek` unconditionally. The same placement applies on the disaggregated router front, which serves the same route. The entry stays `deferred` against #1470 for two reasons recorded on it: `auto` resolves to `deepseek` rather than being detected from the template, because mlxcel's reasoning split uses one marker set for every family it supports; and in a *streamed* response under `none` or `deepseek-legacy` the thinking text reaches `delta.content` but its literal delimiters do not, because the streaming filter drops them as it matches them. The third reason is gone: #1470 settled the `reasoning_in_content` question against the full b10621 tree. Upstream sets that flag in `tools/server/server-schema.cpp` and reports it from `params_to_json`, and no parser reads it, so it is a dead field at this commit and a streamed `deepseek-legacy` response carries the thoughts in both fields exactly as the help text documents, which is what mlxcel already does.
 
 The native `--reasoning-alias-field <none|reasoning>` policy is orthogonal to that placement table. It defaults to duplicating any emitted `reasoning_content` into an identical `reasoning` field for OpenRouter-style clients; `none` keeps the b10621-compatible field alone.
 
@@ -391,7 +391,19 @@ b10621 accepts either Jinja template text or one of 54 built-in identifiers (`ch
 
 ### Still deferred
 
-Four entries are `deferred` against #1470 rather than claimed. `--reasoning-format` is the one whose behavior is otherwise complete; its streamed delimiter loss and the unverified `reasoning_in_content` question keep it there. `--prefill-assistant` is b10621's default and mlxcel diverges from it *with no flag passed*: a trailing assistant message is answered with a fresh turn here and continued upstream. `--reasoning-budget-message` parses and warns at startup but is not yet injected before the end-of-thinking tag. The native `echo` field is a plain completion feature mlxcel lacks. Every other native field in this shard is `not_applicable`: mlxcel's `POST /completion` is a raw-prompt endpoint with no chat template and no chat parsing for them to configure.
+Two entries are `deferred` against #1470, down from four. `--reasoning-format` is the one whose behavior is otherwise complete; the streamed delimiter loss keeps it there. `--reasoning-budget-message` parses and warns at startup but is not yet injected before the end-of-thinking tag. Every native field in this shard other than `echo` is `not_applicable`: mlxcel's `POST /completion` is a raw-prompt endpoint with no chat template and no chat parsing for them to configure.
+
+### Assistant prefill and `echo` (#1470)
+
+`--prefill-assistant` is served, and it is on by default as it is upstream: when the last message of a chat request is an assistant message it is a prefix the model continues, not a turn it answers. `--no-prefill-assistant` restores the pre-#1470 behavior. Two or more trailing assistant messages are refused with b10621's own wording.
+
+mlxcel reaches the continued prompt through the chat template rather than through per-family C++. b10621 renders `messages[:-1]`, then appends a hand-written per-family generation prompt and the continuation text; mlxcel renders `messages[:-1]` with `add_generation_prompt = true`, which *is* the family's own assistant-turn opener, and appends the continuation text with no closing tag. The result is the same prompt for the families upstream has handlers for, and a correct one for every other family mlxcel loads.
+
+The rendering is a prompt-cache key dimension. The continued prompt is a strict prefix of the answered one, so without the dimension a boundary snapshot recorded under one rendering could be adopted by the other, which continues from a different point in the same string; the boundary render itself is skipped entirely under a prefill for the same reason.
+
+`echo` selects whether the prefill leads the response. It is inert on `POST /completion`, which is upstream's behavior too: despite a help text about echoing input tokens, the field's only consumer primes the chat parser so a *continuation's* prefill is not re-emitted, and a raw-prompt request is never a continuation. On the chat routes `echo: true` puts the prefilled assistant text at the head of `message.content`, and of the streamed deltas.
+
+One case is refused rather than served: a trailing assistant message carrying only `reasoning` and no `content`, where the chat template did not prime an open thinking block. The open marker is the template's, and reconstructing it would mean hard-coding a per-family marker table in the request path.
 
 ## Multimodal projectors and request media
 

--- a/src/server/assistant_prefill.rs
+++ b/src/server/assistant_prefill.rs
@@ -1,0 +1,153 @@
+// Copyright 2025-2026 Lablup Inc. and Jeongkyu Shin
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! b10621 `--prefill-assistant` (#1470).
+//!
+//! When the last message of a chat request is an assistant message, b10621
+//! treats it as a prefix the model continues rather than a complete turn:
+//! `oaicompat_chat_params_parse` sets `continue_final_message` to
+//! `COMMON_CHAT_CONTINUATION_AUTO` and `add_generation_prompt` to `false`, and
+//! `common_chat_templates_apply` then renders `messages[:-1]`, appends the
+//! family's own generation prompt, and appends the continuation message's text
+//! with no closing tag.
+//!
+//! mlxcel reaches the same prompt through the template rather than through
+//! per-family C++: it renders `messages[:-1]` with `add_generation_prompt =
+//! true`, which is exactly the family's own assistant-turn opener, and then
+//! appends the continuation text. That is template-driven, so it works for
+//! every family mlxcel loads rather than only the ones with a hand-written
+//! handler.
+//!
+//! Reference:
+//! <https://github.com/ggml-org/llama.cpp/blob/master/tools/server/server-common.cpp>
+//! and
+//! <https://github.com/ggml-org/llama.cpp/blob/master/common/chat.cpp>
+//!
+//! Used by: server::chat_request, server::routes::chat
+
+use crate::server::types::request::{ChatCompletionRequest, Role};
+
+/// b10621's own diagnostic for two or more trailing assistant messages.
+pub(crate) const TWO_TRAILING_ASSISTANTS: &str =
+    "Cannot have 2 or more assistant messages at the end of the list.";
+
+/// mlxcel's refusal for the reasoning-only continuation b10621 calls
+/// `COMMON_CHAT_CONTINUATION_REASONING`.
+pub(crate) const REASONING_ONLY_UNSUPPORTED: &str = "A trailing assistant message carrying only reasoning and no content cannot be prefilled \
+     unless the chat template primes an open thinking block; send `content` to continue the \
+     turn, or pass --no-prefill-assistant to answer it instead";
+
+/// What a resolved prefill contributes to the prompt and to the response.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct AssistantPrefill {
+    /// The continuation text, appended after the rendered generation prompt
+    /// with no closing tag.
+    pub(crate) text: String,
+    /// `true` when the text is reasoning rather than content, so the caller
+    /// appends it inside the thinking block the generation prompt opened.
+    pub(crate) is_reasoning: bool,
+}
+
+/// Decide whether this request's last message is an assistant prefill.
+///
+/// Mirrors b10621's guard exactly: prefill applies only when it is enabled,
+/// the message list is non-empty, and the last role is `assistant`; two or
+/// more trailing assistant messages are an error with upstream's wording.
+pub(crate) fn resolve(
+    request: &ChatCompletionRequest,
+    enabled: bool,
+) -> Result<Option<AssistantPrefill>, String> {
+    if !enabled {
+        return Ok(None);
+    }
+    let messages = &request.messages;
+    let Some(last) = messages.last() else {
+        return Ok(None);
+    };
+    if last.role != Role::Assistant {
+        return Ok(None);
+    }
+    if messages.len() >= 2 && messages[messages.len() - 2].role == Role::Assistant {
+        return Err(TWO_TRAILING_ASSISTANTS.to_string());
+    }
+    // A trailing assistant message that carries tool calls is a completed turn
+    // the next message answers, not a prefix: continuing it would append the
+    // call syntax to the prompt as if the model had started emitting it.
+    if last
+        .tool_calls
+        .as_ref()
+        .is_some_and(|calls| !calls.is_empty())
+    {
+        return Ok(None);
+    }
+
+    let content = last.content.text();
+    if !content.is_empty() {
+        return Ok(Some(AssistantPrefill {
+            text: content,
+            is_reasoning: false,
+        }));
+    }
+    match last.reasoning.as_deref() {
+        Some(reasoning) if !reasoning.is_empty() => Ok(Some(AssistantPrefill {
+            text: reasoning.to_string(),
+            is_reasoning: true,
+        })),
+        // An empty trailing assistant message is upstream's degenerate
+        // continuation: nothing to append, and the generation prompt alone is
+        // already what the model continues from.
+        _ => Ok(Some(AssistantPrefill {
+            text: String::new(),
+            is_reasoning: false,
+        })),
+    }
+}
+
+/// Append a resolved prefill to a rendered prompt.
+///
+/// A content continuation is appended verbatim after the generation prompt.
+/// A reasoning continuation is only representable when the generation prompt
+/// already opened a thinking block (`enable_thinking` on the Qwen-style and
+/// Gemma 4 templates), because the open marker is family-specific and lives in
+/// the template rather than here; otherwise the request is refused rather than
+/// answered with reasoning text that would read as content.
+pub(crate) fn append_to_prompt(
+    prompt: &str,
+    prefill: &AssistantPrefill,
+    primed_thinking_close: Option<&str>,
+) -> Result<String, String> {
+    if prefill.is_reasoning {
+        // A reasoning continuation stays inside the block the prompt opened.
+        let Some(_) = primed_thinking_close else {
+            return Err(REASONING_ONLY_UNSUPPORTED.to_string());
+        };
+        return Ok(format!("{prompt}{}", prefill.text));
+    }
+    // A CONTENT continuation must not land inside a primed thinking block:
+    // b10621 closes the (empty) block first, emitting `<think>\n` + reasoning +
+    // `\n</think>\n\n` before the content. The prompt already ends with the open
+    // marker, so only the closing half is appended here.
+    let closed = match primed_thinking_close {
+        Some(close) => format!("{prompt}\n{close}\n\n"),
+        None => prompt.to_string(),
+    };
+    if prefill.text.is_empty() {
+        return Ok(closed);
+    }
+    Ok(format!("{closed}{}", prefill.text))
+}
+
+#[cfg(test)]
+#[path = "assistant_prefill_tests.rs"]
+mod tests;

--- a/src/server/assistant_prefill_tests.rs
+++ b/src/server/assistant_prefill_tests.rs
@@ -1,0 +1,152 @@
+// Copyright 2025-2026 Lablup Inc. and Jeongkyu Shin
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! `--prefill-assistant` resolution tests (#1470).
+
+use super::*;
+
+fn request(body: &str) -> ChatCompletionRequest {
+    serde_json::from_str(body).expect("fixture request parses")
+}
+
+const USER_THEN_ASSISTANT: &str = r#"{
+    "model": "m",
+    "messages": [
+        {"role": "user", "content": "Finish this: the capital of"},
+        {"role": "assistant", "content": " France is"}
+    ]
+}"#;
+
+#[test]
+fn a_trailing_assistant_message_is_a_prefill_when_enabled() {
+    let prefill = resolve(&request(USER_THEN_ASSISTANT), true)
+        .expect("valid")
+        .expect("a trailing assistant message prefills");
+    assert_eq!(prefill.text, " France is");
+    assert!(!prefill.is_reasoning);
+}
+
+#[test]
+fn the_flag_off_leaves_the_trailing_assistant_message_alone() {
+    assert_eq!(resolve(&request(USER_THEN_ASSISTANT), false), Ok(None));
+}
+
+#[test]
+fn a_trailing_user_message_is_never_a_prefill() {
+    let body = r#"{"model":"m","messages":[{"role":"assistant","content":"hi"},{"role":"user","content":"hello"}]}"#;
+    assert_eq!(resolve(&request(body), true), Ok(None));
+}
+
+#[test]
+fn two_trailing_assistant_messages_are_refused_with_upstreams_wording() {
+    let body = r#"{"model":"m","messages":[
+        {"role":"user","content":"go"},
+        {"role":"assistant","content":"one"},
+        {"role":"assistant","content":"two"}
+    ]}"#;
+    assert_eq!(
+        resolve(&request(body), true),
+        Err(TWO_TRAILING_ASSISTANTS.to_string())
+    );
+}
+
+#[test]
+fn a_trailing_tool_call_message_is_a_completed_turn_not_a_prefix() {
+    let body = r#"{"model":"m","messages":[
+        {"role":"user","content":"weather?"},
+        {"role":"assistant","content":null,"tool_calls":[
+            {"id":"c1","type":"function","function":{"name":"get","arguments":"{}"}}
+        ]}
+    ]}"#;
+    assert_eq!(resolve(&request(body), true), Ok(None));
+}
+
+#[test]
+fn a_reasoning_only_trailing_message_is_a_reasoning_continuation() {
+    let body = r#"{"model":"m","messages":[
+        {"role":"user","content":"think"},
+        {"role":"assistant","content":"","reasoning":"Let me consider"}
+    ]}"#;
+    let prefill = resolve(&request(body), true)
+        .expect("valid")
+        .expect("prefill");
+    assert!(prefill.is_reasoning);
+    assert_eq!(prefill.text, "Let me consider");
+}
+
+#[test]
+fn an_empty_trailing_assistant_message_prefills_nothing_but_still_continues() {
+    let body = r#"{"model":"m","messages":[{"role":"user","content":"go"},{"role":"assistant","content":""}]}"#;
+    let prefill = resolve(&request(body), true)
+        .expect("valid")
+        .expect("prefill");
+    assert!(prefill.text.is_empty());
+    assert_eq!(
+        append_to_prompt("PROMPT<|im_start|>assistant\n", &prefill, None).unwrap(),
+        "PROMPT<|im_start|>assistant\n"
+    );
+}
+
+#[test]
+fn a_content_continuation_is_appended_with_no_closing_tag() {
+    let prefill = AssistantPrefill {
+        text: " France is".to_string(),
+        is_reasoning: false,
+    };
+    assert_eq!(
+        append_to_prompt("...<|im_start|>assistant\n", &prefill, None).unwrap(),
+        "...<|im_start|>assistant\n France is"
+    );
+}
+
+#[test]
+fn a_content_continuation_closes_a_primed_thinking_block_first() {
+    // b10621 emits `<think>\n` + reasoning + `\n</think>\n\n` before the content
+    // when the family supports reasoning; the prompt already carries the open
+    // half, so the continuation must not land inside the block.
+    let prefill = AssistantPrefill {
+        text: " France is".to_string(),
+        is_reasoning: false,
+    };
+    assert_eq!(
+        append_to_prompt(
+            "...<|im_start|>assistant\n<think>\n",
+            &prefill,
+            Some("</think>")
+        )
+        .unwrap(),
+        "...<|im_start|>assistant\n<think>\n\n</think>\n\n France is"
+    );
+}
+
+#[test]
+fn a_reasoning_continuation_needs_a_primed_thinking_block() {
+    let prefill = AssistantPrefill {
+        text: "Let me consider".to_string(),
+        is_reasoning: true,
+    };
+    assert_eq!(
+        append_to_prompt(
+            "...<|im_start|>assistant\n<think>\n",
+            &prefill,
+            Some("</think>")
+        )
+        .unwrap(),
+        "...<|im_start|>assistant\n<think>\nLet me consider"
+    );
+    assert_eq!(
+        append_to_prompt("...<|im_start|>assistant\n", &prefill, None),
+        Err(REASONING_ONLY_UNSUPPORTED.to_string())
+    );
+}

--- a/src/server/chat_request.rs
+++ b/src/server/chat_request.rs
@@ -102,6 +102,15 @@ fn history_boundary_render_attempted() {}
 
 pub(crate) struct PreparedChatRequest {
     pub(crate) prompt: String,
+    /// b10621 `--prefill-assistant` (#1470): the trailing assistant text this
+    /// prompt continues from, when the request had one and prefill is on.
+    ///
+    /// The prompt already carries it; this copy exists so the route can put it
+    /// back at the head of the response when the request sets `echo`, which is
+    /// upstream's only consumer of that field
+    /// (`task_result_state`: an `is_continuation` request with `echo == false`
+    /// primes the parser so the prefill is not re-emitted).
+    pub(crate) assistant_prefill: Option<String>,
     /// The same conversation re-rendered with `add_generation_prompt = false`
     /// (issue #1143): the history-boundary form of this request's prompt.
     ///
@@ -325,7 +334,15 @@ pub(crate) async fn prepare_chat_request(
     request: &ChatCompletionRequest,
     server_default_kwargs: Option<&ChatTemplateKwargs>,
 ) -> Result<PreparedChatRequest> {
-    prepare_chat_request_with_cache(processor, request, server_default_kwargs, false, false).await
+    prepare_chat_request_with_cache(
+        processor,
+        request,
+        server_default_kwargs,
+        false,
+        false,
+        false,
+    )
+    .await
 }
 
 /// Full variant of [`prepare_chat_request`] with explicit prompt-cache
@@ -346,6 +363,7 @@ pub(crate) async fn prepare_chat_request_with_cache(
     server_default_kwargs: Option<&ChatTemplateKwargs>,
     prompt_cache_enabled: bool,
     snapshot_reuse_capable: bool,
+    prefill_assistant: bool,
 ) -> Result<PreparedChatRequest> {
     let declared_images = request.image_urls().len();
     let declared_audio = request.audio_inputs().len();
@@ -394,12 +412,23 @@ pub(crate) async fn prepare_chat_request_with_cache(
     // that follows it, rather than paying for both and discarding the result on
     // the worker thread.
     //
+    // b10621 `--prefill-assistant` (#1470). Resolved before the render because
+    // it decides BOTH which messages the template sees (the continuation
+    // message is dropped) and how the prompt ends (the generation prompt, then
+    // the continuation text, with no closing tag).
+    let prefill = super::assistant_prefill::resolve(request, prefill_assistant)
+        .map_err(|msg| anyhow::anyhow!("{msg}"))?;
+
     let render_history_prefix = prompt_cache_enabled
         && snapshot_reuse_capable
         && !super::prompt_cache::boundary_snapshot_disabled()
         && declared_images == 0
         && declared_audio == 0
-        && declared_videos == 0;
+        && declared_videos == 0
+        // Under a prefill the primary prompt is `messages[:-1]` plus the
+        // continuation text, so a history render of the full list is not a
+        // prefix of it and would produce a snapshot the next turn cannot use.
+        && prefill.is_none();
 
     // Render the prompt, and — when the prompt cache is on — the same
     // conversation as history (`add_generation_prompt = false`). Both renders
@@ -420,7 +449,14 @@ pub(crate) async fn prepare_chat_request_with_cache(
         // shape. The typed `ChatMessage` path only carries role + flattened
         // text, which would otherwise drop image/audio/video positions before
         // processor-aware templates can render their placeholder tokens.
-        let raw_messages = build_raw_json_messages_with_thinking(request, preserve_thinking);
+        let mut raw_messages = build_raw_json_messages_with_thinking(request, preserve_thinking);
+        // Under a prefill the continuation message is not rendered by the
+        // template: it is appended after the generation prompt below.
+        if prefill.is_some()
+            && let Some(array) = raw_messages.as_array_mut()
+        {
+            array.pop();
+        }
         // Build the stripped ChatMessages in parallel so the fallback path can
         // use them without re-running strip_rolling_checkpoint.
         let stripped = build_chat_messages_with_thinking(request, preserve_thinking);
@@ -452,7 +488,10 @@ pub(crate) async fn prepare_chat_request_with_cache(
             }
         }
     } else {
-        let messages = build_chat_messages_with_thinking(request, preserve_thinking);
+        let mut messages = build_chat_messages_with_thinking(request, preserve_thinking);
+        if prefill.is_some() {
+            messages.pop();
+        }
         match processor.apply_with_kwargs(&messages, effective_tools, &merged_kwargs) {
             Ok(rendered) => {
                 let history = render_history_prefix.then(|| {
@@ -525,8 +564,23 @@ pub(crate) async fn prepare_chat_request_with_cache(
         .validate_resolved_image_count()
         .map_err(anyhow::Error::from)?;
 
+    // Append the continuation text after the template's own generation prompt.
+    // A reasoning-only continuation is representable only when that prompt
+    // primed an open thinking block, because the open marker is the template's.
+    let (prompt, assistant_prefill) = match prefill.as_ref() {
+        None => (prompt, None),
+        Some(prefill) => {
+            let primed = super::routes::chat::primed_open_thinking_close_marker(&prompt);
+            let continued = super::assistant_prefill::append_to_prompt(&prompt, prefill, primed)
+                .map_err(|msg| anyhow::anyhow!("{msg}"))?;
+            let echoed = (!prefill.is_reasoning).then(|| prefill.text.clone());
+            (continued, echoed)
+        }
+    };
+
     Ok(PreparedChatRequest {
         prompt,
+        assistant_prefill,
         history_prompt,
         image_data,
         media,

--- a/src/server/chat_request_tests.rs
+++ b/src/server/chat_request_tests.rs
@@ -218,6 +218,7 @@ async fn prepare_chat_request_rejects_image_cardinality_mismatch_and_recovers() 
         None,
         false,
         false,
+        true,
     )
     .await
     .err()
@@ -233,6 +234,7 @@ async fn prepare_chat_request_rejects_image_cardinality_mismatch_and_recovers() 
         None,
         false,
         false,
+        true,
     )
     .await
     .err()
@@ -248,6 +250,7 @@ async fn prepare_chat_request_rejects_image_cardinality_mismatch_and_recovers() 
         None,
         false,
         false,
+        true,
     )
     .await
     .expect("valid request after a rejection must still prepare");
@@ -1677,10 +1680,11 @@ async fn prompt_cache_on_defaults_preserve_thinking_to_true() {
     // flipped to true internally.
     let request = three_turn_request_with_think_blocks();
     let processor = ChatTemplateProcessor::with_template(dump_template());
-    let prepared =
-        prepare_chat_request_with_cache(&processor, &request, None, /* cache */ true, false)
-            .await
-            .unwrap();
+    let prepared = prepare_chat_request_with_cache(
+        &processor, &request, None, /* cache */ true, false, true,
+    )
+    .await
+    .unwrap();
 
     assert!(
         prepared.prompt.contains("<think>"),
@@ -1704,10 +1708,11 @@ async fn prompt_cache_on_respects_explicit_false_override() {
     request.chat_template_kwargs = Some(kw);
 
     let processor = ChatTemplateProcessor::with_template(dump_template());
-    let prepared =
-        prepare_chat_request_with_cache(&processor, &request, None, /* cache */ true, false)
-            .await
-            .unwrap();
+    let prepared = prepare_chat_request_with_cache(
+        &processor, &request, None, /* cache */ true, false, true,
+    )
+    .await
+    .unwrap();
 
     assert!(
         !prepared.prompt.contains("<think>"),
@@ -1732,10 +1737,11 @@ async fn prompt_cache_on_respects_explicit_false_via_extra_body() {
     request.extra_body = Some(extra);
 
     let processor = ChatTemplateProcessor::with_template(dump_template());
-    let prepared =
-        prepare_chat_request_with_cache(&processor, &request, None, /* cache */ true, false)
-            .await
-            .unwrap();
+    let prepared = prepare_chat_request_with_cache(
+        &processor, &request, None, /* cache */ true, false, true,
+    )
+    .await
+    .unwrap();
 
     assert!(
         !prepared.prompt.contains("<think>"),
@@ -1773,6 +1779,7 @@ async fn prompt_cache_on_respects_server_default_false() {
         Some(&server_default),
         /* cache */ true,
         false,
+        true,
     )
     .await
     .unwrap();
@@ -1815,10 +1822,11 @@ async fn preserve_thinking_defaulting_logs_once_per_session() {
     let processor = ChatTemplateProcessor::with_template(dump_template());
 
     // First call should add our session id.
-    let _ =
-        prepare_chat_request_with_cache(&processor, &request, None, /* cache */ true, false)
-            .await
-            .unwrap();
+    let _ = prepare_chat_request_with_cache(
+        &processor, &request, None, /* cache */ true, false, true,
+    )
+    .await
+    .unwrap();
     {
         let set = log_once_sessions().lock().expect("log-once mutex");
         assert!(
@@ -1831,10 +1839,11 @@ async fn preserve_thinking_defaulting_logs_once_per_session() {
     // Second call with the same session id must not grow the set at all
     // (the HashSet::insert call returns false, which is the dedup signal
     // the production code relies on to skip the log).
-    let _ =
-        prepare_chat_request_with_cache(&processor, &request, None, /* cache */ true, false)
-            .await
-            .unwrap();
+    let _ = prepare_chat_request_with_cache(
+        &processor, &request, None, /* cache */ true, false, true,
+    )
+    .await
+    .unwrap();
     {
         let set = log_once_sessions().lock().expect("log-once mutex");
         // The set may have been concurrently modified by parallel tests
@@ -1867,13 +1876,13 @@ async fn preserve_thinking_defaulting_logs_per_distinct_session() {
 
     let mut req_a = three_turn_request_with_think_blocks();
     req_a.prompt_cache_key = Some(uniq_a.clone());
-    let _ = prepare_chat_request_with_cache(&processor, &req_a, None, true, false)
+    let _ = prepare_chat_request_with_cache(&processor, &req_a, None, true, false, true)
         .await
         .unwrap();
 
     let mut req_b = three_turn_request_with_think_blocks();
     req_b.prompt_cache_key = Some(uniq_b.clone());
-    let _ = prepare_chat_request_with_cache(&processor, &req_b, None, true, false)
+    let _ = prepare_chat_request_with_cache(&processor, &req_b, None, true, false, true)
         .await
         .unwrap();
 
@@ -2514,14 +2523,26 @@ async fn history_render_is_a_prefix_of_the_next_turns_prompt() {
     messages_t3.push(text_message(Role::User, "q3"));
 
     reset_history_boundary_render_attempts_for_test();
-    let prep_t2 =
-        prepare_chat_request_with_cache(&processor, &cached_request(messages_t2), None, true, true)
-            .await
-            .unwrap();
-    let prep_t3 =
-        prepare_chat_request_with_cache(&processor, &cached_request(messages_t3), None, true, true)
-            .await
-            .unwrap();
+    let prep_t2 = prepare_chat_request_with_cache(
+        &processor,
+        &cached_request(messages_t2),
+        None,
+        true,
+        true,
+        true,
+    )
+    .await
+    .unwrap();
+    let prep_t3 = prepare_chat_request_with_cache(
+        &processor,
+        &cached_request(messages_t3),
+        None,
+        true,
+        true,
+        true,
+    )
+    .await
+    .unwrap();
     assert_eq!(
         history_boundary_render_attempts_for_test(),
         2,
@@ -2565,7 +2586,7 @@ async fn history_render_is_absent_when_the_model_cannot_reuse_snapshots() {
     let request = cached_request(vec![text_message(Role::User, "q1")]);
     reset_history_boundary_render_attempts_for_test();
 
-    let prepared = prepare_chat_request_with_cache(&processor, &request, None, true, false)
+    let prepared = prepare_chat_request_with_cache(&processor, &request, None, true, false, true)
         .await
         .unwrap();
     assert_eq!(
@@ -2589,7 +2610,7 @@ async fn history_render_is_absent_when_the_prompt_cache_is_off() {
     let processor = ChatTemplateProcessor::with_template(generation_scaffold_template());
     let request = cached_request(vec![text_message(Role::User, "q1")]);
 
-    let prepared = prepare_chat_request_with_cache(&processor, &request, None, false, true)
+    let prepared = prepare_chat_request_with_cache(&processor, &request, None, false, true, true)
         .await
         .unwrap();
     assert!(
@@ -2606,7 +2627,7 @@ async fn history_render_is_absent_when_the_template_render_falls_back() {
     let processor = ChatTemplateProcessor::with_template(broken_template());
     let request = cached_request(vec![text_message(Role::User, "q1")]);
 
-    let prepared = prepare_chat_request_with_cache(&processor, &request, None, true, true)
+    let prepared = prepare_chat_request_with_cache(&processor, &request, None, true, true, true)
         .await
         .unwrap();
     assert!(prepared.history_prompt.is_none());
@@ -2634,7 +2655,7 @@ async fn history_render_is_absent_for_multimodal_requests() {
         tool_calls: None,
     }]);
 
-    let prepared = prepare_chat_request_with_cache(&processor, &request, None, true, true)
+    let prepared = prepare_chat_request_with_cache(&processor, &request, None, true, true, true)
         .await
         .unwrap();
     assert!(prepared.history_prompt.is_none());
@@ -2753,4 +2774,190 @@ fn clip_warmup_target_keeps_only_what_any_next_turn_reproduces() {
     assert_eq!(clip_warmup_target(&[1, 2, 3], &[9, 9, 9]), None);
     assert_eq!(clip_warmup_target(&[], &probe), None);
     assert_eq!(clip_warmup_target(&target, &[]), None);
+}
+
+// ---------------------------------------------------------------------------
+// b10621 `--prefill-assistant` (#1470)
+// ---------------------------------------------------------------------------
+
+/// A template shaped like the Qwen family: each message is a delimited turn,
+/// and `add_generation_prompt` opens an assistant turn the model continues.
+fn prefill_processor() -> ChatTemplateProcessor {
+    ChatTemplateProcessor::with_template(
+        "{% for m in messages %}<|im_start|>{{ m.role }}\n{{ m.content }}<|im_end|>\n{% endfor %}\
+         {% if add_generation_prompt %}<|im_start|>assistant\n{% endif %}"
+            .to_string(),
+    )
+}
+
+fn prefill_request() -> ChatCompletionRequest {
+    request_with_messages(vec![
+        Message {
+            role: Role::User,
+            content: MessageContent::Text("Finish this: the capital of".to_string()),
+            name: None,
+            tool_call_id: None,
+            tool_calls: None,
+            reasoning: None,
+        },
+        Message {
+            role: Role::Assistant,
+            content: MessageContent::Text(" France is".to_string()),
+            name: None,
+            tool_call_id: None,
+            tool_calls: None,
+            reasoning: None,
+        },
+    ])
+}
+
+#[tokio::test]
+async fn a_trailing_assistant_message_is_continued_when_prefill_is_on() {
+    let prepared = prepare_chat_request_with_cache(
+        &prefill_processor(),
+        &prefill_request(),
+        None,
+        false,
+        false,
+        true,
+    )
+    .await
+    .expect("render succeeds");
+    // The continuation text ends the prompt with no closing turn marker, so
+    // the model continues the sentence instead of answering it.
+    assert!(
+        prepared
+            .prompt
+            .ends_with("<|im_start|>assistant\n France is"),
+        "unexpected prompt: {:?}",
+        prepared.prompt
+    );
+    assert_eq!(prepared.assistant_prefill.as_deref(), Some(" France is"));
+}
+
+#[tokio::test]
+async fn no_prefill_assistant_answers_the_trailing_message_instead() {
+    let prepared = prepare_chat_request_with_cache(
+        &prefill_processor(),
+        &prefill_request(),
+        None,
+        false,
+        false,
+        false,
+    )
+    .await
+    .expect("render succeeds");
+    // The assistant message is a completed turn and a fresh one is opened.
+    assert!(
+        prepared
+            .prompt
+            .ends_with(" France is<|im_end|>\n<|im_start|>assistant\n"),
+        "unexpected prompt: {:?}",
+        prepared.prompt
+    );
+    assert_eq!(prepared.assistant_prefill, None);
+}
+
+#[tokio::test]
+async fn the_two_renderings_differ_and_are_not_reachable_from_each_other() {
+    let on = prepare_chat_request_with_cache(
+        &prefill_processor(),
+        &prefill_request(),
+        None,
+        false,
+        false,
+        true,
+    )
+    .await
+    .expect("render succeeds");
+    let off = prepare_chat_request_with_cache(
+        &prefill_processor(),
+        &prefill_request(),
+        None,
+        false,
+        false,
+        false,
+    )
+    .await
+    .expect("render succeeds");
+    assert_ne!(on.prompt, off.prompt);
+    // The continued form is a strict PREFIX of the answered one: the flag
+    // decides whether the trailing assistant message is closed and a fresh
+    // turn opened. That is exactly why the two need different prompt-cache
+    // buckets rather than sharing one: an exact-prefix boundary snapshot
+    // recorded under one rendering would otherwise be adopted by the other,
+    // which continues from a different point in the same string.
+    assert!(
+        off.prompt.starts_with(&on.prompt),
+        "off={:?} on={:?}",
+        off.prompt,
+        on.prompt
+    );
+    assert!(
+        off.prompt.len() > on.prompt.len(),
+        "the answered form adds the closing turn and a fresh generation prompt"
+    );
+}
+
+#[tokio::test]
+async fn a_request_with_no_trailing_assistant_message_is_unaffected_by_the_flag() {
+    let request = request_with_messages(vec![Message {
+        role: Role::User,
+        content: MessageContent::Text("hello".to_string()),
+        name: None,
+        tool_call_id: None,
+        tool_calls: None,
+        reasoning: None,
+    }]);
+    let on =
+        prepare_chat_request_with_cache(&prefill_processor(), &request, None, false, false, true)
+            .await
+            .expect("render succeeds");
+    let off =
+        prepare_chat_request_with_cache(&prefill_processor(), &request, None, false, false, false)
+            .await
+            .expect("render succeeds");
+    assert_eq!(on.prompt, off.prompt);
+    assert_eq!(on.assistant_prefill, None);
+}
+
+#[tokio::test]
+async fn two_trailing_assistant_messages_are_refused_with_upstreams_wording() {
+    let assistant = |text: &str| Message {
+        role: Role::Assistant,
+        content: MessageContent::Text(text.to_string()),
+        name: None,
+        tool_call_id: None,
+        tool_calls: None,
+        reasoning: None,
+    };
+    let request = request_with_messages(vec![
+        Message {
+            role: Role::User,
+            content: MessageContent::Text("go".to_string()),
+            name: None,
+            tool_call_id: None,
+            tool_calls: None,
+            reasoning: None,
+        },
+        assistant("one"),
+        assistant("two"),
+    ]);
+    let err = match prepare_chat_request_with_cache(
+        &prefill_processor(),
+        &request,
+        None,
+        false,
+        false,
+        true,
+    )
+    .await
+    {
+        Ok(_) => panic!("two trailing assistant messages are an error"),
+        Err(err) => err,
+    };
+    assert_eq!(
+        err.to_string(),
+        "Cannot have 2 or more assistant messages at the end of the list."
+    );
 }

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -16,6 +16,7 @@
 
 pub mod anthropic_translator;
 pub mod app;
+pub(crate) mod assistant_prefill;
 pub mod audio_model;
 pub(crate) mod audio_worker;
 pub mod auth;

--- a/src/server/prompt_cache/key.rs
+++ b/src/server/prompt_cache/key.rs
@@ -459,9 +459,25 @@ pub fn template_sig(
     chat_template_kwargs: &ChatTemplateKwargs,
     tool_choice: Option<&ToolChoice>,
     tools: Option<&[Tool]>,
+    assistant_prefill: bool,
 ) -> String {
     let mut hasher = blake3::Hasher::new();
     hasher.update(b"mlxcel:prompt-cache:template-sig:v1");
+
+    // b10621 `--prefill-assistant` (#1470). The same conversation renders two
+    // different prompts depending on whether its trailing assistant message is
+    // continued or answered: one ends with the generation prompt plus the
+    // continuation text, the other renders that message as a completed turn
+    // and opens a fresh one. Without this dimension the two share a bucket and
+    // the second request re-prefills from the point where they diverge.
+    write_field(
+        &mut hasher,
+        if assistant_prefill {
+            b"prefill:on".as_slice()
+        } else {
+            b"prefill:off".as_slice()
+        },
+    );
 
     write_field(&mut hasher, chat_template_source.as_bytes());
 

--- a/src/server/prompt_cache/key_tests.rs
+++ b/src/server/prompt_cache/key_tests.rs
@@ -205,8 +205,8 @@ fn sample_tool(name: &str) -> Tool {
 #[test]
 fn template_sig_is_stable_for_identical_inputs() {
     let kw = ChatTemplateKwargs::from_json_str(r#"{"preserve_thinking": true}"#).unwrap();
-    let a = template_sig("tpl", &kw, None, None);
-    let b = template_sig("tpl", &kw, None, None);
+    let a = template_sig("tpl", &kw, None, None, false);
+    let b = template_sig("tpl", &kw, None, None, false);
     assert_eq!(a, b);
     assert_eq!(a.len(), 64, "must be 64-char hex");
 }
@@ -214,8 +214,8 @@ fn template_sig_is_stable_for_identical_inputs() {
 #[test]
 fn template_sig_changes_when_template_source_changes() {
     let kw = ChatTemplateKwargs::new();
-    let a = template_sig("template-a", &kw, None, None);
-    let b = template_sig("template-b", &kw, None, None);
+    let a = template_sig("template-a", &kw, None, None, false);
+    let b = template_sig("template-b", &kw, None, None, false);
     assert_ne!(a, b);
 }
 
@@ -223,8 +223,8 @@ fn template_sig_changes_when_template_source_changes() {
 fn template_sig_changes_when_kwargs_change() {
     let kw_a = ChatTemplateKwargs::from_json_str(r#"{"preserve_thinking": true}"#).unwrap();
     let kw_b = ChatTemplateKwargs::from_json_str(r#"{"preserve_thinking": false}"#).unwrap();
-    let a = template_sig("tpl", &kw_a, None, None);
-    let b = template_sig("tpl", &kw_b, None, None);
+    let a = template_sig("tpl", &kw_a, None, None, false);
+    let b = template_sig("tpl", &kw_b, None, None, false);
     assert_ne!(a, b);
 }
 
@@ -234,8 +234,8 @@ fn template_sig_canonicalizes_kwargs_key_order() {
     // these to the same digest so map-insertion-order drift is absorbed.
     let kw_a = ChatTemplateKwargs::from_json_str(r#"{"a": 1, "b": 2}"#).unwrap();
     let kw_b = ChatTemplateKwargs::from_json_str(r#"{"b": 2, "a": 1}"#).unwrap();
-    let a = template_sig("tpl", &kw_a, None, None);
-    let b = template_sig("tpl", &kw_b, None, None);
+    let a = template_sig("tpl", &kw_a, None, None, false);
+    let b = template_sig("tpl", &kw_b, None, None, false);
     assert_eq!(a, b, "kwargs key order must not affect the signature");
 }
 
@@ -247,12 +247,14 @@ fn template_sig_changes_when_tool_choice_mode_changes() {
         &kw,
         Some(&ToolChoice::Mode("auto".to_string())),
         None,
+        false,
     );
     let b = template_sig(
         "tpl",
         &kw,
         Some(&ToolChoice::Mode("none".to_string())),
         None,
+        false,
     );
     assert_ne!(a, b);
 }
@@ -260,12 +262,13 @@ fn template_sig_changes_when_tool_choice_mode_changes() {
 #[test]
 fn template_sig_distinguishes_absent_from_auto_tool_choice() {
     let kw = ChatTemplateKwargs::new();
-    let absent = template_sig("tpl", &kw, None, None);
+    let absent = template_sig("tpl", &kw, None, None, false);
     let auto = template_sig(
         "tpl",
         &kw,
         Some(&ToolChoice::Mode("auto".to_string())),
         None,
+        false,
     );
     assert_ne!(absent, auto);
 }
@@ -275,8 +278,8 @@ fn template_sig_changes_when_tools_added() {
     let kw = ChatTemplateKwargs::new();
     let tools_a: Vec<Tool> = vec![];
     let tools_b = vec![sample_tool("get_weather")];
-    let a = template_sig("tpl", &kw, None, Some(&tools_a));
-    let b = template_sig("tpl", &kw, None, Some(&tools_b));
+    let a = template_sig("tpl", &kw, None, Some(&tools_a), false);
+    let b = template_sig("tpl", &kw, None, Some(&tools_b), false);
     assert_ne!(a, b);
 }
 
@@ -285,8 +288,8 @@ fn template_sig_changes_when_tool_removed() {
     let kw = ChatTemplateKwargs::new();
     let two = vec![sample_tool("get_weather"), sample_tool("send_email")];
     let one = vec![sample_tool("get_weather")];
-    let a = template_sig("tpl", &kw, None, Some(&two));
-    let b = template_sig("tpl", &kw, None, Some(&one));
+    let a = template_sig("tpl", &kw, None, Some(&two), false);
+    let b = template_sig("tpl", &kw, None, Some(&one), false);
     assert_ne!(a, b);
 }
 
@@ -297,8 +300,8 @@ fn template_sig_changes_when_tools_reordered() {
     let kw = ChatTemplateKwargs::new();
     let forward = vec![sample_tool("a"), sample_tool("b")];
     let reversed = vec![sample_tool("b"), sample_tool("a")];
-    let a = template_sig("tpl", &kw, None, Some(&forward));
-    let b = template_sig("tpl", &kw, None, Some(&reversed));
+    let a = template_sig("tpl", &kw, None, Some(&forward), false);
+    let b = template_sig("tpl", &kw, None, Some(&reversed), false);
     assert_ne!(
         a, b,
         "tool reordering must invalidate the template signature"
@@ -310,8 +313,8 @@ fn template_sig_treats_empty_tools_and_none_tools_identically() {
     // Both map to the same "no tools" marker in the digest.
     let kw = ChatTemplateKwargs::new();
     let empty: Vec<Tool> = vec![];
-    let a = template_sig("tpl", &kw, None, None);
-    let b = template_sig("tpl", &kw, None, Some(&empty));
+    let a = template_sig("tpl", &kw, None, None, false);
+    let b = template_sig("tpl", &kw, None, Some(&empty), false);
     assert_eq!(a, b);
 }
 
@@ -346,8 +349,8 @@ fn template_sig_changes_with_tool_name() {
     // Two tools with the same type and description but different names must
     // still yield different signatures.
     let kw = ChatTemplateKwargs::new();
-    let a = template_sig("tpl", &kw, None, Some(&[sample_tool("alpha")]));
-    let b = template_sig("tpl", &kw, None, Some(&[sample_tool("beta")]));
+    let a = template_sig("tpl", &kw, None, Some(&[sample_tool("alpha")]), false);
+    let b = template_sig("tpl", &kw, None, Some(&[sample_tool("beta")]), false);
     assert_ne!(a, b);
 }
 
@@ -356,7 +359,7 @@ fn template_sig_fits_into_prompt_cache_key() {
     // Smoke: signature hex can slot straight into the cache key's
     // `template_sig` field.
     let kw = ChatTemplateKwargs::new();
-    let sig = template_sig("tpl", &kw, None, None);
+    let sig = template_sig("tpl", &kw, None, None, false);
     let toks = tokens(4);
     let key = text_key("m", None, sig.as_str(), None, &toks);
     assert_eq!(key.template_sig, sig.as_str());

--- a/src/server/reasoning_effort_tests.rs
+++ b/src/server/reasoning_effort_tests.rs
@@ -921,7 +921,7 @@ fn template_sig_separates_two_top_level_efforts() {
         let mut req = request(user_hi());
         req.reasoning_effort = Some(effort.to_string());
         let resolved = resolve_effective_kwargs(processor, &req, None, &req.merged_extra_body());
-        template_sig(processor.template_source(), &resolved, None, None)
+        template_sig(processor.template_source(), &resolved, None, None, false)
     };
 
     let qwen = qwen3_8();

--- a/src/server/responses_translator.rs
+++ b/src/server/responses_translator.rs
@@ -933,6 +933,7 @@ mod tests {
             None,
             false,
             false,
+            true,
         )
         .await
         {
@@ -958,6 +959,7 @@ mod tests {
             None,
             false,
             false,
+            true,
         )
         .await
         .expect("engine-side render failure should keep fallback behavior");

--- a/src/server/router_front.rs
+++ b/src/server/router_front.rs
@@ -851,6 +851,7 @@ async fn route_chat(
         live.chat_template_kwargs.as_ref(),
         false,
         false,
+        !state.config.no_prefill_assistant,
     )
     .await
     {

--- a/src/server/routes/anthropic.rs
+++ b/src/server/routes/anthropic.rs
@@ -221,6 +221,7 @@ async fn non_stream_messages(
         live.chat_template_kwargs.as_ref(),
         prompt_cache_enabled,
         state.should_render_history_boundary_snapshot(),
+        state.prefill_assistant(),
     )
     .await
     {
@@ -376,6 +377,7 @@ async fn stream_messages(
         live.chat_template_kwargs.as_ref(),
         prompt_cache_enabled,
         state.should_render_history_boundary_snapshot(),
+        state.prefill_assistant(),
     )
     .await
     {
@@ -693,6 +695,7 @@ pub async fn anthropic_count_tokens(
         live.chat_template_kwargs.as_ref(),
         prompt_cache_enabled,
         state.should_render_history_boundary_snapshot(),
+        state.prefill_assistant(),
     )
     .await
     {

--- a/src/server/routes/chat.rs
+++ b/src/server/routes/chat.rs
@@ -139,6 +139,13 @@ pub(crate) fn build_prompt_cache_request_context(
         &merged_kwargs,
         request.tool_choice.as_ref(),
         request.tools.as_deref(),
+        // The dimension only matters when this request actually has a trailing
+        // assistant message: hashing the flag unconditionally would split every
+        // bucket in the store the first time an operator passes
+        // `--no-prefill-assistant`.
+        state.prefill_assistant()
+            && crate::server::assistant_prefill::resolve(request, true)
+                .is_ok_and(|prefill| prefill.is_some()),
     );
     let session_key =
         resolve_session_key(request.resolve_prompt_cache_key(), request.resolve_user()).to_string();
@@ -465,6 +472,7 @@ pub(crate) async fn non_stream_chat_completion(
         live.chat_template_kwargs.as_ref(),
         prompt_cache_enabled,
         state.should_render_history_boundary_snapshot(),
+        state.prefill_assistant(),
     )
     .await
     .map_err(|err| ErrorResponse::new(err.to_string(), "invalid_request_error"))?;
@@ -537,6 +545,16 @@ pub(crate) async fn non_stream_chat_completion(
         super::slots::slot_params_json(&options, false),
         Some(options.max_tokens as i64),
     );
+    // b10621 `echo` (#1470): with a prefilled assistant message and `echo`
+    // set, the prefill leads the response. Upstream reaches the same shape by
+    // NOT priming its chat parser, so the first diff carries the continuation
+    // text; prepending it to the generated text here feeds the identical
+    // string through tool-call parsing, the reasoning split and the
+    // `--reasoning-format` placement.
+    let echo_prefill = request
+        .resolve_echo()
+        .then(|| prepared.assistant_prefill.clone())
+        .flatten();
     let mut result = state
         .model_provider
         .generate_with_media_and_videos_declared_live(
@@ -549,6 +567,10 @@ pub(crate) async fn non_stream_chat_completion(
             &live,
         )
         .map_err(generation_error_to_response)?;
+
+    if let Some(prefill) = echo_prefill.as_deref() {
+        result.text.insert_str(0, prefill);
+    }
 
     // Structured Florence-2 task output (issue #1073): produced only by the
     // seq2seq worker, `None` for every other family. Attached below as the
@@ -894,6 +916,7 @@ pub(crate) async fn stream_asr_completion(
         live.chat_template_kwargs.as_ref(),
         prompt_cache_enabled,
         state.should_render_history_boundary_snapshot(),
+        state.prefill_assistant(),
     )
     .await
     {
@@ -1068,6 +1091,7 @@ async fn stream_chat_completion(
         live.chat_template_kwargs.as_ref(),
         prompt_cache_enabled,
         state.should_render_history_boundary_snapshot(),
+        state.prefill_assistant(),
     )
     .await;
     let prepared = match prepared {
@@ -1076,6 +1100,11 @@ async fn stream_chat_completion(
             return ErrorResponse::new(err.to_string(), "invalid_request_error").into_response();
         }
     };
+    // b10621 `echo` (#1470), captured before `prepared` is consumed.
+    let echo_prefill = request
+        .resolve_echo()
+        .then(|| prepared.assistant_prefill.clone())
+        .flatten();
     // Build the prompt-cache context AFTER preparation so the multimodal
     // digest sees the resolved image/audio bytes.
     let prompt_cache_ctx = build_prompt_cache_request_context(
@@ -1224,6 +1253,21 @@ async fn stream_chat_completion(
         let initial =
             ChatCompletionChunk::initial(request_id_clone.clone(), model_id_clone.clone());
         let _ = finish_events.json(&initial);
+
+        // b10621 `echo` (#1470): a prefilled assistant message leads the
+        // response when `echo` is set. Upstream reaches the same shape by not
+        // priming its chat parser, so the first diff already carries the
+        // continuation text; here it is one content delta ahead of the token
+        // stream, which is byte-identical once the deltas are concatenated.
+        if let Some(prefill) = echo_prefill.as_deref() {
+            let chunk = ChatCompletionChunk::content_with_logprobs(
+                request_id_clone.clone(),
+                model_id_clone.clone(),
+                prefill.to_string(),
+                None,
+            );
+            let _ = finish_events.json(&chunk);
+        }
 
         // Accumulate full output for tool call parsing at the end
         let token_events = finish_events.clone();
@@ -1702,9 +1746,22 @@ const OPEN_THINKING_SUFFIXES: &[&str] = &["<|channel>thought\n", "<think>\n"];
 ///   opening token that never appears because the prompt already contains
 ///   it).
 pub(crate) fn is_prompt_primed_open_thinking(prompt: &str) -> bool {
+    primed_open_thinking_close_marker(prompt).is_some()
+}
+
+/// The close marker the model is expected to emit for the thinking block this
+/// generation prompt primed, or `None` when it primed none.
+///
+/// Paired positionally with [`OPEN_THINKING_SUFFIXES`], and ordered
+/// longest-first with it so a prompt matches exactly one family.
+///
+/// Used by: server::chat_request (b10621 assistant prefill, #1470)
+pub(crate) fn primed_open_thinking_close_marker(prompt: &str) -> Option<&'static str> {
     OPEN_THINKING_SUFFIXES
         .iter()
-        .any(|suffix| prompt.ends_with(suffix))
+        .zip(OPEN_THINKING_CLOSE_MARKERS.iter())
+        .find(|(suffix, _)| prompt.ends_with(**suffix))
+        .map(|(_, close)| *close)
 }
 
 /// Close markers for each supported open-thinking priming convention. Paired

--- a/src/server/routes/prompt_inspection.rs
+++ b/src/server/routes/prompt_inspection.rs
@@ -97,6 +97,7 @@ async fn render_chat_prompt(
         live.chat_template_kwargs.as_ref(),
         prompt_cache_enabled,
         state.should_render_history_boundary_snapshot(),
+        state.prefill_assistant(),
     )
     .await
     .map(|prepared| prepared.prompt)

--- a/src/server/routes/responses.rs
+++ b/src/server/routes/responses.rs
@@ -241,6 +241,7 @@ async fn non_stream_create_response(
         live.chat_template_kwargs.as_ref(),
         prompt_cache_enabled,
         state.should_render_history_boundary_snapshot(),
+        state.prefill_assistant(),
     )
     .await;
     let prepared = match prepared {
@@ -380,6 +381,7 @@ async fn stream_create_response(
         live.chat_template_kwargs.as_ref(),
         prompt_cache_enabled,
         state.should_render_history_boundary_snapshot(),
+        state.prefill_assistant(),
     )
     .await;
     let prepared = match prepared {

--- a/src/server/startup.rs
+++ b/src/server/startup.rs
@@ -2962,8 +2962,9 @@ pub async fn start_server(mut startup: ServerStartupConfig) -> Result<()> {
     // know the request path does not honour it yet.
     if config.no_prefill_assistant {
         tracing::info!(
-            "--no-prefill-assistant is what mlxcel already does: a trailing assistant message \
-             is answered with a fresh turn, not continued. llama-server continues it by default"
+            "--no-prefill-assistant: a trailing assistant message is answered with a fresh turn \
+             rather than continued. Assistant prefill is on by default since #1470, matching \
+             llama-server"
         );
     }
     if config.reasoning_budget_message.is_some() {

--- a/src/server/state.rs
+++ b/src/server/state.rs
@@ -748,6 +748,15 @@ impl AppState {
     pub fn should_render_history_boundary_snapshot(&self) -> bool {
         !self.model_provider.is_loaded() || self.model_provider.supports_snapshot_reuse()
     }
+
+    /// b10621 `--prefill-assistant` / `LLAMA_ARG_PREFILL_ASSISTANT` (#1470).
+    ///
+    /// Upstream prefills by default: a trailing assistant message is a prefix
+    /// the model continues. `--no-prefill-assistant` turns that off and makes
+    /// it a completed turn the model answers instead.
+    pub fn prefill_assistant(&self) -> bool {
+        !self.config.no_prefill_assistant
+    }
 }
 
 #[cfg(test)]

--- a/src/server/types/request.rs
+++ b/src/server/types/request.rs
@@ -967,6 +967,33 @@ impl ChatCompletionRequest {
         }
     }
 
+    /// b10621 `echo` (#1470): whether an assistant prefill is included in the
+    /// output.
+    ///
+    /// Upstream's only consumer is `task_result_state`, which primes the chat
+    /// parser so a continuation's prefill is NOT re-emitted when `echo` is
+    /// false (the default); with `echo` true the prefilled assistant text
+    /// leads the response. The key arrives as an unknown root field and is
+    /// therefore read out of the flattened capture rather than declared, which
+    /// is also how upstream sees it: `oaicompat_chat_params_parse` copies every
+    /// body key it did not handle itself into the native parameter object.
+    ///
+    /// Inert on a request that carries no trailing assistant message, as it is
+    /// upstream.
+    #[must_use]
+    pub fn resolve_echo(&self) -> bool {
+        self.extra_body_fields
+            .get("echo")
+            .and_then(serde_json::Value::as_bool)
+            .or_else(|| {
+                self.extra_body
+                    .as_ref()
+                    .and_then(|extra| extra.get("echo"))
+                    .and_then(serde_json::Value::as_bool)
+            })
+            .unwrap_or(false)
+    }
+
     /// Resolve the request-level `prompt_cache_key`.
     ///
     /// Precedence (first non-empty wins):
@@ -1480,6 +1507,20 @@ pub struct NativeCompletionRequest {
     /// non-empty one is refused with a 400 naming the deferral.
     #[serde(default)]
     pub preserved_tokens: Option<serde_json::Value>,
+
+    /// b10621 `echo` (#1470): include an assistant prefill in the output.
+    ///
+    /// Declared here because upstream declares it in the same native schema,
+    /// and inert here because upstream's only consumer
+    /// (`task_result_state`, which primes the chat parser so a continuation's
+    /// prefill is not re-emitted) fires only when the request is a chat
+    /// continuation. `POST /completion` takes a raw prompt with no chat
+    /// template and therefore never is one, so the field does nothing on this
+    /// route upstream either. The chat routes read the same key out of their
+    /// own body (`ChatCompletionRequest::resolve_echo`), which is where it has
+    /// an effect.
+    #[serde(default)]
+    pub echo: Option<bool>,
 
     // thinking-token budget (Qwen3-family reasoning cap).
     /// Primary / llama.cpp-compatible name for the reasoning-token cap.


### PR DESCRIPTION
## Summary

Implements two of the four surfaces issue #1470 owns in `chat-templates.json`, and settles one of its open questions against the full upstream tree. **Issue #1470 stays OPEN**: `--reasoning-budget-message` and `--reasoning-format` are still `deferred` against it, so this PR deliberately carries no closing keyword.

Delivered: `--prefill-assistant` (b10621's default-on assistant continuation), the `echo` field on both the native and chat surfaces, and a definitive answer to the `reasoning_in_content` question the issue could not resolve from the pinned source set.

## Assistant prefill

`--prefill-assistant` is served and on by default, as upstream: when the last message of a chat request is an assistant message it is a prefix the model continues rather than a turn it answers. `--no-prefill-assistant` restores the pre-#1470 behavior. Two or more trailing assistant messages are refused with b10621's own wording, and only while prefill is enabled, which is upstream's guard too (`inputs.continue_final_message == NONE && opt.prefill_assistant && ... messages.back().role == "assistant"`).

mlxcel reaches the continued prompt **through the template** rather than through per-family C++. b10621 renders `messages[:-1]`, then appends a hand-written per-family generation prompt (`GEN_PREFIX`, `[THINK]`, and so on) plus the continuation text; mlxcel renders `messages[:-1]` with `add_generation_prompt = true`, which *is* the family's own assistant-turn opener, and appends the continuation text with no closing tag. Same prompt for the families upstream has handlers for, and a correct one for every other family mlxcel loads.

A content continuation closes a primed thinking block first. Upstream emits `<think>\n` + reasoning + `\n</think>\n\n` ahead of the content for a reasoning-capable family, and without that step the continuation lands *inside* the model's thoughts, which the real-checkpoint run caught before this was correct: the prompt ended `<think>\nThe capital of France` and the model continued, closed the block, then started over.

The rendering is a prompt-cache key dimension (`template_sig`). The continued prompt is a strict **prefix** of the answered one, so an exact-prefix boundary snapshot recorded under one rendering could otherwise be adopted by the other, which resumes from a different point in the same string. The boundary render is skipped entirely under a prefill for the same reason.

## `echo`

The issue's premise for this field was wrong, and the manifest inherited it: `echo` is not "echo the prompt tokens back". Upstream declares it as `bool echo = false; // Include assistant prefilled msg in output` and its only consumer is `task_result_state`, which primes the chat parser so a **continuation's** assistant prefill is not re-emitted when `echo` is false. On `POST /completion` that branch never fires, because a raw-prompt request is never a continuation, so `echo` is inert there **upstream too**. mlxcel now declares it on the native schema and leaves it inert, which matches; the entry is `supported`, not the missing feature the issue described.

Where upstream's consumer does fire is the chat routes, and `echo` is honored there: `echo: true` puts the prefilled assistant text at the head of `message.content` and of the streamed deltas. The key is read out of the flattened unknown-field capture rather than declared as a struct field, which is also how upstream sees it: `oaicompat_chat_params_parse` copies every body key it did not handle itself into the native parameter object.

## `reasoning_in_content`, settled

The issue asked whether a streamed `deepseek-legacy` response should populate `delta.content` only rather than both fields, and recorded that it could not be checked because upstream's consumer sat outside the pinned source set. Fetched the rest of the b10621 tree and checked: `chat_parser_params.reasoning_in_content` is **set** in `tools/server/server-schema.cpp` (twice) and **reported** by `params_to_json` (twice), and **no parser reads it**. `common/chat.cpp` (3908 lines, the whole parser), `common/chat-peg-parser.cpp` and the auto-parser sources contain no reference to it.

It is a dead field at this commit. A streamed `deepseek-legacy` response therefore carries the thoughts in **both** fields, exactly as the help text documents and exactly as mlxcel already implements, so nothing needs to change and the `--reasoning-format` entry loses that divergence line. That closes one of the issue's acceptance criteria without any code.

## Still deferred against #1470

- `--reasoning-budget-message`: injecting the message before the forced close needs the tokenized run threaded from `ServerConfig` through the model-worker parameter chain to `ThinkingState`, plus a new `ThinkingDecision` variant and a cursor the scheduler advances. Not started here; the flag still parses and warns at startup.
- `--reasoning-format`: the streamed `none` / `deepseek-legacy` delimiter loss. The non-streaming path rebuilds `{open}{thoughts}{close}{answer}` from the parser's own marker pair; the streaming path needs `StreamFilter` to report the marker it matched (a `FilterOutput` field, not a mode) and the chat route plus the disaggregated router front to emit it at the reasoning boundaries. Designed but not written.

Both keep their recorded divergences, and the issue stays open for them.

## Manifest

`--prefill-assistant` moves from `deferred` to `by_design`, with one divergence: a trailing assistant message carrying only `reasoning` and no `content` is refused when the chat template did not prime an open thinking block. The open marker is the template's, and reconstructing it would mean hard-coding a per-family marker table in the request path, which is exactly the per-family C++ this implementation avoids; `revisit_if` names the template-derived marker lookup that would make it expressible. `field:echo` moves to `supported` with the corrected reading of upstream above. `chat-templates.json` now holds two deferred entries, both against #1470.

## Validation (models/mlx/qwen3-4b-4bit, real checkpoint)

Ten checks against a running `mlxcel-server`, then a second server arm under `--no-prefill-assistant`. The prompt itself is checked directly through `POST /apply-template`, because the rendered prompt *is* what this flag changes; the generated text is checked on top of that rather than instead of it. All arms run with `enable_thinking: false`, because a Qwen3 continuation otherwise emits its own bare `</think>` and mlxcel's (pre-existing, upstream-matching) primed-close handling routes the continuation into `reasoning_content`, hiding it from `content`.

| Check | Observed |
|-------|----------|
| The rendered prompt ends with the continuation and no closing turn | `...<\|im_start\|>assistant\n<think>\n\n</think>\n\nThe capital of France` |
| The answered form closes the message and opens a fresh turn | `...The capital of France<\|im_end\|>\n<\|im_start\|>assistant\n<think>\n\n</think>\n\n` |
| A trailing assistant message is continued, not answered | continuation `'is Paris.'`, which does not restate the prefilled words |
| Control: the same conversation without the trailing assistant message | `'The capital of France is Paris.'`, a self-contained answer, different from the continuation |
| `echo: true` leads the response with the prefilled text | `'The capital of France is Paris.'` = prefill + the continuation above |
| Control: `echo: false` vs omitting it | byte-identical |
| Two trailing assistant messages | 400 `Cannot have 2 or more assistant messages at the end of the list.` |
| The streamed continuation vs the non-streaming one | equal after trim (`' is Paris.'`; the non-streaming path trims, the deltas do not) |
| `echo` leads the streamed deltas too | `'The capital of France is Paris.'` |
| Native `/completion` with and without `echo` | byte-identical, which is upstream's behavior on that route |
| Second arm, `--no-prefill-assistant` | the prompt closes the assistant message and opens a fresh turn; two trailing assistant messages are accepted, because upstream's error is gated on prefill being enabled |

## Unit gates

`server::` 2717, `cli::` 252, `--bin mlxcel` 223, `--bin mlxcel-server` 35, `llama_compat_manifest` 4, `cli_help_consistency` 25, `check_llama_compat_manifest.py` OK, `check_cross_repo_refs.py` OK, `cargo fmt --all --check` and `cargo clippy --lib --bins --tests -- -D warnings` clean.

Refs #1470

Refs #1431
