### PR TITLE
fix(server): type XML tool-call arguments by the request schema

### DIFF
--- a/TECHNICAL_REPORTS/1575-xml-tool-call-schema-coercion-20260902.en.md
+++ b/TECHNICAL_REPORTS/1575-xml-tool-call-schema-coercion-20260902.en.md
@@ -1,0 +1,354 @@
+# Technical Report: PR #1575 - fix(server): type XML tool-call arguments by the request schema
+
+**Date**: 2026-09-02
+**Author**: mlxcel maintainers
+**Reviewer**: pending
+**Status**: Completed
+**Languages**: Rust
+**Risk Level**: Medium
+
+---
+
+## Executive Summary
+
+The Qwen3-Coder and MiniMax M2 tool-call parsers guessed each argument's JSON type from the raw text because they never received the request's `tools`. A `string`-typed parameter carrying `02134` reached the client as the number `2134`, and an `integer`-typed parameter written `5.0` reached it as a float. This PR threads the request tool schema into both parsers, routes their values through the coercion helpers MiniMax M3, GLM-4.7 and LongCat already share, and extends the shared integer rule to accept a zero-fraction float literal.
+
+---
+
+## 1. Problem Statement
+
+### 1.1 Background
+
+Two of the XML tool-call grammars mlxcel supports carry no type information in their markup. Qwen3-Coder emits `<function=NAME><parameter=KEY>VALUE</parameter></function>` and MiniMax M2 emits `<invoke name="NAME"><parameter name="KEY">VALUE</parameter></invoke>`; in both, every value is a bare text run. The only place the intended type exists is the `tools` array the client sent with the request, which is exactly what the OpenAI-compatible chat route already has in hand at parse time.
+
+Three parsers in the same file already solved this. `try_minimax_m3`, `try_glm47` and `try_longcat` take `tools`, resolve the called function's schema with `minimax_m3_function_schema`, and coerce each value by its declared type. The two XML parsers did not, because they sat in a dispatch table typed `&[fn(&str) -> Option<ToolCallParseResult>]`: the table's element type is what made passing `tools` impossible, so the parsers guessed instead.
+
+### 1.2 Existing Issues
+
+- **String-typed values were rewritten**: `coerce_minimax_param` tried an `i64` parse, then `f64`, then a boolean word list, before falling back to a string. A US ZIP code `02134` parses as `i64` 2134, so the leading zero was destroyed. A product code `1e5` became `100000.0`. The literal text `true` became a JSON boolean. A tool whose handler expected a string then received a number, and either failed its own validation or silently used the wrong value.
+- **Integer-typed values kept a float form**: a model writing `5.0` for an `integer` parameter produced the JSON float `5.0`. Strict tool implementations reject that, and the schema said unambiguously that the value is an integer.
+- **Guesses with no schema basis**: `yes`, `on`, `no`, `off` were coerced to booleans and `none`, `nil` to null. None of these have any grounding in JSON Schema; they turned legitimate string arguments into wrong-typed ones.
+- **Duplicate coercion logic**: `coerce_minimax_param` was a second, weaker implementation of the same job as `minimax_m3_coerce_leaf`, so schema handling improvements landed in one and not the other.
+
+### 1.3 Risk Assessment
+
+| Risk | Impact | Likelihood |
+|------|--------|------------|
+| An agentic client receives a number where its schema declared a string, and the tool call fails or acts on a corrupted value | High | Certain for any leading-zero, exponent-like, or boolean-word string argument |
+| A tool rejects an `integer` argument delivered as `5.0` | Medium | Occasional (depends on the model's spelling) |
+| The two XML grammars diverge further from the three schema-aware ones as coercion evolves | Medium | Certain over time while the logic is duplicated |
+| A parser change drops a tool call outright when a value fails to parse | High | Avoided by design: every path ends at the raw string |
+
+---
+
+## 2. Technical Review
+
+### 2.1 Security
+
+**Checklist:**
+- [x] Input validation: all parsing operates on untrusted model output; the change adds no new indexing or slicing, only value typing
+- [x] Denial of service: the existing `MINIMAX_M2_MAX_CALLS` / `MINIMAX_M2_MAX_PARAMS_PER_CALL` / `QWEN3_CODER_*` caps and the O(N^2) `break` guards on malformed tags are untouched
+- [x] No panics added: no `unwrap`, `expect`, or indexing outside the test modules
+- [x] No sensitive data logged
+
+**Issues Found:**
+
+| Issue | Severity | Status |
+|-------|----------|--------|
+| None identified | n/a | n/a |
+
+One incidental improvement: `coerce_minimax_param` allocated a lowercase `String` copy of every parameter value to test three null spellings. `coerce_xml_param` uses `eq_ignore_ascii_case`, which allocates nothing.
+
+### 2.2 Performance
+
+**Checklist:**
+- [x] Algorithm complexity: unchanged per parameter, plus one linear scan of the `tools` slice per call and one property lookup per parameter, both matching what MiniMax M3, GLM-4.7 and LongCat already do
+- [x] Memory usage: one fewer `String` allocation per parameter value
+
+Tool-call parsing runs once per completion, on a text buffer the size of one model response, so none of this is on a hot path.
+
+### 2.3 Compatibility & Dependencies
+
+- **Breaking changes**: none at the API level. Behavior changes for clients that relied on the old guesses, listed in section 4.1. The two public functions `try_qwen3_coder` and `try_minimax_m2` change signature, but nothing outside `tool_calls::parser` and the in-file tests calls them.
+- **New dependencies**: none.
+- **Coverage**: both the non-streaming route (`routes/chat.rs`, `parse_tool_calls(&result.text, tools)`) and the end-of-stream route (`parse_tool_calls(&cb.accumulated, tools_ref)`) already pass the request tools, so one change covers streaming and non-streaming alike.
+
+### 2.4 Code Quality
+
+- **Test coverage**: 20 new unit tests; the `server::tool_calls` suite goes from 350 to 370 tests, all passing.
+- **Code complexity**: net simpler. A 37-line hand-rolled coercion ladder is replaced by a 6-line delegation to the shared helper, at the cost of a 2-variant enum in the dispatcher.
+- **Technical debt**: decreased. One of the two duplicate coercion implementations is gone, and two stale comments in `parse_tool_calls` are corrected.
+
+---
+
+## 3. Technical Decisions
+
+### 3.1 A `FormatParser` enum instead of widening every parser's signature
+
+**Context:**
+
+The dispatch table is an ordered list, and its order is load-bearing: `try_functionary_v31` must be tried before `try_qwen3_coder` (both open with `<function=`, and v3.1 declines a non-JSON body), and `try_qwen3_coder` before `try_functionary_v32`. Only 2 of the 15 entries need `tools`, but an array literal admits exactly one element type.
+
+**Alternatives considered:**
+
+| Option | Pros | Cons |
+|--------|------|------|
+| Give all 15 parsers a `tools` parameter | One uniform table type, no wrapper | 13 parsers gain an argument they ignore; every call site and test in the file changes; a reader cannot tell which parsers actually consult the schema |
+| Move the two parsers out of the table, next to `try_minimax_m3` | No table change at all | Silently changes dispatch order relative to Functionary v3.1 and v3.2, which is the one property the table exists to encode |
+| **Chosen: a `FormatParser` enum with `Plain` and `WithTools` variants** | Order preserved exactly; the schema-aware entries are visible at a glance; no parser gains an unused argument | One small enum and a `run` method; entries carry a wrapper name |
+
+**Rationale:**
+
+The table's meaning is its order, so the option that preserves the order literally, line for line, is the safe one. The enum also documents which grammars are schema-aware, which is real information a maintainer needs when adding the next format. `parse_qwen3_coder_still_runs_after_functionary_v31` pins the ordering property that the second option would have broken.
+
+**Trade-offs:**
+
+Each entry now carries a `Plain(...)` or `WithTools(...)` wrapper, which is slightly noisier than a bare function name. The dispatch cost is one `match` per format tried, which is irrelevant next to the string scanning each parser performs.
+
+### 3.2 `null` overrides the declared type; nothing else does
+
+**Context:**
+
+`coerce_xml_param` keeps exactly one rule ahead of the schema: the bare word `null`, in any casing, becomes JSON null even for a `string`-typed parameter.
+
+**Rationale:**
+
+These grammars have no other spelling for a JSON null. A `<parameter=x>null</parameter>` element is the only null a model can write, and both parsers have always emitted one there, so removing the rule would have been a regression for every model that uses it. The narrower reading (a string-typed `null` is the four-character string) would also make the null unreachable whenever the client declares a type.
+
+**Trade-offs:**
+
+A model that genuinely wants the string `"null"` cannot express it in these grammars. That was already true before this PR, and the schema-aware grammars (MiniMax M3, GLM-4.7) do keep `"null"` as a string under a string schema, so the two families disagree on this one input. The XML behavior was kept because changing it is a regression, not a fix, and it is out of the issue's scope.
+
+### 3.3 `integer` normalizes `5.0`, but `number` keeps the written form
+
+**Context:**
+
+The shared `M3Type::Integer` arm previously accepted only `i64` and `u64` literals, so an `integer`-typed `5.0` fell through to the loose fallback and stayed a float. Extending the arm raised the neighbouring question of what `number` should do with an integral literal.
+
+**Rationale:**
+
+Under `integer` the declared type settles it: the value is an integer, so `5.0` is `5`, and the float spelling is the model's formatting, not data. Under `number` both spellings are valid and the schema expresses no preference, so the parser preserves what the model wrote (`5` stays `5`, `5.0` stays `5.0`). Preserving it also keeps the XML parsers' pre-existing output for `number`-typed integral values unchanged, which a blanket float conversion would have altered.
+
+**Trade-offs:**
+
+The float acceptance is bounded by 2^53. Past that an `f64` cannot represent every integer, so converting would round silently; the rule declines instead, and the value stays a float through the fallback. That is a deliberate refusal to guess rather than a gap.
+
+### 3.4 GLM-4.7 and LongCat take the integer rule, not the whole typed path
+
+**Context:**
+
+`coerce_kv_value` (GLM-4.7 and LongCat) honored only a `string` schema and sent every other type to the loose fallback. The issue asked for `integer`-typed `5.0` to become `5` in every XML grammar.
+
+**Rationale:**
+
+Adding an `Integer` arm to `coerce_kv_value` delivers exactly the requested fix. Routing the function through `minimax_m3_typed_coerce` instead would have changed how those two grammars treat `enum`, `anyOf`, `object`, `array` and `boolean` schemas as a side effect, which is a much larger blast radius than the issue justifies and is not covered by their existing tests. The shared helper is `parse_integer_literal`, so the rule cannot drift between the call sites.
+
+**Trade-offs:**
+
+GLM-4.7 and LongCat remain less schema-strict than MiniMax M3. That gap is now explicit in the `coerce_kv_value` doc comment rather than implicit, and closing it is a separate, testable change.
+
+---
+
+## 4. Implementation Details
+
+### 4.1 Behavior change table
+
+| Schema | Raw value | Before | After |
+|--------|-----------|--------|-------|
+| `{"type":"string"}` | `02134` | `2134` | `"02134"` |
+| `{"type":"string"}` | `true` | `true` | `"true"` |
+| `{"type":"string"}` | `1e5` | `100000.0` | `"1e5"` |
+| `{"type":"integer"}` | `5.0` | `5.0` | `5` |
+| `{"type":"integer"}` | `5.5` | `5.5` | `5.5` (loose fallback, call kept) |
+| `{"type":"number"}` | `5` | `5` | `5` |
+| `{"type":"object"}` | `{not json` | `"{not json"` | `"{not json"` |
+| none | `5` / `true` / `null` | `5` / `true` / `null` | unchanged |
+| none | `yes` / `on` / `none` | `true` / `true` / `null` | `"yes"` / `"on"` / `"none"` |
+| none | `[1, 2]` | `[1, 2]` | `[1, 2]` |
+
+One further no-schema difference: the fallback now runs a full JSON parse instead of attempting one only when the text starts with `{` or `[`, so a schema-free value written as a JSON literal is parsed as that literal. This is what MiniMax M3, GLM-4.7 and LongCat already did, so the four grammars now agree.
+
+### 4.2 Key code changes
+
+**File: `src/server/tool_calls/formats.rs`**
+
+```rust
+// Before
+fn coerce_minimax_param(value: &str) -> serde_json::Value {
+    let lower = value.to_lowercase();
+    if lower == "null" || lower == "none" || lower == "nil" { return Value::Null; }
+    if let Ok(i) = value.parse::<i64>() { return Value::Number(i.into()); }
+    // ... f64, then "true"/"1"/"yes"/"on", then "{"/"[" JSON, then String
+}
+
+// After
+fn coerce_xml_param(raw: &str, schema: Option<&serde_json::Value>) -> serde_json::Value {
+    if raw.eq_ignore_ascii_case("null") {
+        return serde_json::Value::Null;
+    }
+    minimax_m3_coerce_leaf(raw, schema)
+}
+```
+
+**Reason for change:** the type belongs to the schema, not to the shape of the text. `minimax_m3_coerce_leaf` already implements the declared-type path, including `enum`, `anyOf`/`oneOf` and array-item resolution, and already ends at the raw string so an unparseable value never drops the call.
+
+```rust
+// After: the shared integer rule
+fn parse_integer_literal(raw: &str) -> Option<serde_json::Value> {
+    if let Some(v) = parse_exact_integer_literal(raw) {
+        return Some(v);
+    }
+    let f = raw.parse::<f64>().ok()?;
+    if f.is_finite() && f.fract() == 0.0 && f.abs() <= INTEGER_FROM_FLOAT_LIMIT {
+        return Some(serde_json::Value::Number((f as i64).into()));
+    }
+    None
+}
+```
+
+**Reason for change:** `integer` should accept the integral value a model spelled as a float, but only where the conversion is exact. `INTEGER_FROM_FLOAT_LIMIT` is 2^53.
+
+**File: `src/server/tool_calls/parser.rs`**
+
+```rust
+// Before
+let parsers: &[fn(&str) -> Option<ToolCallParseResult>] = &[ /* 15 entries */ ];
+for parser in parsers {
+    if let Some(mut result) = parser(text) { /* ... */ }
+}
+
+// After
+enum FormatParser {
+    Plain(fn(&str) -> Option<ToolCallParseResult>),
+    WithTools(fn(&str, Option<&[Tool]>) -> Option<ToolCallParseResult>),
+}
+
+let parsers: &[FormatParser] = &[ /* same 15 entries, same order */ ];
+for parser in parsers {
+    if let Some(mut result) = parser.run(text, tools) { /* ... */ }
+}
+```
+
+**Reason for change:** the table could not carry a parser that needs `tools`. The order is unchanged, which is the property the table exists to encode.
+
+---
+
+## 5. Learning Points
+
+### 5.1 A collection's element type can be the reason a bug exists
+
+**Concept:**
+
+`try_qwen3_coder` and `try_minimax_m2` did not guess types because guessing was thought correct. They guessed because they lived in an array whose element type was `fn(&str) -> Option<...>`, and the data they needed could not travel through that type. The three parsers that escaped the array got the schema; the two that stayed did not.
+
+**Application in this PR:**
+
+The fix is mostly the container change. Once the table can hold a `WithTools` entry, the parser bodies need four lines: look the function up, and pass the per-parameter schema down two call levels.
+
+**Where else this pattern shows up:**
+
+- A registry of handlers typed to the narrowest signature that the first few members happened to need.
+- A trait method that omits a context argument, so implementations reach for globals or heuristics.
+- A callback list whose element type freezes at the first use case, and later members work around it.
+
+The signal is a parser or handler that reimplements information it should have been handed.
+
+### 5.2 Preserving the written form is part of correct coercion
+
+**Concept:**
+
+Coercion is usually framed as "make the value fit the type", but when a type admits several representations, the parser should not choose among them. Under `number`, both `5` and `5.0` are valid, so the parser keeps what the model wrote. Under `integer` only one is valid, so `5.0` becomes `5`.
+
+**Application in this PR:**
+
+`M3Type::Number` tries `parse_exact_integer_literal` before the `f64` parse; `M3Type::Integer` uses the wider `parse_integer_literal`. The `qwen3_coder_number_typed_keeps_written_form` and `minimax_m3_number_typed_keeps_written_form` tests assert both directions with `is_i64()` and `is_f64()`, because `assert_eq!(value, 5)` alone does not distinguish an integer from a float in `serde_json`.
+
+---
+
+## 6. Further Learning
+
+### Key terms
+
+| Keyword | Description | Relevance |
+|---------|-------------|-----------|
+| `minimax_m3_coerce_leaf` | Schema-directed leaf coercion: typed parse, then JSON parse, then loose literal, then raw string | The single coercion path all four XML grammars now reach |
+| `minimax_m3_typed_coerce` | Strict schema-directed parse that returns `None` when the declared type does not apply | Its `None` is what lets `anyOf` try the next alternative and what keeps a call alive on a bad value |
+| `kv_param_schema` | Looks a parameter up in a function schema's `properties` | The per-parameter half of the lookup, paired with `minimax_m3_function_schema` |
+| 2^53 | Largest magnitude at which an `f64` represents every integer | The bound on the zero-fraction float rule |
+
+### Related PRs and issues
+
+- Issue #1336: the specification this PR implements, including the schema table reproduced in section 4.1.
+- The GLM-4.7 and LongCat key/value parsers and the MiniMax M3 namespaced-XML parser are the prior art this PR reuses rather than reimplements.
+
+---
+
+## 7. Change Summary
+
+### Statistics
+
+| Item | Value |
+|------|-------|
+| Files changed | 2 |
+| Lines added | +545 |
+| Lines deleted | -121 |
+| Tests added | 20 |
+
+### Changes by category
+
+| Category | Count | Summary |
+|----------|-------|---------|
+| Correctness | 2 files | Schema-directed typing for the Qwen3-Coder and MiniMax M2 grammars; the shared integer rule accepts a zero-fraction float |
+| Code quality | 1 | `coerce_minimax_param` removed; two stale comments in `parse_tool_calls` corrected |
+| Tests | 20 | Schema, no-schema, boundary and dispatcher-order coverage in both files |
+
+### Related commits
+
+| Hash | Type | Message |
+|------|------|---------|
+| `272afe8` | fix | fix(server): type XML tool-call arguments by the request schema |
+
+---
+
+## 8. Follow-up Actions
+
+### Required
+
+- [ ] Confirm the end-to-end behavior against a real Qwen3-Coder checkpoint (the request and expected `tool_calls[].function.arguments` are in the PR body). This PR was validated by unit tests only; no checkpoint was loaded.
+
+### Monitoring required
+
+- Tool-call arguments reaching clients for the two grammars, specifically string-typed values that look numeric. A client that had adapted to the old coercion (for example by re-stringifying a ZIP code) will now receive the correct string and should stop compensating.
+
+### Future improvements
+
+- Decide whether GLM-4.7 and LongCat should run the full `minimax_m3_typed_coerce` path rather than the string and integer rules only. That is a deliberate scope boundary here, documented on `coerce_kv_value`.
+- Incremental per-delta tool-call argument streaming is still out of scope: the stream path parses once at end of stream.
+- Schema validation errors (missing `required` keys, `enum` rejection) are still not surfaced to the client; the parser coerces and never rejects.
+
+---
+
+## Appendix
+
+### A. Test results
+
+```
+cargo test --profile test-fast --features metal,accelerate --lib server::tool_calls
+test result: ok. 370 passed; 0 failed; 0 ignored; 7313 filtered out
+
+cargo test --profile test-fast --features metal,accelerate --lib server::muse_atem
+test result: ok. 11 passed; 0 failed; 0 ignored; 7672 filtered out
+
+cargo clippy --profile test-fast --lib --tests --features metal,accelerate -- -D warnings
+Finished (no warnings)
+
+cargo fmt --all -- --check
+clean
+```
+
+The four cases the issue asked to keep green pass unchanged: `qwen3_coder_single_call_multiple_params_with_type_coercion`, `minimax_m2_numeric_params`, `minimax_m2_boolean_param`, `minimax_m2_null_param`.
+
+### C. References
+
+- `docs/code-guidelines.md`: the `// Used by:` convention applied to `coerce_xml_param` and `parse_integer_literal`.
+- JSON Schema type keyword: `integer` is a distinct type from `number`, which is why the two arms differ.

--- a/TECHNICAL_REPORTS/1575-xml-tool-call-schema-coercion-20260902.en.md
+++ b/TECHNICAL_REPORTS/1575-xml-tool-call-schema-coercion-20260902.en.md
@@ -11,7 +11,7 @@
 
 ## Executive Summary
 
-The Qwen3-Coder and MiniMax M2 tool-call parsers guessed each argument's JSON type from the raw text because they never received the request's `tools`. A `string`-typed parameter carrying `02134` reached the client as the number `2134`, and an `integer`-typed parameter written `5.0` reached it as a float. This PR threads the request tool schema into both parsers, routes their values through the coercion helpers MiniMax M3, GLM-4.7 and LongCat already share, and extends the shared integer rule to accept a zero-fraction float literal.
+The Qwen3-Coder and MiniMax M2 tool-call parsers guessed each argument's JSON type from the raw text because they never received the request's `tools`. A `string`-typed parameter carrying `02134` reached the client as the number `2134`, and an `integer`-typed parameter written `5.0` reached it as a float. This PR threads the request tool schema into both parsers, routes their values through the coercion helpers MiniMax M3, GLM-4.7 and LongCat already share, and grounds every remaining lenient rule (booleans, null, an integer written with a zero fraction) in a declared type instead of in the shape of the text.
 
 ---
 
@@ -27,7 +27,7 @@ Three parsers in the same file already solved this. `try_minimax_m3`, `try_glm47
 
 - **String-typed values were rewritten**: `coerce_minimax_param` tried an `i64` parse, then `f64`, then a boolean word list, before falling back to a string. A US ZIP code `02134` parses as `i64` 2134, so the leading zero was destroyed. A product code `1e5` became `100000.0`. The literal text `true` became a JSON boolean. A tool whose handler expected a string then received a number, and either failed its own validation or silently used the wrong value.
 - **Integer-typed values kept a float form**: a model writing `5.0` for an `integer` parameter produced the JSON float `5.0`. Strict tool implementations reject that, and the schema said unambiguously that the value is an integer.
-- **Guesses with no schema basis**: `yes`, `on`, `no`, `off` were coerced to booleans and `none`, `nil` to null. None of these have any grounding in JSON Schema; they turned legitimate string arguments into wrong-typed ones.
+- **Guesses applied where nothing declared a type**: `yes`, `on`, `no`, `off` were coerced to booleans and `none`, `nil` to null for every parameter, whether or not the request declared anything. With no declaration those are guesses about English words, not about data.
 - **Duplicate coercion logic**: `coerce_minimax_param` was a second, weaker implementation of the same job as `minimax_m3_coerce_leaf`, so schema handling improvements landed in one and not the other.
 
 ### 1.3 Risk Assessment
@@ -38,6 +38,7 @@ Three parsers in the same file already solved this. `try_minimax_m3`, `try_glm47
 | A tool rejects an `integer` argument delivered as `5.0` | Medium | Occasional (depends on the model's spelling) |
 | The two XML grammars diverge further from the three schema-aware ones as coercion evolves | Medium | Certain over time while the logic is duplicated |
 | A parser change drops a tool call outright when a value fails to parse | High | Avoided by design: every path ends at the raw string |
+| The fix silently does nothing for a model that namespaces its call names | High | Certain for such models until the lookup normalizes the name (fixed here) |
 
 ---
 
@@ -55,9 +56,10 @@ Three parsers in the same file already solved this. `try_minimax_m3`, `try_glm47
 
 | Issue | Severity | Status |
 |-------|----------|--------|
-| None identified | n/a | n/a |
+| Fractional value rounded into an integer past 2^53 (`9007199254740991.5` became an integer) | Medium | Fixed in the second commit: the rule is textual, with no `f64` round trip |
+| Integer value off by one past 2^53 (`9007199254740993.0` became `...992`) | Medium | Fixed in the same change |
 
-One incidental improvement: `coerce_minimax_param` allocated a lowercase `String` copy of every parameter value to test three null spellings. `coerce_xml_param` uses `eq_ignore_ascii_case`, which allocates nothing.
+Both were introduced by the first commit of this PR and found in review before merge. Two incidental improvements: `coerce_minimax_param` allocated a lowercase `String` copy of every parameter value to test three null spellings, where `coerce_xml_param` uses `eq_ignore_ascii_case` and allocates nothing; and `serde_json` rejects a non-finite parse, so no path can produce a `Value::Number` holding an infinity, which would have serialized as `null`.
 
 ### 2.2 Performance
 
@@ -75,9 +77,9 @@ Tool-call parsing runs once per completion, on a text buffer the size of one mod
 
 ### 2.4 Code Quality
 
-- **Test coverage**: 20 new unit tests; the `server::tool_calls` suite goes from 350 to 370 tests, all passing.
-- **Code complexity**: net simpler. A 37-line hand-rolled coercion ladder is replaced by a 6-line delegation to the shared helper, at the cost of a 2-variant enum in the dispatcher.
-- **Technical debt**: decreased. One of the two duplicate coercion implementations is gone, and two stale comments in `parse_tool_calls` are corrected.
+- **Test coverage**: 26 new unit tests; the `server::tool_calls` suite goes from 350 to 376 tests, all passing.
+- **Code complexity**: roughly even. A 37-line hand-rolled coercion ladder is replaced by a schema-directed `coerce_xml_param` plus two small helpers, and the dispatcher gains a 2-variant enum.
+- **Technical debt**: decreased. One of the two duplicate coercion implementations is gone, two stale comments in `parse_tool_calls` are corrected, and the five shared helpers whose caller set widened now carry the `// Used by:` lines the project convention requires.
 
 ---
 
@@ -105,35 +107,49 @@ The table's meaning is its order, so the option that preserves the order literal
 
 Each entry now carries a `Plain(...)` or `WithTools(...)` wrapper, which is slightly noisier than a bare function name. The dispatch cost is one `match` per format tried, which is irrelevant next to the string scanning each parser performs.
 
-### 3.2 `null` overrides the declared type; nothing else does
+### 3.2 Lenient rules are kept, but only where a declared type justifies them
 
 **Context:**
 
-`coerce_xml_param` keeps exactly one rule ahead of the schema: the bare word `null`, in any casing, becomes JSON null even for a `string`-typed parameter.
+The first commit removed every lenient rule the old guesser had (`yes`/`on` to true, `no`/`off` to false, `none`/`nil` to null) and let `null` override the schema in all cases. Review showed both halves were wrong at the edges: under `{"type": "boolean"}` the model writing `yes` now produced the string `"yes"`, which is worse than the guess it replaced, and under `{"type": "string"}` the text `null` still became JSON null, which is the same kind of type violation this PR exists to fix.
 
 **Rationale:**
 
-These grammars have no other spelling for a JSON null. A `<parameter=x>null</parameter>` element is the only null a model can write, and both parsers have always emitted one there, so removing the rule would have been a regression for every model that uses it. The narrower reading (a string-typed `null` is the four-character string) would also make the null unreachable whenever the client declares a type.
+The distinction that matters is not "lenient versus strict", it is whether the leniency has a declared type behind it. `yes` meaning `true` is a guess about English when nothing declares a type, and a reasonable reading when the schema says `boolean`. So `coerce_xml_param` applies the boolean word list only under a `boolean` declaration, and `null` yields JSON null everywhere except a plain `string` declaration, where the text is what the tool asked for. A nullable declaration (`{"type": ["string", "null"]}`) still takes the null, because there the schema says both are possible and the bare word is the only null these grammars can spell.
 
 **Trade-offs:**
 
-A model that genuinely wants the string `"null"` cannot express it in these grammars. That was already true before this PR, and the schema-aware grammars (MiniMax M3, GLM-4.7) do keep `"null"` as a string under a string schema, so the two families disagree on this one input. The XML behavior was kept because changing it is a regression, not a fix, and it is out of the issue's scope.
+Two behaviors now depend on the declaration rather than being uniform, which is more to hold in one's head than a single rule. The doc comment on `coerce_xml_param` states both, and six tests pin them from both directions (with and without a declaration). A model that wants the literal string `"null"` for a non-string parameter still cannot express it; that was true before this PR and is not worth a new escape syntax.
 
-### 3.3 `integer` normalizes `5.0`, but `number` keeps the written form
+### 3.3 The integer rule strips a zero fraction textually, not through `f64`
 
 **Context:**
 
-The shared `M3Type::Integer` arm previously accepted only `i64` and `u64` literals, so an `integer`-typed `5.0` fell through to the loose fallback and stayed a float. Extending the arm raised the neighbouring question of what `number` should do with an integral literal.
+The shared `M3Type::Integer` arm accepted only `i64` and `u64` literals, so an `integer`-typed `5.0` fell through to the loose fallback and stayed a float. The first commit fixed that by parsing to `f64` and checking `fract() == 0.0` under a 2^53 bound.
 
 **Rationale:**
 
-Under `integer` the declared type settles it: the value is an integer, so `5.0` is `5`, and the float spelling is the model's formatting, not data. Under `number` both spellings are valid and the schema expresses no preference, so the parser preserves what the model wrote (`5` stays `5`, `5.0` stays `5.0`). Preserving it also keeps the XML parsers' pre-existing output for `number`-typed integral values unchanged, which a blanket float conversion would have altered.
+That check cannot work, because the rounding happens inside `parse::<f64>()`, before anything can inspect the result. `9007199254740991.5` parses to `...992.0`, passes the zero-fraction test, and becomes an integer; `9007199254740993.0` comes back off by one and passes the bound. The textual rule (split at `.`, require an all-zero fraction, parse the integer part with the exact `i64`/`u64` parser) is exact at every magnitude and needs no bound at all. It also declines the exponent form, which matters because `minimax_m3_typed_coerce` takes the first `anyOf` alternative that succeeds: with the `f64` path, `anyOf: [integer, string]` and the value `1e5` gave `100000` where the string alternative used to own it.
 
 **Trade-offs:**
 
-The float acceptance is bounded by 2^53. Past that an `f64` cannot represent every integer, so converting would round silently; the rule declines instead, and the value stays a float through the fallback. That is a deliberate refusal to guess rather than a gap.
+An `integer`-declared `1e5` is no longer normalized to `100000`; it stays the float `100000.0` through the fallback. That is the price of not stealing identifiers from a string alternative, and the exponent form is far rarer in a model's tool arguments than a decimal point is.
 
-### 3.4 GLM-4.7 and LongCat take the integer rule, not the whole typed path
+### 3.4 `integer` normalizes `5.0`, but `number` keeps the written form
+
+**Context:**
+
+Extending the integer arm raised the neighbouring question of what `number` should do with an integral literal.
+
+**Rationale:**
+
+Under `integer` the declared type settles it: the value is an integer, so `5.0` is `5`, and the decimal point is formatting. Under `number` both spellings are valid and the schema expresses no preference, so the parser preserves what the model wrote (`5` stays `5`, `5.0` stays `5.0`). Preserving it also keeps the XML parsers' pre-existing output for `number`-typed integral values unchanged, which a blanket float conversion would have altered, and it removes a precision loss for integers past 2^53 that the old `f64`-only arm had.
+
+**Trade-offs:**
+
+`M3Type::Number` is shared, so this changes the wire type MiniMax M3 emits for a `number`/`num`/`float`/`double` parameter written as an integer: `5` instead of `5.0`. JSON Schema accepts an integer as a `number`, so no schema is violated, but it is a visible change outside what the issue asked for and is called out in the PR body for that reason.
+
+### 3.5 GLM-4.7 and LongCat take the integer rule, not the whole typed path
 
 **Context:**
 
@@ -147,6 +163,20 @@ Adding an `Integer` arm to `coerce_kv_value` delivers exactly the requested fix.
 
 GLM-4.7 and LongCat remain less schema-strict than MiniMax M3. That gap is now explicit in the `coerce_kv_value` doc comment rather than implicit, and closing it is a separate, testable change.
 
+### 3.6 The schema lookup normalizes a namespaced call name
+
+**Context:**
+
+`minimax_m3_function_schema` matched `t.function.name == name` exactly. But `filter_by_tools` exists precisely because models emit `functions.get_weather`, and it strips that prefix only after parsing.
+
+**Rationale:**
+
+For a namespacing model the sequence was: schema lookup misses, every value takes the loose rules, `filter_by_tools` then strips the prefix and accepts the call. The client gets a successful tool call carrying the exact bug this PR set out to fix, with nothing to indicate the schema was ignored. The lookup now falls back to the bare name after the first `.`, mirroring `filter_by_tools`. The exact match is still tried first, so a tool genuinely registered as `a.b` is unaffected.
+
+**Trade-offs:**
+
+The fallback runs a second linear scan for a namespaced name. With a realistic tool count this is not measurable; if it ever matters, a `HashMap` hoisted out of the call loop is the answer.
+
 ---
 
 ## 4. Implementation Details
@@ -158,15 +188,21 @@ GLM-4.7 and LongCat remain less schema-strict than MiniMax M3. That gap is now e
 | `{"type":"string"}` | `02134` | `2134` | `"02134"` |
 | `{"type":"string"}` | `true` | `true` | `"true"` |
 | `{"type":"string"}` | `1e5` | `100000.0` | `"1e5"` |
+| `{"type":"string"}` | `null` | `null` | `"null"` |
+| `{"type":["string","null"]}` | `null` | `null` | `null` |
+| `{"type":"boolean"}` | `yes` / `on` / `TRUE` | `true` | `true` |
+| `{"type":"boolean"}` | `maybe` | `"maybe"` | `"maybe"` |
 | `{"type":"integer"}` | `5.0` | `5.0` | `5` |
 | `{"type":"integer"}` | `5.5` | `5.5` | `5.5` (loose fallback, call kept) |
 | `{"type":"number"}` | `5` | `5` | `5` |
 | `{"type":"object"}` | `{not json` | `"{not json"` | `"{not json"` |
+| `{"anyOf":[integer,string]}` | `1e5` | `"1e5"` | `"1e5"` |
 | none | `5` / `true` / `null` | `5` / `true` / `null` | unchanged |
 | none | `yes` / `on` / `none` | `true` / `true` / `null` | `"yes"` / `"on"` / `"none"` |
-| none | `[1, 2]` | `[1, 2]` | `[1, 2]` |
+| none | `TRUE` | `true` | `"TRUE"` |
+| namespaced call `functions.f`, `{"type":"string"}` | `02134` | `2134` | `"02134"` |
 
-One further no-schema difference: the fallback now runs a full JSON parse instead of attempting one only when the text starts with `{` or `[`, so a schema-free value written as a JSON literal is parsed as that literal. This is what MiniMax M3, GLM-4.7 and LongCat already did, so the four grammars now agree.
+Two further no-schema differences follow from reusing the shared fallback: it runs a full JSON parse instead of attempting one only when the text starts with `{` or `[`, so a schema-free value written as a JSON literal (`[1, 2]`, or a quoted string) is parsed as that literal; and its boolean words are case-sensitive, so a schema-free `TRUE` is a string. Both match what MiniMax M3, GLM-4.7 and LongCat already did, and a `boolean` declaration restores the lenient reading where one exists.
 
 ### 4.2 Key code changes
 
@@ -183,14 +219,22 @@ fn coerce_minimax_param(value: &str) -> serde_json::Value {
 
 // After
 fn coerce_xml_param(raw: &str, schema: Option<&serde_json::Value>) -> serde_json::Value {
-    if raw.eq_ignore_ascii_case("null") {
+    let declared = schema.and_then(minimax_m3_schema_type);
+    let keeps_raw_text =
+        declared == Some(M3Type::Str) && !schema.is_some_and(schema_type_admits_null);
+    if !keeps_raw_text && raw.eq_ignore_ascii_case("null") {
         return serde_json::Value::Null;
+    }
+    if declared == Some(M3Type::Boolean)
+        && let Some(b) = loose_boolean_word(raw)
+    {
+        return serde_json::Value::Bool(b);
     }
     minimax_m3_coerce_leaf(raw, schema)
 }
 ```
 
-**Reason for change:** the type belongs to the schema, not to the shape of the text. `minimax_m3_coerce_leaf` already implements the declared-type path, including `enum`, `anyOf`/`oneOf` and array-item resolution, and already ends at the raw string so an unparseable value never drops the call.
+**Reason for change:** the type belongs to the schema, not to the shape of the text. `minimax_m3_coerce_leaf` already implements the declared-type path, including `enum`, `anyOf`/`oneOf` and array-item resolution, and already ends at the raw string so an unparseable value never drops the call. The two rules ahead of it are the ones a declaration justifies.
 
 ```rust
 // After: the shared integer rule
@@ -198,15 +242,15 @@ fn parse_integer_literal(raw: &str) -> Option<serde_json::Value> {
     if let Some(v) = parse_exact_integer_literal(raw) {
         return Some(v);
     }
-    let f = raw.parse::<f64>().ok()?;
-    if f.is_finite() && f.fract() == 0.0 && f.abs() <= INTEGER_FROM_FLOAT_LIMIT {
-        return Some(serde_json::Value::Number((f as i64).into()));
+    let (int_part, fraction) = raw.split_once('.')?;
+    if fraction.bytes().any(|b| b != b'0') {
+        return None;
     }
-    None
+    parse_exact_integer_literal(int_part)
 }
 ```
 
-**Reason for change:** `integer` should accept the integral value a model spelled as a float, but only where the conversion is exact. `INTEGER_FROM_FLOAT_LIMIT` is 2^53.
+**Reason for change:** `integer` should accept the integral value a model spelled with a decimal point, and the conversion has to be exact. Doing it as text rather than through `f64` removes both rounding failures and keeps the exponent form out of an `anyOf`'s integer alternative.
 
 **File: `src/server/tool_calls/parser.rs`**
 
@@ -253,7 +297,23 @@ The fix is mostly the container change. Once the table can hold a `WithTools` en
 
 The signal is a parser or handler that reimplements information it should have been handed.
 
-### 5.2 Preserving the written form is part of correct coercion
+### 5.2 A validity check placed after a lossy conversion checks nothing
+
+**Concept:**
+
+The first commit read an integer-with-zero-fraction as `raw.parse::<f64>()`, then guarded with `f.fract() == 0.0 && f.abs() <= 2^53`. Both conditions are evaluated on a value that the parse already rounded, so `9007199254740991.5` passes the fraction test it was meant to fail, and `9007199254740993.0` passes the bound while being off by one. The guard reads as protective and is not.
+
+**Application in this PR:**
+
+The rule became textual: split the string at `.`, require every fraction byte to be `0`, and parse the integer part with the exact integer parser. Nothing is rounded, so there is nothing to check afterwards. `integer_literal_rule_is_textual_and_exact` pins both values that the previous form got wrong.
+
+**Where else this pattern shows up:**
+
+- Range checks after a narrowing cast rather than before it.
+- Precision assertions on a value that has already been through a float round trip.
+- Validating a string after it has been normalized, when the normalization is what destroys the property being validated.
+
+### 5.3 Preserving the written form is part of correct coercion
 
 **Concept:**
 
@@ -274,7 +334,8 @@ Coercion is usually framed as "make the value fit the type", but when a type adm
 | `minimax_m3_coerce_leaf` | Schema-directed leaf coercion: typed parse, then JSON parse, then loose literal, then raw string | The single coercion path all four XML grammars now reach |
 | `minimax_m3_typed_coerce` | Strict schema-directed parse that returns `None` when the declared type does not apply | Its `None` is what lets `anyOf` try the next alternative and what keeps a call alive on a bad value |
 | `kv_param_schema` | Looks a parameter up in a function schema's `properties` | The per-parameter half of the lookup, paired with `minimax_m3_function_schema` |
-| 2^53 | Largest magnitude at which an `f64` represents every integer | The bound on the zero-fraction float rule |
+| `filter_by_tools` | Drops calls to unregistered functions and strips a namespace prefix | The reason the schema lookup has to normalize the same prefix |
+| 2^53 | Largest magnitude at which an `f64` represents every integer | The bound the first commit relied on, and the reason the final rule avoids `f64` entirely |
 
 ### Related PRs and issues
 
@@ -289,24 +350,25 @@ Coercion is usually framed as "make the value fit the type", but when a type adm
 
 | Item | Value |
 |------|-------|
-| Files changed | 2 |
-| Lines added | +545 |
-| Lines deleted | -121 |
-| Tests added | 20 |
+| Source files changed | 2 |
+| Lines added (source, excluding this report) | +786 |
+| Lines deleted (source) | -115 |
+| Tests added | 26 |
 
 ### Changes by category
 
 | Category | Count | Summary |
 |----------|-------|---------|
-| Correctness | 2 files | Schema-directed typing for the Qwen3-Coder and MiniMax M2 grammars; the shared integer rule accepts a zero-fraction float |
-| Code quality | 1 | `coerce_minimax_param` removed; two stale comments in `parse_tool_calls` corrected |
-| Tests | 20 | Schema, no-schema, boundary and dispatcher-order coverage in both files |
+| Correctness | 2 files | Schema-directed typing for the Qwen3-Coder and MiniMax M2 grammars; an exact integer rule; a namespace-normalizing schema lookup |
+| Code quality | 1 | `coerce_minimax_param` removed; two stale `parse_tool_calls` comments corrected; `// Used by:` added to five widened helpers |
+| Tests | 26 | Schema, no-schema, boundary, `anyOf`, namespace and dispatcher-order coverage in both files |
 
 ### Related commits
 
 | Hash | Type | Message |
 |------|------|---------|
 | `272afe8` | fix | fix(server): type XML tool-call arguments by the request schema |
+| `f222376` | fix | fix(server): tighten schema-driven XML tool-call coercion |
 
 ---
 
@@ -323,6 +385,9 @@ Coercion is usually framed as "make the value fit the type", but when a type adm
 ### Future improvements
 
 - Decide whether GLM-4.7 and LongCat should run the full `minimax_m3_typed_coerce` path rather than the string and integer rules only. That is a deliberate scope boundary here, documented on `coerce_kv_value`.
+- `minimax_m3_typed_coerce` returns out of its `anyOf`/`oneOf` loop on the first key present, so a schema carrying an `anyOf` that matches nothing never tries `oneOf` or its own `type`. Pre-existing, unchanged here, worth a separate fix.
+- The `minimax_m3_` prefix on the shared helpers is now misleading, since Qwen3-Coder and MiniMax M2 call them too. A rename to `schema_coerce_leaf` and friends belongs in its own `refactor:` PR.
+- An array-typed parameter carrying one bare scalar yields that scalar, not a one-element array, because these grammars cannot spell a repeated element. `xml_array_typed_bare_scalar_takes_the_item_type` documents it; whether it should wrap is a product decision.
 - Incremental per-delta tool-call argument streaming is still out of scope: the stream path parses once at end of stream.
 - Schema validation errors (missing `required` keys, `enum` rejection) are still not surfaced to the client; the parser coerces and never rejects.
 
@@ -334,10 +399,13 @@ Coercion is usually framed as "make the value fit the type", but when a type adm
 
 ```
 cargo test --profile test-fast --features metal,accelerate --lib server::tool_calls
-test result: ok. 370 passed; 0 failed; 0 ignored; 7313 filtered out
+test result: ok. 376 passed; 0 failed; 0 ignored; 7313 filtered out
 
 cargo test --profile test-fast --features metal,accelerate --lib server::muse_atem
-test result: ok. 11 passed; 0 failed; 0 ignored; 7672 filtered out
+test result: ok. 11 passed; 0 failed; 0 ignored; 7678 filtered out
+
+cargo test --profile test-fast --features metal,accelerate --lib server::routes::chat
+test result: ok. 48 passed; 0 failed; 0 ignored; 7641 filtered out
 
 cargo clippy --profile test-fast --lib --tests --features metal,accelerate -- -D warnings
 Finished (no warnings)
@@ -350,5 +418,5 @@ The four cases the issue asked to keep green pass unchanged: `qwen3_coder_single
 
 ### C. References
 
-- `docs/code-guidelines.md`: the `// Used by:` convention applied to `coerce_xml_param` and `parse_integer_literal`.
+- `docs/code-guidelines.md`: the `// Used by:` convention applied to `coerce_xml_param`, `parse_integer_literal` and the five helpers whose caller set widened.
 - JSON Schema type keyword: `integer` is a distinct type from `number`, which is why the two arms differ.

--- a/TECHNICAL_REPORTS/1575-xml-tool-call-schema-coercion-20260902.ko.md
+++ b/TECHNICAL_REPORTS/1575-xml-tool-call-schema-coercion-20260902.ko.md
@@ -1,0 +1,354 @@
+# 기술 보고서: PR #1575 - fix(server): type XML tool-call arguments by the request schema
+
+**작성일**: 2026-09-02
+**작성자**: mlxcel maintainers
+**리뷰어**: 지정 전
+**상태**: 완료
+**언어**: Rust
+**위험도**: Medium
+
+---
+
+## 요약
+
+Qwen3-Coder와 MiniMax M2 tool-call 파서는 요청의 `tools`를 전달받지 못해 인자의 JSON 타입을 원문 텍스트만 보고 추측했다. 그 결과 `string`으로 선언된 파라미터에 담긴 `02134`가 클라이언트에는 숫자 `2134`로, `integer`로 선언된 파라미터에 모델이 쓴 `5.0`은 실수로 전달됐다. 이 PR은 두 파서에 요청 스키마를 연결하고, MiniMax M3와 GLM-4.7, LongCat이 이미 공유하는 coercion 헬퍼로 값 변환을 일원화했으며, 공유 integer 규칙이 소수부 없는 실수 리터럴도 받도록 확장했다.
+
+---
+
+## 1. 문제 정의
+
+### 1.1 배경
+
+mlxcel이 지원하는 XML tool-call 문법 중 두 가지는 마크업 자체에 타입 정보가 없다. Qwen3-Coder는 `<function=NAME><parameter=KEY>VALUE</parameter></function>`, MiniMax M2는 `<invoke name="NAME"><parameter name="KEY">VALUE</parameter></invoke>` 형태이며, 두 문법 모두 값은 그냥 텍스트다. 의도된 타입이 존재하는 유일한 자리는 클라이언트가 요청에 실어 보낸 `tools` 배열이고, 이 배열은 OpenAI 호환 chat 라우트가 파싱 시점에 이미 손에 쥐고 있다.
+
+같은 파일의 파서 세 개는 이 문제를 이미 해결한 상태였다. `try_minimax_m3`, `try_glm47`, `try_longcat`은 `tools`를 받아 `minimax_m3_function_schema`로 호출된 함수의 스키마를 찾고 선언된 타입에 맞춰 값을 변환한다. XML 파서 두 개만 그러지 못했는데, 이유는 이들이 `&[fn(&str) -> Option<ToolCallParseResult>]` 타입의 디스패치 테이블 안에 있었기 때문이다. 필요한 데이터가 그 원소 타입을 통과할 수 없으니 파서는 추측을 택할 수밖에 없었다.
+
+### 1.2 기존 문제점
+
+- **string 값이 변조됨**: `coerce_minimax_param`은 `i64` 파싱, `f64` 파싱, 불리언 단어 목록을 차례로 시도한 뒤에야 문자열로 떨어뜨렸다. 미국 우편번호 `02134`는 `i64`로 파싱되어 2134가 되면서 앞의 0이 사라진다. 제품 코드 `1e5`는 `100000.0`이 되고, 텍스트 `true`는 JSON 불리언이 된다. 문자열을 기대한 도구 핸들러는 숫자를 받아 자체 검증에서 실패하거나, 조용히 잘못된 값으로 동작한다.
+- **integer 값이 실수 형태로 남음**: 모델이 `integer` 파라미터에 `5.0`을 쓰면 JSON 실수 `5.0`이 그대로 나갔다. 엄격한 도구 구현은 이를 거부하며, 스키마는 이 값이 정수라고 분명히 말하고 있었다.
+- **스키마 근거가 없는 추측**: `yes`, `on`, `no`, `off`를 불리언으로, `none`, `nil`을 null로 바꿨다. JSON Schema 어디에도 근거가 없는 규칙이며, 정상적인 문자열 인자를 잘못된 타입으로 만들었다.
+- **coercion 로직 중복**: `coerce_minimax_param`은 `minimax_m3_coerce_leaf`와 같은 일을 더 약하게 구현한 두 번째 사본이었다. 스키마 처리가 개선되어도 한쪽에만 반영됐다.
+
+### 1.3 위험성
+
+| 위험 | 영향도 | 발생 가능성 |
+|-----|-------|-----------|
+| 스키마가 string으로 선언한 자리에 숫자가 도착해 도구 호출이 실패하거나 손상된 값으로 실행됨 | High | 앞자리 0, 지수 표기, 불리언 단어 형태의 문자열 인자에서는 확정적 |
+| `integer` 인자를 `5.0`으로 받은 도구가 거부함 | Medium | 간헐적 (모델의 표기 방식에 좌우됨) |
+| coercion이 발전할수록 XML 문법 두 개가 스키마 인식 문법 세 개와 더 벌어짐 | Medium | 로직이 중복된 동안에는 시간이 지나면 확정적 |
+| 값 파싱 실패가 tool call 자체를 통째로 버리게 됨 | High | 설계로 회피: 모든 경로의 마지막은 원문 문자열 |
+
+---
+
+## 2. 기술적 검토 사항
+
+### 2.1 보안 관점
+
+**검토 항목:**
+- [x] 입력 검증: 파싱 대상은 전부 신뢰할 수 없는 모델 출력이다. 이번 변경은 인덱싱이나 슬라이싱을 추가하지 않고 값 타이핑만 바꾼다
+- [x] 서비스 거부: 기존 `MINIMAX_M2_MAX_CALLS` / `MINIMAX_M2_MAX_PARAMS_PER_CALL` / `QWEN3_CODER_*` 상한과 잘못된 태그에 대한 O(N^2) 방지용 `break` 가드는 그대로다
+- [x] panic 없음: 테스트 모듈 밖에 `unwrap`, `expect`, 인덱싱을 추가하지 않았다
+- [x] 민감정보 로깅 없음
+
+**발견된 이슈:**
+
+| 이슈 | 심각도 | 상태 |
+|-----|-------|-----|
+| 없음 | n/a | n/a |
+
+부수적 개선이 하나 있다. `coerce_minimax_param`은 null 표기 세 가지를 비교하려고 모든 파라미터 값의 소문자 `String` 사본을 할당했다. `coerce_xml_param`은 `eq_ignore_ascii_case`를 쓰므로 할당이 없다.
+
+### 2.2 성능 관점
+
+**검토 항목:**
+- [x] 알고리즘 복잡도: 파라미터당 비용은 그대로이고, 호출당 `tools` 슬라이스 선형 탐색 1회와 파라미터당 property 조회 1회가 추가된다. MiniMax M3와 GLM-4.7, LongCat이 이미 하고 있는 것과 같다
+- [x] 메모리 사용: 파라미터 값마다 `String` 할당 1회가 줄어든다
+
+tool-call 파싱은 completion당 한 번, 모델 응답 하나 크기의 텍스트 버퍼에 대해 실행되므로 어느 쪽도 hot path가 아니다.
+
+### 2.3 호환성/의존성 관점
+
+- **Breaking Changes**: API 수준에서는 없다. 기존 추측에 의존하던 클라이언트에게는 동작이 바뀌며, 그 목록은 4.1절에 있다. 공개 함수 `try_qwen3_coder`와 `try_minimax_m2`의 시그니처가 바뀌지만 `tool_calls::parser`와 같은 파일의 테스트 외에는 호출자가 없다.
+- **새로운 의존성**: 없음.
+- **적용 범위**: 비스트리밍 라우트(`routes/chat.rs`의 `parse_tool_calls(&result.text, tools)`)와 스트림 종료 라우트(`parse_tool_calls(&cb.accumulated, tools_ref)`)가 이미 요청 tools를 넘기고 있어, 한 번의 변경으로 스트리밍과 비스트리밍이 함께 적용된다.
+
+### 2.4 코드 품질 관점
+
+- **테스트 커버리지**: 단위 테스트 20개 추가. `server::tool_calls` 스위트가 350개에서 370개가 되었고 전부 통과한다.
+- **코드 복잡도**: 전체적으로 단순해졌다. 37줄짜리 수제 coercion 사다리가 공유 헬퍼로의 6줄 위임으로 바뀌었고, 대신 디스패처에 변형 2개짜리 enum이 생겼다.
+- **기술 부채**: 감소. 중복 coercion 구현 둘 중 하나가 사라졌고, `parse_tool_calls`의 오래된 주석 두 곳을 바로잡았다.
+
+---
+
+## 3. 기술적 선택과 그 이유
+
+### 3.1 모든 파서의 시그니처를 넓히는 대신 `FormatParser` enum 도입
+
+**컨텍스트:**
+
+디스패치 테이블은 순서가 곧 의미인 목록이다. `try_functionary_v31`은 `try_qwen3_coder`보다 먼저 시도되어야 하고(둘 다 `<function=`으로 열리며 v3.1은 JSON이 아닌 본문을 거절한다), `try_qwen3_coder`는 `try_functionary_v32`보다 먼저여야 한다. 15개 항목 중 `tools`가 필요한 것은 2개뿐인데, 배열 리터럴은 원소 타입을 하나만 허용한다.
+
+**고려한 대안:**
+
+| 옵션 | 장점 | 단점 |
+|-----|-----|-----|
+| 파서 15개 전부에 `tools` 파라미터 추가 | 테이블 타입이 하나로 통일되고 래퍼가 없다 | 13개 파서가 쓰지도 않는 인자를 갖게 되고, 파일 안의 모든 호출부와 테스트가 바뀌며, 어느 파서가 실제로 스키마를 보는지 알 수 없게 된다 |
+| 두 파서를 테이블 밖 `try_minimax_m3` 옆으로 이동 | 테이블을 건드리지 않는다 | Functionary v3.1, v3.2 대비 디스패치 순서가 조용히 바뀐다. 테이블이 존재하는 이유가 바로 그 순서다 |
+| **선택: `Plain`과 `WithTools` 변형을 가진 `FormatParser` enum** | 순서가 한 줄 단위로 그대로 보존되고, 스키마 인식 항목이 한눈에 보이며, 쓰지 않는 인자를 가진 파서가 생기지 않는다 | 작은 enum과 `run` 메서드가 늘고, 각 항목이 래퍼 이름을 달고 있다 |
+
+**선택 이유:**
+
+테이블의 의미가 순서인 이상, 그 순서를 문자 그대로 보존하는 선택이 안전하다. enum은 어느 문법이 스키마를 인식하는지도 함께 기록하는데, 이는 다음 포맷을 추가하는 사람에게 실제로 필요한 정보다. 두 번째 대안이 깨뜨렸을 순서 속성은 `parse_qwen3_coder_still_runs_after_functionary_v31` 테스트로 고정했다.
+
+**트레이드오프:**
+
+각 항목에 `Plain(...)` 또는 `WithTools(...)` 래퍼가 붙어 함수 이름만 있을 때보다 약간 시끄럽다. 디스패치 비용은 시도하는 포맷마다 `match` 한 번이며, 각 파서가 수행하는 문자열 스캔에 비하면 무시할 수준이다.
+
+### 3.2 선언된 타입을 무시하는 규칙은 `null` 하나뿐
+
+**컨텍스트:**
+
+`coerce_xml_param`은 스키마보다 앞서는 규칙을 정확히 하나만 남겼다. 대소문자를 가리지 않는 `null`이라는 단어는 `string`으로 선언된 파라미터에서도 JSON null이 된다.
+
+**선택 이유:**
+
+이 문법들에는 JSON null을 표기할 다른 방법이 없다. `<parameter=x>null</parameter>`은 모델이 쓸 수 있는 유일한 null이고 두 파서 모두 지금까지 이를 null로 내보냈으므로, 규칙을 없애면 이 표기를 쓰는 모든 모델에 회귀가 된다. 좁게 해석해서 string 타입의 `null`을 네 글자짜리 문자열로 두면, 클라이언트가 타입을 선언하는 순간 null 자체에 도달할 수 없게 된다.
+
+**트레이드오프:**
+
+문자열 `"null"`을 진짜로 보내고 싶은 모델은 이 문법으로 그것을 표현할 수 없다. 이는 이번 PR 이전에도 마찬가지였고, 스키마 인식 문법(MiniMax M3, GLM-4.7)은 string 스키마 아래에서 `"null"`을 문자열로 유지하므로 이 입력 하나에서 두 계열이 갈린다. XML 쪽 동작을 유지한 이유는 바꾸는 쪽이 수정이 아니라 회귀이고, 이슈의 범위도 아니기 때문이다.
+
+### 3.3 `integer`는 `5.0`을 정규화하고 `number`는 표기를 보존
+
+**컨텍스트:**
+
+공유 `M3Type::Integer` 갈래는 `i64`와 `u64` 리터럴만 받았기 때문에 `integer` 타입의 `5.0`은 느슨한 fallback으로 떨어져 실수로 남았다. 이 갈래를 확장하면서 옆의 `number`가 정수 리터럴을 어떻게 다뤄야 하는지가 함께 문제가 됐다.
+
+**선택 이유:**
+
+`integer` 아래에서는 선언된 타입이 답을 정한다. 값은 정수이므로 `5.0`은 `5`이고, 실수 표기는 데이터가 아니라 모델의 서식이다. `number` 아래에서는 두 표기가 모두 유효하고 스키마가 선호를 표현하지 않으므로, 파서는 모델이 쓴 그대로를 유지한다(`5`는 `5`, `5.0`은 `5.0`). 이렇게 두면 `number` 타입 정수값에 대한 XML 파서의 기존 출력도 그대로 유지되는데, 일괄 실수 변환을 택했다면 이 부분이 바뀌었을 것이다.
+
+**트레이드오프:**
+
+실수 허용 범위는 2^53으로 제한된다. 그 너머에서는 `f64`가 모든 정수를 표현하지 못해 변환이 조용히 반올림되므로, 규칙이 거절하고 값은 fallback을 거쳐 실수로 남는다. 이는 빈틈이 아니라 추측하지 않겠다는 의도적 선택이다.
+
+### 3.4 GLM-4.7과 LongCat에는 typed 경로 전체가 아니라 integer 규칙만 적용
+
+**컨텍스트:**
+
+`coerce_kv_value`(GLM-4.7, LongCat)는 `string` 스키마만 존중하고 나머지 타입은 전부 느슨한 fallback으로 보냈다. 이슈는 `integer` 타입 `5.0`이 모든 XML 문법에서 `5`가 되기를 요구했다.
+
+**선택 이유:**
+
+`coerce_kv_value`에 `Integer` 갈래를 추가하면 요구된 수정이 정확히 그만큼 이뤄진다. 대신 이 함수를 `minimax_m3_typed_coerce`로 통째로 태웠다면 `enum`, `anyOf`, `object`, `array`, `boolean` 스키마 처리까지 부수적으로 바뀐다. 이슈가 정당화하는 범위보다 훨씬 넓고, 두 문법의 기존 테스트가 덮지 않는 영역이다. 규칙 자체는 `parse_integer_literal` 하나를 공유하므로 호출부 사이에서 어긋날 수 없다.
+
+**트레이드오프:**
+
+GLM-4.7과 LongCat은 여전히 MiniMax M3보다 스키마에 덜 엄격하다. 그 간극은 이제 `coerce_kv_value` 문서 주석에 명시되어 있고, 좁히는 작업은 별도의 검증 가능한 변경으로 분리된다.
+
+---
+
+## 4. 구현 상세
+
+### 4.1 동작 변화표
+
+| 스키마 | 원문 값 | 변경 전 | 변경 후 |
+|-------|--------|--------|--------|
+| `{"type":"string"}` | `02134` | `2134` | `"02134"` |
+| `{"type":"string"}` | `true` | `true` | `"true"` |
+| `{"type":"string"}` | `1e5` | `100000.0` | `"1e5"` |
+| `{"type":"integer"}` | `5.0` | `5.0` | `5` |
+| `{"type":"integer"}` | `5.5` | `5.5` | `5.5` (느슨한 fallback, 호출 유지) |
+| `{"type":"number"}` | `5` | `5` | `5` |
+| `{"type":"object"}` | `{not json` | `"{not json"` | `"{not json"` |
+| 없음 | `5` / `true` / `null` | `5` / `true` / `null` | 동일 |
+| 없음 | `yes` / `on` / `none` | `true` / `true` / `null` | `"yes"` / `"on"` / `"none"` |
+| 없음 | `[1, 2]` | `[1, 2]` | `[1, 2]` |
+
+스키마가 없을 때의 차이가 하나 더 있다. fallback이 텍스트가 `{` 또는 `[`로 시작할 때만 JSON 파싱을 시도하던 것을 이제 항상 시도하므로, 스키마 없이 JSON 리터럴로 쓰인 값은 그 리터럴로 파싱된다. MiniMax M3와 GLM-4.7, LongCat이 이미 이렇게 동작하고 있었으므로 이제 네 문법의 동작이 일치한다.
+
+### 4.2 주요 코드 변경
+
+**파일: `src/server/tool_calls/formats.rs`**
+
+```rust
+// 변경 전
+fn coerce_minimax_param(value: &str) -> serde_json::Value {
+    let lower = value.to_lowercase();
+    if lower == "null" || lower == "none" || lower == "nil" { return Value::Null; }
+    if let Ok(i) = value.parse::<i64>() { return Value::Number(i.into()); }
+    // ... f64, 그 다음 "true"/"1"/"yes"/"on", 그 다음 "{"/"[" JSON, 마지막에 String
+}
+
+// 변경 후
+fn coerce_xml_param(raw: &str, schema: Option<&serde_json::Value>) -> serde_json::Value {
+    if raw.eq_ignore_ascii_case("null") {
+        return serde_json::Value::Null;
+    }
+    minimax_m3_coerce_leaf(raw, schema)
+}
+```
+
+**변경 이유:** 타입은 텍스트의 생김새가 아니라 스키마에 속한다. `minimax_m3_coerce_leaf`는 `enum`과 `anyOf`/`oneOf`, 배열 item 해석까지 포함한 선언 타입 경로를 이미 구현하고 있고, 마지막이 원문 문자열이므로 파싱 실패가 호출을 버리는 일도 없다.
+
+```rust
+// 변경 후: 공유 integer 규칙
+fn parse_integer_literal(raw: &str) -> Option<serde_json::Value> {
+    if let Some(v) = parse_exact_integer_literal(raw) {
+        return Some(v);
+    }
+    let f = raw.parse::<f64>().ok()?;
+    if f.is_finite() && f.fract() == 0.0 && f.abs() <= INTEGER_FROM_FLOAT_LIMIT {
+        return Some(serde_json::Value::Number((f as i64).into()));
+    }
+    None
+}
+```
+
+**변경 이유:** `integer`는 모델이 실수로 적은 정수값을 받아들여야 하지만, 변환이 정확한 범위 안에서만 그렇다. `INTEGER_FROM_FLOAT_LIMIT`은 2^53이다.
+
+**파일: `src/server/tool_calls/parser.rs`**
+
+```rust
+// 변경 전
+let parsers: &[fn(&str) -> Option<ToolCallParseResult>] = &[ /* 15개 항목 */ ];
+for parser in parsers {
+    if let Some(mut result) = parser(text) { /* ... */ }
+}
+
+// 변경 후
+enum FormatParser {
+    Plain(fn(&str) -> Option<ToolCallParseResult>),
+    WithTools(fn(&str, Option<&[Tool]>) -> Option<ToolCallParseResult>),
+}
+
+let parsers: &[FormatParser] = &[ /* 같은 15개 항목, 같은 순서 */ ];
+for parser in parsers {
+    if let Some(mut result) = parser.run(text, tools) { /* ... */ }
+}
+```
+
+**변경 이유:** 테이블이 `tools`를 필요로 하는 파서를 담을 수 없었다. 순서는 그대로이며, 그 순서가 테이블이 존재하는 이유다.
+
+---
+
+## 5. 학습 포인트
+
+### 5.1 컬렉션의 원소 타입이 버그의 원인일 수 있다
+
+**개념:**
+
+`try_qwen3_coder`와 `try_minimax_m2`가 타입을 추측한 이유는 추측이 옳다고 판단해서가 아니다. 원소 타입이 `fn(&str) -> Option<...>`인 배열 안에 있었고, 필요한 데이터가 그 타입을 통과할 수 없었기 때문이다. 배열 밖으로 나간 파서 셋은 스키마를 받았고, 남은 둘은 받지 못했다.
+
+**이 PR에서의 적용:**
+
+수정의 대부분은 컨테이너 변경이다. 테이블이 `WithTools` 항목을 담을 수 있게 되자 파서 본문에 필요한 것은 네 줄, 즉 함수를 찾고 파라미터별 스키마를 두 단계 아래로 내려보내는 일뿐이었다.
+
+**같은 패턴이 나타나는 곳:**
+
+- 처음 몇 멤버가 필요로 한 가장 좁은 시그니처에 맞춰진 핸들러 레지스트리
+- 컨텍스트 인자를 빠뜨린 트레이트 메서드. 구현체는 전역 상태나 휴리스틱에 손을 뻗는다
+- 첫 사용 사례에서 원소 타입이 굳어버린 콜백 목록. 이후 멤버는 우회로를 만든다
+
+신호는 넘겨받았어야 할 정보를 스스로 다시 만들어내는 파서나 핸들러다.
+
+### 5.2 표기 보존도 올바른 coercion의 일부다
+
+**개념:**
+
+coercion은 보통 "값을 타입에 맞춘다"로 이해되지만, 하나의 타입이 여러 표현을 허용한다면 파서가 그중 하나를 골라서는 안 된다. `number` 아래에서는 `5`와 `5.0`이 모두 유효하므로 모델이 쓴 것을 유지하고, `integer` 아래에서는 유효한 표현이 하나뿐이므로 `5.0`이 `5`가 된다.
+
+**이 PR에서의 적용:**
+
+`M3Type::Number`는 `f64` 파싱 전에 `parse_exact_integer_literal`을 먼저 시도하고, `M3Type::Integer`는 더 넓은 `parse_integer_literal`을 쓴다. `qwen3_coder_number_typed_keeps_written_form`과 `minimax_m3_number_typed_keeps_written_form` 테스트는 `is_i64()`와 `is_f64()`로 양쪽을 모두 단언한다. `serde_json`에서는 `assert_eq!(value, 5)`만으로 정수와 실수를 구분할 수 없기 때문이다.
+
+---
+
+## 6. 추가 학습 리소스
+
+### 핵심 키워드
+
+| 키워드 | 설명 | 관련성 |
+|-------|-----|-------|
+| `minimax_m3_coerce_leaf` | 스키마 기반 leaf coercion: 타입 파싱, JSON 파싱, 느슨한 리터럴, 원문 문자열 순서 | 이제 네 XML 문법이 모두 도달하는 단일 coercion 경로 |
+| `minimax_m3_typed_coerce` | 선언 타입이 맞지 않으면 `None`을 돌려주는 엄격한 스키마 파싱 | 그 `None` 덕분에 `anyOf`가 다음 대안을 시도하고, 잘못된 값에도 호출이 살아남는다 |
+| `kv_param_schema` | 함수 스키마의 `properties`에서 파라미터를 찾는다 | `minimax_m3_function_schema`와 짝을 이루는 파라미터 단위 조회 |
+| 2^53 | `f64`가 모든 정수를 표현하는 최대 크기 | 소수부 없는 실수 규칙의 경계 |
+
+### 관련 PR/이슈
+
+- Issue #1336: 이 PR이 구현한 명세. 4.1절의 스키마 표가 여기서 왔다.
+- GLM-4.7 / LongCat key-value 파서와 MiniMax M3 네임스페이스 XML 파서는 이 PR이 재구현하지 않고 재사용한 선행 구현이다.
+
+---
+
+## 7. 변경 요약
+
+### 통계
+
+| 항목 | 값 |
+|-----|---|
+| 변경된 파일 수 | 2 |
+| 추가된 라인 | +545 |
+| 삭제된 라인 | -121 |
+| 테스트 추가 | 20 |
+
+### 카테고리별 변경
+
+| 카테고리 | 변경 수 | 주요 내용 |
+|---------|--------|----------|
+| Correctness | 파일 2개 | Qwen3-Coder / MiniMax M2 문법의 스키마 기반 타이핑, 공유 integer 규칙의 소수부 없는 실수 허용 |
+| Code Quality | 1 | `coerce_minimax_param` 제거, `parse_tool_calls`의 오래된 주석 2곳 수정 |
+| Tests | 20 | 두 파일에 스키마, 무스키마, 경계값, 디스패처 순서 커버리지 추가 |
+
+### 관련 커밋
+
+| Hash | Type | Message |
+|------|------|---------|
+| `272afe8` | fix | fix(server): type XML tool-call arguments by the request schema |
+
+---
+
+## 8. 후속 조치
+
+### 완료 필요
+
+- [ ] 실제 Qwen3-Coder 체크포인트로 end-to-end 동작 확인 (요청과 기대 `tool_calls[].function.arguments`는 PR 본문에 있다). 이 PR은 단위 테스트로만 검증했고 체크포인트를 올리지 않았다.
+
+### 모니터링 필요
+
+- 두 문법에서 클라이언트로 나가는 tool-call 인자, 특히 숫자처럼 보이는 string 타입 값. 기존 coercion에 맞춰 우편번호를 다시 문자열로 되돌리는 식으로 보정하던 클라이언트는 이제 올바른 문자열을 받으므로 보정을 걷어내야 한다.
+
+### 향후 개선 사항
+
+- GLM-4.7과 LongCat을 string, integer 규칙만이 아니라 `minimax_m3_typed_coerce` 전체 경로로 태울지 결정. 이번에는 의도적으로 범위를 끊었고 `coerce_kv_value` 주석에 남겼다.
+- 델타 단위 증분 tool-call 인자 스트리밍은 여전히 범위 밖이다. 스트림 경로는 스트림 종료 시점에 한 번 파싱한다.
+- 스키마 검증 오류(`required` 키 누락, `enum` 불일치)는 아직 클라이언트에 전달되지 않는다. 파서는 변환만 하고 거부하지 않는다.
+
+---
+
+## 부록
+
+### A. 테스트 결과
+
+```
+cargo test --profile test-fast --features metal,accelerate --lib server::tool_calls
+test result: ok. 370 passed; 0 failed; 0 ignored; 7313 filtered out
+
+cargo test --profile test-fast --features metal,accelerate --lib server::muse_atem
+test result: ok. 11 passed; 0 failed; 0 ignored; 7672 filtered out
+
+cargo clippy --profile test-fast --lib --tests --features metal,accelerate -- -D warnings
+Finished (no warnings)
+
+cargo fmt --all -- --check
+clean
+```
+
+이슈가 유지를 요구한 네 케이스는 수정 없이 통과한다: `qwen3_coder_single_call_multiple_params_with_type_coercion`, `minimax_m2_numeric_params`, `minimax_m2_boolean_param`, `minimax_m2_null_param`.
+
+### C. 참고 자료
+
+- `docs/code-guidelines.md`: `coerce_xml_param`과 `parse_integer_literal`에 적용한 `// Used by:` 규약.
+- JSON Schema type 키워드: `integer`는 `number`와 구분되는 별도 타입이며, 두 갈래가 다르게 동작하는 근거다.

--- a/TECHNICAL_REPORTS/1575-xml-tool-call-schema-coercion-20260902.ko.md
+++ b/TECHNICAL_REPORTS/1575-xml-tool-call-schema-coercion-20260902.ko.md
@@ -11,7 +11,7 @@
 
 ## 요약
 
-Qwen3-Coder와 MiniMax M2 tool-call 파서는 요청의 `tools`를 전달받지 못해 인자의 JSON 타입을 원문 텍스트만 보고 추측했다. 그 결과 `string`으로 선언된 파라미터에 담긴 `02134`가 클라이언트에는 숫자 `2134`로, `integer`로 선언된 파라미터에 모델이 쓴 `5.0`은 실수로 전달됐다. 이 PR은 두 파서에 요청 스키마를 연결하고, MiniMax M3와 GLM-4.7, LongCat이 이미 공유하는 coercion 헬퍼로 값 변환을 일원화했으며, 공유 integer 규칙이 소수부 없는 실수 리터럴도 받도록 확장했다.
+Qwen3-Coder와 MiniMax M2 tool-call 파서는 요청의 `tools`를 전달받지 못해 인자의 JSON 타입을 원문 텍스트만 보고 추측했다. 그 결과 `string`으로 선언된 파라미터에 담긴 `02134`가 클라이언트에는 숫자 `2134`로, `integer`로 선언된 파라미터에 모델이 쓴 `5.0`은 실수로 전달됐다. 이 PR은 두 파서에 요청 스키마를 연결하고, MiniMax M3와 GLM-4.7, LongCat이 이미 공유하는 coercion 헬퍼로 값 변환을 일원화했으며, 남은 관대한 규칙(불리언, null, 소수부가 0인 정수)을 텍스트 모양이 아니라 선언된 타입에 근거하도록 정리했다.
 
 ---
 
@@ -27,7 +27,7 @@ mlxcel이 지원하는 XML tool-call 문법 중 두 가지는 마크업 자체�
 
 - **string 값이 변조됨**: `coerce_minimax_param`은 `i64` 파싱, `f64` 파싱, 불리언 단어 목록을 차례로 시도한 뒤에야 문자열로 떨어뜨렸다. 미국 우편번호 `02134`는 `i64`로 파싱되어 2134가 되면서 앞의 0이 사라진다. 제품 코드 `1e5`는 `100000.0`이 되고, 텍스트 `true`는 JSON 불리언이 된다. 문자열을 기대한 도구 핸들러는 숫자를 받아 자체 검증에서 실패하거나, 조용히 잘못된 값으로 동작한다.
 - **integer 값이 실수 형태로 남음**: 모델이 `integer` 파라미터에 `5.0`을 쓰면 JSON 실수 `5.0`이 그대로 나갔다. 엄격한 도구 구현은 이를 거부하며, 스키마는 이 값이 정수라고 분명히 말하고 있었다.
-- **스키마 근거가 없는 추측**: `yes`, `on`, `no`, `off`를 불리언으로, `none`, `nil`을 null로 바꿨다. JSON Schema 어디에도 근거가 없는 규칙이며, 정상적인 문자열 인자를 잘못된 타입으로 만들었다.
+- **타입 선언이 없는 자리에까지 적용된 추측**: 요청이 무엇을 선언했든 상관없이 `yes`, `on`, `no`, `off`는 불리언으로, `none`, `nil`은 null로 바뀌었다. 선언이 없다면 이는 데이터에 대한 추론이 아니라 영어 단어에 대한 추측이다.
 - **coercion 로직 중복**: `coerce_minimax_param`은 `minimax_m3_coerce_leaf`와 같은 일을 더 약하게 구현한 두 번째 사본이었다. 스키마 처리가 개선되어도 한쪽에만 반영됐다.
 
 ### 1.3 위험성
@@ -38,6 +38,7 @@ mlxcel이 지원하는 XML tool-call 문법 중 두 가지는 마크업 자체�
 | `integer` 인자를 `5.0`으로 받은 도구가 거부함 | Medium | 간헐적 (모델의 표기 방식에 좌우됨) |
 | coercion이 발전할수록 XML 문법 두 개가 스키마 인식 문법 세 개와 더 벌어짐 | Medium | 로직이 중복된 동안에는 시간이 지나면 확정적 |
 | 값 파싱 실패가 tool call 자체를 통째로 버리게 됨 | High | 설계로 회피: 모든 경로의 마지막은 원문 문자열 |
+| 호출 이름에 네임스페이스를 붙이는 모델에서는 수정이 아무 일도 하지 않음 | High | 그런 모델에서는 확정적 (이번에 조회 정규화로 해결) |
 
 ---
 
@@ -55,9 +56,10 @@ mlxcel이 지원하는 XML tool-call 문법 중 두 가지는 마크업 자체�
 
 | 이슈 | 심각도 | 상태 |
 |-----|-------|-----|
-| 없음 | n/a | n/a |
+| 2^53 부근에서 소수값이 반올림되어 정수가 됨 (`9007199254740991.5`가 정수로 변환) | Medium | 두 번째 커밋에서 수정. 규칙을 텍스트 기반으로 바꿔 `f64` 왕복을 제거 |
+| 2^53 부근에서 정수가 1 어긋남 (`9007199254740993.0`이 `...992`로) | Medium | 같은 변경에서 수정 |
 
-부수적 개선이 하나 있다. `coerce_minimax_param`은 null 표기 세 가지를 비교하려고 모든 파라미터 값의 소문자 `String` 사본을 할당했다. `coerce_xml_param`은 `eq_ignore_ascii_case`를 쓰므로 할당이 없다.
+두 건 모두 이 PR의 첫 커밋이 만든 결함이며 머지 전 리뷰에서 발견했다. 부수적 개선도 둘 있다. `coerce_minimax_param`은 null 표기 세 가지를 비교하려고 모든 파라미터 값의 소문자 `String` 사본을 할당했지만 `coerce_xml_param`은 `eq_ignore_ascii_case`를 써서 할당이 없다. 또한 `serde_json`은 무한대 파싱을 거부하므로, 직렬화 시 `null`이 되어버릴 비유한 실수를 담은 `Value::Number`가 만들어지는 경로는 존재하지 않는다.
 
 ### 2.2 성능 관점
 
@@ -75,9 +77,9 @@ tool-call 파싱은 completion당 한 번, 모델 응답 하나 크기의 텍스
 
 ### 2.4 코드 품질 관점
 
-- **테스트 커버리지**: 단위 테스트 20개 추가. `server::tool_calls` 스위트가 350개에서 370개가 되었고 전부 통과한다.
-- **코드 복잡도**: 전체적으로 단순해졌다. 37줄짜리 수제 coercion 사다리가 공유 헬퍼로의 6줄 위임으로 바뀌었고, 대신 디스패처에 변형 2개짜리 enum이 생겼다.
-- **기술 부채**: 감소. 중복 coercion 구현 둘 중 하나가 사라졌고, `parse_tool_calls`의 오래된 주석 두 곳을 바로잡았다.
+- **테스트 커버리지**: 단위 테스트 26개 추가. `server::tool_calls` 스위트가 350개에서 376개가 되었고 전부 통과한다.
+- **코드 복잡도**: 대체로 비슷하다. 37줄짜리 수제 coercion 사다리가 스키마 기반 `coerce_xml_param`과 작은 헬퍼 두 개로 바뀌었고, 디스패처에 변형 2개짜리 enum이 생겼다.
+- **기술 부채**: 감소. 중복 coercion 구현 둘 중 하나가 사라졌고, `parse_tool_calls`의 오래된 주석 두 곳을 바로잡았으며, 호출자 범위가 넓어진 공유 헬퍼 다섯 개에 프로젝트 규약이 요구하는 `// Used by:` 주석을 달았다.
 
 ---
 
@@ -105,35 +107,49 @@ tool-call 파싱은 completion당 한 번, 모델 응답 하나 크기의 텍스
 
 각 항목에 `Plain(...)` 또는 `WithTools(...)` 래퍼가 붙어 함수 이름만 있을 때보다 약간 시끄럽다. 디스패치 비용은 시도하는 포맷마다 `match` 한 번이며, 각 파서가 수행하는 문자열 스캔에 비하면 무시할 수준이다.
 
-### 3.2 선언된 타입을 무시하는 규칙은 `null` 하나뿐
+### 3.2 관대한 규칙은 유지하되 선언된 타입이 뒷받침할 때만
 
 **컨텍스트:**
 
-`coerce_xml_param`은 스키마보다 앞서는 규칙을 정확히 하나만 남겼다. 대소문자를 가리지 않는 `null`이라는 단어는 `string`으로 선언된 파라미터에서도 JSON null이 된다.
+첫 커밋은 기존 추측기의 관대한 규칙(`yes`/`on` → true, `no`/`off` → false, `none`/`nil` → null)을 전부 없애고 `null`은 스키마와 무관하게 null이 되게 했다. 리뷰에서 양쪽 다 경계에서 틀렸음이 드러났다. `{"type": "boolean"}` 아래에서 모델이 쓴 `yes`가 문자열 `"yes"`가 되는데, 이는 대체한 추측보다 나쁘다. 하필 불리언으로 읽을 근거가 가장 확실한 자리이기 때문이다. 반대로 `{"type": "string"}` 아래의 텍스트 `null`은 여전히 JSON null이 되는데, 이는 이 PR이 없애려던 바로 그 타입 위반이다.
 
 **선택 이유:**
 
-이 문법들에는 JSON null을 표기할 다른 방법이 없다. `<parameter=x>null</parameter>`은 모델이 쓸 수 있는 유일한 null이고 두 파서 모두 지금까지 이를 null로 내보냈으므로, 규칙을 없애면 이 표기를 쓰는 모든 모델에 회귀가 된다. 좁게 해석해서 string 타입의 `null`을 네 글자짜리 문자열로 두면, 클라이언트가 타입을 선언하는 순간 null 자체에 도달할 수 없게 된다.
+중요한 구분은 "관대한가 엄격한가"가 아니라 그 관대함에 선언된 타입이라는 근거가 있는가다. `yes`를 `true`로 읽는 것은 아무 타입도 선언되지 않았다면 영어 단어에 대한 추측이지만, 스키마가 `boolean`이라고 말한다면 타당한 해석이다. 그래서 `coerce_xml_param`은 불리언 단어 목록을 `boolean` 선언이 있을 때만 적용하고, `null`은 평범한 `string` 선언을 제외한 모든 곳에서 JSON null이 된다. string 선언 아래에서는 텍스트가 곧 도구가 요구한 값이기 때문이다. `{"type": ["string", "null"]}` 같은 nullable 선언은 여전히 null을 받는다. 스키마가 둘 다 가능하다고 말하고 있고, 그 단어가 이 문법이 표기할 수 있는 유일한 null이기 때문이다.
 
 **트레이드오프:**
 
-문자열 `"null"`을 진짜로 보내고 싶은 모델은 이 문법으로 그것을 표현할 수 없다. 이는 이번 PR 이전에도 마찬가지였고, 스키마 인식 문법(MiniMax M3, GLM-4.7)은 string 스키마 아래에서 `"null"`을 문자열로 유지하므로 이 입력 하나에서 두 계열이 갈린다. XML 쪽 동작을 유지한 이유는 바꾸는 쪽이 수정이 아니라 회귀이고, 이슈의 범위도 아니기 때문이다.
+두 동작이 균일한 규칙이 아니라 선언에 따라 갈리므로 머릿속에 담아야 할 것이 늘었다. `coerce_xml_param`의 문서 주석에 둘 다 적었고, 테스트 6개가 선언이 있을 때와 없을 때 양방향으로 고정한다. string이 아닌 파라미터에 문자열 `"null"`을 넣고 싶은 모델은 여전히 표현할 방법이 없는데, 이는 이 PR 이전에도 마찬가지였고 새 이스케이프 문법을 만들 만한 사안은 아니다.
 
-### 3.3 `integer`는 `5.0`을 정규화하고 `number`는 표기를 보존
+### 3.3 integer 규칙은 `f64`가 아니라 텍스트로 소수부를 떼어낸다
 
 **컨텍스트:**
 
-공유 `M3Type::Integer` 갈래는 `i64`와 `u64` 리터럴만 받았기 때문에 `integer` 타입의 `5.0`은 느슨한 fallback으로 떨어져 실수로 남았다. 이 갈래를 확장하면서 옆의 `number`가 정수 리터럴을 어떻게 다뤄야 하는지가 함께 문제가 됐다.
+공유 `M3Type::Integer` 갈래는 `i64`와 `u64` 리터럴만 받았기 때문에 `integer` 타입의 `5.0`은 느슨한 fallback으로 떨어져 실수로 남았다. 첫 커밋은 이를 `f64`로 파싱한 뒤 2^53 상한 아래에서 `fract() == 0.0`을 확인하는 방식으로 고쳤다.
 
 **선택 이유:**
 
-`integer` 아래에서는 선언된 타입이 답을 정한다. 값은 정수이므로 `5.0`은 `5`이고, 실수 표기는 데이터가 아니라 모델의 서식이다. `number` 아래에서는 두 표기가 모두 유효하고 스키마가 선호를 표현하지 않으므로, 파서는 모델이 쓴 그대로를 유지한다(`5`는 `5`, `5.0`은 `5.0`). 이렇게 두면 `number` 타입 정수값에 대한 XML 파서의 기존 출력도 그대로 유지되는데, 일괄 실수 변환을 택했다면 이 부분이 바뀌었을 것이다.
+그 검사는 성립할 수 없다. 반올림이 `parse::<f64>()` 안에서, 즉 무엇도 결과를 들여다보기 전에 일어나기 때문이다. `9007199254740991.5`는 `...992.0`으로 파싱되어 소수부 0 검사를 통과하고 정수가 된다. `9007199254740993.0`은 1 어긋난 값으로 돌아오면서 상한도 통과한다. 텍스트 규칙(`.`에서 자르고, 소수부가 전부 0인지 확인하고, 정수부를 정확한 정수 파서로 파싱)은 모든 크기에서 정확하며 상한 자체가 필요 없다. 또한 지수 표기를 거절하는데, `minimax_m3_typed_coerce`가 `anyOf` 대안 중 처음 성공한 것을 택하기 때문에 이 점이 중요하다. `f64` 경로에서는 `anyOf: [integer, string]`에 값 `1e5`가 오면 string 대안이 가져가던 것을 integer가 `100000`으로 채갔다.
 
 **트레이드오프:**
 
-실수 허용 범위는 2^53으로 제한된다. 그 너머에서는 `f64`가 모든 정수를 표현하지 못해 변환이 조용히 반올림되므로, 규칙이 거절하고 값은 fallback을 거쳐 실수로 남는다. 이는 빈틈이 아니라 추측하지 않겠다는 의도적 선택이다.
+`integer`로 선언된 `1e5`는 더 이상 `100000`으로 정규화되지 않고 fallback을 거쳐 실수 `100000.0`으로 남는다. 이는 string 대안의 식별자를 빼앗지 않기 위한 대가이며, 모델의 도구 인자에서 지수 표기는 소수점보다 훨씬 드물다.
 
-### 3.4 GLM-4.7과 LongCat에는 typed 경로 전체가 아니라 integer 규칙만 적용
+### 3.4 `integer`는 `5.0`을 정규화하고 `number`는 표기를 보존
+
+**컨텍스트:**
+
+integer 갈래를 확장하면서 옆의 `number`가 정수 리터럴을 어떻게 다뤄야 하는지가 함께 문제가 됐다.
+
+**선택 이유:**
+
+`integer` 아래에서는 선언된 타입이 답을 정한다. 값은 정수이므로 `5.0`은 `5`이고 소수점은 서식일 뿐이다. `number` 아래에서는 두 표기가 모두 유효하고 스키마가 선호를 표현하지 않으므로, 파서는 모델이 쓴 그대로를 유지한다(`5`는 `5`, `5.0`은 `5.0`). 이렇게 두면 `number` 타입 정수값에 대한 XML 파서의 기존 출력도 그대로 유지되고, 기존 `f64` 전용 갈래에 있던 2^53 이상 정수의 정밀도 손실도 사라진다.
+
+**트레이드오프:**
+
+`M3Type::Number`는 공유 코드이므로, MiniMax M3가 `number`/`num`/`float`/`double` 파라미터를 정수로 받았을 때 내보내는 값의 타입이 `5.0`에서 `5`로 바뀐다. JSON Schema는 정수를 `number`로 받아들이므로 스키마 위반은 아니지만, 이슈가 요구한 범위 밖의 눈에 보이는 변화라서 PR 본문에 명시했다.
+
+### 3.5 GLM-4.7과 LongCat에는 typed 경로 전체가 아니라 integer 규칙만 적용
 
 **컨텍스트:**
 
@@ -147,6 +163,20 @@ tool-call 파싱은 completion당 한 번, 모델 응답 하나 크기의 텍스
 
 GLM-4.7과 LongCat은 여전히 MiniMax M3보다 스키마에 덜 엄격하다. 그 간극은 이제 `coerce_kv_value` 문서 주석에 명시되어 있고, 좁히는 작업은 별도의 검증 가능한 변경으로 분리된다.
 
+### 3.6 스키마 조회가 네임스페이스 붙은 호출 이름을 정규화한다
+
+**컨텍스트:**
+
+`minimax_m3_function_schema`는 `t.function.name == name` 완전 일치로만 찾았다. 그런데 `filter_by_tools`가 존재하는 이유 자체가 모델이 `functions.get_weather` 같은 이름을 내보내기 때문이며, 이 접두사는 파싱이 끝난 뒤에야 제거된다.
+
+**선택 이유:**
+
+네임스페이스를 쓰는 모델에서는 순서가 이랬다. 스키마 조회 실패 → 모든 값이 느슨한 규칙을 탐 → `filter_by_tools`가 접두사를 떼고 호출을 승인. 클라이언트는 이 PR이 없애려던 바로 그 버그를 품은 성공한 tool call을 받으며, 스키마가 무시됐다는 표시는 어디에도 없다. 이제 조회는 첫 `.` 뒤의 이름으로 한 번 더 시도하며, 이는 `filter_by_tools`와 같은 정규화다. 완전 일치를 먼저 시도하므로 이름이 실제로 `a.b`인 도구는 영향을 받지 않는다.
+
+**트레이드오프:**
+
+네임스페이스가 붙은 이름에서는 선형 탐색이 한 번 더 돈다. 현실적인 도구 개수에서는 측정되지 않으며, 문제가 된다면 호출 루프 밖으로 `HashMap`을 끌어올리는 것이 답이다.
+
 ---
 
 ## 4. 구현 상세
@@ -158,15 +188,21 @@ GLM-4.7과 LongCat은 여전히 MiniMax M3보다 스키마에 덜 엄격하다. 
 | `{"type":"string"}` | `02134` | `2134` | `"02134"` |
 | `{"type":"string"}` | `true` | `true` | `"true"` |
 | `{"type":"string"}` | `1e5` | `100000.0` | `"1e5"` |
+| `{"type":"string"}` | `null` | `null` | `"null"` |
+| `{"type":["string","null"]}` | `null` | `null` | `null` |
+| `{"type":"boolean"}` | `yes` / `on` / `TRUE` | `true` | `true` |
+| `{"type":"boolean"}` | `maybe` | `"maybe"` | `"maybe"` |
 | `{"type":"integer"}` | `5.0` | `5.0` | `5` |
 | `{"type":"integer"}` | `5.5` | `5.5` | `5.5` (느슨한 fallback, 호출 유지) |
 | `{"type":"number"}` | `5` | `5` | `5` |
 | `{"type":"object"}` | `{not json` | `"{not json"` | `"{not json"` |
+| `{"anyOf":[integer,string]}` | `1e5` | `"1e5"` | `"1e5"` |
 | 없음 | `5` / `true` / `null` | `5` / `true` / `null` | 동일 |
 | 없음 | `yes` / `on` / `none` | `true` / `true` / `null` | `"yes"` / `"on"` / `"none"` |
-| 없음 | `[1, 2]` | `[1, 2]` | `[1, 2]` |
+| 없음 | `TRUE` | `true` | `"TRUE"` |
+| 네임스페이스 호출 `functions.f`, `{"type":"string"}` | `02134` | `2134` | `"02134"` |
 
-스키마가 없을 때의 차이가 하나 더 있다. fallback이 텍스트가 `{` 또는 `[`로 시작할 때만 JSON 파싱을 시도하던 것을 이제 항상 시도하므로, 스키마 없이 JSON 리터럴로 쓰인 값은 그 리터럴로 파싱된다. MiniMax M3와 GLM-4.7, LongCat이 이미 이렇게 동작하고 있었으므로 이제 네 문법의 동작이 일치한다.
+공유 fallback을 재사용하면서 스키마가 없을 때의 차이가 둘 더 생겼다. 텍스트가 `{` 또는 `[`로 시작할 때만 JSON 파싱을 시도하던 것을 이제 항상 시도하므로 JSON 리터럴로 쓰인 값(`[1, 2]`, 따옴표로 감싼 문자열)은 그 리터럴로 파싱된다. 그리고 불리언 단어 비교가 대소문자를 구분하므로 스키마 없는 `TRUE`는 문자열이다. 둘 다 MiniMax M3와 GLM-4.7, LongCat이 이미 하던 동작이며, `boolean` 선언이 있으면 관대한 해석이 되살아난다.
 
 ### 4.2 주요 코드 변경
 
@@ -183,14 +219,22 @@ fn coerce_minimax_param(value: &str) -> serde_json::Value {
 
 // 변경 후
 fn coerce_xml_param(raw: &str, schema: Option<&serde_json::Value>) -> serde_json::Value {
-    if raw.eq_ignore_ascii_case("null") {
+    let declared = schema.and_then(minimax_m3_schema_type);
+    let keeps_raw_text =
+        declared == Some(M3Type::Str) && !schema.is_some_and(schema_type_admits_null);
+    if !keeps_raw_text && raw.eq_ignore_ascii_case("null") {
         return serde_json::Value::Null;
+    }
+    if declared == Some(M3Type::Boolean)
+        && let Some(b) = loose_boolean_word(raw)
+    {
+        return serde_json::Value::Bool(b);
     }
     minimax_m3_coerce_leaf(raw, schema)
 }
 ```
 
-**변경 이유:** 타입은 텍스트의 생김새가 아니라 스키마에 속한다. `minimax_m3_coerce_leaf`는 `enum`과 `anyOf`/`oneOf`, 배열 item 해석까지 포함한 선언 타입 경로를 이미 구현하고 있고, 마지막이 원문 문자열이므로 파싱 실패가 호출을 버리는 일도 없다.
+**변경 이유:** 타입은 텍스트의 생김새가 아니라 스키마에 속한다. `minimax_m3_coerce_leaf`는 `enum`과 `anyOf`/`oneOf`, 배열 item 해석까지 포함한 선언 타입 경로를 이미 구현하고 있고, 마지막이 원문 문자열이므로 파싱 실패가 호출을 버리는 일도 없다. 그 앞에 놓인 두 규칙은 선언이 정당화하는 것들이다.
 
 ```rust
 // 변경 후: 공유 integer 규칙
@@ -198,15 +242,15 @@ fn parse_integer_literal(raw: &str) -> Option<serde_json::Value> {
     if let Some(v) = parse_exact_integer_literal(raw) {
         return Some(v);
     }
-    let f = raw.parse::<f64>().ok()?;
-    if f.is_finite() && f.fract() == 0.0 && f.abs() <= INTEGER_FROM_FLOAT_LIMIT {
-        return Some(serde_json::Value::Number((f as i64).into()));
+    let (int_part, fraction) = raw.split_once('.')?;
+    if fraction.bytes().any(|b| b != b'0') {
+        return None;
     }
-    None
+    parse_exact_integer_literal(int_part)
 }
 ```
 
-**변경 이유:** `integer`는 모델이 실수로 적은 정수값을 받아들여야 하지만, 변환이 정확한 범위 안에서만 그렇다. `INTEGER_FROM_FLOAT_LIMIT`은 2^53이다.
+**변경 이유:** `integer`는 모델이 소수점을 붙여 쓴 정수값을 받아들여야 하고, 그 변환은 정확해야 한다. `f64` 대신 텍스트로 처리하면 반올림 결함 두 가지가 사라지고 지수 표기가 `anyOf`의 integer 대안에 끼어들지 않는다.
 
 **파일: `src/server/tool_calls/parser.rs`**
 
@@ -253,7 +297,23 @@ for parser in parsers {
 
 신호는 넘겨받았어야 할 정보를 스스로 다시 만들어내는 파서나 핸들러다.
 
-### 5.2 표기 보존도 올바른 coercion의 일부다
+### 5.2 손실이 일어난 뒤에 놓인 검사는 아무것도 검사하지 않는다
+
+**개념:**
+
+첫 커밋은 소수부가 0인 정수를 `raw.parse::<f64>()`로 읽은 뒤 `f.fract() == 0.0 && f.abs() <= 2^53`으로 걸렀다. 두 조건 모두 파싱이 이미 반올림한 값 위에서 평가되므로, `9007199254740991.5`는 걸러져야 할 소수부 검사를 통과하고 `9007199254740993.0`은 1 어긋난 채로 상한을 통과한다. 보호 장치처럼 읽히지만 실제로는 아니다.
+
+**이 PR에서의 적용:**
+
+규칙을 텍스트 기반으로 바꿨다. `.`에서 문자열을 자르고, 소수부 바이트가 전부 `0`인지 확인하고, 정수부를 정확한 정수 파서로 읽는다. 반올림이 없으니 뒤에서 검사할 것도 없다. `integer_literal_rule_is_textual_and_exact`가 이전 형태가 틀렸던 두 값을 모두 고정한다.
+
+**같은 패턴이 나타나는 곳:**
+
+- 축소 캐스팅 이전이 아니라 이후에 놓인 범위 검사
+- 이미 float 왕복을 거친 값에 대한 정밀도 단언
+- 정규화가 파괴하는 속성을 정규화 이후에 검증하는 문자열 검사
+
+### 5.3 표기 보존도 올바른 coercion의 일부다
 
 **개념:**
 
@@ -274,7 +334,8 @@ coercion은 보통 "값을 타입에 맞춘다"로 이해되지만, 하나의 �
 | `minimax_m3_coerce_leaf` | 스키마 기반 leaf coercion: 타입 파싱, JSON 파싱, 느슨한 리터럴, 원문 문자열 순서 | 이제 네 XML 문법이 모두 도달하는 단일 coercion 경로 |
 | `minimax_m3_typed_coerce` | 선언 타입이 맞지 않으면 `None`을 돌려주는 엄격한 스키마 파싱 | 그 `None` 덕분에 `anyOf`가 다음 대안을 시도하고, 잘못된 값에도 호출이 살아남는다 |
 | `kv_param_schema` | 함수 스키마의 `properties`에서 파라미터를 찾는다 | `minimax_m3_function_schema`와 짝을 이루는 파라미터 단위 조회 |
-| 2^53 | `f64`가 모든 정수를 표현하는 최대 크기 | 소수부 없는 실수 규칙의 경계 |
+| `filter_by_tools` | 등록되지 않은 함수 호출을 버리고 네임스페이스 접두사를 제거한다 | 스키마 조회가 같은 접두사를 정규화해야 하는 이유 |
+| 2^53 | `f64`가 모든 정수를 표현하는 최대 크기 | 첫 커밋이 의지했던 상한이자, 최종 규칙이 `f64` 자체를 피한 이유 |
 
 ### 관련 PR/이슈
 
@@ -289,24 +350,25 @@ coercion은 보통 "값을 타입에 맞춘다"로 이해되지만, 하나의 �
 
 | 항목 | 값 |
 |-----|---|
-| 변경된 파일 수 | 2 |
-| 추가된 라인 | +545 |
-| 삭제된 라인 | -121 |
-| 테스트 추가 | 20 |
+| 변경된 소스 파일 수 | 2 |
+| 추가된 라인 (소스, 이 보고서 제외) | +786 |
+| 삭제된 라인 (소스) | -115 |
+| 테스트 추가 | 26 |
 
 ### 카테고리별 변경
 
 | 카테고리 | 변경 수 | 주요 내용 |
 |---------|--------|----------|
-| Correctness | 파일 2개 | Qwen3-Coder / MiniMax M2 문법의 스키마 기반 타이핑, 공유 integer 규칙의 소수부 없는 실수 허용 |
-| Code Quality | 1 | `coerce_minimax_param` 제거, `parse_tool_calls`의 오래된 주석 2곳 수정 |
-| Tests | 20 | 두 파일에 스키마, 무스키마, 경계값, 디스패처 순서 커버리지 추가 |
+| Correctness | 파일 2개 | Qwen3-Coder / MiniMax M2 문법의 스키마 기반 타이핑, 정확한 integer 규칙, 네임스페이스를 정규화하는 스키마 조회 |
+| Code Quality | 1 | `coerce_minimax_param` 제거, `parse_tool_calls`의 오래된 주석 2곳 수정, 범위가 넓어진 헬퍼 5개에 `// Used by:` 추가 |
+| Tests | 26 | 두 파일에 스키마, 무스키마, 경계값, `anyOf`, 네임스페이스, 디스패처 순서 커버리지 추가 |
 
 ### 관련 커밋
 
 | Hash | Type | Message |
 |------|------|---------|
 | `272afe8` | fix | fix(server): type XML tool-call arguments by the request schema |
+| `f222376` | fix | fix(server): tighten schema-driven XML tool-call coercion |
 
 ---
 
@@ -323,6 +385,9 @@ coercion은 보통 "값을 타입에 맞춘다"로 이해되지만, 하나의 �
 ### 향후 개선 사항
 
 - GLM-4.7과 LongCat을 string, integer 규칙만이 아니라 `minimax_m3_typed_coerce` 전체 경로로 태울지 결정. 이번에는 의도적으로 범위를 끊었고 `coerce_kv_value` 주석에 남겼다.
+- `minimax_m3_typed_coerce`는 `anyOf`/`oneOf` 루프에서 키가 존재하면 곧바로 반환하므로, 아무 대안도 맞지 않는 `anyOf`를 가진 스키마는 `oneOf`나 자신의 `type`을 끝내 시도하지 않는다. 기존 동작이며 이번에 건드리지 않았지만 별도 수정 대상이다.
+- 공유 헬퍼의 `minimax_m3_` 접두사는 이제 오해를 부른다. Qwen3-Coder와 MiniMax M2도 호출하기 때문이다. `schema_coerce_leaf` 식의 개명은 별도 `refactor:` PR로 다룬다.
+- array 타입 파라미터가 스칼라 하나를 담고 있으면 1원소 배열이 아니라 그 스칼라가 된다. 이 문법들이 반복 요소를 표기할 수 없기 때문이다. `xml_array_typed_bare_scalar_takes_the_item_type`가 이를 문서화하며, 배열로 감쌀지는 제품 결정 사항이다.
 - 델타 단위 증분 tool-call 인자 스트리밍은 여전히 범위 밖이다. 스트림 경로는 스트림 종료 시점에 한 번 파싱한다.
 - 스키마 검증 오류(`required` 키 누락, `enum` 불일치)는 아직 클라이언트에 전달되지 않는다. 파서는 변환만 하고 거부하지 않는다.
 
@@ -334,10 +399,13 @@ coercion은 보통 "값을 타입에 맞춘다"로 이해되지만, 하나의 �
 
 ```
 cargo test --profile test-fast --features metal,accelerate --lib server::tool_calls
-test result: ok. 370 passed; 0 failed; 0 ignored; 7313 filtered out
+test result: ok. 376 passed; 0 failed; 0 ignored; 7313 filtered out
 
 cargo test --profile test-fast --features metal,accelerate --lib server::muse_atem
-test result: ok. 11 passed; 0 failed; 0 ignored; 7672 filtered out
+test result: ok. 11 passed; 0 failed; 0 ignored; 7678 filtered out
+
+cargo test --profile test-fast --features metal,accelerate --lib server::routes::chat
+test result: ok. 48 passed; 0 failed; 0 ignored; 7641 filtered out
 
 cargo clippy --profile test-fast --lib --tests --features metal,accelerate -- -D warnings
 Finished (no warnings)
@@ -350,5 +418,5 @@ clean
 
 ### C. 참고 자료
 
-- `docs/code-guidelines.md`: `coerce_xml_param`과 `parse_integer_literal`에 적용한 `// Used by:` 규약.
+- `docs/code-guidelines.md`: `coerce_xml_param`, `parse_integer_literal`과 호출자 범위가 넓어진 헬퍼 다섯 개에 적용한 `// Used by:` 규약.
 - JSON Schema type 키워드: `integer`는 `number`와 구분되는 별도 타입이며, 두 갈래가 다르게 동작하는 근거다.

--- a/src/server/tool_calls/formats.rs
+++ b/src/server/tool_calls/formats.rs
@@ -1064,23 +1064,74 @@ fn extract_minimax_parameters(body: &str, fn_schema: Option<&serde_json::Value>)
 
 /// Convert a raw XML parameter value to JSON using its declared schema.
 ///
-/// `null` in any casing is the one value that ignores the schema: the XML
-/// grammars carry no other spelling for a JSON null, and both parsers have
-/// always emitted one here. Everything else goes through the shared MiniMax M3
-/// leaf coercion, so a `string`-typed parameter keeps its raw text and a
-/// numeric or boolean one is typed by its declaration instead of by guesswork
-/// on the text. A value that fits neither its declared type nor a JSON literal
-/// stays a string, so a call is never dropped for being unparseable.
+/// Two rules run ahead of the shared leaf coercion. Both are grounded in the
+/// declared type rather than in the shape of the text, which is the difference
+/// between this and the guesswork it replaced.
 ///
-/// The guesses this replaced (`yes`/`on` to `true`, `no`/`off` to `false`,
-/// `none`/`nil` to null) had no schema basis and are gone: those words are now
-/// the strings the model wrote.
+/// 1. The bare word `null` in any casing is JSON null: these grammars have no
+///    other spelling for one, and both parsers have always emitted one here. A
+///    parameter declared a plain `string` is the exception, because there the
+///    declaration says the value is text and `null` is a legitimate query, ref
+///    or filename. A type that explicitly admits null, as in
+///    `{"type": ["string", "null"]}`, keeps the null.
+/// 2. A parameter declared `boolean` also accepts the words the strict JSON
+///    reading rejects: `yes`, `on`, `1` and their negatives, plus any casing of
+///    `true` and `false`. The declaration is the basis the old schema-free
+///    guess never had. Without it those words stay the strings the model wrote.
+///
+/// Everything else goes through the shared MiniMax M3 leaf coercion, so a
+/// `string`-typed parameter keeps its raw text and a numeric one is typed by
+/// its declaration. A value that fits neither its declared type nor a JSON
+/// literal stays a string, so a call is never dropped for being unparseable.
+///
+/// The schema-free guesses this replaced are gone: `yes`/`on`, `no`/`off` and
+/// `none`/`nil` are now the strings the model wrote unless a `boolean`
+/// declaration says otherwise.
 // Used by: try_minimax_m2, try_qwen3_coder
 fn coerce_xml_param(raw: &str, schema: Option<&serde_json::Value>) -> serde_json::Value {
-    if raw.eq_ignore_ascii_case("null") {
+    let declared = schema.and_then(minimax_m3_schema_type);
+    let keeps_raw_text =
+        declared == Some(M3Type::Str) && !schema.is_some_and(schema_type_admits_null);
+    if !keeps_raw_text && raw.eq_ignore_ascii_case("null") {
         return serde_json::Value::Null;
     }
+    if declared == Some(M3Type::Boolean)
+        && let Some(b) = loose_boolean_word(raw)
+    {
+        return serde_json::Value::Bool(b);
+    }
     minimax_m3_coerce_leaf(raw, schema)
+}
+
+/// Whether a schema's `type` explicitly admits JSON null, as a nullable
+/// declaration such as `{"type": ["string", "null"]}` does.
+// Used by: coerce_xml_param
+fn schema_type_admits_null(schema: &serde_json::Value) -> bool {
+    match schema.get("type") {
+        Some(serde_json::Value::Array(items)) => items.iter().any(|v| v.as_str() == Some("null")),
+        _ => false,
+    }
+}
+
+/// The boolean a `boolean`-declared parameter spells, including the words a
+/// strict JSON reading rejects. Case-insensitive; `None` when the text is not
+/// one of them, so the caller falls through to its declared-type path.
+// Used by: coerce_xml_param
+fn loose_boolean_word(raw: &str) -> Option<bool> {
+    let raw = raw.trim();
+    if ["true", "yes", "on", "1"]
+        .iter()
+        .any(|w| raw.eq_ignore_ascii_case(w))
+    {
+        return Some(true);
+    }
+    if ["false", "no", "off", "0"]
+        .iter()
+        .any(|w| raw.eq_ignore_ascii_case(w))
+    {
+        return Some(false);
+    }
+    None
 }
 
 // Defensive caps mirroring the MiniMax M2 parser: bound parallel-call and
@@ -2003,13 +2054,26 @@ fn minimax_m3_extract_invoke_name(attr_region: &str) -> Option<String> {
 }
 
 /// Look up a function's JSON-schema `parameters` object by name.
+///
+/// A namespaced call name (`functions.get_weather`) falls back to the bare name
+/// after the first `.`, the same normalisation `filter_by_tools` applies when it
+/// matches a parsed call against the registered tools. Without that fallback the
+/// lookup misses for every namespacing model, every value silently takes the
+/// loose rules, and the call still succeeds, so nothing marks the schema as
+/// having been ignored.
+// Used by: try_minimax_m3, try_glm47, try_longcat, try_minimax_m2, try_qwen3_coder
 fn minimax_m3_function_schema<'a>(
     tools: Option<&'a [Tool]>,
     name: &str,
 ) -> Option<&'a serde_json::Value> {
-    tools?
+    let tools = tools?;
+    tools
         .iter()
         .find(|t| t.function.name == name)
+        .or_else(|| {
+            name.split_once('.')
+                .and_then(|(_, bare)| tools.iter().find(|t| t.function.name == bare))
+        })
         .and_then(|t| t.function.parameters.as_ref())
 }
 
@@ -2230,6 +2294,7 @@ fn minimax_m3_child_in_schema<'a>(
 
 /// Coerce a leaf value string using the element's schema, then a JSON parse,
 /// then a loose literal parse, then the raw string.
+// Used by: MiniMax M3, MiniMax M2, Qwen3-Coder
 fn minimax_m3_coerce_leaf(raw: &str, schema: Option<&serde_json::Value>) -> serde_json::Value {
     if let Some(schema) = schema {
         // A repeated tag declared as `list`/`array` arrives here one occurrence
@@ -2256,6 +2321,7 @@ fn minimax_m3_coerce_leaf(raw: &str, schema: Option<&serde_json::Value>) -> serd
 /// Strict, schema-directed coercion. Returns `None` when the declared type does
 /// not apply (so the caller falls back), which is what lets `anyOf`/`oneOf` try
 /// the next alternative and `enum` reject a non-member.
+// Used by: MiniMax M3, MiniMax M2, Qwen3-Coder (through minimax_m3_coerce_leaf)
 fn minimax_m3_typed_coerce(raw: &str, schema: &serde_json::Value) -> Option<serde_json::Value> {
     if let Some(members) = schema.get("enum").and_then(|e| e.as_array()) {
         return members
@@ -2295,9 +2361,6 @@ fn minimax_m3_typed_coerce(raw: &str, schema: &serde_json::Value) -> Option<serd
     }
 }
 
-/// Largest magnitude an `f64` carries with full integer precision (2^53).
-const INTEGER_FROM_FLOAT_LIMIT: f64 = 9_007_199_254_740_992.0;
-
 /// Parse a raw value as a JSON integer, exactly as written.
 // Used by: parse_integer_literal, minimax_m3_typed_coerce (number arm)
 fn parse_exact_integer_literal(raw: &str) -> Option<serde_json::Value> {
@@ -2311,23 +2374,30 @@ fn parse_exact_integer_literal(raw: &str) -> Option<serde_json::Value> {
 
 /// Parse a raw value as a JSON integer for an `integer`-typed parameter.
 ///
-/// Accepts an `i64` or `u64` literal, plus a float literal with no fractional
-/// part (`5.0`, `1e5`), which models emit often enough for an `integer`-typed
-/// parameter to be worth honouring: the declared type says the value is an
-/// integer, so `5.0` is `5`, not the float the text spells. The float arm is
-/// bounded by 2^53 because past that an `f64` no longer carries every integer;
-/// an out-of-range value declines here and stays a float through the caller's
-/// fallback rather than being silently rounded.
+/// Accepts an `i64` or `u64` literal, plus the same literal written with a zero
+/// fraction (`5.0`, `-5.000`), which models emit often enough for an
+/// `integer`-typed parameter to be worth honouring: the declared type says the
+/// value is an integer, so `5.0` is `5` and the decimal point is formatting.
+///
+/// The fraction is stripped textually rather than through an `f64` round trip,
+/// for two reasons. A round trip rounds before anything can inspect the result,
+/// so `9007199254740991.5` would arrive with an empty fraction and become an
+/// integer, and `9007199254740993.0` would come back off by one. It also admits
+/// the exponent form, and under `anyOf: [integer, string]` the integer
+/// alternative is tried first, so an identifier such as `1e5` would be taken
+/// from the string alternative that should own it. Text with an exponent, or
+/// with an integer part outside `i64`/`u64`, declines here and stays a number
+/// through the caller's fallback.
 // Used by: minimax_m3_typed_coerce (integer arm), coerce_kv_value
 fn parse_integer_literal(raw: &str) -> Option<serde_json::Value> {
     if let Some(v) = parse_exact_integer_literal(raw) {
         return Some(v);
     }
-    let f = raw.parse::<f64>().ok()?;
-    if f.is_finite() && f.fract() == 0.0 && f.abs() <= INTEGER_FROM_FLOAT_LIMIT {
-        return Some(serde_json::Value::Number((f as i64).into()));
+    let (int_part, fraction) = raw.split_once('.')?;
+    if fraction.bytes().any(|b| b != b'0') {
+        return None;
     }
-    None
+    parse_exact_integer_literal(int_part)
 }
 
 /// Map a schema's `type` (a string, or the first non-`null` of a type array) to
@@ -2367,6 +2437,7 @@ fn minimax_m3_enum_member_matches(member: &serde_json::Value, raw: &str) -> bool
 
 /// Schema-free coercion: JSON parse, then a loose literal parse (numbers and
 /// booleans), then the raw string.
+// Used by: MiniMax M3, MiniMax M2, Qwen3-Coder, GLM-4.7, LongCat
 fn minimax_m3_fallback_coerce(raw: &str) -> serde_json::Value {
     if let Ok(v) = serde_json::from_str::<serde_json::Value>(raw) {
         return v;
@@ -2767,6 +2838,7 @@ fn shell_split(s: &str) -> Vec<String> {
 }
 
 /// Look up a parameter's JSON schema inside a function's `parameters` object.
+// Used by: GLM-4.7, LongCat, MiniMax M2, Qwen3-Coder
 fn kv_param_schema<'a>(
     fn_schema: Option<&'a serde_json::Value>,
     key: &str,
@@ -5005,18 +5077,182 @@ mod tests {
     }
 
     #[test]
-    fn xml_null_literal_is_null_under_any_schema() {
-        // The XML grammars spell a JSON null only as the bare word, so it wins
-        // over the declared type in both parsers.
+    fn xml_null_literal_is_null_except_under_a_plain_string_schema() {
+        // The bare word is the only JSON null these grammars can spell, so it
+        // wins over every declared type but a plain `string`, where the
+        // declaration says the value is text (a query, a ref, a filename).
         let schema = serde_json::json!({
             "type": "object",
-            "properties": {"val": {"type": "string"}}
+            "properties": {
+                "text": {"type": "string"},
+                "maybe_text": {"type": ["string", "null"]},
+                "n": {"type": "integer"}
+            }
         });
         let tools = vec![m3_tool("f", schema)];
-        let qwen = try_qwen3_coder(&qwen_block("f", &[("val", "NULL")]), Some(&tools)).unwrap();
-        assert_eq!(xml_args(&qwen, 0)["val"], serde_json::Value::Null);
-        let m2 = try_minimax_m2(&m2_block("f", &[("val", "null")]), Some(&tools)).unwrap();
-        assert_eq!(xml_args(&m2, 0)["val"], serde_json::Value::Null);
+        let params = &[("text", "NULL"), ("maybe_text", "null"), ("n", "null")];
+
+        let qwen = try_qwen3_coder(&qwen_block("f", params), Some(&tools)).unwrap();
+        let args = xml_args(&qwen, 0);
+        assert_eq!(args["text"], "NULL", "a string-typed value keeps its text");
+        assert!(args["text"].is_string());
+        assert_eq!(
+            args["maybe_text"],
+            serde_json::Value::Null,
+            "a nullable declaration still takes the null"
+        );
+        assert_eq!(args["n"], serde_json::Value::Null);
+
+        let m2 = try_minimax_m2(&m2_block("f", params), Some(&tools)).unwrap();
+        let args = xml_args(&m2, 0);
+        assert_eq!(args["text"], "NULL");
+        assert_eq!(args["maybe_text"], serde_json::Value::Null);
+        assert_eq!(args["n"], serde_json::Value::Null);
+    }
+
+    #[test]
+    fn xml_boolean_typed_accepts_the_words_a_strict_json_read_rejects() {
+        // A `boolean` declaration is the schema basis the old free-text guess
+        // never had, so `yes` and `on` are booleans here and strings without it.
+        let schema = serde_json::json!({
+            "type": "object",
+            "properties": {
+                "a": {"type": "boolean"},
+                "b": {"type": "boolean"},
+                "c": {"type": "boolean"},
+                "d": {"type": "boolean"},
+                "e": {"type": "boolean"},
+                "f": {"type": "boolean"},
+                "g": {"type": "boolean"}
+            }
+        });
+        let tools = vec![m3_tool("f", schema)];
+        let params = &[
+            ("a", "true"),
+            ("b", "TRUE"),
+            ("c", "yes"),
+            ("d", "on"),
+            ("e", "1"),
+            ("f", "off"),
+            ("g", "maybe"),
+        ];
+
+        for args in [
+            xml_args(
+                &try_qwen3_coder(&qwen_block("f", params), Some(&tools)).unwrap(),
+                0,
+            ),
+            xml_args(
+                &try_minimax_m2(&m2_block("f", params), Some(&tools)).unwrap(),
+                0,
+            ),
+        ] {
+            assert_eq!(args["a"], true);
+            assert_eq!(
+                args["b"], true,
+                "casing must not matter under a declaration"
+            );
+            assert_eq!(args["c"], true);
+            assert_eq!(args["d"], true);
+            assert_eq!(args["e"], true);
+            assert_eq!(args["f"], false);
+            assert_eq!(
+                args["g"], "maybe",
+                "a non-boolean word is not invented into one"
+            );
+        }
+    }
+
+    #[test]
+    fn xml_boolean_words_need_a_declaration() {
+        // Without a `boolean` schema the same words stay the text the model
+        // wrote, matching MiniMax M3, GLM-4.7 and LongCat.
+        let output = qwen_block("f", &[("a", "yes"), ("b", "on"), ("c", "TRUE")]);
+        let args = xml_args(&try_qwen3_coder(&output, None).unwrap(), 0);
+        assert_eq!(args["a"], "yes");
+        assert_eq!(args["b"], "on");
+        assert_eq!(args["c"], "TRUE");
+    }
+
+    #[test]
+    fn xml_parsers_resolve_a_namespaced_function_name() {
+        // A model that namespaces its call (`functions.f`) must still find the
+        // schema; `filter_by_tools` strips the same prefix after parsing.
+        let tools = vec![m3_tool("f", zip_and_count_schema())];
+        let qwen = try_qwen3_coder(
+            &qwen_block("functions.f", &[("zip", "02134")]),
+            Some(&tools),
+        )
+        .unwrap();
+        assert_eq!(xml_args(&qwen, 0)["zip"], "02134");
+        let m2 =
+            try_minimax_m2(&m2_block("functions.f", &[("zip", "02134")]), Some(&tools)).unwrap();
+        assert_eq!(xml_args(&m2, 0)["zip"], "02134");
+    }
+
+    #[test]
+    fn minimax_m2_without_schema_uses_loose_rules() {
+        // The mirror of the Qwen3-Coder case, including the words that used to
+        // be guessed into booleans and null.
+        let output = m2_block(
+            "f",
+            &[
+                ("n", "5"),
+                ("flag", "true"),
+                ("val", "null"),
+                ("word", "yes"),
+                ("nil_word", "none"),
+            ],
+        );
+        let args = xml_args(&try_minimax_m2(&output, None).unwrap(), 0);
+        assert_eq!(args["n"], 5);
+        assert_eq!(args["flag"], true);
+        assert_eq!(args["val"], serde_json::Value::Null);
+        assert_eq!(args["word"], "yes");
+        assert_eq!(args["nil_word"], "none", "only `null` is null");
+    }
+
+    #[test]
+    fn xml_array_typed_bare_scalar_takes_the_item_type() {
+        // These grammars have no way to spell a repeated element, so an
+        // array-typed parameter carrying one bare scalar is coerced against
+        // `items` and stays a scalar. Documented rather than changed: the loose
+        // rules produced the same scalar before this path existed.
+        let output = qwen_block("f", &[("ids", "3"), ("names", r#"["a", "b"]"#)]);
+        let schema = serde_json::json!({
+            "type": "object",
+            "properties": {
+                "ids": {"type": "array", "items": {"type": "integer"}},
+                "names": {"type": "array", "items": {"type": "string"}}
+            }
+        });
+        let tools = vec![m3_tool("f", schema)];
+        let args = xml_args(&try_qwen3_coder(&output, Some(&tools)).unwrap(), 0);
+        assert_eq!(args["ids"], 3);
+        assert_eq!(args["names"], serde_json::json!(["a", "b"]));
+    }
+
+    #[test]
+    fn minimax_m3_anyof_integer_or_string_keeps_the_exponent_form_a_string() {
+        // The integer alternative is tried first, so widening it must not let
+        // it claim an identifier the string alternative used to take.
+        let body = format!("{}{}", m3_el("x", "1e5"), m3_el("y", "5.0"));
+        let output = m3_block(&[("f", &body)]);
+        let schema = serde_json::json!({
+            "type": "object",
+            "properties": {
+                "x": {"anyOf": [{"type": "integer"}, {"type": "string"}]},
+                "y": {"anyOf": [{"type": "integer"}, {"type": "string"}]}
+            }
+        });
+        let tools = vec![m3_tool("f", schema)];
+        let args = m3_args(&try_minimax_m3(&output, Some(&tools)).unwrap(), 0);
+        assert_eq!(args["x"], "1e5");
+        assert!(args["x"].is_string());
+        assert_eq!(
+            args["y"], 5,
+            "a zero fraction is the integer the schema allows"
+        );
     }
 
     #[test]
@@ -5108,25 +5344,36 @@ mod tests {
     }
 
     #[test]
-    fn integer_literal_rule_declines_beyond_exact_float_range() {
-        // Past 2^53 an f64 no longer carries every integer, so the float arm
-        // declines rather than round; the loose fallback keeps it a number.
+    fn integer_literal_rule_is_textual_and_exact() {
+        // Zero fractions are stripped as text, so the result is exact at every
+        // magnitude and a fractional value can never round its way to an
+        // integer. Both properties fail under an f64 round trip.
+        assert_eq!(parse_integer_literal("5"), Some(serde_json::json!(5)));
+        assert_eq!(parse_integer_literal("5.0"), Some(serde_json::json!(5)));
+        assert_eq!(parse_integer_literal("-5.000"), Some(serde_json::json!(-5)));
+        assert_eq!(parse_integer_literal("5."), Some(serde_json::json!(5)));
+        assert_eq!(parse_integer_literal("5.5"), None);
+        assert_eq!(parse_integer_literal(".5"), None);
+        assert_eq!(parse_integer_literal("5.0.0"), None);
+        // Exact past 2^53, where an f64 round trip comes back off by one.
         assert_eq!(
-            parse_integer_literal("9007199254740992.0"),
-            Some(serde_json::json!(9_007_199_254_740_992_i64))
+            parse_integer_literal("9007199254740993.0"),
+            Some(serde_json::json!(9_007_199_254_740_993_i64))
         );
-        assert_eq!(parse_integer_literal("9007199254740994.0"), None);
+        // An f64 round trip rounds this to a zero fraction and would call it an
+        // integer.
+        assert_eq!(parse_integer_literal("9007199254740991.5"), None);
+        // The exponent form belongs to the string alternative of an `anyOf`.
+        assert_eq!(parse_integer_literal("1e5"), None);
         assert_eq!(parse_integer_literal("inf"), None);
         assert_eq!(parse_integer_literal("nan"), None);
-        assert_eq!(
-            parse_integer_literal("1e5"),
-            Some(serde_json::json!(100_000))
-        );
         assert_eq!(parse_integer_literal("abc"), None);
-        // A u64 literal past i64::MAX still parses exactly.
+        // A u64 literal past i64::MAX still parses exactly; one past u64 does
+        // not, and stays a number through the caller's fallback.
         assert_eq!(
             parse_integer_literal("18446744073709551615"),
             Some(serde_json::json!(18_446_744_073_709_551_615_u64))
         );
+        assert_eq!(parse_integer_literal("18446744073709551616.0"), None);
     }
 }

--- a/src/server/tool_calls/formats.rs
+++ b/src/server/tool_calls/formats.rs
@@ -894,11 +894,15 @@ const MINIMAX_M2_MAX_PARAMS_PER_CALL: usize = 1024;
 /// `<invoke name="fn_name"><parameter name="k">v</parameter></invoke>`
 ///
 /// Multiple `<invoke>` blocks may appear sequentially for parallel tool calls.
-/// Parameter values are converted to their most likely JSON types (number,
-/// boolean, null, object/array via JSON parse) before falling back to string.
+///
+/// `tools` supplies the per-function JSON schema each parameter value is typed
+/// by: a `string`-typed parameter keeps its raw text (`02134` stays `"02134"`),
+/// an `integer`-typed one accepts a zero-fraction float literal, and a value
+/// that fits neither its declared type nor a JSON literal stays a string, so a
+/// call is never dropped. Without a schema the loose literal rules apply.
 ///
 /// Mirrors the upstream Python rewrite in mlx-lm PR #1171 (commit 6d11468).
-pub fn try_minimax_m2(text: &str) -> Option<ToolCallParseResult> {
+pub fn try_minimax_m2(text: &str, tools: Option<&[Tool]>) -> Option<ToolCallParseResult> {
     let invoke_open = "<invoke name=";
     let invoke_close = "</invoke>";
 
@@ -942,7 +946,8 @@ pub fn try_minimax_m2(text: &str) -> Option<ToolCallParseResult> {
             b
         };
 
-        let arguments = extract_minimax_parameters(body);
+        let fn_schema = minimax_m3_function_schema(tools, &function_name);
+        let arguments = extract_minimax_parameters(body, fn_schema);
         calls.push(ParsedToolCall {
             name: function_name,
             arguments,
@@ -985,8 +990,9 @@ fn extract_quoted_name(s: &str) -> String {
 /// Parse all `<parameter name="k">v</parameter>` tags inside an `<invoke>` body.
 ///
 /// Returns a JSON object string mapping parameter names to their typed values.
-/// Type coercion order: null → integer → float → boolean → JSON object/array → string.
-fn extract_minimax_parameters(body: &str) -> String {
+/// `fn_schema` is the called function's JSON-schema `parameters` object; each
+/// value is typed by its declared type through [`coerce_xml_param`].
+fn extract_minimax_parameters(body: &str, fn_schema: Option<&serde_json::Value>) -> String {
     let param_open = "<parameter name=";
     let param_close = "</parameter>";
 
@@ -1037,8 +1043,8 @@ fn extract_minimax_parameters(body: &str) -> String {
         }
         let raw_value = raw_value.trim();
 
-        let json_value = coerce_minimax_param(raw_value);
         if !param_name.is_empty() {
+            let json_value = coerce_xml_param(raw_value, kv_param_schema(fn_schema, &param_name));
             pairs.push((param_name, json_value));
         }
 
@@ -1056,45 +1062,25 @@ fn extract_minimax_parameters(body: &str) -> String {
     serde_json::to_string(&serde_json::Value::Object(map)).unwrap_or_else(|_| "{}".to_string())
 }
 
-/// Convert a raw string parameter value to the most specific JSON type.
+/// Convert a raw XML parameter value to JSON using its declared schema.
 ///
-/// Priority: null → integer → float → boolean → JSON object/array → string.
-fn coerce_minimax_param(value: &str) -> serde_json::Value {
-    // Null
-    let lower = value.to_lowercase();
-    if lower == "null" || lower == "none" || lower == "nil" {
+/// `null` in any casing is the one value that ignores the schema: the XML
+/// grammars carry no other spelling for a JSON null, and both parsers have
+/// always emitted one here. Everything else goes through the shared MiniMax M3
+/// leaf coercion, so a `string`-typed parameter keeps its raw text and a
+/// numeric or boolean one is typed by its declaration instead of by guesswork
+/// on the text. A value that fits neither its declared type nor a JSON literal
+/// stays a string, so a call is never dropped for being unparseable.
+///
+/// The guesses this replaced (`yes`/`on` to `true`, `no`/`off` to `false`,
+/// `none`/`nil` to null) had no schema basis and are gone: those words are now
+/// the strings the model wrote.
+// Used by: try_minimax_m2, try_qwen3_coder
+fn coerce_xml_param(raw: &str, schema: Option<&serde_json::Value>) -> serde_json::Value {
+    if raw.eq_ignore_ascii_case("null") {
         return serde_json::Value::Null;
     }
-
-    // Integer (try before float so we preserve exact integer representation)
-    if let Ok(i) = value.parse::<i64>() {
-        return serde_json::Value::Number(serde_json::Number::from(i));
-    }
-
-    // Float
-    if let Ok(f) = value.parse::<f64>()
-        && let Some(n) = serde_json::Number::from_f64(f)
-    {
-        return serde_json::Value::Number(n);
-    }
-
-    // Boolean
-    if lower == "true" || lower == "1" || lower == "yes" || lower == "on" {
-        return serde_json::Value::Bool(true);
-    }
-    if lower == "false" || lower == "0" || lower == "no" || lower == "off" {
-        return serde_json::Value::Bool(false);
-    }
-
-    // JSON object or array
-    if (value.starts_with('{') || value.starts_with('['))
-        && let Ok(v) = serde_json::from_str::<serde_json::Value>(value)
-    {
-        return v;
-    }
-
-    // Fallback: string
-    serde_json::Value::String(value.to_string())
+    minimax_m3_coerce_leaf(raw, schema)
 }
 
 // Defensive caps mirroring the MiniMax M2 parser: bound parallel-call and
@@ -1123,7 +1109,11 @@ const QWEN3_CODER_MAX_PARAMS_PER_CALL: usize = 1024;
 ///
 /// The surrounding `<tool_call>` wrapper is not required: scanning for
 /// `<function=` naturally skips it, matching Qwen3-Coder variants that omit it.
-pub fn try_qwen3_coder(text: &str) -> Option<ToolCallParseResult> {
+///
+/// `tools` supplies the per-function JSON schema each parameter value is typed
+/// by, exactly as in [`try_minimax_m2`]: a `string`-typed parameter keeps its
+/// raw text rather than being guessed into a number or a boolean.
+pub fn try_qwen3_coder(text: &str, tools: Option<&[Tool]>) -> Option<ToolCallParseResult> {
     let fn_open = "<function=";
     let fn_close = "</function>";
 
@@ -1166,7 +1156,8 @@ pub fn try_qwen3_coder(text: &str) -> Option<ToolCallParseResult> {
         };
 
         if !function_name.is_empty() {
-            let arguments = extract_qwen_parameters(body);
+            let fn_schema = minimax_m3_function_schema(tools, &function_name);
+            let arguments = extract_qwen_parameters(body, fn_schema);
             calls.push(ParsedToolCall {
                 name: function_name,
                 arguments,
@@ -1196,8 +1187,9 @@ pub fn try_qwen3_coder(text: &str) -> Option<ToolCallParseResult> {
 /// Mirrors [`extract_minimax_parameters`] but keys on the bare `<parameter=`
 /// opener (Qwen3-Coder) rather than `<parameter name=` (MiniMax M2). Values are
 /// stripped of one surrounding newline (the model pretty-prints each parameter
-/// on its own line) then trimmed, and typed via [`coerce_minimax_param`].
-fn extract_qwen_parameters(body: &str) -> String {
+/// on its own line) then trimmed, and typed via [`coerce_xml_param`] against the
+/// called function's schema in `fn_schema`.
+fn extract_qwen_parameters(body: &str, fn_schema: Option<&serde_json::Value>) -> String {
     let param_open = "<parameter=";
     let param_close = "</parameter>";
 
@@ -1242,7 +1234,8 @@ fn extract_qwen_parameters(body: &str) -> String {
         let raw_value = raw_value.trim();
 
         if !param_name.is_empty() {
-            pairs.push((param_name, coerce_minimax_param(raw_value)));
+            let json_value = coerce_xml_param(raw_value, kv_param_schema(fn_schema, &param_name));
+            pairs.push((param_name, json_value));
         }
 
         if pairs.len() >= QWEN3_CODER_MAX_PARAMS_PER_CALL {
@@ -2278,20 +2271,15 @@ fn minimax_m3_typed_coerce(raw: &str, schema: &serde_json::Value) -> Option<serd
         }
     }
     match minimax_m3_schema_type(schema)? {
-        M3Type::Integer => raw
-            .parse::<i64>()
-            .ok()
-            .map(|i| serde_json::Value::Number(i.into()))
-            .or_else(|| {
-                raw.parse::<u64>()
-                    .ok()
-                    .map(|u| serde_json::Value::Number(u.into()))
-            }),
-        M3Type::Number => raw
-            .parse::<f64>()
-            .ok()
-            .and_then(serde_json::Number::from_f64)
-            .map(serde_json::Value::Number),
+        M3Type::Integer => parse_integer_literal(raw),
+        // An integral literal keeps its written form under `number` (`5` stays
+        // `5`, `5.0` stays `5.0`); only `integer` normalises `5.0` to `5`.
+        M3Type::Number => parse_exact_integer_literal(raw).or_else(|| {
+            raw.parse::<f64>()
+                .ok()
+                .and_then(serde_json::Number::from_f64)
+                .map(serde_json::Value::Number)
+        }),
         M3Type::Boolean => match raw.trim() {
             "true" | "True" => Some(serde_json::Value::Bool(true)),
             "false" | "False" => Some(serde_json::Value::Bool(false)),
@@ -2305,6 +2293,41 @@ fn minimax_m3_typed_coerce(raw: &str, schema: &serde_json::Value) -> Option<serd
             .filter(|v| v.is_array()),
         M3Type::Str => Some(serde_json::Value::String(raw.to_string())),
     }
+}
+
+/// Largest magnitude an `f64` carries with full integer precision (2^53).
+const INTEGER_FROM_FLOAT_LIMIT: f64 = 9_007_199_254_740_992.0;
+
+/// Parse a raw value as a JSON integer, exactly as written.
+// Used by: parse_integer_literal, minimax_m3_typed_coerce (number arm)
+fn parse_exact_integer_literal(raw: &str) -> Option<serde_json::Value> {
+    if let Ok(i) = raw.parse::<i64>() {
+        return Some(serde_json::Value::Number(i.into()));
+    }
+    raw.parse::<u64>()
+        .ok()
+        .map(|u| serde_json::Value::Number(u.into()))
+}
+
+/// Parse a raw value as a JSON integer for an `integer`-typed parameter.
+///
+/// Accepts an `i64` or `u64` literal, plus a float literal with no fractional
+/// part (`5.0`, `1e5`), which models emit often enough for an `integer`-typed
+/// parameter to be worth honouring: the declared type says the value is an
+/// integer, so `5.0` is `5`, not the float the text spells. The float arm is
+/// bounded by 2^53 because past that an `f64` no longer carries every integer;
+/// an out-of-range value declines here and stays a float through the caller's
+/// fallback rather than being silently rounded.
+// Used by: minimax_m3_typed_coerce (integer arm), coerce_kv_value
+fn parse_integer_literal(raw: &str) -> Option<serde_json::Value> {
+    if let Some(v) = parse_exact_integer_literal(raw) {
+        return Some(v);
+    }
+    let f = raw.parse::<f64>().ok()?;
+    if f.is_finite() && f.fract() == 0.0 && f.abs() <= INTEGER_FROM_FLOAT_LIMIT {
+        return Some(serde_json::Value::Number((f as i64).into()));
+    }
+    None
 }
 
 /// Map a schema's `type` (a string, or the first non-`null` of a type array) to
@@ -2755,14 +2778,26 @@ fn kv_param_schema<'a>(
 }
 
 /// Coerce a raw argument value using schema-aware rules: a `string`-typed
-/// parameter keeps its raw text; any other type (or no schema) falls back to a
-/// JSON parse, then a loose literal parse (numbers, booleans, lists), then the
-/// raw string. Reuses the MiniMax M3 schema-type mapper and fallback coercion.
+/// parameter keeps its raw text, an `integer`-typed one takes the shared
+/// integer rule (so a zero-fraction float literal such as `5.0` becomes `5`),
+/// and any other type (or no schema) falls back to a JSON parse, then a loose
+/// literal parse (numbers, booleans, lists), then the raw string. Reuses the
+/// MiniMax M3 schema-type mapper and fallback coercion.
+///
+/// This grammar deliberately stops at those two declared types rather than
+/// running the full [`minimax_m3_typed_coerce`] path: the loose fallback is
+/// what GLM-4.7 and LongCat have always used for every other type.
 fn coerce_kv_value(raw: &str, param_schema: Option<&serde_json::Value>) -> serde_json::Value {
-    if let Some(schema) = param_schema
-        && minimax_m3_schema_type(schema) == Some(M3Type::Str)
-    {
-        return serde_json::Value::String(raw.to_string());
+    if let Some(schema) = param_schema {
+        match minimax_m3_schema_type(schema) {
+            Some(M3Type::Str) => return serde_json::Value::String(raw.to_string()),
+            Some(M3Type::Integer) => {
+                if let Some(v) = parse_integer_literal(raw) {
+                    return v;
+                }
+            }
+            _ => {}
+        }
     }
     minimax_m3_fallback_coerce(raw)
 }
@@ -3359,7 +3394,7 @@ mod tests {
     fn minimax_m2_single_tool_call() {
         // From upstream test_tool_parsing.py: single invoke with a string parameter
         let text = "<invoke name=\"get_current_temperature\">\n<parameter name=\"location\">London</parameter>\n</invoke>";
-        let result = try_minimax_m2(text).unwrap();
+        let result = try_minimax_m2(text, None).unwrap();
         assert_eq!(result.tool_calls.len(), 1);
         assert_eq!(result.tool_calls[0].name, "get_current_temperature");
         let args: serde_json::Value =
@@ -3372,7 +3407,7 @@ mod tests {
     fn minimax_m2_parallel_tool_calls() {
         // From upstream test_minimax_m2: two parallel invocations in one response
         let text = "<invoke name=\"search\">\n<parameter name=\"query\">weather</parameter>\n</invoke>\n<invoke name=\"read_file\">\n<parameter name=\"path\">/tmp/test.txt</parameter>\n</invoke>";
-        let result = try_minimax_m2(text).unwrap();
+        let result = try_minimax_m2(text, None).unwrap();
         assert_eq!(result.tool_calls.len(), 2);
         assert_eq!(result.tool_calls[0].name, "search");
         let args0: serde_json::Value =
@@ -3388,7 +3423,7 @@ mod tests {
     fn minimax_m2_numeric_params() {
         // From upstream test_parsers: multiply with numeric a and b
         let text = "<invoke name=\"multiply\">\n<parameter name=\"a\">12234585</parameter>\n<parameter name=\"b\">48838483920</parameter>\n</invoke>";
-        let result = try_minimax_m2(text).unwrap();
+        let result = try_minimax_m2(text, None).unwrap();
         assert_eq!(result.tool_calls.len(), 1);
         assert_eq!(result.tool_calls[0].name, "multiply");
         let args: serde_json::Value =
@@ -3401,7 +3436,7 @@ mod tests {
     #[test]
     fn minimax_m2_boolean_param() {
         let text = "<invoke name=\"fn\">\n<parameter name=\"active\">true</parameter>\n</invoke>";
-        let result = try_minimax_m2(text).unwrap();
+        let result = try_minimax_m2(text, None).unwrap();
         let args: serde_json::Value =
             serde_json::from_str(&result.tool_calls[0].arguments).unwrap();
         assert_eq!(args["active"], true);
@@ -3410,7 +3445,7 @@ mod tests {
     #[test]
     fn minimax_m2_null_param() {
         let text = "<invoke name=\"fn\">\n<parameter name=\"val\">null</parameter>\n</invoke>";
-        let result = try_minimax_m2(text).unwrap();
+        let result = try_minimax_m2(text, None).unwrap();
         let args: serde_json::Value =
             serde_json::from_str(&result.tool_calls[0].arguments).unwrap();
         assert_eq!(args["val"], serde_json::Value::Null);
@@ -3419,7 +3454,7 @@ mod tests {
     #[test]
     fn minimax_m2_json_object_param() {
         let text = "<invoke name=\"fn\">\n<parameter name=\"config\">{\"key\": \"val\", \"n\": 1}</parameter>\n</invoke>";
-        let result = try_minimax_m2(text).unwrap();
+        let result = try_minimax_m2(text, None).unwrap();
         let args: serde_json::Value =
             serde_json::from_str(&result.tool_calls[0].arguments).unwrap();
         let config = &args["config"];
@@ -3429,13 +3464,17 @@ mod tests {
 
     #[test]
     fn minimax_m2_no_match_plain_text() {
-        assert!(try_minimax_m2("Hello, world!").is_none());
+        assert!(try_minimax_m2("Hello, world!", None).is_none());
     }
 
     #[test]
     fn minimax_m2_no_match_hermes_format() {
         assert!(
-            try_minimax_m2(r#"<tool_call>{"name": "fn", "arguments": {}}</tool_call>"#).is_none()
+            try_minimax_m2(
+                r#"<tool_call>{"name": "fn", "arguments": {}}</tool_call>"#,
+                None
+            )
+            .is_none()
         );
     }
 
@@ -3443,7 +3482,7 @@ mod tests {
     fn minimax_m2_single_quotes_name() {
         // Name quoted with single quotes (edge case)
         let text = "<invoke name='search'>\n<parameter name='query'>rust</parameter>\n</invoke>";
-        let result = try_minimax_m2(text).unwrap();
+        let result = try_minimax_m2(text, None).unwrap();
         assert_eq!(result.tool_calls[0].name, "search");
         let args: serde_json::Value =
             serde_json::from_str(&result.tool_calls[0].arguments).unwrap();
@@ -3454,7 +3493,7 @@ mod tests {
     fn minimax_m2_missing_close_invoke() {
         // No </invoke> closing tag: still parses what it can
         let text = "<invoke name=\"search\">\n<parameter name=\"query\">rust</parameter>\n";
-        let result = try_minimax_m2(text).unwrap();
+        let result = try_minimax_m2(text, None).unwrap();
         assert_eq!(result.tool_calls.len(), 1);
         assert_eq!(result.tool_calls[0].name, "search");
     }
@@ -3468,15 +3507,15 @@ mod tests {
         // skips that block or returns no calls — but never panics.
         let text = "<invoke name=\">\n<parameter name=\"k\">v</parameter>\n</invoke>";
         // Must not panic.
-        let _ = try_minimax_m2(text);
+        let _ = try_minimax_m2(text, None);
 
         // Same check for a single apostrophe.
         let text = "<invoke name='>\n<parameter name=\"k\">v</parameter>\n</invoke>";
-        let _ = try_minimax_m2(text);
+        let _ = try_minimax_m2(text, None);
 
         // Same check inside a parameter name.
         let text = "<invoke name=\"fn\">\n<parameter name=\">v</parameter>\n</invoke>";
-        let _ = try_minimax_m2(text);
+        let _ = try_minimax_m2(text, None);
     }
 
     #[test]
@@ -3486,7 +3525,7 @@ mod tests {
         // first call.  Same fix pattern as
         // `functionary_v31_malformed_trailing_tag_preserves_prior_calls`.
         let text = "<invoke name=\"get_weather\">\n<parameter name=\"loc\">Paris</parameter>\n</invoke><invoke name=\"broken_no_close";
-        let result = try_minimax_m2(text).unwrap();
+        let result = try_minimax_m2(text, None).unwrap();
         assert_eq!(result.tool_calls.len(), 1);
         assert_eq!(result.tool_calls[0].name, "get_weather");
         let args: serde_json::Value =
@@ -3511,7 +3550,7 @@ mod tests {
         body.push_str("</invoke>");
 
         let start = std::time::Instant::now();
-        let result = try_minimax_m2(&body);
+        let result = try_minimax_m2(&body, None);
         let elapsed = start.elapsed();
 
         // Should complete in well under one second on any reasonable hardware.
@@ -3534,7 +3573,7 @@ mod tests {
         // MINIMAX_M2_MAX_CALLS to bound memory amplification.
         let one = "<invoke name=\"x\"><parameter name=\"a\">1</parameter></invoke>";
         let huge = one.repeat(10_000);
-        let result = try_minimax_m2(&huge).unwrap();
+        let result = try_minimax_m2(&huge, None).unwrap();
         assert!(
             result.tool_calls.len() <= MINIMAX_M2_MAX_CALLS,
             "expected <= {}, got {}",
@@ -3553,7 +3592,7 @@ mod tests {
             body.push_str(&format!("<parameter name=\"k{i}\">v</parameter>"));
         }
         body.push_str("</invoke>");
-        let result = try_minimax_m2(&body).unwrap();
+        let result = try_minimax_m2(&body, None).unwrap();
         let args: serde_json::Value =
             serde_json::from_str(&result.tool_calls[0].arguments).unwrap();
         let obj = args.as_object().unwrap();
@@ -4794,5 +4833,300 @@ mod tests {
     fn longcat_malformed_returns_none() {
         assert!(try_longcat("plain text with no markers", None).is_none());
         assert!(try_longcat("<longcat_tool_call></longcat_tool_call>", None).is_none());
+    }
+
+    // ------------------------------------------------------------------
+    // Schema-driven coercion for the XML parameter grammars (#1336)
+    // ------------------------------------------------------------------
+
+    /// The parsed `arguments` object of one call.
+    fn xml_args(result: &ToolCallParseResult, idx: usize) -> serde_json::Value {
+        serde_json::from_str(&result.tool_calls[idx].arguments).expect("arguments must be JSON")
+    }
+
+    /// A Qwen3-Coder call: `<function=NAME>` with one `<parameter=KEY>` per pair.
+    fn qwen_block(name: &str, params: &[(&str, &str)]) -> String {
+        let body: String = params
+            .iter()
+            .map(|(k, v)| format!("<parameter={k}>{v}</parameter>"))
+            .collect();
+        format!("<tool_call><function={name}>{body}</function></tool_call>")
+    }
+
+    /// A MiniMax M2 call: `<invoke name="NAME">` with one `<parameter name="KEY">` per pair.
+    fn m2_block(name: &str, params: &[(&str, &str)]) -> String {
+        let body: String = params
+            .iter()
+            .map(|(k, v)| format!("<parameter name=\"{k}\">{v}</parameter>"))
+            .collect();
+        format!("<invoke name=\"{name}\">{body}</invoke>")
+    }
+
+    /// A tool registered without a `parameters` schema.
+    fn schemaless_tool(name: &str) -> Tool {
+        Tool {
+            tool_type: "function".to_string(),
+            function: crate::server::types::request::FunctionDefinition {
+                name: name.to_string(),
+                description: None,
+                parameters: None,
+            },
+        }
+    }
+
+    fn zip_and_count_schema() -> serde_json::Value {
+        serde_json::json!({
+            "type": "object",
+            "properties": {
+                "zip": {"type": "string"},
+                "n": {"type": "integer"}
+            }
+        })
+    }
+
+    #[test]
+    fn qwen3_coder_string_typed_param_keeps_numeric_text() {
+        // The same numeric-looking text under two declared types: the string
+        // keeps its leading zero, the integer is coerced (and loses it).
+        let output = qwen_block("f", &[("zip", "02134"), ("n", "02134")]);
+        let tools = vec![m3_tool("f", zip_and_count_schema())];
+        let result = try_qwen3_coder(&output, Some(&tools)).unwrap();
+        let args = xml_args(&result, 0);
+        assert_eq!(args["zip"], "02134");
+        assert!(
+            args["zip"].is_string(),
+            "a string-typed param stays a string"
+        );
+        assert_eq!(args["n"], 2134);
+    }
+
+    #[test]
+    fn qwen3_coder_string_typed_true_stays_string() {
+        let output = qwen_block("f", &[("flag", "true"), ("exp", "1e5")]);
+        let schema = serde_json::json!({
+            "type": "object",
+            "properties": {"flag": {"type": "string"}, "exp": {"type": "string"}}
+        });
+        let tools = vec![m3_tool("f", schema)];
+        let args = xml_args(&try_qwen3_coder(&output, Some(&tools)).unwrap(), 0);
+        assert_eq!(args["flag"], "true");
+        assert!(args["flag"].is_string());
+        assert_eq!(args["exp"], "1e5");
+        assert!(args["exp"].is_string());
+    }
+
+    #[test]
+    fn qwen3_coder_integer_typed_accepts_zero_fraction_float() {
+        let output = qwen_block("f", &[("n", "5.0")]);
+        let tools = vec![m3_tool("f", zip_and_count_schema())];
+        let args = xml_args(&try_qwen3_coder(&output, Some(&tools)).unwrap(), 0);
+        assert_eq!(args["n"], 5);
+        assert!(args["n"].is_i64(), "an integer-typed 5.0 is the integer 5");
+    }
+
+    #[test]
+    fn qwen3_coder_integer_typed_keeps_fractional_value_as_number() {
+        // A value that does not fit its declared type is not a reason to drop
+        // the call: it falls back to the loose rules and stays a number.
+        let output = qwen_block("f", &[("n", "5.5")]);
+        let tools = vec![m3_tool("f", zip_and_count_schema())];
+        let result = try_qwen3_coder(&output, Some(&tools)).unwrap();
+        assert_eq!(result.tool_calls.len(), 1);
+        assert_eq!(xml_args(&result, 0)["n"], 5.5);
+    }
+
+    #[test]
+    fn qwen3_coder_number_typed_keeps_written_form() {
+        // `number` accepts both spellings, so neither is rewritten.
+        let output = qwen_block("f", &[("a", "5"), ("b", "5.0")]);
+        let schema = serde_json::json!({
+            "type": "object",
+            "properties": {"a": {"type": "number"}, "b": {"type": "number"}}
+        });
+        let tools = vec![m3_tool("f", schema)];
+        let args = xml_args(&try_qwen3_coder(&output, Some(&tools)).unwrap(), 0);
+        assert_eq!(args["a"], 5);
+        assert!(args["a"].is_i64());
+        assert_eq!(args["b"], 5.0);
+        assert!(args["b"].is_f64());
+    }
+
+    #[test]
+    fn qwen3_coder_object_typed_invalid_json_falls_back_to_string() {
+        let output = qwen_block("f", &[("cfg", "{not json")]);
+        let schema = serde_json::json!({
+            "type": "object",
+            "properties": {"cfg": {"type": "object"}}
+        });
+        let tools = vec![m3_tool("f", schema)];
+        let result = try_qwen3_coder(&output, Some(&tools)).unwrap();
+        assert_eq!(result.tool_calls.len(), 1, "the call must survive");
+        assert_eq!(xml_args(&result, 0)["cfg"], "{not json");
+    }
+
+    #[test]
+    fn qwen3_coder_object_typed_valid_json_parses() {
+        let output = qwen_block("f", &[("cfg", r#"{"a": 1}"#)]);
+        let schema = serde_json::json!({
+            "type": "object",
+            "properties": {"cfg": {"type": "object"}}
+        });
+        let tools = vec![m3_tool("f", schema)];
+        let args = xml_args(&try_qwen3_coder(&output, Some(&tools)).unwrap(), 0);
+        assert_eq!(args["cfg"], serde_json::json!({"a": 1}));
+    }
+
+    #[test]
+    fn qwen3_coder_without_schema_uses_loose_rules() {
+        // A tool registered without `parameters` keeps the schema-free
+        // behaviour: numbers and booleans are guessed, `null` is null, and a
+        // word that is neither stays the string the model wrote.
+        let output = qwen_block(
+            "f",
+            &[
+                ("n", "5"),
+                ("flag", "true"),
+                ("val", "null"),
+                ("word", "yes"),
+                ("list", "[1, 2]"),
+                ("text", "plain words"),
+            ],
+        );
+        let tools = vec![schemaless_tool("f")];
+        for tools in [None, Some(tools.as_slice())] {
+            let args = xml_args(&try_qwen3_coder(&output, tools).unwrap(), 0);
+            assert_eq!(args["n"], 5);
+            assert_eq!(args["flag"], true);
+            assert_eq!(args["val"], serde_json::Value::Null);
+            assert_eq!(args["word"], "yes", "`yes` has no schema basis for true");
+            assert_eq!(args["list"], serde_json::json!([1, 2]));
+            assert_eq!(args["text"], "plain words");
+        }
+    }
+
+    #[test]
+    fn xml_null_literal_is_null_under_any_schema() {
+        // The XML grammars spell a JSON null only as the bare word, so it wins
+        // over the declared type in both parsers.
+        let schema = serde_json::json!({
+            "type": "object",
+            "properties": {"val": {"type": "string"}}
+        });
+        let tools = vec![m3_tool("f", schema)];
+        let qwen = try_qwen3_coder(&qwen_block("f", &[("val", "NULL")]), Some(&tools)).unwrap();
+        assert_eq!(xml_args(&qwen, 0)["val"], serde_json::Value::Null);
+        let m2 = try_minimax_m2(&m2_block("f", &[("val", "null")]), Some(&tools)).unwrap();
+        assert_eq!(xml_args(&m2, 0)["val"], serde_json::Value::Null);
+    }
+
+    #[test]
+    fn minimax_m2_string_typed_param_keeps_numeric_text() {
+        let output = m2_block("f", &[("zip", "02134"), ("n", "02134")]);
+        let tools = vec![m3_tool("f", zip_and_count_schema())];
+        let args = xml_args(&try_minimax_m2(&output, Some(&tools)).unwrap(), 0);
+        assert_eq!(args["zip"], "02134");
+        assert!(args["zip"].is_string());
+        assert_eq!(args["n"], 2134);
+    }
+
+    #[test]
+    fn minimax_m2_integer_typed_accepts_zero_fraction_float() {
+        let output = m2_block("f", &[("n", "5.0")]);
+        let tools = vec![m3_tool("f", zip_and_count_schema())];
+        let args = xml_args(&try_minimax_m2(&output, Some(&tools)).unwrap(), 0);
+        assert_eq!(args["n"], 5);
+        assert!(args["n"].is_i64());
+    }
+
+    #[test]
+    fn xml_parsers_ignore_a_schema_for_a_different_function() {
+        // The schema is looked up by the called function's name; an unrelated
+        // tool in the request must not type this call's parameters.
+        let output = qwen_block("f", &[("zip", "02134")]);
+        let tools = vec![m3_tool("other", zip_and_count_schema())];
+        let args = xml_args(&try_qwen3_coder(&output, Some(&tools)).unwrap(), 0);
+        assert_eq!(
+            args["zip"], 2134,
+            "no schema for `f`, so the loose rules run"
+        );
+    }
+
+    #[test]
+    fn minimax_m3_integer_typed_accepts_zero_fraction_float() {
+        let output = m3_block(&[("f", &m3_el("n", "5.0"))]);
+        let schema = serde_json::json!({
+            "type": "object",
+            "properties": {"n": {"type": "integer"}}
+        });
+        let tools = vec![m3_tool("f", schema)];
+        let args = m3_args(&try_minimax_m3(&output, Some(&tools)).unwrap(), 0);
+        assert_eq!(args["n"], 5);
+        assert!(args["n"].is_i64());
+    }
+
+    #[test]
+    fn minimax_m3_number_typed_keeps_written_form() {
+        let body = format!("{}{}", m3_el("a", "5"), m3_el("b", "5.0"));
+        let output = m3_block(&[("f", &body)]);
+        let schema = serde_json::json!({
+            "type": "object",
+            "properties": {"a": {"type": "number"}, "b": {"type": "num"}}
+        });
+        let tools = vec![m3_tool("f", schema)];
+        let args = m3_args(&try_minimax_m3(&output, Some(&tools)).unwrap(), 0);
+        assert_eq!(args["a"], 5);
+        assert!(args["a"].is_i64());
+        assert_eq!(args["b"], 5.0);
+        assert!(args["b"].is_f64());
+    }
+
+    #[test]
+    fn glm47_integer_typed_accepts_zero_fraction_float() {
+        let output = glm_block("f", &[("n", "5.0"), ("s", "5.0")]);
+        let schema = serde_json::json!({
+            "type": "object",
+            "properties": {"n": {"type": "integer"}, "s": {"type": "string"}}
+        });
+        let tools = vec![m3_tool("f", schema)];
+        let args = kv_args(&try_glm47(&output, Some(&tools)).unwrap(), 0);
+        assert_eq!(args["n"], 5);
+        assert!(args["n"].is_i64());
+        assert_eq!(args["s"], "5.0", "a string-typed value is still untouched");
+    }
+
+    #[test]
+    fn longcat_integer_typed_accepts_zero_fraction_float() {
+        let output = longcat_block("f", &[("n", "5.0"), ("m", "5.5")]);
+        let schema = serde_json::json!({
+            "type": "object",
+            "properties": {"n": {"type": "integer"}, "m": {"type": "integer"}}
+        });
+        let tools = vec![m3_tool("f", schema)];
+        let args = kv_args(&try_longcat(&output, Some(&tools)).unwrap(), 0);
+        assert_eq!(args["n"], 5);
+        assert_eq!(args["m"], 5.5, "a fractional value stays a number");
+    }
+
+    #[test]
+    fn integer_literal_rule_declines_beyond_exact_float_range() {
+        // Past 2^53 an f64 no longer carries every integer, so the float arm
+        // declines rather than round; the loose fallback keeps it a number.
+        assert_eq!(
+            parse_integer_literal("9007199254740992.0"),
+            Some(serde_json::json!(9_007_199_254_740_992_i64))
+        );
+        assert_eq!(parse_integer_literal("9007199254740994.0"), None);
+        assert_eq!(parse_integer_literal("inf"), None);
+        assert_eq!(parse_integer_literal("nan"), None);
+        assert_eq!(
+            parse_integer_literal("1e5"),
+            Some(serde_json::json!(100_000))
+        );
+        assert_eq!(parse_integer_literal("abc"), None);
+        // A u64 literal past i64::MAX still parses exactly.
+        assert_eq!(
+            parse_integer_literal("18446744073709551615"),
+            Some(serde_json::json!(18_446_744_073_709_551_615_u64))
+        );
     }
 }

--- a/src/server/tool_calls/parser.rs
+++ b/src/server/tool_calls/parser.rs
@@ -225,6 +225,31 @@ fn post_close_whitespace<'a>(raw: &'a str, close: &str) -> &'a str {
     &rest[..rest.len() - rest.trim_start().len()]
 }
 
+/// One entry of the ordered format table [`parse_tool_calls`] walks.
+///
+/// Most format parsers read only the generated text. The two XML grammars that
+/// spell an argument's type nowhere in their markup (MiniMax M2 and
+/// Qwen3-Coder) also need the request's `tools` to type each value by its
+/// declared schema, so the table carries both shapes rather than being an array
+/// of one `fn(&str)` pointer type. The variant says only which arguments an
+/// entry takes; dispatch is still the table order, top to bottom, and moving a
+/// parser between the variants does not move it in that order.
+enum FormatParser {
+    /// Parses the text alone.
+    Plain(fn(&str) -> Option<ToolCallParseResult>),
+    /// Parses the text against the request's tool schemas.
+    WithTools(fn(&str, Option<&[Tool]>) -> Option<ToolCallParseResult>),
+}
+
+impl FormatParser {
+    fn run(&self, text: &str, tools: Option<&[Tool]>) -> Option<ToolCallParseResult> {
+        match self {
+            Self::Plain(parse) => parse(text),
+            Self::WithTools(parse) => parse(text, tools),
+        }
+    }
+}
+
 /// Parse model output for tool calls, trying each known format in order.
 ///
 /// `tools` is the set of tools that were passed in the request.  When
@@ -276,16 +301,14 @@ pub fn parse_tool_calls(raw_output: &str, tools: Option<&[Tool]>) -> ToolCallPar
         }
     }
 
-    // MiniMax M3 (namespaced XML). Handled ahead of the marker loop below for two
-    // reasons: it is the only parser that needs the request tool schema (for
-    // schema-aware value coercion), and its embedded `<invoke name=` / `<tool_call>`
-    // substrings would otherwise be claimed by the generic marker parsers
-    // (`try_minimax_m2`, `try_hermes`) that run in the loop. Its `]<]minimax[>[`
-    // namespace token is highly distinctive, so it declines (returns `None`)
-    // cleanly on any non-M3 output, and this placement keeps it before the
-    // generic JSON parsers (`try_llama3` / `try_generic_json`). When its calls
-    // filter down to empty, execution falls through to the loop just like a
-    // declined parser.
+    // MiniMax M3 (namespaced XML). Handled ahead of the marker loop below because
+    // its embedded `<invoke name=` / `<tool_call>` substrings would otherwise be
+    // claimed by the generic marker parsers (`try_minimax_m2`, `try_hermes`) that
+    // run in the loop. Its `]<]minimax[>[` namespace token is highly distinctive,
+    // so it declines (returns `None`) cleanly on any non-M3 output, and this
+    // placement keeps it before the generic JSON parsers (`try_llama3` /
+    // `try_generic_json`). When its calls filter down to empty, execution falls
+    // through to the loop just like a declined parser.
     if let Some(mut result) = formats::try_minimax_m3(text, tools) {
         if let Some(tools) = tools {
             result.tool_calls = filter_by_tools(result.tool_calls, tools);
@@ -299,14 +322,14 @@ pub fn parse_tool_calls(raw_output: &str, tools: Option<&[Tool]>) -> ToolCallPar
     // LongCat-Flash emit tool calls in an XML-ish key/value grammar:
     // `NAME<arg_key>KEY</arg_key><arg_value>VALUE</arg_value>`. Both need the
     // request tool schema for schema-aware value coercion (a `string`-typed
-    // parameter keeps its raw text), so like try_minimax_m3 they run here ahead of
-    // the marker loop rather than inside the `fn(&str)` array. GLM shares the
-    // `<tool_call>` block tags with Hermes; try_glm47 declines cleanly on a bare
-    // `{name, arguments}` JSON body so it falls through to try_hermes in the loop
-    // below (a Hermes call is never misrouted to GLM), while the non-JSON
-    // key/value grammar is claimed here before Hermes sees it. When calls filter
-    // down to empty, execution falls through to the loop just like a declined
-    // parser.
+    // parameter keeps its raw text), and like try_minimax_m3 they run here ahead
+    // of the marker loop so the loop's generic parsers cannot claim them first.
+    // GLM shares the `<tool_call>` block tags with Hermes; try_glm47 declines
+    // cleanly on a bare `{name, arguments}` JSON body so it falls through to
+    // try_hermes in the loop below (a Hermes call is never misrouted to GLM),
+    // while the non-JSON key/value grammar is claimed here before Hermes sees
+    // it. When calls filter down to empty, execution falls through to the loop
+    // just like a declined parser.
     if let Some(mut result) = formats::try_glm47(text, tools) {
         if let Some(tools) = tools {
             result.tool_calls = filter_by_tools(result.tool_calls, tools);
@@ -326,29 +349,30 @@ pub fn parse_tool_calls(raw_output: &str, tools: Option<&[Tool]>) -> ToolCallPar
     }
 
     // Try each format in order of specificity (most distinctive markers first)
-    let parsers: &[fn(&str) -> Option<ToolCallParseResult>] = &[
-        formats::try_granite, // <response><tool_call> — more specific than bare Hermes
-        formats::try_gemma4,  // <|tool_call>call:... — pipe-delimited, before Hermes
-        formats::try_function_gemma, // <start_function_call>call:... (distinct markers from Gemma 4)
-        formats::try_hermes,         // <tool_call> — Hermes/Qwen/DeepSeek
-        formats::try_minimax_m2, // <invoke name=...><parameter name=...>...</parameter></invoke>
-        formats::try_kimi_k2,    // <|tool_calls_section_begin|>...<|tool_calls_section_end|>
+    use FormatParser::{Plain, WithTools};
+    let parsers: &[FormatParser] = &[
+        Plain(formats::try_granite), // <response><tool_call> — more specific than bare Hermes
+        Plain(formats::try_gemma4),  // <|tool_call>call:... — pipe-delimited, before Hermes
+        Plain(formats::try_function_gemma), // <start_function_call>call:... (distinct markers from Gemma 4)
+        Plain(formats::try_hermes),         // <tool_call> — Hermes/Qwen/DeepSeek
+        WithTools(formats::try_minimax_m2), // <invoke name=...><parameter name=...>...</parameter></invoke>
+        Plain(formats::try_kimi_k2), // <|tool_calls_section_begin|>...<|tool_calls_section_end|>
         // [TOOL_CALLS]NAME[ARGS]{json}; declines (returns None) without [ARGS], so the
         // older JSON-array format below still falls through to try_mistral_nemo.
-        formats::try_mistral_bracket,
-        formats::try_mistral_nemo,    // [TOOL_CALLS]
-        formats::try_functionary_v31, // <function=name>{json}
-        formats::try_qwen3_coder, // <function=name><parameter=key>val</parameter> (after v31, which declines non-JSON bodies)
-        formats::try_functionary_v32, // >>>name\n
+        Plain(formats::try_mistral_bracket),
+        Plain(formats::try_mistral_nemo),    // [TOOL_CALLS]
+        Plain(formats::try_functionary_v31), // <function=name>{json}
+        WithTools(formats::try_qwen3_coder), // <function=name><parameter=key>val</parameter> (after v31, which declines non-JSON bodies)
+        Plain(formats::try_functionary_v32), // >>>name\n
         // <|tool_call_start|>[func(arg=value)]<|tool_call_end|> — pythonic, before generic JSON
-        formats::try_pythonic,
-        formats::try_llama3,       // {"name": ..., "parameters": ...}
-        formats::try_generic_json, // {"name": ..., "arguments": ...}
-        formats::try_command_r,    // Action: / Action Input: — least specific
+        Plain(formats::try_pythonic),
+        Plain(formats::try_llama3), // {"name": ..., "parameters": ...}
+        Plain(formats::try_generic_json), // {"name": ..., "arguments": ...}
+        Plain(formats::try_command_r), // Action: / Action Input: — least specific
     ];
 
     for parser in parsers {
-        if let Some(mut result) = parser(text) {
+        if let Some(mut result) = parser.run(text, tools) {
             // Filter tool calls to only those in the provided tool set
             if let Some(tools) = tools {
                 result.tool_calls = filter_by_tools(result.tool_calls, tools);
@@ -1241,6 +1265,72 @@ mod tests {
         let result = parse_tool_calls(output, Some(&tools));
         assert!(result.has_tool_calls());
         assert_eq!(arg_obj(&result.tool_calls[0])["location"], "Berlin");
+    }
+
+    #[test]
+    fn parse_qwen3_coder_passes_request_schema_to_parser() {
+        // End to end through the dispatcher: the request schema must reach the
+        // Qwen3-Coder parser, or a string-typed ZIP code loses its leading zero.
+        let output = "<tool_call><function=forecast><parameter=zip>02134</parameter><parameter=days>3</parameter></function></tool_call>";
+        let schema = serde_json::json!({
+            "type": "object",
+            "properties": {"zip": {"type": "string"}, "days": {"type": "integer"}},
+            "required": ["zip", "days"]
+        });
+        let tools = vec![make_tool_with_schema("forecast", schema)];
+        let result = parse_tool_calls(output, Some(&tools));
+        assert_eq!(
+            result.format,
+            Some(crate::server::tool_calls::ToolCallFormat::Qwen3Coder)
+        );
+        let args = arg_obj(&result.tool_calls[0]);
+        assert_eq!(args["zip"], "02134");
+        assert!(args["zip"].is_string());
+        assert_eq!(args["days"], 3);
+    }
+
+    #[test]
+    fn parse_minimax_m2_passes_request_schema_to_parser() {
+        let output =
+            "<invoke name=\"forecast\">\n<parameter name=\"zip\">02134</parameter>\n</invoke>";
+        let schema = serde_json::json!({
+            "type": "object",
+            "properties": {"zip": {"type": "string"}}
+        });
+        let tools = vec![make_tool_with_schema("forecast", schema)];
+        let result = parse_tool_calls(output, Some(&tools));
+        assert_eq!(
+            result.format,
+            Some(crate::server::tool_calls::ToolCallFormat::MinimaxM2)
+        );
+        assert_eq!(arg_obj(&result.tool_calls[0])["zip"], "02134");
+    }
+
+    #[test]
+    fn parse_qwen3_coder_still_runs_after_functionary_v31() {
+        // Threading `tools` through the table must not reorder it: a JSON body
+        // is still Functionary v3.1's, an XML body is still Qwen3-Coder's.
+        let schema = serde_json::json!({
+            "type": "object",
+            "properties": {"location": {"type": "string"}}
+        });
+        let tools = vec![make_tool_with_schema("get_weather", schema)];
+
+        let json_body = r#"<function=get_weather>{"location": "Paris"}</function>"#;
+        let functionary = parse_tool_calls(json_body, Some(&tools));
+        assert_eq!(
+            functionary.format,
+            Some(crate::server::tool_calls::ToolCallFormat::FunctionaryV31)
+        );
+        assert_eq!(arg_obj(&functionary.tool_calls[0])["location"], "Paris");
+
+        let xml_body = "<tool_call><function=get_weather><parameter=location>Paris</parameter></function></tool_call>";
+        let qwen = parse_tool_calls(xml_body, Some(&tools));
+        assert_eq!(
+            qwen.format,
+            Some(crate::server::tool_calls::ToolCallFormat::Qwen3Coder)
+        );
+        assert_eq!(arg_obj(&qwen.tool_calls[0])["location"], "Paris");
     }
 
     // -- namespace normalization tests -----------------------------------------

--- a/src/server/tool_calls/parser.rs
+++ b/src/server/tool_calls/parser.rs
@@ -351,10 +351,10 @@ pub fn parse_tool_calls(raw_output: &str, tools: Option<&[Tool]>) -> ToolCallPar
     // Try each format in order of specificity (most distinctive markers first)
     use FormatParser::{Plain, WithTools};
     let parsers: &[FormatParser] = &[
-        Plain(formats::try_granite), // <response><tool_call> — more specific than bare Hermes
-        Plain(formats::try_gemma4),  // <|tool_call>call:... — pipe-delimited, before Hermes
+        Plain(formats::try_granite), // <response><tool_call>: more specific than bare Hermes
+        Plain(formats::try_gemma4),  // <|tool_call>call:...: pipe-delimited, before Hermes
         Plain(formats::try_function_gemma), // <start_function_call>call:... (distinct markers from Gemma 4)
-        Plain(formats::try_hermes),         // <tool_call> — Hermes/Qwen/DeepSeek
+        Plain(formats::try_hermes),         // <tool_call>: Hermes/Qwen/DeepSeek
         WithTools(formats::try_minimax_m2), // <invoke name=...><parameter name=...>...</parameter></invoke>
         Plain(formats::try_kimi_k2), // <|tool_calls_section_begin|>...<|tool_calls_section_end|>
         // [TOOL_CALLS]NAME[ARGS]{json}; declines (returns None) without [ARGS], so the
@@ -368,7 +368,7 @@ pub fn parse_tool_calls(raw_output: &str, tools: Option<&[Tool]>) -> ToolCallPar
         Plain(formats::try_pythonic),
         Plain(formats::try_llama3), // {"name": ..., "parameters": ...}
         Plain(formats::try_generic_json), // {"name": ..., "arguments": ...}
-        Plain(formats::try_command_r), // Action: / Action Input: — least specific
+        Plain(formats::try_command_r), // Action: / Action Input: is the least specific
     ];
 
     for parser in parsers {


### PR DESCRIPTION
## Summary

The Qwen3-Coder (`<function=NAME><parameter=KEY>VALUE</parameter>`) and MiniMax M2 (`<invoke name><parameter name>`) tool-call parsers never received the request's `tools`, so they guessed each argument's JSON type from the raw text. A `string`-typed parameter whose value looked numeric or boolean was rewritten: `02134` became `2134`, `1e5` became `100000.0`, `true` became the boolean; an `integer`-typed parameter written as `5.0` came out as the float `5.0`. Both routes that parse a completion (non-streaming and end-of-stream) already hold the tool set, so the schema was available all along and only these two parsers could not reach it. They now type every value by its declared schema through the same helpers MiniMax M3, GLM-4.7 and LongCat already use, and every remaining lenient rule is grounded in a declared type rather than in the shape of the text.

## What changed

`src/server/tool_calls/formats.rs`: `try_qwen3_coder` and `try_minimax_m2` take `tools`, resolve the called function with `minimax_m3_function_schema`, and pass the per-parameter schema down through `extract_qwen_parameters` / `extract_minimax_parameters` to the new `coerce_xml_param`, which delegates to the shared `minimax_m3_coerce_leaf`. `coerce_minimax_param` is deleted.

`coerce_xml_param` keeps two rules ahead of the shared coercion, both requiring a declaration to apply. The bare word `null` in any casing is JSON null, because these grammars have no other spelling for one, except under a plain `string` declaration where the text is what the tool asked for (a query, a ref, a filename); a nullable `{"type": ["string", "null"]}` still takes the null. And a `boolean`-declared parameter accepts the words a strict JSON read rejects (`yes`, `on`, `1` and their negatives, plus any casing of `true`/`false`), which is the schema basis the old free-text guess never had. Without a declaration those same words stay the strings the model wrote, matching the three schema-aware grammars. A value that fits neither its declared type nor a JSON literal stays a string, so an unparseable argument still never drops the call.

`src/server/tool_calls/parser.rs`: the format table was an array of one `fn(&str)` pointer type, which is the reason the two parsers could not be handed `tools`. It is now an array of a small `FormatParser` enum (`Plain` / `WithTools`) in the same order as before, so dispatch order is unchanged: Functionary v3.1 still claims a JSON body ahead of Qwen3-Coder, and Qwen3-Coder still runs ahead of Functionary v3.2. Two stale comments in `parse_tool_calls` are corrected: MiniMax M3 is no longer "the only parser that needs the request tool schema", and the GLM/LongCat block no longer refers to an `fn(&str)` array that does not exist.

The shared `integer` arm now also accepts a literal written with a zero fraction (`5.0`, `-5.000`). The fraction is stripped textually and the integer part parsed exactly, rather than round-tripping through `f64`: a round trip rounds before any guard can inspect the result, which would turn `9007199254740991.5` into an integer and bring `9007199254740993.0` back off by one. Doing it as text is exact at every magnitude and keeps the exponent form out, which matters because `minimax_m3_typed_coerce` takes the first `anyOf` alternative that succeeds and `anyOf: [integer, string]` should still hand an identifier like `1e5` to the string alternative. Because the arm is shared, `integer`-typed `5.0` becomes `5` for MiniMax M3 too, and `coerce_kv_value` picks the same rule up for GLM-4.7 and LongCat; every other declared type in that key/value grammar keeps the loose fallback it has always used.

`minimax_m3_function_schema` now falls back to the bare name after the first `.` when an exact match misses, the same normalization `filter_by_tools` applies. Without it a model that namespaces its calls (`functions.get_weather`) missed the schema lookup, every value silently took the loose rules, and the call still succeeded, so the whole fix no-opped with nothing to show for it.

The `number` arm now tries an exact integer literal before the float parse, so a `number`-typed value keeps the form the model wrote (`5` stays `5`, `5.0` stays `5.0`). That arm is shared with MiniMax M3, so a `number`/`num`/`float`/`double` parameter written as an integer now serializes as `5` rather than `5.0`. JSON Schema accepts an integer as a `number`, and it removes a precision loss past 2^53 that the previous float-only arm had, but it is a visible change beyond what the issue asked for.

## Behavior table

| schema | raw | before | after |
|---|---|---|---|
| `{"type":"string"}` | `02134` | `2134` | `"02134"` |
| `{"type":"string"}` | `true` | `true` | `"true"` |
| `{"type":"string"}` | `1e5` | `100000.0` | `"1e5"` |
| `{"type":"string"}` | `null` | `null` | `"null"` |
| `{"type":["string","null"]}` | `null` | `null` | `null` |
| `{"type":"boolean"}` | `yes` / `on` / `TRUE` | `true` | `true` |
| `{"type":"integer"}` | `5.0` | `5.0` | `5` |
| `{"type":"integer"}` | `5.5` | `5.5` | `5.5` (loose fallback, call kept) |
| `{"type":"number"}` | `5` | `5` | `5` |
| `{"type":"object"}` | `{not json` | `"{not json"` | `"{not json"` |
| `{"anyOf":[integer,string]}` | `1e5` | `"1e5"` | `"1e5"` |
| none | `5` / `true` / `null` | `5` / `true` / `null` | unchanged |
| none | `yes` / `on` / `none` / `TRUE` | `true` / `true` / `null` / `true` | `"yes"` / `"on"` / `"none"` / `"TRUE"` |
| `functions.f` call, `{"type":"string"}` | `02134` | `2134` | `"02134"` |

One further no-schema difference: the fallback now runs a full JSON parse rather than only trying one when the text starts with `{` or `[`, so a schema-free value written as a JSON literal (`[1, 2]`, or a quoted string) is parsed as that literal. This is the behavior MiniMax M3, GLM-4.7 and LongCat already had, so the four grammars now agree.

## Test plan

- [x] `cargo test --profile test-fast --features metal,accelerate --lib server::tool_calls` (376 passed, 0 failed)
- [x] `cargo test --profile test-fast --features metal,accelerate --lib server::muse_atem` (11 passed, 0 failed)
- [x] `cargo test --profile test-fast --features metal,accelerate --lib server::routes::chat` (48 passed, 0 failed)
- [x] `cargo clippy --profile test-fast --lib --tests --features metal,accelerate -- -D warnings`
- [x] `cargo fmt --all -- --check`

26 new unit tests cover: string, integer, number, boolean, object, array and no-schema values in both XML grammars; the fractional-value fallback that keeps the call; the null rule across plain-string, nullable and schema-free declarations; the boolean words with and without a declaration; a namespaced call name; a request whose schema names a different function; the textual integer rule including both values an `f64` round trip gets wrong; the `anyOf: [integer, string]` exponent case; the shared integer rule reaching MiniMax M3, GLM-4.7 and LongCat; and the unchanged dispatcher order (JSON body to Functionary v3.1, XML body to Qwen3-Coder). The four cases the issue asked to keep green (`qwen3_coder_single_call_multiple_params_with_type_coercion`, `minimax_m2_numeric_params`, `minimax_m2_boolean_param`, `minimax_m2_null_param`) pass unchanged.

## Changes during review

Review of the first commit found five defects, four of them regressions the schema-driven path introduced against the guesses it replaced, all fixed in `f222376`: a `boolean`-declared `yes`/`on`/`TRUE` degraded to a string; the `null` shortcut overrode an explicit `string` declaration; the integer rule's `f64` round trip rounded a fractional value into an integer and returned an off-by-one past 2^53, and its exponent form let an `anyOf` integer alternative claim an identifier; and the schema lookup missed entirely for a namespaced call name. The `// Used by:` comments the repository's contributor guidelines require were also added to the five shared helpers whose caller set widened from three grammars to five.

Three findings were deliberately left for follow-ups rather than widened into this PR: `minimax_m3_typed_coerce` returns out of its `anyOf`/`oneOf` loop on the first key present (pre-existing); the `minimax_m3_` prefix on the now-shared helpers deserves a rename in its own `refactor:` PR; and an array-typed parameter carrying one bare scalar yields that scalar rather than a one-element array, which `xml_array_typed_bare_scalar_takes_the_item_type` documents as current behavior.

## Server sanity check (not run here, no checkpoint on this host)

This is parser-only work covered by unit tests, so no model was loaded. To confirm end to end against a Qwen3-Coder export that emits the `<function=...><parameter=...>` grammar:

```
./target/release/mlxcel-server -m models/<qwen3-coder-dir> --port 8080
curl -s localhost:8080/v1/chat/completions -H 'content-type: application/json' -d '{
  "model": "x", "messages": [{"role": "user", "content": "Look up the forecast for ZIP code 02134 for the next 3 days using the tool."}],
  "tools": [{"type": "function", "function": {"name": "forecast", "parameters": {"type": "object",
    "properties": {"zip": {"type": "string"}, "days": {"type": "integer"}}, "required": ["zip", "days"]}}}]}'
```

Expected: `choices[0].message.tool_calls[0].function.arguments` parses to `{"zip": "02134", "days": 3}`, with `zip` a JSON string (leading zero intact) and `days` a JSON integer. Repeating the request with `"stream": true` gives the same arguments in the final tool-call delta, since both routes call `parse_tool_calls(text, tools)`.

Closes #1336
