### PR TITLE
fix(server): harden b10621 generation bounds and idle sleep

### DIFF
--- a/src/server/batch/scheduler/decode_tick.rs
+++ b/src/server/batch/scheduler/decode_tick.rs
@@ -15,6 +15,22 @@
 use super::*;
 
 impl BatchScheduler {
+    /// Finish a sequence when a b10621 generation bound fired.
+    ///
+    /// Call this immediately after streaming a decoded piece, after applying
+    /// any string-stop result. That ordering preserves `StopSequence` when a
+    /// string stop and `n_indent` / `t_max_predict_ms` land on the same piece.
+    pub(super) fn finish_on_generation_bound(seq: &mut SequenceInfo) {
+        if !seq.state.is_finished()
+            && seq.bound_stopped()
+            && let Err(err) = seq
+                .state
+                .transition_to(SequenceState::Finished(FinishReason::Length))
+        {
+            tracing::error!("State transition error: {err}");
+        }
+    }
+
     /// Whether a bounded sequence must stop now because its next token would
     /// not fit the KV window with context shifting disabled (#1472).
     ///
@@ -994,19 +1010,7 @@ impl BatchScheduler {
                 tracing::error!("State transition error: {err}");
             }
 
-            // b10621's `n_indent` / `t_max_predict_ms` end a healthy request
-            // with `stop_type: "limit"` (#1477). Guarded on the sequence not
-            // already being finished, so a string stop that landed on the same
-            // piece keeps its own classification: upstream evaluates the stop
-            // strings first and stops feeding tokens there.
-            if !seq.state.is_finished()
-                && seq.bound_stopped()
-                && let Err(err) = seq
-                    .state
-                    .transition_to(SequenceState::Finished(FinishReason::Length))
-            {
-                tracing::error!("State transition error: {err}");
-            }
+            Self::finish_on_generation_bound(seq);
 
             if !seq.state.is_finished()
                 && structured_stopped
@@ -1186,19 +1190,7 @@ impl BatchScheduler {
                 tracing::error!("State transition error: {err}");
             }
 
-            // b10621's `n_indent` / `t_max_predict_ms` end a healthy request
-            // with `stop_type: "limit"` (#1477). Guarded on the sequence not
-            // already being finished, so a string stop that landed on the same
-            // piece keeps its own classification: upstream evaluates the stop
-            // strings first and stops feeding tokens there.
-            if !seq.state.is_finished()
-                && seq.bound_stopped()
-                && let Err(err) = seq
-                    .state
-                    .transition_to(SequenceState::Finished(FinishReason::Length))
-            {
-                tracing::error!("State transition error: {err}");
-            }
+            Self::finish_on_generation_bound(seq);
 
             if !seq.state.is_finished()
                 && seq.generated_tokens.len() >= seq.max_tokens
@@ -1483,6 +1475,12 @@ impl BatchScheduler {
         {
             tracing::error!("State transition error: {err}");
         }
+
+        // The common one-request decode dispatch reaches this single-step
+        // path rather than either batched loop. Keep b10621's generation
+        // bounds in the shared post-stream finalizer so all three paths stop
+        // with `stop_type: "limit"` (#1431 post-merge audit).
+        Self::finish_on_generation_bound(seq);
 
         if !seq.state.is_finished()
             && structured_stopped

--- a/src/server/batch/scheduler/run_loop.rs
+++ b/src/server/batch/scheduler/run_loop.rs
@@ -207,6 +207,19 @@ impl BatchScheduler {
         self.handle_incoming(req)
     }
 
+    /// Clear cross-request cache state before idle sleep tears down the model.
+    ///
+    /// Paged prompt-cache entries must be cleared while this scheduler's
+    /// `CachePool` is still alive: the store can queue their detached block
+    /// pins, but only the pool can release them. Model-owned snapshots and
+    /// dense entries drop during the same clear.
+    pub(crate) fn prepare_idle_sleep(&mut self) {
+        if let Some(store) = self.prompt_cache.as_ref() {
+            store.clear();
+        }
+        self.drain_store_paged_releases();
+    }
+
     /// Give the request channel back after [`run`](Self::run) returns,
     /// consuming the scheduler (#1440).
     ///

--- a/src/server/batch/scheduler_prompt_cache_tests.rs
+++ b/src/server/batch/scheduler_prompt_cache_tests.rs
@@ -1033,6 +1033,47 @@ fn release_detached_paged_reclaims_blocks_to_pool() {
     }
 }
 
+/// Clearing the store for idle sleep must queue every parked paged entry
+/// instead of dropping it with retained block pins. The scheduler drains this
+/// queue before its pool is destroyed.
+#[test]
+fn clear_queues_paged_entries_then_pool_reclaims() {
+    let store = test_store();
+    let model = PagedStub {
+        layout: PagedKvLayout::uniform(1, 4, 128).unwrap(),
+    };
+    let mut pool = CachePool::new(4);
+    let (set, blocks) = mint_paged_set(&mut pool, &model, 6);
+    let tokens: Vec<i32> = (0..16).collect();
+    store
+        .insert(
+            &make_key("m", "s", "tpl", &tokens),
+            CacheEntry::new(tokens.clone(), set),
+        )
+        .expect("insert paged entry");
+
+    store.clear();
+    assert_eq!(store.stats().entries, 0);
+    assert_eq!(store.bytes(), 0);
+    assert!(
+        store.has_pending_paged_releases(),
+        "clear must queue the paged entry's pins"
+    );
+
+    let drained = store.drain_pending_paged_releases();
+    assert_eq!(drained.len(), 1);
+    for paged in drained {
+        pool.release_detached_paged(paged);
+    }
+    for block in blocks {
+        assert_eq!(
+            pool.paged_pool_ref().unwrap().refcount(block),
+            0,
+            "idle-sleep clear must make every block reusable"
+        );
+    }
+}
+
 /// An LRU-evicted paged entry must hand its block pins to the release queue
 /// (its `Drop` only warns), and draining + releasing them returns the blocks
 /// to the pool. Before the fix the evicted set dropped and leaked its pins.

--- a/src/server/batch/scheduler_tests.rs
+++ b/src/server/batch/scheduler_tests.rs
@@ -20,7 +20,7 @@
 use std::sync::Arc;
 use std::sync::atomic::AtomicBool;
 use std::sync::mpsc;
-use std::time::Instant;
+use std::time::{Duration, Instant};
 
 use mlxcel_core::cache::SequenceId;
 use mlxcel_core::generate::SamplingConfig;
@@ -31,9 +31,10 @@ use super::{
     resolve_max_batch_prefill_tokens, select_eviction_victim_from, vlm_prefix_sharing_allowed,
 };
 use crate::server::batch::active::ActiveBatch;
+use crate::server::batch::generation_bounds::GenerationBounds;
 use crate::server::batch::queue::PrefillQueue;
 use crate::server::batch::sequence::{
-    BatchSchedulerAction, RequestPriority, SequenceInfo, SequenceState,
+    BatchSchedulerAction, FinishReason, RequestPriority, SequenceInfo, SequenceState,
 };
 use crate::server::batch::stop_matcher::StopMatcher;
 use crate::server::config::{DecodeStorageBackend, PreemptionPolicy};
@@ -2153,4 +2154,47 @@ fn a_context_bound_stop_is_reported_as_truncated_with_stop_type_limit() {
     let result = seq.take_generation_result(&tokenizer, 0);
     assert_eq!(result.stop_kind, StopKind::ContextExhausted);
     assert_eq!(result.finish_reason, "length");
+}
+
+#[test]
+fn generation_deadline_finalizer_stops_single_sequence_decode_as_length() {
+    use super::BatchScheduler;
+
+    let (mut seq, _rx) = make_test_sequence(92);
+    seq.state = SequenceState::Decoding;
+    seq.bounds = GenerationBounds::new(0, Some(0));
+
+    // The deadline starts with the first decoded piece and, like b10621, is
+    // evaluated only when a later newline-bearing piece arrives.
+    seq.stream_decoded_text("prefix".to_owned(), Some(10), None);
+    std::thread::sleep(Duration::from_millis(2));
+    seq.stream_decoded_text("\n".to_owned(), Some(11), None);
+    assert!(seq.bound_stopped());
+
+    BatchScheduler::finish_on_generation_bound(&mut seq);
+    assert!(matches!(
+        seq.state,
+        SequenceState::Finished(FinishReason::Length)
+    ));
+}
+
+#[test]
+fn generation_bound_finalizer_preserves_a_prior_string_stop() {
+    use super::BatchScheduler;
+
+    let (mut seq, _rx) = make_test_sequence(93);
+    seq.state = SequenceState::Decoding;
+    seq.bounds = GenerationBounds::new(0, Some(0));
+    seq.stream_decoded_text("prefix".to_owned(), Some(10), None);
+    std::thread::sleep(Duration::from_millis(2));
+    seq.stream_decoded_text("\n".to_owned(), Some(11), None);
+    seq.state
+        .transition_to(SequenceState::Finished(FinishReason::StopSequence))
+        .expect("string stop transition succeeds");
+
+    BatchScheduler::finish_on_generation_bound(&mut seq);
+    assert!(matches!(
+        seq.state,
+        SequenceState::Finished(FinishReason::StopSequence)
+    ));
 }

--- a/src/server/model_worker.rs
+++ b/src/server/model_worker.rs
@@ -738,20 +738,26 @@ pub(crate) fn spawn_model_worker_with_batch_config(
                 if !scheduler.idle_sleep_due() {
                     break;
                 }
+                // Clear the cross-request store and return paged KV pins while
+                // the scheduler still owns the CachePool. Dropping a paged
+                // detached set directly cannot update the pool refcounts.
+                scheduler.prepare_idle_sleep();
                 request_rx = scheduler.into_request_rx();
-                // Dropping the scheduler frees the weights, but the prompt-prefix
-                // cache is a separate `Arc` whose detached KV blocks would survive
-                // the sleep and defeat half its purpose. Upstream frees its KV with
-                // the context it destroys, so clear ours here; the store refills on
-                // its own after the reload.
-                if let Some(store) = sched_config.prompt_cache.as_ref() {
-                    store.clear();
-                }
+                // Consuming the scheduler above drops the model and all MLX
+                // arrays it owned. Release those now-unused buffers from MLX's
+                // allocator cache too; otherwise idle sleep retains almost the
+                // entire model allocation and reload only reuses the cache.
+                mlxcel_core::memory::clear_cache();
+                let memory = mlxcel_core::memory::snapshot();
                 sleeping.store(true, Ordering::Release);
                 // `loaded` deliberately stays true: the server is up, just asleep,
                 // and `/health` answers 200 through the sleep exactly as b10621's
                 // does.
-                tracing::info!("Server is entering sleeping state, model freed");
+                tracing::info!(
+                    active_bytes = memory.active_bytes,
+                    cache_bytes = memory.cache_bytes,
+                    "Server is entering sleeping state, model freed"
+                );
                 match request_rx.recv() {
                     Ok(req) => {
                         sleeping.store(false, Ordering::Release);

--- a/src/server/prompt_cache/store.rs
+++ b/src/server/prompt_cache/store.rs
@@ -1372,7 +1372,14 @@ impl PromptCacheStore {
     /// Drop every entry. Primarily for tests and shutdown paths.
     pub fn clear(&self) {
         let mut guard = self.inner.write().expect("prompt cache inner lock");
-        guard.entries.clear();
+        // A paged entry owns block pins that its Drop implementation cannot
+        // return without the scheduler's CachePool. Route every live entry
+        // through the same pending-release queue used by eviction before the
+        // map drops its Arcs (#1431 post-merge idle-sleep audit).
+        let entries = std::mem::take(&mut guard.entries);
+        for slot in entries.into_values() {
+            guard.stash_paged_pins_for_release(&slot.entry);
+        }
         guard.tries.clear();
         guard.snapshots.clear();
         guard.total_bytes = 0;


### PR DESCRIPTION
## Summary

- Finalize b10621 `n_indent` and `t_max_predict_ms` bounds in the common single-sequence decode path, using one shared finalizer across all decode branches while preserving string-stop precedence.
- Route idle-sleep prompt-cache clearing through the paged-pin release queue while the scheduler still owns its `CachePool`, preventing retained block pins from being dropped outside the pool lifecycle.
- Clear MLX's allocator cache after the scheduler and model are torn down, and log the post-clear active and cached byte counts so idle-sleep memory release is observable.
- Add focused regressions for deadline finalization, stop-reason precedence, and paged-block reclamation.

## Post-merge audit findings

- **Correctness:** Epic #1431's generation-bound implementation observed decoded text in every path, but `decode_single_step` never transitioned a fired bound to `Finished(Length)`. Since the scheduler uses that path for the normal one-request case, active bounds could continue until EOS or the token limit.
- **Reliability and performance:** The idle-sleep path dropped the scheduler without explicitly clearing MLX's free-buffer cache, so most model memory remained cached. Its direct `PromptCacheStore::clear()` also bypassed the existing paged-release queue, producing retained-block warnings and leaving the pool unable to reclaim those pins cleanly.
- **Security:** The audit reviewed the epic's request parsing, authentication-sensitive routes, transport boundaries, and media handling. No new security defect requiring a correction was found.

## Validation

- `make verify` passed the CI-faithful workspace gate: crate versions, kernel dtype keys, b10621 manifest validation, formatting, Clippy with warnings denied, and the full single-threaded `test-fast` workspace suite.
- Focused generation-bound, prompt-cache, and cache-reset regression suites passed.
- A release `mlxcel-server` built from this branch was exercised with the real Qwen2.5 0.5B 4-bit checkpoint. A native `/completion` request with `t_max_predict_ms: 1` stopped on the first generated newline after 23 of 128 requested tokens and reported `stop_type: "limit"`.
- Repeated two-second idle-sleep and wake cycles reported `active_bytes=0 cache_bytes=0` after teardown, and no `DetachedPagedCacheSet` retained-block warning was emitted.

Refs #1431. Follow-up to #1527 and #1528.
