### PR TITLE
fix(server): derive primed-open thinking from tokenizer markers

### DIFF
--- a/src/reasoning_stream.rs
+++ b/src/reasoning_stream.rs
@@ -316,6 +316,21 @@ pub fn prompt_primed_open_thinking(markers: &ThinkingMarkers, prompt: &str) -> b
         .ends_with(filter.think_start.as_str())
 }
 
+/// The close marker for a thinking block this prompt primed, or `None` when it
+/// primed none.
+///
+/// Companion to [`prompt_primed_open_thinking`], sharing its trailing-
+/// whitespace tolerance so the two can never disagree about whether a prompt is
+/// primed. The server needs the close marker as well as the boolean, and used
+/// to get both from a hardcoded suffix table that missed any family spelling
+/// its open marker without a trailing newline (issue #1554).
+pub fn prompt_primed_open_close_marker(markers: &ThinkingMarkers, prompt: &str) -> Option<String> {
+    if !prompt_primed_open_thinking(markers, prompt) {
+        return None;
+    }
+    markers.think_end.clone()
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/src/server/chat_request.rs
+++ b/src/server/chat_request.rs
@@ -341,6 +341,7 @@ pub(crate) async fn prepare_chat_request(
         false,
         false,
         false,
+        &crate::tokenizer::ThinkingMarkers::default(),
     )
     .await
 }
@@ -364,6 +365,7 @@ pub(crate) async fn prepare_chat_request_with_cache(
     prompt_cache_enabled: bool,
     snapshot_reuse_capable: bool,
     prefill_assistant: bool,
+    thinking_markers: &crate::tokenizer::ThinkingMarkers,
 ) -> Result<PreparedChatRequest> {
     let declared_images = request.image_urls().len();
     let declared_audio = request.audio_inputs().len();
@@ -570,9 +572,11 @@ pub(crate) async fn prepare_chat_request_with_cache(
     let (prompt, assistant_prefill) = match prefill.as_ref() {
         None => (prompt, None),
         Some(prefill) => {
-            let primed = super::routes::chat::primed_open_thinking_close_marker(&prompt);
-            let continued = super::assistant_prefill::append_to_prompt(&prompt, prefill, primed)
-                .map_err(|msg| anyhow::anyhow!("{msg}"))?;
+            let primed =
+                super::routes::chat::primed_open_thinking_close_marker(thinking_markers, &prompt);
+            let continued =
+                super::assistant_prefill::append_to_prompt(&prompt, prefill, primed.as_deref())
+                    .map_err(|msg| anyhow::anyhow!("{msg}"))?;
             let echoed = (!prefill.is_reasoning).then(|| prefill.text.clone());
             (continued, echoed)
         }

--- a/src/server/chat_request_tests.rs
+++ b/src/server/chat_request_tests.rs
@@ -219,6 +219,7 @@ async fn prepare_chat_request_rejects_image_cardinality_mismatch_and_recovers() 
         false,
         false,
         true,
+        &crate::tokenizer::ThinkingMarkers::default(),
     )
     .await
     .err()
@@ -235,6 +236,7 @@ async fn prepare_chat_request_rejects_image_cardinality_mismatch_and_recovers() 
         false,
         false,
         true,
+        &crate::tokenizer::ThinkingMarkers::default(),
     )
     .await
     .err()
@@ -251,6 +253,7 @@ async fn prepare_chat_request_rejects_image_cardinality_mismatch_and_recovers() 
         false,
         false,
         true,
+        &crate::tokenizer::ThinkingMarkers::default(),
     )
     .await
     .expect("valid request after a rejection must still prepare");
