### PR TITLE
fix(bench): reject --target paths without a file name

### DIFF
--- a/src/bin/speculative_bench.rs
+++ b/src/bin/speculative_bench.rs
@@ -805,14 +805,19 @@ fn main() -> Result<()> {
             .as_deref()
             .context("--target is required when --sweep is not set")?
             .to_path_buf();
+        let target_file_name = target.file_name().with_context(|| {
+            format!(
+                "--target must name a model directory, got {}",
+                target.display()
+            )
+        })?;
         let pairing_name = format!("{} ({})", target.display(), args.kind);
         let synthetic = Pairing {
             name: Box::leak(pairing_name.into_boxed_str()),
             target_subdir: Box::leak(
-                target
-                    .file_name()
-                    .map(|s| s.to_string_lossy().into_owned())
-                    .unwrap_or_else(|| "(target)".to_string())
+                target_file_name
+                    .to_string_lossy()
+                    .into_owned()
                     .into_boxed_str(),
             ),
             draft_subdir: args
@@ -826,7 +831,7 @@ fn main() -> Result<()> {
         // The synthetic pairing references the canonical layout via
         // `resolve_model_dir`; pass the explicit `--target` directly so an
         // operator who points at a non-canonical path is honored.
-        let row = if synthetic.target_subdir == target.file_name().unwrap().to_string_lossy() {
+        let row = if synthetic.target_subdir == target_file_name.to_string_lossy() {
             // Default canonical path; fall back to `bench_one_pairing` which
             // re-resolves via `resolve_model_dir`.
             bench_one_pairing(&synthetic, &args.prompt, args.batch, args.max_tokens)


### PR DESCRIPTION
## Summary

`speculative_bench` used `target.file_name().unwrap()` on the `--target` CLI path. `Path::file_name()` is `None` for values like `..` or `/`, so the bench aborted with a panic instead of a diagnostic.

## Changes

- Require `file_name()` once with `anyhow` context: `--target must name a model directory, got <path>`
- Reuse that value for the canonical `models/<name>` comparison

## Testing

- `cargo fmt --all -- --check` passed
- Confirmed `Path::file_name()` is `None` for `..`, `models/foo/..`, `.`, and `/`
- No harness exists for this binary's path logic; compiling it pulls in MLX, so no unit test was added

Manual repro after a release build:

```bash
./target/release/speculative_bench --target .. --kind none
./target/release/speculative_bench --target / --kind none
```

Fixes #1242