### PR TITLE
fix(models): accept an Inkling sub-config that carries a field and its alias

### DIFF
--- a/src/loading/vlm_inkling.rs
+++ b/src/loading/vlm_inkling.rs
@@ -33,13 +33,17 @@ pub(crate) fn load_inkling_vlm(model_path: &Path) -> Result<LoadedModel> {
     let (config_raw, full_config) = read_sanitized_vlm_config(model_path)?;
     let config = InklingConfig::from_json_with_sidecar(model_path, &config_raw)
         .map_err(anyhow::Error::msg)?;
-    let vision_config: InklingVisionConfig = serde_json::from_value(
-        full_config
-            .get("vision_config")
-            .cloned()
-            .ok_or_else(|| anyhow::anyhow!("Missing vision_config in Inkling config.json"))?,
-    )
-    .map_err(|error| anyhow::anyhow!("Failed to parse Inkling vision_config: {error}"))?;
+    // The vision half is deserialized straight off the raw config rather than
+    // through `InklingConfig`, so it needs the same `decoder_dmodel` /
+    // `text_hidden_size` reconciliation that path applies (issue #1549).
+    let mut vision_value = full_config
+        .get("vision_config")
+        .cloned()
+        .ok_or_else(|| anyhow::anyhow!("Missing vision_config in Inkling config.json"))?;
+    crate::models::inkling::reconcile_vision_text_width_alias(&mut vision_value)
+        .map_err(anyhow::Error::msg)?;
+    let vision_config: InklingVisionConfig = serde_json::from_value(vision_value)
+        .map_err(|error| anyhow::anyhow!("Failed to parse Inkling vision_config: {error}"))?;
     if vision_config.text_hidden_size != config.text_config.hidden_size {
         anyhow::bail!(
             "Inkling vision text width {} does not match decoder hidden_size {}",

--- a/src/models/inkling.rs
+++ b/src/models/inkling.rs
@@ -22,7 +22,7 @@
 mod attention;
 mod mlp;
 mod runtime;
-mod sanitize;
+pub(crate) mod sanitize;
 mod speculative;
 mod validation;
 mod validation_shapes;
@@ -270,12 +270,22 @@ pub struct InklingConfig {
     pub quantization_config: Option<serde_json::Value>,
 }
 
+/// Reconcile the `decoder_dmodel` / `text_hidden_size` spelling on a bare
+/// `vision_config` object, for the loader path that deserializes it directly
+/// rather than through [`InklingConfig`] (issue #1549).
+pub(crate) fn reconcile_vision_text_width_alias(
+    value: &mut serde_json::Value,
+) -> Result<(), String> {
+    sanitize::reconcile_text_width_alias(value, "vision_config")
+}
+
 impl InklingConfig {
     pub(crate) fn from_json_with_sidecar(path: &Path, raw: &str) -> Result<Self, String> {
         let raw = super::sanitize_config_json(raw);
         let mut value: serde_json::Value =
             serde_json::from_str(&raw).map_err(|e| format!("Failed to parse config.json: {e}"))?;
         sanitize::promote_nvfp4_config(path, &mut value)?;
+        sanitize::reconcile_text_width_aliases(&mut value)?;
         serde_json::from_value(value).map_err(|e| format!("Failed to parse Inkling config: {e}"))
     }
 

--- a/src/models/inkling/sanitize.rs
+++ b/src/models/inkling/sanitize.rs
@@ -490,3 +490,67 @@ fn normalized_e4m3(value: UniquePtr<MlxArray>) -> Result<UniquePtr<MlxArray>, St
     }
     Ok(mlxcel_core::from_bytes(&encoded, &shape, dtype::UINT8))
 }
+
+/// Serde field aliases declared by the Inkling sub-configs, as
+/// `(canonical, alias)`.
+///
+/// Serde treats a field and its alias as the SAME field, so an object carrying
+/// both spellings is a duplicate-field error and the whole config fails to
+/// deserialize, even when the values agree. Published checkpoints disagree on
+/// which spelling they use, so neither can be dropped from the structs:
+///
+/// * `mlx-community/Inkling-Small-mlx-4bit` and
+///   `thinkingmachines/Inkling-Small-NVFP4` ship only the aliases, so those are
+///   load-bearing.
+/// * `inference-optimization/Inkling-0.6B-A0.6B` ships BOTH spellings of all
+///   three pairs, at matching values, and was rejected outright before this
+///   (issue #1549).
+///
+/// Keep this in step with the `#[serde(alias = ...)]` attributes on
+/// [`crate::vision::encoders::inkling_hmlp::InklingVisionConfig`] and
+/// [`crate::audio::inkling_tower::InklingAudioConfig`]. It is a list rather
+/// than a single special case because fixing these one key at a time is how
+/// the second one (`num_channels`) went unnoticed until the first was fixed.
+const ALIASED_FIELDS: &[(&str, &str)] = &[
+    ("text_hidden_size", "decoder_dmodel"),
+    ("num_channels", "n_channels"),
+];
+
+/// Collapse every declared alias pair inside one sub-config object.
+///
+/// Equal values collapse to the canonical spelling. Disagreeing values are an
+/// error rather than a silent pick: the two keys name one quantity, and a
+/// checkpoint that gives them different values is contradicting itself in a way
+/// that would otherwise surface much later as a shape mismatch.
+pub(crate) fn reconcile_text_width_alias(
+    section: &mut serde_json::Value,
+    section_name: &str,
+) -> Result<(), String> {
+    let Some(obj) = section.as_object_mut() else {
+        return Ok(());
+    };
+    for (canonical, alias) in ALIASED_FIELDS {
+        let (Some(c), Some(a)) = (obj.get(*canonical).cloned(), obj.get(*alias).cloned()) else {
+            continue;
+        };
+        if c != a {
+            return Err(format!(
+                "Inkling {section_name} declares {canonical} {c} and {alias} {a}; \
+                 they are the same quantity and must agree"
+            ));
+        }
+        obj.remove(*alias);
+    }
+    Ok(())
+}
+
+/// Apply [`reconcile_text_width_alias`] to every sub-config that carries the
+/// pairs, so both this crate's config entry points see one spelling.
+pub(crate) fn reconcile_text_width_aliases(value: &mut serde_json::Value) -> Result<(), String> {
+    for name in ["vision_config", "audio_config"] {
+        if let Some(section) = value.get_mut(name) {
+            reconcile_text_width_alias(section, name)?;
+        }
+    }
+    Ok(())
+}

--- a/src/models/inkling_tests.rs
+++ b/src/models/inkling_tests.rs
@@ -479,3 +479,79 @@ fn sanitize_rejects_reverse_mixed_routed_weight_dtypes() {
     };
     assert!(error.contains("cannot mix native NVFP4"));
 }
+
+/// Issue #1549: the vision and audio sub-configs declare
+/// `#[serde(alias = "decoder_dmodel")] text_hidden_size`, and serde treats a
+/// field and its alias as the same field. A checkpoint carrying both keys was
+/// therefore a duplicate-field error and failed to load outright, even with the
+/// two values in agreement.
+///
+/// Neither spelling can be dropped: `Inkling-Small-mlx-4bit` and
+/// `Inkling-Small-NVFP4` ship only `decoder_dmodel`, while
+/// `Inkling-0.6B-A0.6B` ships both.
+#[test]
+fn inkling_config_accepts_both_text_width_spellings() {
+    let with_both = |v: serde_json::Value| {
+        let mut cfg = v;
+        crate::models::inkling::sanitize::reconcile_text_width_aliases(&mut cfg).map(|()| cfg)
+    };
+
+    // Every declared pair, both spellings, matching values: each collapses to
+    // its canonical name. This is the real Inkling-0.6B shape, which carries
+    // all three pairs doubled.
+    let out = with_both(serde_json::json!({
+        "vision_config": {
+            "decoder_dmodel": 1024, "text_hidden_size": 1024,
+            "n_channels": 3, "num_channels": 3,
+        },
+        "audio_config": {"decoder_dmodel": 1024, "text_hidden_size": 1024},
+    }))
+    .expect("agreeing values must reconcile");
+    for sec in ["vision_config", "audio_config"] {
+        assert_eq!(out[sec]["text_hidden_size"], 1024);
+        assert!(
+            out[sec].get("decoder_dmodel").is_none(),
+            "the alias must be removed so serde sees one key"
+        );
+    }
+    assert_eq!(out["vision_config"]["num_channels"], 3);
+    assert!(
+        out["vision_config"].get("n_channels").is_none(),
+        "num_channels/n_channels must reconcile too; fixing these one key at a \
+         time is how this pair went unnoticed until text_hidden_size was fixed"
+    );
+
+    // Alias only: untouched, which is what the Inkling-Small checkpoints need.
+    let out = with_both(serde_json::json!({
+        "vision_config": {"decoder_dmodel": 4096},
+        "audio_config": {"decoder_dmodel": 4096},
+    }))
+    .expect("alias-only must pass through");
+    assert_eq!(out["vision_config"]["decoder_dmodel"], 4096);
+    assert!(out["vision_config"].get("text_hidden_size").is_none());
+
+    // Canonical only: also untouched.
+    let out = with_both(serde_json::json!({"vision_config": {"text_hidden_size": 512}}))
+        .expect("canonical-only must pass through");
+    assert_eq!(out["vision_config"]["text_hidden_size"], 512);
+
+    // Disagreeing values are an error, not a silent pick: the two keys name one
+    // quantity, and choosing either would surface later as a shape mismatch.
+    let err = with_both(serde_json::json!({
+        "vision_config": {"decoder_dmodel": 1024, "text_hidden_size": 2048},
+    }))
+    .expect_err("contradictory widths must be rejected");
+    assert!(
+        err.contains("must agree") && err.contains("vision_config"),
+        "unhelpful error: {err}"
+    );
+    let err = with_both(serde_json::json!({
+        "vision_config": {"n_channels": 1, "num_channels": 3},
+    }))
+    .expect_err("contradictory channel counts must be rejected too");
+    assert!(err.contains("must agree"), "unhelpful error: {err}");
+
+    // A sub-config that is absent, or not an object, is not an error.
+    assert!(with_both(serde_json::json!({"text_config": {"hidden_size": 8}})).is_ok());
+    assert!(with_both(serde_json::json!({"vision_config": null})).is_ok());
+}


### PR DESCRIPTION
## Summary

`inference-optimization/Inkling-0.6B-A0.6B` could not be loaded at all. Config parse failed with `duplicate field 'text_hidden_size'`, and once that key was handled, with `duplicate field 'num_channels'`.

## Cause

`InklingVisionConfig` (`src/vision/encoders/inkling_hmlp.rs`) and `InklingAudioConfig` (`src/audio/inkling_tower.rs`) declare serde aliases:

```rust
#[serde(default = "default_channels", alias = "n_channels")]  pub num_channels: usize,
#[serde(default = "default_hidden_size", alias = "decoder_dmodel")]  pub text_hidden_size: usize,
```

Serde treats a field and its alias as the **same field**, so an object carrying both spellings is a duplicate-field error and the whole config fails to deserialize, even with the two values in agreement.

## Neither spelling can be dropped

Read off the three downloaded checkpoints:

| checkpoint | `decoder_dmodel` | `text_hidden_size` | `n_channels` | `num_channels` |
|---|---|---|---|---|
| `mlx-community/Inkling-Small-mlx-4bit` | 4096 | absent | present | absent |
| `thinkingmachines/Inkling-Small-NVFP4` | 4096 | absent | present | absent |
| `inference-optimization/Inkling-0.6B-A0.6B` | 1024 | 1024 | 3 | 3 |

The Inkling-Small checkpoints ship only the aliases, so the aliases are load-bearing. The 0.6B ships both spellings of every pair at matching values and was rejected outright.

## Fix

Equal values collapse to the canonical spelling. **Disagreeing values are an error rather than a silent pick**: the two keys name one quantity, and choosing either would surface much later as a shape mismatch.

The reconciliation is driven by a list of `(canonical, alias)` pairs rather than a special case per key, because fixing these one at a time is exactly how `num_channels` went unnoticed until `text_hidden_size` was fixed. That reasoning is recorded on the constant and asserted in the test, so the next alias added to those structs has an obvious place to go.

Both parse paths get it: `InklingConfig::from_json_with_sidecar` for `audio_config`, and `src/loading/vlm_inkling.rs`, which deserializes `vision_config` directly off the raw config value. Fixing only the first leaves the vision half failing.

## Test plan

- [x] `inkling_config_accepts_both_text_width_spellings`: every declared pair doubled at matching values collapses to the canonical name (the real 0.6B shape); alias-only passes through untouched (the Inkling-Small shape); canonical-only passes through; contradictory values are rejected for **both** pairs with an error naming the section; an absent, null, or non-object sub-config is not an error.
- [x] `cargo test --lib models::inkling` 26, `vision::encoders::inkling` 5, `audio::inkling` 11, all passing.
- [x] `cargo clippy --lib --tests -- -D warnings` exit 0; `cargo fmt --check` clean.

**Verified on all three real checkpoints**, which is what this bug required and what CI could not do:

| checkpoint | config parse | load | generate |
|---|---|---|---|
| Inkling-0.6B-A0.6B | now passes | loads | aborts on a separate SWA shape mismatch |
| Inkling-Small-mlx-4bit | passes | loads | same separate abort |
| Inkling-Small-NVFP4 | passes | loads, 23.2 GB resident, 968 bf16 tensors converted | same separate abort |

NVFP4 matters as its own row: it reaches deserialization through `promote_nvfp4_config`, a different path, and also passes.

## What this does not fix

All three checkpoints still abort during generation with `[broadcast_shapes] Shapes (1,32) and (1,8) cannot be broadcast` (`(1,8)` and `(1,4)` on the 0.6B). Those operands match `swa_num_attention_heads` and `swa_num_key_value_heads` exactly on every checkpoint, so it is a sliding-window-attention GQA problem, independent of config parsing and not introduced here. Being able to reach it is the progress this PR makes. Tracked separately.

## Note on `mlxcel inspect`

`inspect` reported FITS for the 0.6B while it could not load, because it reads the safetensors header and never deserializes the full config. An inspect pass is not evidence that a checkpoint loads.

Closes #1560
Refs #1549