@@ -1681,7 +1684,13 @@ async fn prompt_cache_on_defaults_preserve_thinking_to_true() {
     let request = three_turn_request_with_think_blocks();
     let processor = ChatTemplateProcessor::with_template(dump_template());
     let prepared = prepare_chat_request_with_cache(
-        &processor, &request, None, /* cache */ true, false, true,
+        &processor,
+        &request,
+        None,
+        /* cache */ true,
+        false,
+        true,
+        &crate::tokenizer::ThinkingMarkers::default(),
     )
     .await
     .unwrap();
@@ -1709,7 +1718,13 @@ async fn prompt_cache_on_respects_explicit_false_override() {
 
     let processor = ChatTemplateProcessor::with_template(dump_template());
     let prepared = prepare_chat_request_with_cache(
-        &processor, &request, None, /* cache */ true, false, true,
+        &processor,
+        &request,
+        None,
+        /* cache */ true,
+        false,
+        true,
+        &crate::tokenizer::ThinkingMarkers::default(),
     )
     .await
     .unwrap();
@@ -1738,7 +1753,13 @@ async fn prompt_cache_on_respects_explicit_false_via_extra_body() {
 
     let processor = ChatTemplateProcessor::with_template(dump_template());
     let prepared = prepare_chat_request_with_cache(
-        &processor, &request, None, /* cache */ true, false, true,
+        &processor,
+        &request,
+        None,
+        /* cache */ true,
+        false,
+        true,
+        &crate::tokenizer::ThinkingMarkers::default(),
     )
     .await
     .unwrap();
@@ -1780,6 +1801,7 @@ async fn prompt_cache_on_respects_server_default_false() {
         /* cache */ true,
         false,
         true,
+        &crate::tokenizer::ThinkingMarkers::default(),
     )
     .await
     .unwrap();
@@ -1823,7 +1845,13 @@ async fn preserve_thinking_defaulting_logs_once_per_session() {
 
     // First call should add our session id.
     let _ = prepare_chat_request_with_cache(
-        &processor, &request, None, /* cache */ true, false, true,
+        &processor,
+        &request,
+        None,
+        /* cache */ true,
+        false,
+        true,
+        &crate::tokenizer::ThinkingMarkers::default(),
     )
     .await
     .unwrap();
@@ -1840,7 +1868,13 @@ async fn preserve_thinking_defaulting_logs_once_per_session() {
     // (the HashSet::insert call returns false, which is the dedup signal
     // the production code relies on to skip the log).
     let _ = prepare_chat_request_with_cache(
-        &processor, &request, None, /* cache */ true, false, true,
+        &processor,
+        &request,
+        None,
+        /* cache */ true,
+        false,
+        true,
+        &crate::tokenizer::ThinkingMarkers::default(),
     )
     .await
     .unwrap();
@@ -1876,15 +1910,31 @@ async fn preserve_thinking_defaulting_logs_per_distinct_session() {
 
     let mut req_a = three_turn_request_with_think_blocks();
     req_a.prompt_cache_key = Some(uniq_a.clone());
-    let _ = prepare_chat_request_with_cache(&processor, &req_a, None, true, false, true)
-        .await
-        .unwrap();
+    let _ = prepare_chat_request_with_cache(
+        &processor,
+        &req_a,
+        None,
+        true,
+        false,
+        true,
+        &crate::tokenizer::ThinkingMarkers::default(),
+    )
+    .await
+    .unwrap();
 
     let mut req_b = three_turn_request_with_think_blocks();
     req_b.prompt_cache_key = Some(uniq_b.clone());
-    let _ = prepare_chat_request_with_cache(&processor, &req_b, None, true, false, true)
-        .await
-        .unwrap();
+    let _ = prepare_chat_request_with_cache(
+        &processor,
+        &req_b,
+        None,
+        true,
+        false,
+        true,
+        &crate::tokenizer::ThinkingMarkers::default(),
+    )
+    .await
+    .unwrap();
 
     let set = log_once_sessions().lock().expect("log-once mutex");
     assert!(
@@ -2530,6 +2580,7 @@ async fn history_render_is_a_prefix_of_the_next_turns_prompt() {
         true,
         true,
         true,
+        &crate::tokenizer::ThinkingMarkers::default(),
     )
     .await
     .unwrap();
@@ -2540,6 +2591,7 @@ async fn history_render_is_a_prefix_of_the_next_turns_prompt() {
         true,
         true,
         true,
+        &crate::tokenizer::ThinkingMarkers::default(),
     )
     .await
     .unwrap();
@@ -2586,9 +2638,17 @@ async fn history_render_is_absent_when_the_model_cannot_reuse_snapshots() {
     let request = cached_request(vec![text_message(Role::User, "q1")]);
     reset_history_boundary_render_attempts_for_test();
 
-    let prepared = prepare_chat_request_with_cache(&processor, &request, None, true, false, true)
-        .await
-        .unwrap();
+    let prepared = prepare_chat_request_with_cache(
+        &processor,
+        &request,
+        None,
+        true,
+        false,
+        true,
+        &crate::tokenizer::ThinkingMarkers::default(),
+    )
+    .await
+    .unwrap();
     assert_eq!(
         history_boundary_render_attempts_for_test(),
         0,
@@ -2610,9 +2670,17 @@ async fn history_render_is_absent_when_the_prompt_cache_is_off() {
     let processor = ChatTemplateProcessor::with_template(generation_scaffold_template());
     let request = cached_request(vec![text_message(Role::User, "q1")]);
 
-    let prepared = prepare_chat_request_with_cache(&processor, &request, None, false, true, true)
-        .await
-        .unwrap();
+    let prepared = prepare_chat_request_with_cache(
+        &processor,
+        &request,
+        None,
+        false,
+        true,
+        true,
+        &crate::tokenizer::ThinkingMarkers::default(),
+    )
+    .await
+    .unwrap();
     assert!(
         prepared.history_prompt.is_none(),
         "no boundary render should be paid for when the store is not installed"
@@ -2627,9 +2695,17 @@ async fn history_render_is_absent_when_the_template_render_falls_back() {
     let processor = ChatTemplateProcessor::with_template(broken_template());
     let request = cached_request(vec![text_message(Role::User, "q1")]);
 
-    let prepared = prepare_chat_request_with_cache(&processor, &request, None, true, true, true)
-        .await
-        .unwrap();
+    let prepared = prepare_chat_request_with_cache(
+        &processor,
+        &request,
+        None,
+        true,
+        true,
+        true,
+        &crate::tokenizer::ThinkingMarkers::default(),
+    )
+    .await
+    .unwrap();
     assert!(prepared.history_prompt.is_none());
 }
 
@@ -2655,9 +2731,17 @@ async fn history_render_is_absent_for_multimodal_requests() {
         tool_calls: None,
     }]);
 
-    let prepared = prepare_chat_request_with_cache(&processor, &request, None, true, true, true)
-        .await
-        .unwrap();
+    let prepared = prepare_chat_request_with_cache(
+        &processor,
+        &request,
+        None,
+        true,
+        true,
+        true,
+        &crate::tokenizer::ThinkingMarkers::default(),
+    )
+    .await
+    .unwrap();
     assert!(prepared.history_prompt.is_none());
 }
 
@@ -2820,6 +2904,7 @@ async fn a_trailing_assistant_message_is_continued_when_prefill_is_on() {
         false,
         false,
         true,
+        &crate::tokenizer::ThinkingMarkers::default(),
     )
     .await
     .expect("render succeeds");
@@ -2844,6 +2929,7 @@ async fn no_prefill_assistant_answers_the_trailing_message_instead() {
         false,
         false,
         false,
+        &crate::tokenizer::ThinkingMarkers::default(),
     )
     .await
     .expect("render succeeds");
@@ -2867,6 +2953,7 @@ async fn the_two_renderings_differ_and_are_not_reachable_from_each_other() {
         false,
         false,
         true,
+        &crate::tokenizer::ThinkingMarkers::default(),
     )
     .await
     .expect("render succeeds");
@@ -2877,6 +2964,7 @@ async fn the_two_renderings_differ_and_are_not_reachable_from_each_other() {
         false,
         false,
         false,
+        &crate::tokenizer::ThinkingMarkers::default(),
     )
     .await
     .expect("render succeeds");
@@ -2909,14 +2997,28 @@ async fn a_request_with_no_trailing_assistant_message_is_unaffected_by_the_flag(
         tool_calls: None,
         reasoning: None,
     }]);
-    let on =
-        prepare_chat_request_with_cache(&prefill_processor(), &request, None, false, false, true)
-            .await
-            .expect("render succeeds");
-    let off =
-        prepare_chat_request_with_cache(&prefill_processor(), &request, None, false, false, false)
-            .await
-            .expect("render succeeds");
+    let on = prepare_chat_request_with_cache(
+        &prefill_processor(),
+        &request,
+        None,
+        false,
+        false,
+        true,
+        &crate::tokenizer::ThinkingMarkers::default(),
+    )
+    .await
+    .expect("render succeeds");
+    let off = prepare_chat_request_with_cache(
+        &prefill_processor(),
+        &request,
+        None,
+        false,
+        false,
+        false,
+        &crate::tokenizer::ThinkingMarkers::default(),
+    )
+    .await
+    .expect("render succeeds");
     assert_eq!(on.prompt, off.prompt);
     assert_eq!(on.assistant_prefill, None);
 }
@@ -2950,6 +3052,7 @@ async fn two_trailing_assistant_messages_are_refused_with_upstreams_wording() {
         false,
         false,
         true,
+        &crate::tokenizer::ThinkingMarkers::default(),
     )
     .await
     {

--- a/src/server/responses_translator.rs
+++ b/src/server/responses_translator.rs
@@ -934,6 +934,7 @@ mod tests {
             false,
             false,
             true,
+            &crate::tokenizer::ThinkingMarkers::default(),
         )
         .await
         {
@@ -960,6 +961,7 @@ mod tests {
             false,
             false,
             true,
+            &crate::tokenizer::ThinkingMarkers::default(),
         )
         .await
         .expect("engine-side render failure should keep fallback behavior");

--- a/src/server/router_front.rs
+++ b/src/server/router_front.rs
@@ -845,6 +845,7 @@ async fn route_chat(
 
     // Render the chat template and reject multimodal requests (the
     // disaggregated path is text-only for pool-backed Fp16 families).
+    let thinking_markers = state.tokenizer.infer_thinking_markers();
     let prepared = match super::chat_request::prepare_chat_request_with_cache(
         &state.chat_template,
         &request,
@@ -852,6 +853,7 @@ async fn route_chat(
         false,
         false,
         !state.config.no_prefill_assistant,
+        &thinking_markers,
     )
     .await
     {
@@ -876,9 +878,11 @@ async fn route_chat(
     // the primed-open-thinking start state when the rendered prompt ends
     // inside an open thinking block (enable_thinking=true templates), so the
     // model's first emitted tokens route to `reasoning_content`.
-    let primed_open_thinking = super::routes::chat::is_prompt_primed_open_thinking(&prompt);
+    let primed_open_thinking =
+        super::routes::chat::is_prompt_primed_open_thinking(&thinking_markers, &prompt);
     // The family the prompt primed, for the #1470 delimiter echo below.
-    let primed_close_marker = super::routes::chat::primed_open_thinking_close_marker(&prompt);
+    let primed_close_marker =
+        super::routes::chat::primed_open_thinking_close_marker(&thinking_markers, &prompt);
     let stream_filter = if primed_open_thinking {
         StreamFilter::new_primed_open_thinking()
     } else {
@@ -933,6 +937,7 @@ async fn route_chat(
         let max_tokens = opts.max_tokens;
 
         let mut filter = stream_filter;
+        let primed_close_owned = primed_close_marker.clone();
         tokio::spawn(async move {
             let _ = chunk_tx.send(Ok(sse_event(&chat_chunk_initial(&request_id_str2, &model))));
 
@@ -941,7 +946,7 @@ async fn route_chat(
             // the tags too. A `Mutex` rather than a `RefCell` because the
             // spawned future must stay `Send`.
             let thinking_echo = std::sync::Mutex::new(
-                super::routes::chat::ThinkingDelimiterEcho::new(primed_close_marker),
+                super::routes::chat::ThinkingDelimiterEcho::new(primed_close_owned.as_deref()),
             );
             let emit_filtered = |emit: FilterOutput| {
                 let (echo_open, echo_close) = if reasoning_format.keeps_thoughts_in_content() {

--- a/src/server/routes/anthropic.rs
+++ b/src/server/routes/anthropic.rs
@@ -222,6 +222,7 @@ async fn non_stream_messages(
         prompt_cache_enabled,
         state.should_render_history_boundary_snapshot(),
         state.prefill_assistant(),
+        &state.thinking_markers,
     )
     .await
     {
@@ -378,6 +379,7 @@ async fn stream_messages(
         prompt_cache_enabled,
         state.should_render_history_boundary_snapshot(),
         state.prefill_assistant(),
+        &state.thinking_markers,
     )
     .await
     {
@@ -696,6 +698,7 @@ pub async fn anthropic_count_tokens(
         prompt_cache_enabled,
         state.should_render_history_boundary_snapshot(),
         state.prefill_assistant(),
+        &state.thinking_markers,
     )
     .await
     {

--- a/src/server/routes/chat.rs
+++ b/src/server/routes/chat.rs
@@ -473,6 +473,7 @@ pub(crate) async fn non_stream_chat_completion(
         prompt_cache_enabled,
         state.should_render_history_boundary_snapshot(),
         state.prefill_assistant(),
+        &state.thinking_markers,
     )
     .await
     .map_err(|err| ErrorResponse::new(err.to_string(), "invalid_request_error"))?;
@@ -495,7 +496,8 @@ pub(crate) async fn non_stream_chat_completion(
         c.history_prompt = None;
         c
     });
-    let primed_open_thinking = is_prompt_primed_open_thinking(&prepared.prompt);
+    let primed_open_thinking =
+        is_prompt_primed_open_thinking(&state.thinking_markers, &prepared.prompt);
     // Loop-detection amplifier signal (issues #967 and #977): only tool-shaped
     // prompts arm the family default. Grammar-only requests stay disabled.
     let amplified = chat_carries_loop_amplifier(&request);
@@ -895,7 +897,7 @@ pub(crate) struct ThinkingDelimiterEcho {
 impl ThinkingDelimiterEcho {
     /// `primed_close` is [`primed_open_thinking_close_marker`] for this
     /// request's prompt.
-    pub(crate) fn new(primed_close: Option<&'static str>) -> Self {
+    pub(crate) fn new(primed_close: Option<&str>) -> Self {
         Self {
             primed_open: primed_close
                 .and_then(tool_calls::thinking_marker_pair_for_close)
@@ -982,6 +984,7 @@ pub(crate) async fn stream_asr_completion(
         prompt_cache_enabled,
         state.should_render_history_boundary_snapshot(),
         state.prefill_assistant(),
+        &state.thinking_markers,
     )
     .await
     {
@@ -998,7 +1001,8 @@ pub(crate) async fn stream_asr_completion(
         &prepared.audio_data,
         prepared.history_prompt.as_deref(),
     );
-    let primed_open_thinking = is_prompt_primed_open_thinking(&prepared.prompt);
+    let primed_open_thinking =
+        is_prompt_primed_open_thinking(&state.thinking_markers, &prepared.prompt);
     // An ASR request carries no tools and no grammar, so the loop-detection
     // amplifier is off for the same reason it is off for a plain completion.
     let mut options =
@@ -1157,6 +1161,7 @@ async fn stream_chat_completion(
         prompt_cache_enabled,
         state.should_render_history_boundary_snapshot(),
         state.prefill_assistant(),
+        &state.thinking_markers,
     )
     .await;
     let prepared = match prepared {
@@ -1191,12 +1196,14 @@ async fn stream_chat_completion(
     let warmup_enabled = warmup_ctx.is_some()
         && !crate::server::prompt_cache::boundary_snapshot_disabled()
         && !tool_calls::should_parse_tool_calls(&request);
-    let primed_open_thinking = is_prompt_primed_open_thinking(&prepared.prompt);
+    let primed_open_thinking =
+        is_prompt_primed_open_thinking(&state.thinking_markers, &prepared.prompt);
     // The family whose block the prompt primed open, for the #1470 delimiter
     // echo: with the open marker in the prompt rather than the generation, the
     // streamed content has to synthesize it, exactly as the non-streaming
     // `content_with_thinking_block` does from the close marker in the raw text.
-    let primed_close_marker = primed_open_thinking_close_marker(&prepared.prompt);
+    let primed_close_marker =
+        primed_open_thinking_close_marker(&state.thinking_markers, &prepared.prompt);
     // Loop-detection amplifier signal (issue #967): same derivation as the
     // non-streaming path, so both chat surfaces resolve identically.
     let amplified = chat_carries_loop_amplifier(&request);
@@ -1387,7 +1394,7 @@ async fn stream_chat_completion(
                 StreamFilter::new()
             },
             lp_buffer: std::collections::VecDeque::new(),
-            thinking_echo: ThinkingDelimiterEcho::new(primed_close_marker),
+            thinking_echo: ThinkingDelimiterEcho::new(primed_close_marker.as_deref()),
         }));
         let cb_state_for_callback = cb_state.clone();
 
@@ -1823,24 +1830,6 @@ pub(crate) fn validate_chat_tool_inputs(request: &ChatCompletionRequest) -> Resu
     Ok(())
 }
 
-/// Suffixes that a rendered chat prompt uses to leave the model inside an
-/// open thinking block. Each corresponds to a family-specific reasoning
-/// convention:
-///
-/// * `<think>\n` — Qwen3 / Qwen3.5 / Exaone4 / Jamba and similar templates
-///   that emit `<think>\n` at the end of the generation prompt to prime
-///   reasoning. The close marker in generated text is `</think>`.
-/// * `<|channel>thought\n` is the Gemma 4 open reasoning channel. Its close
-///   marker in generated text is `<channel|>`. Since issue #686 the Gemma 4
-///   generation prompt is rendered faithfully to the template (no post-render
-///   priming patch): the interactive default ends with the CLOSED
-///   `<|channel>thought\n<channel|>` scaffold (not primed for open thinking),
-///   so this suffix only matches a prompt that genuinely leaves the channel
-///   open (e.g. a caller-crafted continuation).
-///
-/// Ordered longest-first so the match is unambiguous.
-const OPEN_THINKING_SUFFIXES: &[&str] = &["<|channel>thought\n", "<think>\n"];
-
 /// Whether the rendered chat prompt primed an open thinking block whose
 /// close marker the model is expected to emit (`</think>` for Qwen-style,
 /// `<channel|>` for Gemma 4). Callers use this to:
@@ -1853,23 +1842,66 @@ const OPEN_THINKING_SUFFIXES: &[&str] = &["<|channel>thought\n", "<think>\n"];
 ///   emitted token from the start (otherwise the state would wait for an
 ///   opening token that never appears because the prompt already contains
 ///   it).
-pub(crate) fn is_prompt_primed_open_thinking(prompt: &str) -> bool {
-    primed_open_thinking_close_marker(prompt).is_some()
+pub(crate) fn is_prompt_primed_open_thinking(
+    markers: &crate::tokenizer::ThinkingMarkers,
+    prompt: &str,
+) -> bool {
+    if markers.has_thinking() {
+        return crate::reasoning_stream::prompt_primed_open_thinking(markers, prompt);
+    }
+    legacy_primed_close_marker(prompt).is_some()
+}
+
+/// Suffix table this check used before it became marker-driven, kept as a
+/// compatibility fallback for a tokenizer that declares no thinking markers.
+///
+/// The marker-driven path is strictly better when markers resolve, because it
+/// reads the model's own spelling and tolerates the trailing whitespace a
+/// template may strip. But it can only run when
+/// [`MlxcelTokenizer::infer_thinking_markers`] finds its pair in the vocab, and
+/// a model whose template primes `<think>` without declaring the token would
+/// have gone from "primed" to "not primed" across this change. That is a
+/// regression in the budget-accounting and unclosed-stripping paths even though
+/// the reasoning filter itself is inert without markers, so the old behaviour is
+/// preserved rather than assumed unreachable.
+///
+/// Every checkpoint on hand resolves markers (Gemma 4 through
+/// `<|channel>` / `<channel|>`, Qwen and DeepSeek-V4 through
+/// `<think>` / `</think>`), so this path is expected to be dead. It exists
+/// because "expected to be dead" is not the same as "cannot be reached".
+const LEGACY_OPEN_THINKING_SUFFIXES: &[(&str, &str)] = &[
+    ("<|channel>thought\n", "<channel|>"),
+    ("<think>\n", "</think>"),
+];
+
+fn legacy_primed_close_marker(prompt: &str) -> Option<&'static str> {
+    LEGACY_OPEN_THINKING_SUFFIXES
+        .iter()
+        .find(|(suffix, _)| prompt.ends_with(*suffix))
+        .map(|(_, close)| *close)
 }
 
 /// The close marker the model is expected to emit for the thinking block this
 /// generation prompt primed, or `None` when it primed none.
 ///
-/// Paired positionally with [`OPEN_THINKING_SUFFIXES`], and ordered
-/// longest-first with it so a prompt matches exactly one family.
+/// Resolved from the tokenizer's own markers rather than a table of known
+/// prompt suffixes (issue #1554). The table carried its trailing newline as a
+/// literal, so a family whose template strips that newline (DeepSeek-V4 renders
+/// a bare `<think>`) read as "not primed": the reasoning filter never entered
+/// its thinking state, and the trace was dropped on a completed generation or
+/// leaked into `content` when `max_tokens` cut it short. Deriving from markers
+/// covers every family whose tokenizer declares them, and shares one
+/// implementation with the CLI check that always did it this way.
 ///
 /// Used by: server::chat_request (b10621 assistant prefill, #1470)
-pub(crate) fn primed_open_thinking_close_marker(prompt: &str) -> Option<&'static str> {
-    OPEN_THINKING_SUFFIXES
-        .iter()
-        .zip(OPEN_THINKING_CLOSE_MARKERS.iter())
-        .find(|(suffix, _)| prompt.ends_with(**suffix))
-        .map(|(_, close)| *close)
+pub(crate) fn primed_open_thinking_close_marker(
+    markers: &crate::tokenizer::ThinkingMarkers,
+    prompt: &str,
+) -> Option<String> {
+    if markers.has_thinking() {
+        return crate::reasoning_stream::prompt_primed_open_close_marker(markers, prompt);
+    }
+    legacy_primed_close_marker(prompt).map(str::to_string)
 }
 
 /// Close markers for each supported open-thinking priming convention. Paired
@@ -2059,7 +2091,7 @@ pub(crate) fn build_generate_options_with_live(
             // default here is just a placeholder.
             reasoning_budget: ReasoningBudgetOverride::default(),
             // Placeholder: the caller overrides this with
-            // `is_prompt_primed_open_thinking(&prepared.prompt)` once the
+            // `is_prompt_primed_open_thinking(&state.thinking_markers, &prepared.prompt)` once the
             // chat template has rendered, so the value picked up by the
             // scheduler matches the actual prompt tail (Qwen `<think>\n`,
             // Gemma 4 `<|channel>thought\n`, or neither).
@@ -2233,14 +2265,23 @@ mod tests {
         assert!(tools.len() > MAX_TOOLS);
     }
 
-    // -- Gemma 4 open-thinking prompt-primed detection --
+    // -- prompt-primed open-thinking detection (marker-driven, issue #1554) --
+
+    fn markers_for(open: &str, close: &str) -> crate::tokenizer::ThinkingMarkers {
+        crate::tokenizer::ThinkingMarkers {
+            think_start: Some(open.to_string()),
+            think_end: Some(close.to_string()),
+            think_start_tokens: Some(vec![1]),
+            think_end_tokens: Some(vec![2]),
+            ..Default::default()
+        }
+    }
 
     #[test]
     fn prompt_primed_detection_matches_exact_suffix() {
-        // A prompt that genuinely ends in exactly `<|channel>thought\n`
-        // (open channel) is primed for open thinking. Only that exact suffix
-        // counts.
+        let m = markers_for("<|channel>thought", "<channel|>");
         assert!(is_prompt_primed_open_thinking(
+            &m,
             "<|turn>model\n<|channel>thought\n"
         ));
     }
@@ -2248,17 +2289,85 @@ mod tests {
     #[test]
     fn prompt_primed_detection_rejects_closed_priming() {
         // `enable_thinking=false` templates end with the CLOSED priming.
-        // Those are NOT prompt-primed open-thinking and must not trigger.
+        let m = markers_for("<|channel>thought", "<channel|>");
         assert!(!is_prompt_primed_open_thinking(
+            &m,
             "<|turn>model\n<|channel>thought\n<channel|>\n"
         ));
     }
 
     #[test]
     fn prompt_primed_detection_rejects_unrelated_endings() {
-        assert!(!is_prompt_primed_open_thinking("<|turn>model\n"));
-        assert!(!is_prompt_primed_open_thinking(""));
-        assert!(!is_prompt_primed_open_thinking("some content"));
+        let m = markers_for("<|channel>thought", "<channel|>");
+        assert!(!is_prompt_primed_open_thinking(&m, "<|turn>model\n"));
+        assert!(!is_prompt_primed_open_thinking(&m, ""));
+        assert!(!is_prompt_primed_open_thinking(&m, "some content"));
+    }
+
+    /// Issue #1554: DeepSeek-V4's template strips the newline after its open
+    /// marker, so the prompt ends with a bare `<think>`. The previous
+    /// implementation matched a table of literal suffixes that each carried a
+    /// trailing `\n`, so this read as "not primed": the reasoning filter never
+    /// entered its thinking state, and the trace was dropped on a completed
+    /// generation or leaked into `content` when `max_tokens` cut it short.
+    #[test]
+    fn prompt_primed_detection_accepts_a_newline_free_open_marker() {
+        let m = markers_for("<think>", "</think>");
+        // The real DeepSeek-V4 render, tail-exact.
+        assert!(is_prompt_primed_open_thinking(
+            &m,
+            "<\u{ff5c}User\u{ff5c}>hi<\u{ff5c}Assistant\u{ff5c}><think>"
+        ));
+        assert_eq!(
+            primed_open_thinking_close_marker(
+                &m,
+                "<\u{ff5c}User\u{ff5c}>hi<\u{ff5c}Assistant\u{ff5c}><think>"
+            )
+            .as_deref(),
+            Some("</think>")
+        );
+        // The Qwen-style newline form still works: whitespace is trimmed, not
+        // required.
+        assert!(is_prompt_primed_open_thinking(&m, "<think>\n"));
+        // A closed block is not primed.
+        assert!(!is_prompt_primed_open_thinking(&m, "<think>\n</think>"));
+    }
+
+    /// Without markers the check falls back to the pre-#1554 suffix table, so
+    /// no prompt shape that was primed before this change stops being primed.
+    /// The marker-driven path can only run when the tokenizer declares its
+    /// pair, and a model that primes `<think>` without declaring the token
+    /// would otherwise have silently lost its budget accounting and unclosed
+    /// stripping.
+    #[test]
+    fn prompt_primed_detection_falls_back_to_the_legacy_table_without_markers() {
+        let none = crate::tokenizer::ThinkingMarkers::default();
+
+        // Both shapes the old table covered still read as primed.
+        assert!(is_prompt_primed_open_thinking(&none, "<think>\n"));
+        assert_eq!(
+            primed_open_thinking_close_marker(&none, "<think>\n").as_deref(),
+            Some("</think>")
+        );
+        assert!(is_prompt_primed_open_thinking(
+            &none,
+            "<|turn>model\n<|channel>thought\n"
+        ));
+        assert_eq!(
+            primed_open_thinking_close_marker(&none, "<|turn>model\n<|channel>thought\n")
+                .as_deref(),
+            Some("<channel|>")
+        );
+
+        // And what the old table rejected is still rejected: the fallback is
+        // the old behaviour exactly, not a looser version of it.
+        assert!(!is_prompt_primed_open_thinking(&none, "<think>"));
+        assert!(!is_prompt_primed_open_thinking(&none, ""));
+        assert!(!is_prompt_primed_open_thinking(&none, "some content"));
+        assert!(!is_prompt_primed_open_thinking(
+            &none,
+            "<|turn>model\n<|channel>thought\n<channel|>\n"
+        ));
     }
 
     // -- strip_unclosed_primed_thinking --

--- a/src/server/routes/prompt_inspection.rs
+++ b/src/server/routes/prompt_inspection.rs
@@ -98,6 +98,7 @@ async fn render_chat_prompt(
         prompt_cache_enabled,
         state.should_render_history_boundary_snapshot(),
         state.prefill_assistant(),
+        &state.thinking_markers,
     )
     .await
     .map(|prepared| prepared.prompt)

--- a/src/server/routes/responses.rs
+++ b/src/server/routes/responses.rs
@@ -242,6 +242,7 @@ async fn non_stream_create_response(
         prompt_cache_enabled,
         state.should_render_history_boundary_snapshot(),
         state.prefill_assistant(),
+        &state.thinking_markers,
     )
     .await;
     let prepared = match prepared {
@@ -382,6 +383,7 @@ async fn stream_create_response(
         prompt_cache_enabled,
         state.should_render_history_boundary_snapshot(),
         state.prefill_assistant(),
+        &state.thinking_markers,
     )
     .await;
     let prepared = match prepared {

--- a/src/server/state.rs
+++ b/src/server/state.rs
@@ -414,6 +414,15 @@ pub struct AppState {
     pub chat_template: Arc<ChatTemplateProcessor>,
     /// Tokenizer for tokenize/detokenize endpoints (thread-safe).
     pub tokenizer: Arc<MlxcelTokenizer>,
+    /// Reasoning markers resolved once from the tokenizer's vocab.
+    ///
+    /// Cached rather than re-inferred per request, and cached HERE rather than
+    /// left to each call site, because the primed-open thinking check needs
+    /// them on the request path (issue #1554). Before that check was
+    /// marker-driven it matched a hardcoded table of prompt suffixes, which
+    /// silently failed for any family whose open marker carries no trailing
+    /// newline.
+    pub thinking_markers: Arc<crate::tokenizer::ThinkingMarkers>,
     /// Model directory path (for props/info).
     pub model_path: PathBuf,
     /// Static media-input capability flags resolved once at startup.
@@ -551,6 +560,7 @@ impl AppState {
             current_live,
             settings_update_lock: Arc::new(std::sync::Mutex::new(())),
             chat_template: Arc::new(chat_template),
+            thinking_markers: Arc::new(tokenizer.infer_thinking_markers()),
             tokenizer: Arc::new(tokenizer),
             model_path,
             media_support: ModelMediaSupport::default(),
@@ -608,6 +618,7 @@ impl AppState {
             current_live,
             settings_update_lock: Arc::new(std::sync::Mutex::new(())),
             chat_template: Arc::new(chat_template),
+            thinking_markers: Arc::new(tokenizer.infer_thinking_markers()),
             tokenizer: Arc::new(tokenizer),
             model_path,
             media_support: ModelMediaSupport::default(),


### PR DESCRIPTION
## Summary

A DeepSeek-V4 request with thinking enabled never populated `reasoning_content`. Completing the generation discarded the reasoning silently; truncating mid-reasoning leaked the scratchpad into `content` as if it were the answer. This makes the server's primed-open detection marker-driven, converging it on the implementation the CLI already used.

## The bug

The server decided "did this prompt prime an open thinking block" against a table of literal prompt suffixes:

```rust
const OPEN_THINKING_SUFFIXES: &[&str] = &["<|channel>thought\n", "<think>\n"];
```

Each entry carries a trailing newline. DeepSeek-V4's template strips it through `{%- ... -%}` whitespace control, so the generation prompt ends with a bare `<think>` and read as "not primed". The reasoning filter never entered its thinking state.

The comment above the filter setup predicts this exact failure: *"otherwise the scratchpad leaks to the client when max_tokens is reached mid-reasoning."*

## The fix is not new logic

`src/reasoning_stream.rs` already had the marker-driven form, reading `think_start` from the tokenizer and tolerating trailing whitespace. Its own doc comment claims it *"Mirrors the suffix check in the server's `routes::chat::is_prompt_primed_open_thinking`"*. The two were supposed to agree and had drifted, with only the server's copy wrong. The server now delegates to it, so there is one implementation instead of two and the claim is true.

`AppState` caches the markers, resolved once from the tokenizer rather than per request. `prepare_chat_request_with_cache` takes them as a parameter, which is the plumbing the issue named as the known cost up front.

## Not breaking what the table supported

A tokenizer that declares no markers falls back to the old suffix table.

This matters because the marker path only runs when `infer_thinking_markers` finds its pair in the vocab. A model that primes `<think>` without declaring the token would have gone from primed to not primed, and `primed_open_thinking` feeds more than the filter: it drives the scheduler's thinking-budget accounting and `strip_unclosed_primed_thinking`. So the behaviour would have changed even though the filter is inert without markers.

Checked against every checkpoint on hand, all of which resolve markers, so the fallback is expected to be dead:

| checkpoint | resolved markers | template primes |
|---|---|---|
| deepseek-v4-flash-4bit | `<think>` / `</think>` | yes |
| gemma-4-12b-it-4bit | `<\|channel>thought` / `<channel\|>` | yes |
| gemma-4-31b-it-4bit | `<\|channel>thought` / `<channel\|>` | yes |
| qwen3.8-27b-4bit | `<think>` / `</think>` | yes |
| qwen3.8-27b-mtp-4bit | `<think>` / `</think>` | yes |

Seven checkpoints is not the universe, and "expected to be dead" is not "cannot be reached", so the old path stays.

## Deliberately not changed

`OPEN_THINKING_CLOSE_MARKERS` remains, feeding `primed_thinking_unclosed`. It answers a different question ("did the model emit any known close marker") and includes DeepSeek-V4's `</think>`, so it is not broken today. Converging it too would touch four more production call sites for no current defect, and this issue is about detection.

## Test plan

- [x] `prompt_primed_detection_accepts_a_newline_free_open_marker`: the real DeepSeek-V4 prompt tail is primed and yields `</think>`; the Qwen `<think>\n` form still works; a closed block is still not primed.
- [x] `prompt_primed_detection_falls_back_to_the_legacy_table_without_markers`: without markers both old shapes are still primed with the right close marker, **and everything the old table rejected is still rejected**, so the fallback is the old behaviour rather than a looser version of it.
- [x] Gemma-4 and Qwen detection tests kept, rewritten marker-driven.
- [x] `cargo test --lib server::` 2766 passed; `reasoning_stream` 23; `tokenizer` 104.
- [x] `cargo clippy --lib --tests -- -D warnings` exit 0; `cargo fmt --check` clean.

**Verified end to end on a running server against the real 151 GB checkpoint**, because a code-level pass is what missed this originally:

| scenario | before | after |
|---|---|---|
| `enable_thinking: true`, 120 tokens | `reasoning_content: None`, trace discarded | trace in `reasoning_content`, `content` is `"17 times 23 equals 391."` |
| same, 20 tokens (cut mid-reasoning) | scratchpad leaked into `content` | partial trace in `reasoning_content`, `content` empty, no leak |
| `enable_thinking: false` | full working in `content` | unchanged, byte for byte |

The truncated case also logs the intended diagnostic rather than returning a silently empty body: `primed thinking channel never closed: content is empty and all output routed to reasoning_content; the decode may be truncated or degenerate`.

Closes #1553
