### PR TITLE
fix(lora): refuse adapters that do not map onto the model

### DIFF
--- a/TECHNICAL_REPORTS/1576-lora-adapter-tensor-validation-20260902.en.md
+++ b/TECHNICAL_REPORTS/1576-lora-adapter-tensor-validation-20260902.en.md
@@ -1,0 +1,378 @@
+# Technical Report: PR #1576 - fix(lora): refuse adapters that do not map onto the model
+
+**Date**: 2026-09-02
+**Author**: mlxcel maintainers
+**Reviewer**: n/a
+**Status**: Completed
+**Languages**: Rust
+**Risk Level**: Medium
+
+---
+
+## Executive Summary
+
+LoRA adapter loading silently discarded every tensor it could not apply, so an adapter trained for a different architecture, a renamed projection, or a DoRA checkpoint produced a running server that answered from unmodified base weights while its startup log reported the adapter as fused. This PR validates every adapter tensor against the base weight map before the first write, reports every offender in one error, replaces the fabricated "fused into N layers" count with the number of pairs actually applied, and refuses DoRA by name. The fused path, the pipeline-parallel stage path, and the unfused runtime serving path now share one validator.
+
+---
+
+## 1. Problem Statement
+
+### 1.1 Background
+
+`mlxcel-server --adapter <dir>` and `mlxcel generate --adapter <dir>` fuse a LoRA adapter into the base weight map before model construction. The fusion loop grouped adapter tensors by their `.lora_a` / `.lora_b` stem, resolved each stem to a base weight key, and added `scale * (B @ A)` into that key. Every step of that resolution was best-effort.
+
+### 1.2 Existing Issues
+
+- **Missing base weight was a warning.** `find_base_weight_name` never failed: when none of its three candidates existed in the checkpoint it returned `"{name}.weight"` anyway, "the most likely candidate". The fusion loop then looked that key up, missed, logged `tracing::warn!("Base weight not found for LoRA layer ...")`, and continued. An adapter with 84 pairs against a model that has none of them fused nothing and still loaded.
+- **Unrecognised tensors were discarded.** Anything that did not end in `.lora_a` or `.lora_b` was skipped by a comment that read `// Ignore other weights (like scales for DoRA)`. A DoRA magnitude vector, a stray `.weight`, and the HuggingFace PEFT `.lora_A.weight` spelling this build does not read all vanished at that line.
+- **The reported count was fabricated.** `apply_lora_adapters` and `apply_stage_lora_adapter` both computed `modified_count` by counting `.lora_a` keys in the adapter file and logged it as `Fused LoRA adapters into N layers`. The number was the adapter's own size, entirely independent of how many pairs survived to reach `mlxcel_core::add`.
+- **DoRA was accepted as LoRA.** `AdapterConfig::is_lora()` returned true for `FineTuneType::DoRA`, so a DoRA adapter passed the type gate and had its low-rank pair applied without the per-output-row magnitude vectors its own tooling folds in.
+- **The unfused runtime path had the same three defects.** `stage_runtime_adapters`, the default channel for the b10621 `--lora` spellings since #1439, carried an identical `warn!`-and-continue block with a source comment stating that #1328 owned making both paths strict.
+
+Measured on the pre-change `target/release/mlxcel` against local checkpoints: `models/mlx/qwen2.5-0.5b-bf16` with a copy of `models/lora-dense-test` whose `model.layers.0.self_attn.q_proj.lora_a` had been renamed to `...lora_a.bogus` loaded, fused 71 of 72 pairs, and generated normally. The same base with the same adapter declared `"fine_tune_type": "dora"` also loaded and generated.
+
+### 1.3 Risk Assessment
+
+| Risk | Impact | Likelihood |
+|------|--------|------------|
+| Serving base weights under an adapter's name, with no error anywhere | High | High for any adapter/checkpoint mismatch |
+| Partially applied adapter (some layers fused, some skipped) | High | High for a layer-count mismatch |
+| DoRA applied as LoRA, producing weights that match neither base nor fine-tune | Medium | Medium, gated on DoRA adapter availability |
+| Operator trusting a fused-layer count that never described reality | Medium | Certain whenever any tensor was skipped |
+
+---
+
+## 2. Technical Review
+
+### 2.1 Security
+
+Not a security change. The failure class is a silent correctness fault, not an exposure. One adjacent property does improve: an adapter directory is now fully described by the error it produces, so an operator can no longer be misled into believing a fine-tune is in effect when it is not.
+
+**Checklist:**
+- [x] Input validation (adapter tensor names and base-weight resolution are now checked, not assumed)
+- [ ] Authentication/Authorization (not applicable)
+- [ ] Data encryption (not applicable)
+- [x] Logging (the fused count is now a measured value; no sensitive data is logged)
+
+### 2.2 Performance
+
+No measurable effect. Validation walks the adapter's tensor names once, which is bounded by the adapter file size (hundreds of keys), and the work it does was already being done inline in the fusion loop. Nothing changes in the MLX call sequence for a valid adapter, so decode throughput and load time are unaffected.
+
+### 2.3 Compatibility & Dependencies
+
+- **Breaking Changes**: yes, deliberately. Adapters that used to load while applying nothing, or applying only part of themselves, now fail the load. This is the point of the change. Three public signatures changed: `fuse_lora_weights_into` returns `Result<usize>` instead of `Result<()>`, `apply_stage_lora_adapter` returns `Result<usize>` instead of `Result<()>`, and `AdapterConfig::is_lora()` is replaced by `AdapterConfig::is_fusable_lora()`. `fuse_lora_weights` and `apply_lora_adapters` keep their signatures.
+- **New Dependencies**: none.
+- **Compatibility**: mlx-lm adapters (`<layer>.lora_a` / `<layer>.lora_b`) and HuggingFace PEFT `<layer>.base_layer` naming both still resolve. The PEFT `lora_A.weight` / `lora_B.weight` spelling was never read by this code and now fails loudly instead of loading as a no-op.
+
+### 2.4 Code Quality
+
+- **Test Coverage**: the `lora` module gained 14 tests (11 in `loader_tests.rs`, 4 in the new `runtime_tests.rs`, 1 in `config.rs`, offset by the two stage-path tests added in `partial_loading_adapter_tests.rs`). The `--lib lora` selector goes from 47 to 61 passing tests.
+- **Code Complexity**: `fuse_lora_weights_into` shrank. Its pairing, resolution, and skip handling moved into `validate_adapter_tensors`, leaving a loop that only computes and adds deltas.
+- **Technical Debt**: decreased. The runtime path's `// #1328 owns making both strict` marker is discharged, and the two paths now share one definition of what a valid adapter tensor is instead of two drifting copies.
+
+---
+
+## 3. Technical Decisions
+
+### 3.1 Collect every violation instead of failing on the first
+
+**Context:**
+An adapter built for the wrong architecture does not have one bad tensor; it has one bad tensor per layer per target module. A 28-layer adapter against a 24-layer model has 12 unmapped pairs, and a genuinely foreign adapter has all of them.
+
+**Alternatives Considered:**
+
+| Option | Pros | Cons |
+|--------|------|------|
+| Fail on the first offender | Simplest code, shortest error | Needs one load attempt per offending layer to learn the extent of the mismatch; each attempt reloads the whole checkpoint |
+| Warn on all, fail if none applied | Keeps partial adapters working | Preserves the exact defect: a partially applied adapter is the dangerous case, not the fully unmapped one |
+| **Chosen: collect all, fail once** | One load attempt gives the complete picture; the offender list distinguishes "wrong architecture" from "one renamed tensor" at a glance | Longer error text for a fully foreign adapter |
+
+**Rationale:**
+The diagnostic value is in the shape of the offender list. Twelve consecutive layer indices at the tail says "the adapter has more layers than the model"; one line says "somebody renamed a tensor"; every layer says "wrong architecture entirely". A first-failure error cannot convey any of that.
+
+**Trade-offs:**
+A foreign adapter produces a long error. Accepted: the alternative is a short error that requires repeated whole-checkpoint loads to expand.
+
+### 3.2 Remove the `find_base_weight_name` fallback rather than check the result at the call site
+
+**Context:**
+`find_base_weight_name` returned `Result<String>` but could not fail. When no candidate matched it returned the first candidate anyway, and both callers followed it with a `contains_key` check and a warning.
+
+**Alternatives Considered:**
+
+| Option | Pros | Cons |
+|--------|------|------|
+| Keep the fallback, make the callers bail instead of warn | Smallest diff | The function still reports a key it knows does not exist, and the next caller repeats the mistake |
+| **Chosen: return `Option<String>`, drop the fallback** | "Resolved" and "exists" become the same answer; the type makes the check unskippable | Touches every caller, including the runtime path |
+
+**Rationale:**
+The fallback is the root cause, not the symptom. A function that answers "here is the key, it may or may not be there" invites exactly the `warn!`-and-continue the issue is about, and it invited it twice independently. Making the absence a `None` moves the decision to the type system.
+
+**Trade-offs:**
+The runtime path had to change in the same PR because it shared the function. That turned out to be the right scope anyway (see 3.4).
+
+### 3.3 Zero applied pairs is an error on the whole-model path only
+
+**Context:**
+An adapter that applies nothing is exactly the failure this PR exists to report. But a pipeline-parallel stage that owns layers 16 to 31 legitimately applies nothing when the adapter targets layers 0 to 15.
+
+**Alternatives Considered:**
+
+| Option | Pros | Cons |
+|--------|------|------|
+| Error on zero everywhere | Uniform rule | Breaks every valid partial-layer adapter under pipeline parallelism |
+| Never error on zero | No false positives | An empty adapter file loads silently, which is the defect again |
+| **Chosen: error on the whole-model path, return the count on the stage path** | Both cases are correct | The rule has to be documented where a future reader would otherwise "fix" the asymmetry |
+
+**Rationale:**
+The whole-model path sees the entire adapter and the entire checkpoint, so zero is unambiguous. A stage sees a filtered slice of both and cannot distinguish "this adapter is wrong" from "this adapter is not mine". The stage returns the count so its caller has the number, and `src/distributed/pipeline/stage_executor/llama.rs` carries a comment stating why the check is absent there.
+
+**Trade-offs:**
+A pipeline-parallel run where *no* stage applies anything is still not detected. Catching that needs cross-stage coordination and is left as future work (section 8).
+
+### 3.4 Extend the same validator to the unfused runtime path
+
+**Context:**
+The issue's "Out of scope" section names runtime LoRA, but it was written before #1439 landed `stage_runtime_adapters`, and that function carries the comment `Unmatched tensors warn with the same posture as the fused path (#1328 owns making both strict)`.
+
+**Alternatives Considered:**
+
+| Option | Pros | Cons |
+|--------|------|------|
+| Fused path only, minimal edit to the runtime path for the `Option` signature | Smallest scope | Leaves the identical defect on the channel that `--lora` selects by default; ships a fix whose acceptance criterion "DoRA adapters are refused" is only half true |
+| **Chosen: share `validate_adapter_tensors` and `reject_unsupported_fine_tune_type`** | One definition of a valid adapter; discharges the marker the tree already left | Larger diff than the issue body implies |
+
+**Rationale:**
+The runtime path had to be edited regardless because it called `find_base_weight_name`. Given that, leaving it lenient would ship a fix that does not hold on the default server channel, and would leave two copies of the pairing logic to drift.
+
+**Trade-offs:**
+`stage_runtime_adapters` gained a zero-staged check that `RuntimeLoraSet` route tests do not exercise; it is covered by the new `runtime_tests.rs` instead.
+
+---
+
+## 4. Implementation Details
+
+### 4.1 Architecture Changes
+
+```
+[Before]
+apply_lora_adapters ─┐
+                     ├─> fuse_lora_weights_into ─> pair inline ─> warn+skip ─> add
+apply_stage_lora_adapter ┘                                  ^
+                                                            └── find_base_weight_name (never fails)
+stage_runtime_adapters ──> pair inline ──> warn+skip ──> stage term
+
+[After]
+apply_lora_adapters ─┐
+                     ├─> fuse_lora_weights_into ─┐
+apply_stage_lora_adapter ┘                       ├─> validate_adapter_tensors ─> Vec<FusablePair> | one error
+                                                 │        ^
+stage_runtime_adapters ──────────────────────────┘        └── find_base_weight_name -> Option<String>
+```
+
+### 4.2 Key Code Changes
+
+**File: `src/lora/loader.rs`**
+
+```rust
+// Before
+let base_weight_name = find_base_weight_name(&base_name, base_weights)?;
+let Some(base_weight) = base_weights.get(&base_weight_name) else {
+    tracing::warn!("Base weight not found for LoRA layer {}: tried {}", base_name, base_weight_name);
+    continue;
+};
+
+// After
+let pairs = validate_adapter_tensors(base_weights, adapter_weights)?;
+```
+
+**Reason for change:** the resolution and the existence check are one decision, taken for the whole adapter before any write, so a failure names every offender and leaves `base_weights` untouched.
+
+**File: `src/lora/loader.rs`**
+
+```rust
+// After
+if !violations.is_empty() {
+    violations.sort();
+    let count = violations.len();
+    let noun = if count == 1 { "tensor" } else { "tensors" };
+    anyhow::bail!(
+        "{count} adapter {noun} cannot be applied to this model:\n  {}\n\
+         Every tensor in a fusable adapter has to be one half of a <layer>.lora_a / \
+         <layer>.lora_b pair whose base weight this checkpoint holds; skipping the rest \
+         would serve weights that match neither the base model nor the fine-tune.",
+        violations.join("\n  "),
+    );
+}
+```
+
+**Reason for change:** `WeightMap` is a `HashMap`, so an unsorted report would reorder between runs and make the error untestable and hard to diff. The returned `Vec<FusablePair>` is sorted by base weight key for the same reason.
+
+**File: `src/lora/config.rs`**
+
+```rust
+// Before
+pub fn is_lora(&self) -> bool {
+    matches!(self.fine_tune_type, FineTuneType::LoRA | FineTuneType::DoRA)
+}
+
+// After
+pub fn is_fusable_lora(&self) -> bool {
+    self.fine_tune_type == FineTuneType::LoRA
+}
+```
+
+**Reason for change:** the old name asserted something the body did not deliver, and every one of its three call sites used it as a "can I apply this?" gate. Renaming it removes the trap rather than patching the callers.
+
+### 4.3 Data Model Changes
+
+None. No on-disk format, config schema, or wire format changes.
+
+---
+
+## 5. Learning Points
+
+### 5.1 A resolver that cannot fail pushes the failure to every caller
+
+**Concept:**
+When a lookup helper returns a best guess instead of an absence, its return type stops carrying the information the caller needs. Every caller then has to re-derive "did this actually resolve?" and each one can get it wrong independently.
+
+**Application in this PR:**
+`find_base_weight_name` returned `Result<String>` and ended with `Ok(format!("{}.weight", lora_name))` when nothing matched. Both of its callers followed it with a `contains_key` check and a `tracing::warn!`, and both chose to continue. Changing the signature to `Option<String>` made the absence unrepresentable as a success and collapsed two divergent handlings into one.
+
+**Common Use Cases:**
+- Name or path resolvers that fall back to a "default" candidate
+- Config lookups that substitute a default instead of reporting the key as unset
+- Any `Result` whose body has no `Err` arm reachable from the failure it is supposed to describe
+
+**Example Code:**
+```rust
+// The shape to avoid: the Ok value may or may not exist.
+fn resolve(name: &str, map: &Map) -> Result<String> {
+    for c in candidates(name) { if map.contains_key(&c) { return Ok(c); } }
+    Ok(format!("{name}.weight")) // "most likely candidate"
+}
+
+// The shape that forces the caller to decide once.
+fn resolve(name: &str, map: &Map) -> Option<String> {
+    candidates(name).into_iter().find(|c| map.contains_key(c))
+}
+```
+
+### 5.2 A count derived from the input is not a report about the output
+
+**Concept:**
+Logging "processed N items" where N came from measuring the input, not from counting completed work, produces a log line that is correct exactly when nothing went wrong and misleading exactly when something did.
+
+**Application in this PR:**
+`modified_count` counted `.lora_a` keys in the adapter file. It matched reality only when every pair fused, which is the case where nobody reads the log. On every skip it overstated, which is the case where somebody does.
+
+**Common Use Cases:**
+- Batch processors reporting the batch size instead of the success count
+- Migration tools reporting the number of files found instead of the number applied
+- Any "N items" log written before the loop that produces them
+
+### 5.3 Adapter fusion and quantized checkpoints
+
+**Concept:**
+A 4-bit MLX checkpoint stores a projection's `.weight` as packed `uint32` with a separate `.scales` / `.biases` plane. A LoRA delta is a dense float matrix in `[out_features, in_features]`.
+
+**Application in this PR:**
+Establishing an honest smoke plan surfaced that the fused `--adapter` path cannot be exercised on a quantized checkpoint at all: `models/mlx/qwen3-0.6b-4bit` stores `q_proj.weight` as `[2048, 128]` `U32` while the delta is `[2048, 1024]`, so the pre-existing shape guard fires before this PR's validation is even reached. The unfused runtime path handles this correctly, because `validate_pair_shapes` pins `in_features` through the scales plane's group count rather than the packed width. This is not changed by this PR; it is recorded so the next person planning an adapter smoke test picks a bf16 checkpoint for the fused path and a quantized one for `--lora`.
+
+---
+
+## 6. Further Learning
+
+### Key Terms
+
+| Keyword | Description | Relevance |
+|---------|-------------|-----------|
+| `LoRA` | Low-rank adaptation: a frozen base weight plus `scale * B @ A` | The delta this code applies |
+| `DoRA` | Weight-decomposed LoRA: the low-rank pair plus a per-output-row magnitude vector | Accepted as LoRA before this PR, refused after |
+| `fusion` | Adding the delta into the base weight at load, before model construction | The path `--adapter` and `--lora-fuse` take |
+| `runtime LoRA` | Keeping the pair unfused behind a live scale handle the layers read per forward | The default `--lora` channel since #1439 |
+| `base_layer` | HuggingFace PEFT's name for the wrapped frozen projection | One of the three base-weight candidates |
+| `LayerFilter` | A pipeline stage's owned layer range plus embedding/lm_head flags | Why zero applied pairs is valid on the stage path |
+
+### Related Technologies/Frameworks
+
+- **mlx-lm**: reference implementation for adapter naming and scaling
+  - https://github.com/ml-explore/mlx-lm
+- **HuggingFace PEFT**: the `base_layer` / `lora_A` / `lora_B` naming convention
+  - https://github.com/huggingface/peft
+
+### Related PRs/Issues
+
+- Issue #1328: the defect this PR closes
+- Issue #1439: added the unfused runtime path, which left the `#1328 owns making both strict` marker this PR discharges
+
+---
+
+## 7. Change Summary
+
+### Statistics
+
+| Item | Value |
+|------|-------|
+| Files changed | 11 |
+| Lines added | +941 |
+| Lines deleted | -180 |
+| Tests added | 17 |
+
+### Changes by Category
+
+| Category | Count | Summary |
+|----------|-------|---------|
+| Correctness | 5 | Tensor validation, base-weight resolution, applied-pair count, DoRA refusal, runtime-path parity |
+| Code Quality | 2 | Shared validator across three call paths, shared on-disk adapter fixture for tests |
+| Documentation | 1 | `docs/server-features.md` records the acceptance rule and the stage exception |
+
+### Related Commits
+
+| Hash | Type | Message |
+|------|------|---------|
+| `fc6467a` | fix | fix(lora): refuse adapters whose tensors do not map onto the model |
+
+---
+
+## 8. Follow-up Actions
+
+### Required
+
+- [ ] Real-checkpoint smoke against `models/mlx/qwen2.5-0.5b-bf16` with `models/lora-dense-test` (72 applied pairs), `models/lora-runtime-test` (12 unmapped pairs reported), a renamed-tensor copy, and a DoRA-declared copy. The exact commands and expectations are in the PR body.
+
+### Monitoring Required
+
+- Startup failures naming `adapter tensors cannot be applied` on deployments that previously started successfully. Such a failure is the defect being reported, not a regression, but the adapter in question was serving base weights and the operator should be told.
+
+### Future Improvements
+
+- A pipeline-parallel run in which no stage applies any pair is still undetected. Detecting it needs a cross-stage tally after all stages report.
+- DoRA fusion (`W' = m * (W + scale * B A) / ||W + scale * B A||` per output row) remains unimplemented; it needs a DoRA checkpoint to validate against.
+- Fused adapter application on a quantized base is unsupported (dequantize, add, requantize). Today it fails on the shape guard. The unfused `--lora` path is the working answer for quantized checkpoints.
+- The HuggingFace PEFT `lora_A.weight` / `lora_B.weight` spelling is now reported clearly rather than silently ignored, but is still not read.
+
+---
+
+## Appendix
+
+### A. Test Results
+
+| Command | Result |
+|---------|--------|
+| `cargo test --profile test-fast --features metal,accelerate --lib lora` | 61 passed, 0 failed |
+| `cargo test --profile test-fast --features metal,accelerate --lib distributed::pipeline` | 323 passed, 0 failed |
+| `cargo test --profile test-fast --features metal,accelerate --lib loading::` | 312 passed, 0 failed |
+| `cargo clippy --profile test-fast --lib --tests --features metal,accelerate -- -D warnings` | clean |
+| `cargo fmt --all -- --check` | clean |
+
+### B. Performance Benchmarks
+
+Not applicable. Validation touches load time only, bounded by the adapter's key count, and the MLX call sequence for a valid adapter is unchanged.
+
+### C. References
+
+- `src/lora/loader.rs`: `validate_adapter_tensors`, `find_base_weight_name`, `reject_unsupported_fine_tune_type`
+- `src/lora/runtime.rs`: `stage_runtime_adapters`
+- `docs/server-features.md`: "LoRA adapters"

--- a/TECHNICAL_REPORTS/1576-lora-adapter-tensor-validation-20260902.en.md
+++ b/TECHNICAL_REPORTS/1576-lora-adapter-tensor-validation-20260902.en.md
@@ -66,9 +66,9 @@ No measurable effect. Validation walks the adapter's tensor names once, which is
 
 ### 2.4 Code Quality
 
-- **Test Coverage**: the `lora` module gained 14 tests (11 in `loader_tests.rs`, 4 in the new `runtime_tests.rs`, 1 in `config.rs`, offset by the two stage-path tests added in `partial_loading_adapter_tests.rs`). The `--lib lora` selector goes from 47 to 61 passing tests.
+- **Test Coverage**: the `--lib lora` selector goes from 47 to 62 passing tests, from 18 new cases across `loader_tests.rs`, the new `runtime_tests.rs`, `config.rs`, and `partial_loading_adapter_tests.rs`.
 - **Code Complexity**: `fuse_lora_weights_into` shrank. Its pairing, resolution, and skip handling moved into `validate_adapter_tensors`, leaving a loop that only computes and adds deltas.
-- **Technical Debt**: decreased. The runtime path's `// #1328 owns making both strict` marker is discharged, and the two paths now share one definition of what a valid adapter tensor is instead of two drifting copies.
+- **Technical Debt**: decreased. The two paths now share one definition of what a valid adapter tensor is instead of two drifting copies, and `src/lora/runtime.rs`'s `// #1328 owns making both strict` marker is discharged. The two `mlxcel_core::runtime_lora` markers with the same wording covered a different hole and are corrected to point at #1577 rather than deleted.
 
 ---
 
@@ -109,7 +109,7 @@ A foreign adapter produces a long error. Accepted: the alternative is a short er
 The fallback is the root cause, not the symptom. A function that answers "here is the key, it may or may not be there" invites exactly the `warn!`-and-continue the issue is about, and it invited it twice independently. Making the absence a `None` moves the decision to the type system.
 
 **Trade-offs:**
-The runtime path had to change in the same PR because it shared the function. That turned out to be the right scope anyway (see 3.4).
+The runtime path had to change in the same PR because it shared the function. That turned out to be the right scope anyway (see 3.5).
 
 ### 3.3 Zero applied pairs is an error on the whole-model path only
 
@@ -130,7 +130,25 @@ The whole-model path sees the entire adapter and the entire checkpoint, so zero 
 **Trade-offs:**
 A pipeline-parallel run where *no* stage applies anything is still not detected. Catching that needs cross-stage coordination and is left as future work (section 8).
 
-### 3.4 Extend the same validator to the unfused runtime path
+### 3.4 Keep the family capability gate ahead of fusion
+
+**Context:**
+About 20 families set `adapter_unsupported_message` in `src/model_metadata.rs`, and that verdict was taken inside `load_model_from_weights`, which runs after fusion. While fusion skipped what it could not apply, the order did not matter: a Qwen VL checkpoint warn-skipped through fusion and then produced "Qwen3.5 VLM does not support adapter loading".
+
+**Alternatives Considered:**
+
+| Option | Pros | Cons |
+|--------|------|------|
+| Leave the gate where it is | No change | For any of those families whose key paths do not match the adapter's, the operator now gets a wall of `no base weight` lines and never sees the sentence explaining the real situation |
+| **Chosen: hoist a second call ahead of fusion, keep the original as backstop** | The explanatory error wins; base weights are never read for a load that cannot succeed | `config.json` is parsed twice, and the check exists in two places |
+
+**Rationale:**
+This is a diagnostics regression that the strictness change introduces rather than an independent defect: the message was reachable only because fusion used to succeed vacuously. Fixing it belongs in the same change that breaks it.
+
+**Trade-offs:**
+Two `config.json` reads per adapter load, which is negligible next to the weight load it now precedes.
+
+### 3.5 Extend the same validator to the unfused runtime path
 
 **Context:**
 The issue's "Out of scope" section names runtime LoRA, but it was written before #1439 landed `stage_runtime_adapters`, and that function carries the comment `Unmatched tensors warn with the same posture as the fused path (#1328 owns making both strict)`.
@@ -305,7 +323,8 @@ Establishing an honest smoke plan surfaced that the fused `--adapter` path canno
 ### Related PRs/Issues
 
 - Issue #1328: the defect this PR closes
-- Issue #1439: added the unfused runtime path, which left the `#1328 owns making both strict` marker this PR discharges
+- Issue #1439: added the unfused runtime path, which left the `#1328 owns making both strict` marker this PR discharges for adapter tensors
+- Issue #1577: the residual this PR does not close, where a staged runtime term is never claimed by any layer constructor
 
 ---
 
@@ -315,24 +334,26 @@ Establishing an honest smoke plan surfaced that the fused `--adapter` path canno
 
 | Item | Value |
 |------|-------|
-| Files changed | 11 |
-| Lines added | +941 |
-| Lines deleted | -180 |
-| Tests added | 17 |
+| Files changed | 14 |
+| Lines added | +1820 |
+| Lines deleted | -186 |
+| Tests added | 18 |
 
 ### Changes by Category
 
 | Category | Count | Summary |
 |----------|-------|---------|
 | Correctness | 5 | Tensor validation, base-weight resolution, applied-pair count, DoRA refusal, runtime-path parity |
+| Diagnostics | 3 | Family capability gate ahead of fusion, adapter config path in the parse error, PEFT naming reported once |
 | Code Quality | 2 | Shared validator across three call paths, shared on-disk adapter fixture for tests |
-| Documentation | 1 | `docs/server-features.md` records the acceptance rule and the stage exception |
+| Documentation | 2 | `docs/server-features.md` records the acceptance rule and the stage exception; two `runtime_lora` comments corrected to point at #1577 |
 
 ### Related Commits
 
 | Hash | Type | Message |
 |------|------|---------|
 | `fc6467a` | fix | fix(lora): refuse adapters whose tensors do not map onto the model |
+| `45a391f` | fix | fix(lora): keep family and PEFT adapter diagnostics readable |
 
 ---
 
@@ -348,10 +369,13 @@ Establishing an honest smoke plan surfaced that the fused `--adapter` path canno
 
 ### Future Improvements
 
+- Issue #1577: unclaimed runtime terms are still only logged. A term whose tensor mapped onto a real base weight but whose prefix no layer constructor claims leaves those layers serving base weights after a load that succeeded. `SwitchLinear` (every MoE family's expert path) is the confirmed example. The adjacent case is worse: `src/models/nemotron_h.rs` destructures a `UnifiedLinear::Quantized` for its fused Mamba-2 kernel and never consults `runtime_lora::any_active`, so its terms are claimed and still never reach the forward pass. Making the unclaimed list a load failure was left out of this change because it is a hard-failure change to the default `--lora` channel that cannot be validated without real checkpoints across many families.
+- Issue #1577 also records that the fused single-process path validates against the raw checkpoint while the pipeline-stage path validates against a `sanitize_tied_embeddings`-processed map, so an `lm_head` pair on a tied-embeddings checkpoint now fails on one path and applies on the other. Neither direction is obviously right, since adapting `lm_head` separately on a tied model breaks the tie.
+- MoE LoRA is unsupported on both paths: `mlx-lm`'s `LoRASwitchLinear` writes 3-D `lora_a` / `lora_b`, which `compute_lora_delta` has always rejected with "Expected 2D LoRA matrices". Not a regression, recorded in #1577.
 - A pipeline-parallel run in which no stage applies any pair is still undetected. Detecting it needs a cross-stage tally after all stages report.
 - DoRA fusion (`W' = m * (W + scale * B A) / ||W + scale * B A||` per output row) remains unimplemented; it needs a DoRA checkpoint to validate against.
 - Fused adapter application on a quantized base is unsupported (dequantize, add, requantize). Today it fails on the shape guard. The unfused `--lora` path is the working answer for quantized checkpoints.
-- The HuggingFace PEFT `lora_A.weight` / `lora_B.weight` spelling is now reported clearly rather than silently ignored, but is still not read.
+- The HuggingFace PEFT `lora_A.weight` / `lora_B.weight` spelling is now reported clearly, once per adapter with the conversion step, rather than silently ignored, but is still not read.
 
 ---
 
@@ -361,7 +385,7 @@ Establishing an honest smoke plan surfaced that the fused `--adapter` path canno
 
 | Command | Result |
 |---------|--------|
-| `cargo test --profile test-fast --features metal,accelerate --lib lora` | 61 passed, 0 failed |
+| `cargo test --profile test-fast --features metal,accelerate --lib lora` | 62 passed, 0 failed |
 | `cargo test --profile test-fast --features metal,accelerate --lib distributed::pipeline` | 323 passed, 0 failed |
 | `cargo test --profile test-fast --features metal,accelerate --lib loading::` | 312 passed, 0 failed |
 | `cargo clippy --profile test-fast --lib --tests --features metal,accelerate -- -D warnings` | clean |

--- a/TECHNICAL_REPORTS/1576-lora-adapter-tensor-validation-20260902.ko.md
+++ b/TECHNICAL_REPORTS/1576-lora-adapter-tensor-validation-20260902.ko.md
@@ -66,9 +66,9 @@ LoRA 어댑터 로딩은 적용할 수 없는 텐서를 조용히 버렸다. 그
 
 ### 2.4 코드 품질
 
-- **테스트 커버리지**: `lora` 모듈에 테스트 14개가 늘었다(`loader_tests.rs` 11개, 신규 `runtime_tests.rs` 4개, `config.rs` 1개, 여기에 `partial_loading_adapter_tests.rs`의 스테이지 경로 테스트 2개). `--lib lora` 셀렉터 기준 47개에서 61개로 늘었다.
+- **테스트 커버리지**: `--lib lora` 셀렉터 기준 47개에서 62개로 늘었다. `loader_tests.rs`, 신규 `runtime_tests.rs`, `config.rs`, `partial_loading_adapter_tests.rs`에 걸쳐 신규 케이스 18개.
 - **코드 복잡도**: `fuse_lora_weights_into`가 짧아졌다. 쌍 구성, 해석, 건너뛰기 처리가 `validate_adapter_tensors`로 옮겨가고, 델타를 계산해 더하는 루프만 남았다.
-- **기술 부채**: 감소. 런타임 경로의 `// #1328 owns making both strict` 표식이 해소됐고, 두 경로가 서로 어긋날 수 있는 복사본 두 벌 대신 유효한 어댑터 텐서의 정의 하나를 공유한다.
+- **기술 부채**: 감소. 두 경로가 서로 어긋날 수 있는 복사본 두 벌 대신 유효한 어댑터 텐서의 정의 하나를 공유하고, `src/lora/runtime.rs`의 `// #1328 owns making both strict` 표식이 해소됐다. 같은 문구를 단 `mlxcel_core::runtime_lora`의 표식 두 개는 다른 결함을 가리키고 있었으므로, 삭제하지 않고 #1577을 가리키도록 정정했다.
 
 ---
 
@@ -109,7 +109,7 @@ LoRA 어댑터 로딩은 적용할 수 없는 텐서를 조용히 버렸다. 그
 폴백이 증상이 아니라 근본 원인이다. "키를 줄 텐데, 있을 수도 없을 수도 있다"고 답하는 함수는 이 이슈가 다루는 `warn!` 후 continue를 정확히 유도하고, 실제로 독립적으로 두 번 유도했다. 부재를 `None`으로 만들면 판단이 타입 시스템으로 넘어간다.
 
 **트레이드오프:**
-함수를 공유하던 런타임 경로를 같은 PR에서 고쳐야 했다. 결과적으로는 그게 옳은 범위였다(3.4 참조).
+함수를 공유하던 런타임 경로를 같은 PR에서 고쳐야 했다. 결과적으로는 그게 옳은 범위였다(3.5 참조).
 
 ### 3.3 적용 쌍 0개는 전체 모델 경로에서만 에러
 
@@ -130,7 +130,25 @@ LoRA 어댑터 로딩은 적용할 수 없는 텐서를 조용히 버렸다. 그
 **트레이드오프:**
 어떤 스테이지도 아무것도 적용하지 않은 파이프라인 병렬 실행은 여전히 감지되지 않는다. 이를 잡으려면 스테이지 간 조율이 필요하며 후속 과제로 남긴다(8절).
 
-### 3.4 같은 검증기를 비융합 런타임 경로까지 확장
+### 3.4 패밀리 capability 게이트를 융합보다 앞에 두기
+
+**맥락:**
+`src/model_metadata.rs`에서 20여 개 패밀리가 `adapter_unsupported_message`를 설정하는데, 그 판정은 융합 이후에 실행되는 `load_model_from_weights` 안에서 내려졌다. 융합이 적용할 수 없는 것을 건너뛰던 동안에는 순서가 문제되지 않았다. Qwen VL 체크포인트는 융합을 경고와 함께 통과한 뒤 "Qwen3.5 VLM does not support adapter loading"를 냈다.
+
+**검토한 대안:**
+
+| 선택지 | 장점 | 단점 |
+|--------|------|------|
+| 게이트를 그대로 둔다 | 변경 없음 | 해당 패밀리 중 키 경로가 어댑터와 맞지 않는 경우, 운영자는 `no base weight` 줄의 벽만 보고 실제 상황을 설명하는 문장은 영영 못 본다 |
+| **선택: 융합 앞에 호출을 하나 더 두고 원래 검사는 백스톱으로 유지** | 설명이 담긴 에러가 이긴다, 성공할 수 없는 로딩을 위해 베이스 가중치를 읽지 않는다 | `config.json`을 두 번 파싱, 검사가 두 곳에 존재 |
+
+**근거:**
+이것은 독립된 결함이 아니라 엄격화가 불러온 진단 퇴행이다. 그 메시지는 융합이 공허하게 성공하던 덕분에만 도달 가능했다. 그러니 그것을 깨뜨리는 변경과 같은 곳에서 고치는 게 맞다.
+
+**트레이드오프:**
+어댑터 로딩마다 `config.json`을 두 번 읽는다. 그 뒤에 오는 가중치 로딩에 비하면 무시할 수준이다.
+
+### 3.5 같은 검증기를 비융합 런타임 경로까지 확장
 
 **맥락:**
 이슈의 "Out of scope" 절이 런타임 LoRA를 언급하지만, 그 문장은 #1439가 `stage_runtime_adapters`를 넣기 전에 쓰인 것이고, 해당 함수에는 `Unmatched tensors warn with the same posture as the fused path (#1328 owns making both strict)`라는 주석이 달려 있다.
@@ -305,7 +323,8 @@ fn resolve(name: &str, map: &Map) -> Option<String> {
 ### 관련 PR/이슈
 
 - 이슈 #1328: 이 PR이 닫는 결함
-- 이슈 #1439: 비융합 런타임 경로를 추가하면서 이 PR이 해소하는 `#1328 owns making both strict` 표식을 남김
+- 이슈 #1439: 비융합 런타임 경로를 추가하면서, 어댑터 텐서에 한해 이 PR이 해소하는 `#1328 owns making both strict` 표식을 남김
+- 이슈 #1577: 이 PR이 닫지 않는 잔여 결함. 스테이징된 런타임 항을 어떤 레이어 생성자도 클레임하지 않는 경우
 
 ---
 
@@ -315,24 +334,26 @@ fn resolve(name: &str, map: &Map) -> Option<String> {
 
 | 항목 | 값 |
 |------|-----|
-| 변경 파일 | 11 |
-| 추가 라인 | +941 |
-| 삭제 라인 | -180 |
-| 추가 테스트 | 17 |
+| 변경 파일 | 14 |
+| 추가 라인 | +1820 |
+| 삭제 라인 | -186 |
+| 추가 테스트 | 18 |
 
 ### 카테고리별 변경
 
 | 카테고리 | 개수 | 요약 |
 |----------|------|------|
 | 정합성 | 5 | 텐서 검증, 베이스 가중치 해석, 적용 쌍 개수, DoRA 거부, 런타임 경로 동등성 |
+| 진단 | 3 | 패밀리 capability 게이트를 융합 앞으로, 파싱 에러에 어댑터 설정 경로 명시, PEFT 명명을 한 번만 보고 |
 | 코드 품질 | 2 | 세 호출 경로가 검증기 공유, 테스트가 온디스크 어댑터 픽스처 공유 |
-| 문서 | 1 | `docs/server-features.md`에 수용 규칙과 스테이지 예외 기록 |
+| 문서 | 2 | `docs/server-features.md`에 수용 규칙과 스테이지 예외 기록, `runtime_lora` 주석 2개를 #1577을 가리키도록 정정 |
 
 ### 관련 커밋
 
 | 해시 | 유형 | 메시지 |
 |------|------|--------|
 | `fc6467a` | fix | fix(lora): refuse adapters whose tensors do not map onto the model |
+| `45a391f` | fix | fix(lora): keep family and PEFT adapter diagnostics readable |
 
 ---
 
@@ -348,10 +369,13 @@ fn resolve(name: &str, map: &Map) -> Option<String> {
 
 ### 향후 개선
 
+- 이슈 #1577: 클레임되지 않은 런타임 항은 여전히 로그만 남는다. 텐서는 실제 베이스 가중치에 대응됐지만 그 prefix를 클레임하는 레이어 생성자가 없는 항은, 성공한 로딩 뒤에도 해당 레이어가 베이스 가중치를 서빙하게 만든다. `SwitchLinear`(모든 MoE 패밀리의 전문가 경로)가 확인된 사례다. 인접 사례는 더 나쁘다. `src/models/nemotron_h.rs`는 융합 Mamba-2 커널을 위해 `UnifiedLinear::Quantized`를 구조 분해하면서 `runtime_lora::any_active`를 전혀 참조하지 않으므로, 그 항은 클레임됐는데도 forward에 도달하지 않는다. 클레임되지 않은 목록을 로딩 실패로 만드는 일은 이번 변경에서 제외했다. 기본 `--lora` 채널에 대한 하드 실패 변경이고, 다수 패밀리의 실제 체크포인트 없이는 검증할 수 없기 때문이다.
+- 이슈 #1577은 융합 단일 프로세스 경로가 원본 체크포인트를 대상으로 검증하는 반면 파이프라인 스테이지 경로는 `sanitize_tied_embeddings`를 거친 맵을 대상으로 검증한다는 점도 기록한다. 그래서 tied embeddings 체크포인트에서 `lm_head` 쌍은 한 경로에서는 실패하고 다른 경로에서는 적용된다. tied 모델에서 `lm_head`만 따로 적응시키면 tie가 깨지므로, 어느 방향이 옳은지는 자명하지 않다.
+- MoE LoRA는 두 경로 모두 미지원이다. `mlx-lm`의 `LoRASwitchLinear`는 3차원 `lora_a` / `lora_b`를 쓰는데 `compute_lora_delta`가 예전부터 "Expected 2D LoRA matrices"로 거부해 왔다. 회귀는 아니며 #1577에 기록했다.
 - 어떤 스테이지도 쌍을 적용하지 않은 파이프라인 병렬 실행은 여전히 감지되지 않는다. 감지하려면 모든 스테이지 보고 후의 스테이지 간 집계가 필요하다.
 - DoRA 융합(출력 행별로 `W' = m * (W + scale * B A) / ||W + scale * B A||`)은 미구현이다. 검증할 DoRA 체크포인트가 있어야 한다.
 - 양자화 베이스에 대한 융합 어댑터 적용은 미지원이다(역양자화, 덧셈, 재양자화). 지금은 shape 가드에서 실패한다. 양자화 체크포인트에는 비융합 `--lora` 경로가 동작하는 답이다.
-- HuggingFace PEFT의 `lora_A.weight` / `lora_B.weight` 표기는 이제 조용히 무시되는 대신 명확히 보고되지만, 여전히 읽지는 않는다.
+- HuggingFace PEFT의 `lora_A.weight` / `lora_B.weight` 표기는 이제 조용히 무시되는 대신 어댑터당 한 줄로 변환 방법과 함께 명확히 보고되지만, 여전히 읽지는 않는다.
 
 ---
 
@@ -361,7 +385,7 @@ fn resolve(name: &str, map: &Map) -> Option<String> {
 
 | 명령 | 결과 |
 |------|------|
-| `cargo test --profile test-fast --features metal,accelerate --lib lora` | 61 passed, 0 failed |
+| `cargo test --profile test-fast --features metal,accelerate --lib lora` | 62 passed, 0 failed |
 | `cargo test --profile test-fast --features metal,accelerate --lib distributed::pipeline` | 323 passed, 0 failed |
 | `cargo test --profile test-fast --features metal,accelerate --lib loading::` | 312 passed, 0 failed |
 | `cargo clippy --profile test-fast --lib --tests --features metal,accelerate -- -D warnings` | clean |

--- a/TECHNICAL_REPORTS/1576-lora-adapter-tensor-validation-20260902.ko.md
+++ b/TECHNICAL_REPORTS/1576-lora-adapter-tensor-validation-20260902.ko.md
@@ -1,0 +1,378 @@
+# 기술 보고서: PR #1576 - fix(lora): refuse adapters that do not map onto the model
+
+**작성일**: 2026-09-02
+**작성자**: mlxcel maintainers
+**리뷰어**: 없음
+**상태**: 완료
+**언어**: Rust
+**위험도**: Medium
+
+---
+
+## 요약
+
+LoRA 어댑터 로딩은 적용할 수 없는 텐서를 조용히 버렸다. 그래서 다른 아키텍처용으로 학습된 어댑터, 이름이 바뀐 프로젝션, DoRA 체크포인트를 물려도 서버는 정상 기동했고, 시작 로그는 어댑터가 융합됐다고 보고하는데 실제로는 손대지 않은 베이스 가중치로 응답했다. 이 PR은 첫 쓰기 이전에 모든 어댑터 텐서를 베이스 가중치 맵에 대조해 검증하고, 위반 항목을 하나의 에러에 전부 담아 보고하며, 조작된 "N개 레이어 융합" 카운트를 실제로 적용된 쌍의 개수로 바꾸고, DoRA를 이름을 명시해 거부한다. 융합 경로, 파이프라인 병렬 스테이지 경로, 비융합 런타임 서빙 경로가 이제 하나의 검증기를 공유한다.
+
+---
+
+## 1. 문제 정의
+
+### 1.1 배경
+
+`mlxcel-server --adapter <dir>`와 `mlxcel generate --adapter <dir>`는 모델 생성 전에 LoRA 어댑터를 베이스 가중치 맵에 융합한다. 융합 루프는 어댑터 텐서를 `.lora_a` / `.lora_b` 어간으로 묶고, 각 어간을 베이스 가중치 키로 해석한 뒤, 그 키에 `scale * (B @ A)`를 더했다. 이 해석 과정의 모든 단계가 best-effort였다.
+
+### 1.2 기존 문제
+
+- **베이스 가중치가 없으면 경고로 끝났다.** `find_base_weight_name`은 실패할 수 없는 함수였다. 후보 세 개 중 어느 것도 체크포인트에 없으면 "가장 그럴듯한 후보"라며 `"{name}.weight"`를 그대로 돌려줬다. 융합 루프는 그 키를 찾다 실패하고 `tracing::warn!("Base weight not found for LoRA layer ...")`를 남긴 뒤 계속 진행했다. 대응되는 레이어가 하나도 없는 84쌍짜리 어댑터가 아무것도 융합하지 않은 채로 로딩에 성공했다.
+- **인식되지 않는 텐서는 버려졌다.** `.lora_a`나 `.lora_b`로 끝나지 않는 것은 `// Ignore other weights (like scales for DoRA)`라는 주석과 함께 건너뛰었다. DoRA 크기(magnitude) 벡터, 떠도는 `.weight`, 이 빌드가 읽지 않는 HuggingFace PEFT의 `.lora_A.weight` 표기가 모두 그 줄에서 사라졌다.
+- **보고된 개수가 조작된 값이었다.** `apply_lora_adapters`와 `apply_stage_lora_adapter`는 어댑터 파일의 `.lora_a` 키를 세어 `modified_count`를 만들고 `Fused LoRA adapters into N layers`로 기록했다. 이 값은 어댑터 자체의 크기일 뿐, 실제로 `mlxcel_core::add`까지 도달한 쌍의 수와 전혀 무관했다.
+- **DoRA가 LoRA로 통과했다.** `AdapterConfig::is_lora()`가 `FineTuneType::DoRA`에 대해 true를 반환했다. 그래서 DoRA 어댑터가 타입 게이트를 통과했고, 자체 툴링이 접어 넣는 출력 행별 크기 벡터 없이 저랭크 쌍만 적용됐다.
+- **비융합 런타임 경로에 같은 결함 세 가지가 있었다.** #1439 이후 b10621 `--lora` 표기의 기본 채널인 `stage_runtime_adapters`에도 동일한 `warn!` 후 continue 블록이 있었고, #1328이 두 경로를 모두 엄격하게 만드는 일을 담당한다는 주석이 소스에 남아 있었다.
+
+변경 전 `target/release/mlxcel`로 로컬 체크포인트에 대해 측정한 결과: `models/mlx/qwen2.5-0.5b-bf16`에 `models/lora-dense-test`의 복사본(단, `model.layers.0.self_attn.q_proj.lora_a`를 `...lora_a.bogus`로 개명)을 물리면 로딩에 성공해 72쌍 중 71쌍을 융합하고 정상 생성했다. 같은 베이스에 같은 어댑터를 `"fine_tune_type": "dora"`로 선언해도 마찬가지로 로딩되고 생성됐다.
+
+### 1.3 위험 평가
+
+| 위험 | 영향 | 발생 가능성 |
+|------|------|------------|
+| 어댑터 이름을 달고 베이스 가중치를 서빙, 어디에도 에러 없음 | High | 어댑터/체크포인트 불일치 시 High |
+| 부분 적용된 어댑터(일부 레이어만 융합) | High | 레이어 수 불일치 시 High |
+| DoRA가 LoRA로 적용되어 베이스도 파인튜닝도 아닌 가중치 생성 | Medium | DoRA 어댑터 확보 여부에 좌우, Medium |
+| 운영자가 실제를 반영한 적 없는 융합 레이어 수를 신뢰 | Medium | 텐서가 하나라도 건너뛰어지면 확실 |
+
+---
+
+## 2. 기술 검토
+
+### 2.1 보안
+
+보안 변경은 아니다. 이 결함군은 노출이 아니라 조용한 정합성 오류다. 다만 인접한 속성 하나가 개선된다. 이제 어댑터 디렉터리는 그것이 만들어내는 에러로 완전히 설명되므로, 파인튜닝이 적용되고 있다고 운영자가 오인할 여지가 없어진다.
+
+**체크리스트:**
+- [x] 입력 검증(어댑터 텐서 이름과 베이스 가중치 해석을 가정하지 않고 검사)
+- [ ] 인증/인가(해당 없음)
+- [ ] 데이터 암호화(해당 없음)
+- [x] 로깅(융합 개수가 실측값으로 바뀜, 민감 정보 로깅 없음)
+
+### 2.2 성능
+
+측정 가능한 영향 없음. 검증은 어댑터의 텐서 이름을 한 번 순회하며, 그 비용은 어댑터 파일 크기(키 수백 개)로 제한된다. 게다가 같은 작업이 이미 융합 루프 안에서 인라인으로 수행되고 있었다. 유효한 어댑터에 대해 MLX 호출 순서는 그대로이므로 디코드 처리량과 로딩 시간은 변하지 않는다.
+
+### 2.3 호환성 및 의존성
+
+- **파괴적 변경**: 있음, 의도한 것이다. 아무것도 적용하지 않으면서 로딩되던 어댑터, 자신의 일부만 적용하던 어댑터가 이제 로딩에 실패한다. 그것이 이 변경의 목적이다. 공개 시그니처 세 개가 바뀌었다. `fuse_lora_weights_into`가 `Result<()>` 대신 `Result<usize>`를, `apply_stage_lora_adapter`가 `Result<()>` 대신 `Result<usize>`를 반환하고, `AdapterConfig::is_lora()`가 `AdapterConfig::is_fusable_lora()`로 대체됐다. `fuse_lora_weights`와 `apply_lora_adapters`의 시그니처는 유지된다.
+- **신규 의존성**: 없음.
+- **호환성**: mlx-lm 어댑터(`<layer>.lora_a` / `<layer>.lora_b`)와 HuggingFace PEFT의 `<layer>.base_layer` 명명 모두 그대로 해석된다. PEFT의 `lora_A.weight` / `lora_B.weight` 표기는 이 코드가 원래 읽은 적이 없으며, 이제 무동작으로 로딩되는 대신 명시적으로 실패한다.
+
+### 2.4 코드 품질
+
+- **테스트 커버리지**: `lora` 모듈에 테스트 14개가 늘었다(`loader_tests.rs` 11개, 신규 `runtime_tests.rs` 4개, `config.rs` 1개, 여기에 `partial_loading_adapter_tests.rs`의 스테이지 경로 테스트 2개). `--lib lora` 셀렉터 기준 47개에서 61개로 늘었다.
+- **코드 복잡도**: `fuse_lora_weights_into`가 짧아졌다. 쌍 구성, 해석, 건너뛰기 처리가 `validate_adapter_tensors`로 옮겨가고, 델타를 계산해 더하는 루프만 남았다.
+- **기술 부채**: 감소. 런타임 경로의 `// #1328 owns making both strict` 표식이 해소됐고, 두 경로가 서로 어긋날 수 있는 복사본 두 벌 대신 유효한 어댑터 텐서의 정의 하나를 공유한다.
+
+---
+
+## 3. 기술적 선택과 그 이유
+
+### 3.1 첫 위반에서 멈추지 않고 전부 모아 보고
+
+**맥락:**
+잘못된 아키텍처용 어댑터에는 나쁜 텐서가 하나 있는 게 아니다. 레이어마다, 대상 모듈마다 하나씩 있다. 24레이어 모델에 물린 28레이어 어댑터에는 대응되지 않는 쌍이 12개 있고, 완전히 다른 어댑터라면 전부다.
+
+**검토한 대안:**
+
+| 선택지 | 장점 | 단점 |
+|--------|------|------|
+| 첫 위반에서 실패 | 코드가 가장 단순, 에러가 짧음 | 불일치 범위를 알려면 위반 레이어 수만큼 로딩을 반복해야 하고, 매번 체크포인트 전체를 다시 읽음 |
+| 전부 경고하고 하나도 적용 안 됐을 때만 실패 | 부분 어댑터가 계속 동작 | 결함을 그대로 보존, 위험한 쪽은 완전 불일치가 아니라 부분 적용임 |
+| **선택: 전부 모아 한 번에 실패** | 로딩 한 번으로 전체 그림 확보, 위반 목록의 형태만 봐도 "아키텍처가 다름"과 "텐서 하나 개명"이 구분됨 | 완전히 다른 어댑터에서는 에러 텍스트가 길어짐 |
+
+**근거:**
+진단 가치는 위반 목록의 형태에 있다. 꼬리 쪽 레이어 인덱스 12개가 연속으로 나오면 "어댑터의 레이어가 모델보다 많다"는 뜻이고, 한 줄이면 "누군가 텐서 이름을 바꿨다"는 뜻이며, 모든 레이어가 나오면 "아키텍처 자체가 다르다"는 뜻이다. 첫 실패만 보고하는 에러는 이 중 어느 것도 전달하지 못한다.
+
+**트레이드오프:**
+낯선 어댑터에서는 에러가 길어진다. 감수한다. 대안은 짧은 에러 대신 체크포인트 전체 로딩을 반복해야 범위를 알 수 있는 구조다.
+
+### 3.2 호출부에서 결과를 검사하는 대신 `find_base_weight_name`의 폴백을 제거
+
+**맥락:**
+`find_base_weight_name`은 `Result<String>`을 반환했지만 실패할 수 없었다. 어느 후보도 맞지 않으면 첫 후보를 그대로 반환했고, 두 호출부 모두 그 뒤에 `contains_key` 검사와 경고를 붙였다.
+
+**검토한 대안:**
+
+| 선택지 | 장점 | 단점 |
+|--------|------|------|
+| 폴백은 두고 호출부가 경고 대신 실패하게 | 변경 폭이 가장 작음 | 함수가 여전히 존재하지 않는다고 스스로 아는 키를 보고하고, 다음 호출부가 같은 실수를 반복 |
+| **선택: `Option<String>` 반환, 폴백 제거** | "해석됨"과 "존재함"이 같은 답이 되고, 타입이 검사를 생략할 수 없게 만듦 | 런타임 경로를 포함한 모든 호출부를 건드림 |
+
+**근거:**
+폴백이 증상이 아니라 근본 원인이다. "키를 줄 텐데, 있을 수도 없을 수도 있다"고 답하는 함수는 이 이슈가 다루는 `warn!` 후 continue를 정확히 유도하고, 실제로 독립적으로 두 번 유도했다. 부재를 `None`으로 만들면 판단이 타입 시스템으로 넘어간다.
+
+**트레이드오프:**
+함수를 공유하던 런타임 경로를 같은 PR에서 고쳐야 했다. 결과적으로는 그게 옳은 범위였다(3.4 참조).
+
+### 3.3 적용 쌍 0개는 전체 모델 경로에서만 에러
+
+**맥락:**
+아무것도 적용하지 않는 어댑터는 이 PR이 보고하려는 실패 그 자체다. 그러나 레이어 16~31을 소유한 파이프라인 병렬 스테이지는 어댑터가 레이어 0~15를 겨냥할 때 정당하게 아무것도 적용하지 않는다.
+
+**검토한 대안:**
+
+| 선택지 | 장점 | 단점 |
+|--------|------|------|
+| 모든 곳에서 0을 에러로 | 규칙이 일관됨 | 파이프라인 병렬에서 유효한 부분 레이어 어댑터가 전부 깨짐 |
+| 0을 절대 에러로 보지 않음 | 오탐 없음 | 빈 어댑터 파일이 조용히 로딩됨, 결함이 그대로 |
+| **선택: 전체 모델 경로만 에러, 스테이지 경로는 개수 반환** | 두 경우 모두 옳음 | 나중에 누군가 이 비대칭을 "고치려" 할 수 있으므로 규칙을 코드에 기록해야 함 |
+
+**근거:**
+전체 모델 경로는 어댑터 전체와 체크포인트 전체를 본다. 그래서 0은 모호하지 않다. 스테이지는 양쪽의 걸러진 조각만 보므로 "이 어댑터가 잘못됐다"와 "이 어댑터는 내 것이 아니다"를 구분할 수 없다. 스테이지는 호출자가 그 수를 갖도록 개수를 반환하고, `src/distributed/pipeline/stage_executor/llama.rs`에 그곳에는 왜 검사가 없는지 설명하는 주석을 남겼다.
+
+**트레이드오프:**
+어떤 스테이지도 아무것도 적용하지 않은 파이프라인 병렬 실행은 여전히 감지되지 않는다. 이를 잡으려면 스테이지 간 조율이 필요하며 후속 과제로 남긴다(8절).
+
+### 3.4 같은 검증기를 비융합 런타임 경로까지 확장
+
+**맥락:**
+이슈의 "Out of scope" 절이 런타임 LoRA를 언급하지만, 그 문장은 #1439가 `stage_runtime_adapters`를 넣기 전에 쓰인 것이고, 해당 함수에는 `Unmatched tensors warn with the same posture as the fused path (#1328 owns making both strict)`라는 주석이 달려 있다.
+
+**검토한 대안:**
+
+| 선택지 | 장점 | 단점 |
+|--------|------|------|
+| 융합 경로만 고치고 런타임 경로는 `Option` 시그니처 대응만 | 범위가 가장 작음 | `--lora`가 기본으로 선택하는 채널에 동일 결함이 남고, "DoRA 어댑터를 거부한다"는 인수 조건이 절반만 참인 수정이 나감 |
+| **선택: `validate_adapter_tensors`와 `reject_unsupported_fine_tune_type` 공유** | 유효한 어댑터의 정의가 하나, 트리에 이미 남아 있던 표식을 해소 | 이슈 본문이 암시하는 것보다 diff가 큼 |
+
+**근거:**
+런타임 경로는 `find_base_weight_name`을 호출하므로 어차피 수정해야 했다. 그 상황에서 관대하게 남겨두면 기본 서버 채널에서는 성립하지 않는 수정을 내보내는 셈이고, 쌍 구성 로직 복사본 두 벌이 어긋날 여지를 남긴다.
+
+**트레이드오프:**
+`stage_runtime_adapters`에 스테이징 0개 검사가 추가됐는데 `RuntimeLoraSet` 라우트 테스트는 이를 실행하지 않는다. 대신 신규 `runtime_tests.rs`가 담당한다.
+
+---
+
+## 4. 구현 상세
+
+### 4.1 아키텍처 변경
+
+```
+[변경 전]
+apply_lora_adapters ─┐
+                     ├─> fuse_lora_weights_into ─> 인라인 쌍 구성 ─> warn+skip ─> add
+apply_stage_lora_adapter ┘                                    ^
+                                                              └── find_base_weight_name (실패 불가)
+stage_runtime_adapters ──> 인라인 쌍 구성 ──> warn+skip ──> 항 스테이징
+
+[변경 후]
+apply_lora_adapters ─┐
+                     ├─> fuse_lora_weights_into ─┐
+apply_stage_lora_adapter ┘                       ├─> validate_adapter_tensors ─> Vec<FusablePair> | 단일 에러
+                                                 │        ^
+stage_runtime_adapters ──────────────────────────┘        └── find_base_weight_name -> Option<String>
+```
+
+### 4.2 주요 코드 변경
+
+**파일: `src/lora/loader.rs`**
+
+```rust
+// 변경 전
+let base_weight_name = find_base_weight_name(&base_name, base_weights)?;
+let Some(base_weight) = base_weights.get(&base_weight_name) else {
+    tracing::warn!("Base weight not found for LoRA layer {}: tried {}", base_name, base_weight_name);
+    continue;
+};
+
+// 변경 후
+let pairs = validate_adapter_tensors(base_weights, adapter_weights)?;
+```
+
+**변경 이유:** 해석과 존재 검사는 하나의 판단이며, 어떤 쓰기보다 앞서 어댑터 전체에 대해 내려진다. 그래야 실패가 모든 위반 항목을 지목하고 `base_weights`는 손대지 않은 상태로 남는다.
+
+**파일: `src/lora/loader.rs`**
+
+```rust
+// 변경 후
+if !violations.is_empty() {
+    violations.sort();
+    let count = violations.len();
+    let noun = if count == 1 { "tensor" } else { "tensors" };
+    anyhow::bail!(
+        "{count} adapter {noun} cannot be applied to this model:\n  {}\n\
+         Every tensor in a fusable adapter has to be one half of a <layer>.lora_a / \
+         <layer>.lora_b pair whose base weight this checkpoint holds; skipping the rest \
+         would serve weights that match neither the base model nor the fine-tune.",
+        violations.join("\n  "),
+    );
+}
+```
+
+**변경 이유:** `WeightMap`은 `HashMap`이라 정렬하지 않은 보고는 실행마다 순서가 달라져 테스트도 diff도 어려워진다. 반환되는 `Vec<FusablePair>`도 같은 이유로 베이스 가중치 키 기준으로 정렬한다.
+
+**파일: `src/lora/config.rs`**
+
+```rust
+// 변경 전
+pub fn is_lora(&self) -> bool {
+    matches!(self.fine_tune_type, FineTuneType::LoRA | FineTuneType::DoRA)
+}
+
+// 변경 후
+pub fn is_fusable_lora(&self) -> bool {
+    self.fine_tune_type == FineTuneType::LoRA
+}
+```
+
+**변경 이유:** 옛 이름은 본문이 지키지 않는 것을 주장했고, 세 호출부 모두 이를 "이걸 적용해도 되나?" 게이트로 썼다. 호출부를 땜질하는 대신 이름을 바꿔 함정 자체를 없앴다.
+
+### 4.3 데이터 모델 변경
+
+없음. 온디스크 포맷, 설정 스키마, 와이어 포맷 모두 그대로다.
+
+---
+
+## 5. 학습 포인트
+
+### 5.1 실패할 수 없는 해석 함수는 실패를 모든 호출부로 떠민다
+
+**개념:**
+조회 헬퍼가 부재 대신 최선의 추측을 반환하면, 반환 타입이 호출자에게 필요한 정보를 더는 담지 못한다. 그러면 모든 호출자가 "이게 실제로 해석된 건가?"를 각자 다시 판단해야 하고, 각자 독립적으로 틀릴 수 있다.
+
+**이 PR에서의 적용:**
+`find_base_weight_name`은 `Result<String>`을 반환하면서 아무것도 맞지 않을 때 `Ok(format!("{}.weight", lora_name))`으로 끝났다. 두 호출부 모두 그 뒤에 `contains_key` 검사와 `tracing::warn!`을 붙였고, 둘 다 계속 진행하는 쪽을 택했다. 시그니처를 `Option<String>`으로 바꾸자 부재를 성공으로 표현할 수 없게 되었고, 갈라져 있던 두 처리가 하나로 합쳐졌다.
+
+**일반적인 사례:**
+- "기본" 후보로 폴백하는 이름/경로 해석기
+- 키가 설정되지 않았다고 보고하는 대신 기본값을 대입하는 설정 조회
+- 설명해야 할 실패로부터 `Err` 갈래에 도달할 수 없는 모든 `Result`
+
+**예시 코드:**
+```rust
+// 피해야 할 형태: Ok 값이 존재할 수도 없을 수도 있다.
+fn resolve(name: &str, map: &Map) -> Result<String> {
+    for c in candidates(name) { if map.contains_key(&c) { return Ok(c); } }
+    Ok(format!("{name}.weight")) // "가장 그럴듯한 후보"
+}
+
+// 호출자가 한 번만 판단하게 강제하는 형태.
+fn resolve(name: &str, map: &Map) -> Option<String> {
+    candidates(name).into_iter().find(|c| map.contains_key(c))
+}
+```
+
+### 5.2 입력에서 뽑은 개수는 출력에 대한 보고가 아니다
+
+**개념:**
+완료된 작업을 센 것이 아니라 입력을 잰 N으로 "N개 처리함"을 기록하면, 아무 문제가 없을 때만 정확하고 문제가 생겼을 때만 오해를 부르는 로그가 나온다.
+
+**이 PR에서의 적용:**
+`modified_count`는 어댑터 파일의 `.lora_a` 키를 셌다. 모든 쌍이 융합됐을 때만 실제와 일치했는데, 그때는 아무도 로그를 읽지 않는다. 건너뛴 경우마다 과장했는데, 그때는 누군가 읽는다.
+
+**일반적인 사례:**
+- 성공 개수 대신 배치 크기를 보고하는 배치 처리기
+- 적용된 파일 수 대신 발견한 파일 수를 보고하는 마이그레이션 도구
+- 결과를 만드는 루프보다 앞서 쓰인 모든 "N items" 로그
+
+### 5.3 어댑터 융합과 양자화 체크포인트
+
+**개념:**
+4비트 MLX 체크포인트는 프로젝션의 `.weight`를 패킹된 `uint32`로 저장하고 `.scales` / `.biases` 평면을 따로 둔다. LoRA 델타는 `[out_features, in_features]` 형태의 조밀한 실수 행렬이다.
+
+**이 PR에서의 적용:**
+정직한 스모크 계획을 세우는 과정에서, 융합 `--adapter` 경로는 양자화 체크포인트로는 아예 검증할 수 없다는 사실이 드러났다. `models/mlx/qwen3-0.6b-4bit`는 `q_proj.weight`를 `[2048, 128]` `U32`로 저장하는데 델타는 `[2048, 1024]`이므로, 이 PR의 검증에 닿기도 전에 기존 shape 가드가 먼저 발동한다. 비융합 런타임 경로는 이를 올바르게 처리한다. `validate_pair_shapes`가 패킹된 폭이 아니라 scales 평면의 그룹 수로 `in_features`를 고정하기 때문이다. 이 PR이 바꾼 부분은 아니고, 다음에 어댑터 스모크를 계획하는 사람이 융합 경로에는 bf16 체크포인트를, `--lora`에는 양자화 체크포인트를 고르도록 기록해 둔다.
+
+---
+
+## 6. 추가 학습
+
+### 핵심 용어
+
+| 키워드 | 설명 | 이 PR에서의 의미 |
+|--------|------|-----------------|
+| `LoRA` | 저랭크 적응: 동결된 베이스 가중치에 `scale * B @ A`를 더함 | 이 코드가 적용하는 델타 |
+| `DoRA` | 가중치 분해 LoRA: 저랭크 쌍에 출력 행별 크기 벡터를 더함 | 이 PR 전에는 LoRA로 통과, 이후에는 거부 |
+| `fusion` | 모델 생성 전에 로딩 시점에 델타를 베이스 가중치에 더하는 것 | `--adapter`와 `--lora-fuse`가 타는 경로 |
+| `runtime LoRA` | 쌍을 융합하지 않고 레이어가 forward마다 읽는 라이브 스케일 핸들 뒤에 두는 것 | #1439 이후 `--lora`의 기본 채널 |
+| `base_layer` | 감싸인 동결 프로젝션에 대한 HuggingFace PEFT의 이름 | 베이스 가중치 후보 세 개 중 하나 |
+| `LayerFilter` | 파이프라인 스테이지가 소유한 레이어 범위와 embedding/lm_head 플래그 | 스테이지 경로에서 적용 쌍 0개가 유효한 이유 |
+
+### 관련 기술/프레임워크
+
+- **mlx-lm**: 어댑터 명명과 스케일링의 레퍼런스 구현
+  - https://github.com/ml-explore/mlx-lm
+- **HuggingFace PEFT**: `base_layer` / `lora_A` / `lora_B` 명명 규약
+  - https://github.com/huggingface/peft
+
+### 관련 PR/이슈
+
+- 이슈 #1328: 이 PR이 닫는 결함
+- 이슈 #1439: 비융합 런타임 경로를 추가하면서 이 PR이 해소하는 `#1328 owns making both strict` 표식을 남김
+
+---
+
+## 7. 변경 요약
+
+### 통계
+
+| 항목 | 값 |
+|------|-----|
+| 변경 파일 | 11 |
+| 추가 라인 | +941 |
+| 삭제 라인 | -180 |
+| 추가 테스트 | 17 |
+
+### 카테고리별 변경
+
+| 카테고리 | 개수 | 요약 |
+|----------|------|------|
+| 정합성 | 5 | 텐서 검증, 베이스 가중치 해석, 적용 쌍 개수, DoRA 거부, 런타임 경로 동등성 |
+| 코드 품질 | 2 | 세 호출 경로가 검증기 공유, 테스트가 온디스크 어댑터 픽스처 공유 |
+| 문서 | 1 | `docs/server-features.md`에 수용 규칙과 스테이지 예외 기록 |
+
+### 관련 커밋
+
+| 해시 | 유형 | 메시지 |
+|------|------|--------|
+| `fc6467a` | fix | fix(lora): refuse adapters whose tensors do not map onto the model |
+
+---
+
+## 8. 후속 조치
+
+### 필수
+
+- [ ] `models/mlx/qwen2.5-0.5b-bf16`에 대한 실제 체크포인트 스모크: `models/lora-dense-test`(72쌍 적용), `models/lora-runtime-test`(대응 없는 12쌍 보고), 텐서를 개명한 복사본, DoRA로 선언한 복사본. 정확한 명령과 기대값은 PR 본문에 있다.
+
+### 모니터링 필요
+
+- 기존에 정상 기동하던 배포에서 `adapter tensors cannot be applied`를 지목하는 시작 실패. 이런 실패는 회귀가 아니라 결함이 보고되는 것이지만, 해당 어댑터는 그동안 베이스 가중치를 서빙하고 있었으므로 운영자에게 알려야 한다.
+
+### 향후 개선
+
+- 어떤 스테이지도 쌍을 적용하지 않은 파이프라인 병렬 실행은 여전히 감지되지 않는다. 감지하려면 모든 스테이지 보고 후의 스테이지 간 집계가 필요하다.
+- DoRA 융합(출력 행별로 `W' = m * (W + scale * B A) / ||W + scale * B A||`)은 미구현이다. 검증할 DoRA 체크포인트가 있어야 한다.
+- 양자화 베이스에 대한 융합 어댑터 적용은 미지원이다(역양자화, 덧셈, 재양자화). 지금은 shape 가드에서 실패한다. 양자화 체크포인트에는 비융합 `--lora` 경로가 동작하는 답이다.
+- HuggingFace PEFT의 `lora_A.weight` / `lora_B.weight` 표기는 이제 조용히 무시되는 대신 명확히 보고되지만, 여전히 읽지는 않는다.
+
+---
+
+## 부록
+
+### A. 테스트 결과
+
+| 명령 | 결과 |
+|------|------|
+| `cargo test --profile test-fast --features metal,accelerate --lib lora` | 61 passed, 0 failed |
+| `cargo test --profile test-fast --features metal,accelerate --lib distributed::pipeline` | 323 passed, 0 failed |
+| `cargo test --profile test-fast --features metal,accelerate --lib loading::` | 312 passed, 0 failed |
+| `cargo clippy --profile test-fast --lib --tests --features metal,accelerate -- -D warnings` | clean |
+| `cargo fmt --all -- --check` | clean |
+
+### B. 성능 벤치마크
+
+해당 없음. 검증은 어댑터 키 수로 제한된 로딩 시간에만 관여하고, 유효한 어댑터에 대한 MLX 호출 순서는 변하지 않는다.
+
+### C. 참고 자료
+
+- `src/lora/loader.rs`: `validate_adapter_tensors`, `find_base_weight_name`, `reject_unsupported_fine_tune_type`
+- `src/lora/runtime.rs`: `stage_runtime_adapters`
+- `docs/server-features.md`: "LoRA adapters"

--- a/docs/server-features.md
+++ b/docs/server-features.md
@@ -146,6 +146,18 @@ overhead, but the scales then remain fixed for the life of the process. Live
 updates and per-request selection are refused in fused mode. Distributed
 tensor and pipeline loaders currently imply fused behavior.
 
+An adapter has to map onto the checkpoint it is loaded with, on the fused and
+the unfused path alike. Every tensor in `adapters.safetensors` must be one half
+of a `<layer>.lora_a` / `<layer>.lora_b` pair whose base weight the model
+actually holds. An adapter trained for another architecture, a renamed
+projection, or a stray tensor fails the load with every offending name listed,
+rather than starting a server that answers from the base weights while
+reporting the adapter as loaded. DoRA adapters are refused outright: applying
+their low-rank pair without the magnitude vectors would produce weights that
+match neither the base model nor the fine-tune. In a pipeline-parallel run a
+stage that owns none of the adapter's layers still applies nothing, which stays
+a valid load.
+
 ## Sampling, structured output, and reasoning
 
 The server exposes the commonly used llama-server sampling stages, including

--- a/src/distributed/pipeline/partial_loading_adapter_tests.rs
+++ b/src/distributed/pipeline/partial_loading_adapter_tests.rs
@@ -531,7 +531,7 @@ fn stage_local_fusion_rejects_a_conv1d_layout_stage_weight_map() {
     let before = sum_of(&base, key);
 
     let err = match crate::lora::apply_stage_lora_adapter(&mut base, &tmp_dir, &filter) {
-        Ok(()) => panic!("a Conv1D-layout stage weight map must not fuse"),
+        Ok(fused) => panic!("a Conv1D-layout stage weight map must not fuse ({fused} applied)"),
         Err(err) => err.to_string(),
     };
     assert!(err.contains("Conv1D"), "{err}");
@@ -573,6 +573,91 @@ fn stage_local_fusion_still_applies_to_an_out_in_stage_weight_map() {
     // 16 entries of 1.0, plus a delta of scale (1.0) * rank (2) everywhere.
     let fused = sum_of(&base, "model.layers.0.self_attn.q_proj.weight");
     assert!((fused - 48.0).abs() < 1e-4, "unexpected fused sum: {fused}");
+
+    let _ = std::fs::remove_dir_all(&tmp_dir);
+}
+
+#[test]
+fn stage_with_no_in_range_adapter_tensors_is_valid() {
+    // An adapter may target a subset of the model's layers, so a stage that
+    // owns none of them applies nothing and must still load. The whole-model
+    // path treats zero applied pairs as a failed load; this path must not
+    // (issue #1328).
+    use mlxcel_core::weights::WeightMap;
+
+    let mut base: WeightMap = WeightMap::new();
+    base.insert(
+        "model.layers.5.self_attn.q_proj.weight".into(),
+        mlxcel_core::ones(&[4, 4], mlxcel_core::dtype::FLOAT32),
+    );
+
+    let tmp_dir = temp_dir("out_of_range");
+    write_adapter_dir(&tmp_dir, "model.layers.0.self_attn.q_proj", 4, 2, 4);
+
+    let filter = LayerFilter {
+        layer_range: 5..6,
+        has_embedding: false,
+        has_lm_head: false,
+    };
+
+    let fused = crate::lora::apply_stage_lora_adapter(&mut base, &tmp_dir, &filter)
+        .expect("a stage that owns none of the adapter's layers still loads");
+    assert_eq!(fused, 0);
+
+    // And the stage's own weights are untouched.
+    let after = sum_of(&base, "model.layers.5.self_attn.q_proj.weight");
+    assert!(
+        (after - 16.0).abs() < 1e-5,
+        "stage weights drifted: {after}"
+    );
+
+    let _ = std::fs::remove_dir_all(&tmp_dir);
+}
+
+#[test]
+fn stage_local_fusion_reports_the_pairs_it_applied() {
+    // The count the stage logs must be the number of pairs fused, not the
+    // number of adapter keys read.
+    use mlxcel_core::weights::WeightMap;
+
+    let mut base: WeightMap = WeightMap::new();
+    for layer in 0..2 {
+        base.insert(
+            format!("model.layers.{layer}.self_attn.q_proj.weight"),
+            mlxcel_core::ones(&[4, 4], mlxcel_core::dtype::FLOAT32),
+        );
+    }
+
+    let tmp_dir = temp_dir("counted");
+    std::fs::create_dir_all(&tmp_dir).unwrap();
+    std::fs::write(
+        tmp_dir.join("adapter_config.json"),
+        r#"{"fine_tune_type": "lora", "lora_parameters": {"rank": 2, "scale": 1.0}}"#,
+    )
+    .unwrap();
+    let mut tensors: std::collections::HashMap<String, OwnedTensor> =
+        std::collections::HashMap::new();
+    for layer in 0..2 {
+        tensors.insert(
+            format!("model.layers.{layer}.self_attn.q_proj.lora_a"),
+            ones_tensor(4, 2),
+        );
+        tensors.insert(
+            format!("model.layers.{layer}.self_attn.q_proj.lora_b"),
+            ones_tensor(2, 4),
+        );
+    }
+    safetensors::serialize_to_file(&tensors, None, &tmp_dir.join("adapters.safetensors")).unwrap();
+
+    let filter = LayerFilter {
+        layer_range: 0..2,
+        has_embedding: false,
+        has_lm_head: false,
+    };
+
+    let fused = crate::lora::apply_stage_lora_adapter(&mut base, &tmp_dir, &filter)
+        .expect("both in-range pairs apply");
+    assert_eq!(fused, 2);
 
     let _ = std::fs::remove_dir_all(&tmp_dir);
 }

--- a/src/distributed/pipeline/stage_executor/llama.rs
+++ b/src/distributed/pipeline/stage_executor/llama.rs
@@ -58,7 +58,17 @@ impl LlamaStageExecutor {
         // falls inside this stage's range, avoiding wasteful reads of
         // adapter tensors owned by other stages.
         if let Some(path) = adapter_path {
-            crate::lora::apply_stage_lora_adapter(&mut weights, path, &effective_filter)?;
+            // Zero applied pairs is a valid outcome here and must never be
+            // gated on, unlike the whole-model path: an adapter may target a
+            // subset of the model's layers, so a stage that owns none of them
+            // legitimately applies nothing. The count is logged with the stage
+            // index because the loader's own log line cannot name the stage.
+            let fused =
+                crate::lora::apply_stage_lora_adapter(&mut weights, path, &effective_filter)?;
+            tracing::debug!(
+                "stage {stage_index} applied {fused} LoRA pair(s) from {}",
+                path.display()
+            );
         }
 
         filter_weight_map(&mut weights, &effective_filter);

--- a/src/lib/mlxcel-core/src/runtime_lora.rs
+++ b/src/lib/mlxcel-core/src/runtime_lora.rs
@@ -31,9 +31,15 @@
 //! on one worker thread and two models must never see each other's
 //! adapters), and the layer constructors in [`crate::layers`] claim the
 //! terms for the prefixes they build. Whatever is left after construction is
-//! reported back to the loader, which logs it exactly like the fused path
-//! logs an unmatched adapter tensor (strict refusal is issue #1328's scope,
-//! for both paths).
+//! reported back to the loader, which logs it.
+//!
+//! Note that an unclaimed term is not the same hole as an unmatched adapter
+//! tensor. Issue #1328 made an adapter tensor that maps onto no base weight a
+//! hard load failure on the fused and the unfused path alike. An unclaimed
+//! term is one whose tensor did map onto a real base weight, but whose prefix
+//! no constructor here reads runtime terms for, so those layers still serve
+//! base weights after a load that succeeded. That is still only logged; issue
+//! #1577 owns making it strict.
 //!
 //! A term whose user scale reads `0.0` contributes nothing and, crucially,
 //! changes nothing about the base computation path, so a model loaded with
@@ -217,8 +223,10 @@ pub fn claim(prefix: &str) -> Vec<RuntimeLoraTerm> {
 }
 
 /// Drain whatever construction did not claim, returning the layer prefixes.
-/// The loader logs these with the same warning posture as the fused path's
-/// unmatched-tensor case (#1328 owns making both strict).
+///
+/// The loader only logs these. The fused path's unmatched-tensor case became a
+/// hard failure in #1328, but an unclaimed term is a different hole and is not
+/// covered by it: issue #1577 owns turning this into a load failure.
 pub fn drain_unclaimed() -> Vec<String> {
     PENDING.with(|pending| pending.borrow_mut().drain().map(|(k, _)| k).collect())
 }

--- a/src/loading/mod.rs
+++ b/src/loading/mod.rs
@@ -853,10 +853,10 @@ pub fn load_model_with_adapter_specs(
             })?;
             continue;
         }
-        weights =
-            lora::apply_lora_adapters_scaled(&weights, &spec.path, spec.scale).map_err(|e| {
-                anyhow::anyhow!("LoRA adapter {} failed to fuse: {e}", spec.path.display())
-            })?;
+        // Not re-wrapped with the adapter path: every failure inside
+        // `apply_lora_adapters_scaled` already names the directory it came
+        // from, so a wrapper here only printed it twice.
+        weights = lora::apply_lora_adapters_scaled(&weights, &spec.path, spec.scale)?;
     }
     let model = load_model_from_weights(model_path, &mut weights)?;
     let tokenizer = tokenizer::load_tokenizer(model_path)?;

--- a/src/loading/mod.rs
+++ b/src/loading/mod.rs
@@ -796,6 +796,7 @@ pub fn load_model_with_adapter(
     let model_path = model_path.as_path();
     // Disable CUDA graphs for Gemma 4 before any weight realisation (issue #688).
     maybe_disable_cuda_graphs_for_model(get_model_type(model_path)?);
+    reject_adapter_unsupported_family(model_path)?;
     // Load base weights
     let base_weights = mlxcel_core::weights::load_weights_from_dir(model_path)
         .map_err(|e| anyhow::anyhow!("{}", e))?;
@@ -827,6 +828,7 @@ pub fn load_model_with_adapter_specs(
     let model_path = resolve_model_dir(model_path);
     let model_path = model_path.as_path();
     maybe_disable_cuda_graphs_for_model(get_model_type(model_path)?);
+    reject_adapter_unsupported_family(model_path)?;
     let mut weights = mlxcel_core::weights::load_weights_from_dir(model_path)
         .map_err(|e| anyhow::anyhow!("{}", e))?;
     if let Some(set) = runtime {
@@ -861,6 +863,30 @@ pub fn load_model_with_adapter_specs(
     let model = load_model_from_weights(model_path, &mut weights)?;
     let tokenizer = tokenizer::load_tokenizer(model_path)?;
     Ok((model, tokenizer))
+}
+
+/// Refuse an adapter for a family that cannot take one, before any fusion runs.
+///
+/// The same verdict is taken again inside [`load_model_from_weights`], which is
+/// where it has always lived, but that runs *after* fusion. The ordering was
+/// harmless while fusion skipped whatever it could not apply. Now that an
+/// unmapped adapter tensor fails the load (#1328), a family that refuses
+/// adapters outright would answer with a line per adapter tensor instead of the
+/// one sentence that explains the situation, and the operator would never see
+/// it. Checking here also means the base weights are never read for a load that
+/// cannot succeed.
+///
+/// Used by: [`load_model_with_adapter`], [`load_model_with_adapter_specs`]
+fn reject_adapter_unsupported_family(model_path: &Path) -> Result<()> {
+    let model_type = get_model_type(model_path)?;
+    let config_path = model_path.join("config.json");
+    let config_str = sanitize_config_json(&std::fs::read_to_string(&config_path)?);
+    let config_value: serde_json::Value = parse_model_config(&config_str)?;
+    let policy = model_load_policy(model_type, Some(&config_value))?;
+    if let Some(message) = policy.capabilities.adapter_unsupported_message {
+        return Err(anyhow::anyhow!(message));
+    }
+    Ok(())
 }
 
 /// Build a model from pre-loaded weights (used by adapter loading)

--- a/src/lora/config.rs
+++ b/src/lora/config.rs
@@ -135,9 +135,16 @@ impl AdapterConfig {
         Ok(config)
     }
 
-    /// Check if this is a LoRA adapter (not full fine-tuning)
-    pub fn is_lora(&self) -> bool {
-        matches!(self.fine_tune_type, FineTuneType::LoRA | FineTuneType::DoRA)
+    /// Whether this adapter is plain LoRA, the only kind this build can apply.
+    ///
+    /// DoRA is deliberately excluded. This used to be `is_lora()`, which
+    /// answered `true` for DoRA as well, so a DoRA adapter was accepted and
+    /// then applied as if its magnitude vectors did not exist, producing
+    /// weights that match neither the base model nor the fine-tune (issue
+    /// #1328). Rejecting it is [`crate::lora::AdapterConfig`]'s job only in the
+    /// sense of reporting the type; the message lives with the loaders.
+    pub fn is_fusable_lora(&self) -> bool {
+        self.fine_tune_type == FineTuneType::LoRA
     }
 
     /// Get the effective LoRA scale
@@ -178,7 +185,21 @@ mod tests {
     fn test_parse_minimal_config() {
         let json = r#"{"fine_tune_type": "lora"}"#;
         let config: AdapterConfig = serde_json::from_str(json).unwrap();
-        assert!(config.is_lora());
+        assert!(config.is_fusable_lora());
         assert_eq!(config.num_layers, -1);
+    }
+
+    #[test]
+    fn dora_and_full_are_not_fusable_lora() {
+        for json in [
+            r#"{"fine_tune_type": "dora"}"#,
+            r#"{"fine_tune_type": "full"}"#,
+        ] {
+            let config: AdapterConfig = serde_json::from_str(json).unwrap();
+            assert!(
+                !config.is_fusable_lora(),
+                "must not be treated as plain LoRA: {json}"
+            );
+        }
     }
 }

--- a/src/lora/config.rs
+++ b/src/lora/config.rs
@@ -130,7 +130,7 @@ impl AdapterConfig {
             .with_context(|| format!("Failed to read adapter config: {:?}", config_path))?;
 
         let config: AdapterConfig = serde_json::from_str(&config_str)
-            .with_context(|| "Failed to parse adapter_config.json")?;
+            .with_context(|| format!("Failed to parse {}", config_path.display()))?;
 
         Ok(config)
     }
@@ -141,8 +141,8 @@ impl AdapterConfig {
     /// answered `true` for DoRA as well, so a DoRA adapter was accepted and
     /// then applied as if its magnitude vectors did not exist, producing
     /// weights that match neither the base model nor the fine-tune (issue
-    /// #1328). Rejecting it is [`crate::lora::AdapterConfig`]'s job only in the
-    /// sense of reporting the type; the message lives with the loaders.
+    /// #1328). This only reports the type; the refusal message lives with the
+    /// loaders, in `reject_unsupported_fine_tune_type`.
     pub fn is_fusable_lora(&self) -> bool {
         self.fine_tune_type == FineTuneType::LoRA
     }

--- a/src/lora/loader.rs
+++ b/src/lora/loader.rs
@@ -24,9 +24,10 @@ use anyhow::Result;
 use mlxcel_core::MlxArray;
 use mlxcel_core::UniquePtr;
 use mlxcel_core::weights::WeightMap;
+use std::collections::HashMap;
 use std::path::Path;
 
-use super::config::AdapterConfig;
+use super::config::{AdapterConfig, FineTuneType};
 
 /// Load adapter weights from a safetensors file
 pub(crate) fn load_adapter_weights(adapter_path: &Path) -> Result<WeightMap> {
@@ -58,6 +59,181 @@ pub(crate) fn load_adapter_weights(adapter_path: &Path) -> Result<WeightMap> {
     Ok(weights)
 }
 
+/// Refuse an adapter whose `fine_tune_type` this build cannot apply.
+///
+/// DoRA is refused rather than treated as LoRA. A DoRA checkpoint carries a
+/// per-output-row magnitude vector alongside its low-rank pair, and applying
+/// only the pair produces weights that match neither the base model nor the
+/// fine-tune. Accepting it used to be silent because `is_lora()` returned true
+/// for it and the magnitude tensors were dropped as "other weights".
+///
+/// Used by: [`apply_lora_adapters_scaled`], [`apply_stage_lora_adapter`],
+/// [`super::runtime::RuntimeLoraSet::from_specs`]
+pub(super) fn reject_unsupported_fine_tune_type(
+    config: &AdapterConfig,
+    adapter_path: &Path,
+) -> Result<()> {
+    if config.is_fusable_lora() {
+        return Ok(());
+    }
+    if config.fine_tune_type == FineTuneType::DoRA {
+        anyhow::bail!(
+            "DoRA adapters are not supported: {} declares fine_tune_type dora; fuse it with its \
+             own tooling first",
+            adapter_path.display()
+        );
+    }
+    anyhow::bail!(
+        "Adapter {} is not LoRA type: {:?}. Full fine-tuning adapters should be loaded directly.",
+        adapter_path.display(),
+        config.fine_tune_type
+    );
+}
+
+/// One adapter tensor pair that has been checked against the base weights and
+/// can be applied to them.
+///
+/// The adapter's own layer path is carried alongside the resolved base weight
+/// key because the two differ (`...q_proj` against `...q_proj.weight`, and the
+/// HuggingFace PEFT `...q_proj.base_layer` against that same `.weight`), and
+/// the fusion diagnostics name both.
+pub(super) struct FusablePair {
+    /// The `.lora_a` / `.lora_b` key stem, i.e. the adapter's own layer path.
+    pub(super) layer: String,
+    /// The base weight key this pair's delta is applied to.
+    pub(super) base_weight_name: String,
+    pub(super) lora_a: UniquePtr<MlxArray>,
+    pub(super) lora_b: UniquePtr<MlxArray>,
+}
+
+/// The base weight keys a LoRA layer path can resolve to, most specific first.
+///
+/// Used by: [`find_base_weight_name`], [`validate_adapter_tensors`]
+fn base_weight_candidates(lora_name: &str) -> Vec<String> {
+    let mut candidates = vec![format!("{lora_name}.weight"), lora_name.to_string()];
+    // HuggingFace PEFT wraps the frozen projection in a `.base_layer`, which
+    // resolves to the same `.weight` the other conventions name directly.
+    let peft = lora_name.replace(".base_layer", ".weight");
+    if !candidates.contains(&peft) {
+        candidates.push(peft);
+    }
+    candidates
+}
+
+/// Find the base weight name a LoRA layer name resolves to, or `None` when the
+/// checkpoint holds none of the candidates.
+///
+/// This deliberately has no fallback. It used to return `"{name}.weight"` when
+/// nothing matched, which made "resolved" and "exists" indistinguishable to the
+/// caller: that is how an adapter trained for a different architecture reached
+/// the fusion loop, got skipped with a `warn!`, and left the model serving base
+/// weights while every log line said the adapter was loaded (issue #1328).
+///
+/// Used by: [`validate_adapter_tensors`]
+fn find_base_weight_name(lora_name: &str, base_weights: &WeightMap) -> Option<String> {
+    base_weight_candidates(lora_name)
+        .into_iter()
+        .find(|candidate| base_weights.contains_key(candidate))
+}
+
+/// Pair up the adapter's tensors and check every one of them against the base
+/// weights, returning the pairs that can be applied or one error listing every
+/// tensor that cannot.
+///
+/// Three rules, each of which used to be a `warn!` and a `continue` that left
+/// the base weight in place:
+///
+/// 1. Every tensor is one half of a `<layer>.lora_a` / `<layer>.lora_b` pair.
+///    A DoRA magnitude vector, a stray `.weight`, and the HuggingFace PEFT
+///    `.lora_A.weight` spelling this build does not read all land here.
+/// 2. Both halves of every pair are present.
+/// 3. Every pair resolves to a base weight this checkpoint actually holds.
+///
+/// Rank compatibility and the delta-versus-base shape check stay where they
+/// already were, in [`compute_lora_delta`] and the fusion loop's shape guard,
+/// because both need the computed delta.
+///
+/// Violations are collected rather than reported one at a time: an adapter
+/// built for the wrong architecture fails on every layer, and reporting the
+/// first one would need as many load attempts as the model has layers. Both
+/// the violation list and the returned pairs are sorted, because [`WeightMap`]
+/// is a `HashMap` and neither the diagnostic nor the fusion order may depend on
+/// its iteration order.
+///
+/// Used by: [`fuse_lora_weights_into`], [`super::runtime::stage_runtime_adapters`]
+pub(super) fn validate_adapter_tensors(
+    base_weights: &WeightMap,
+    adapter_weights: &WeightMap,
+) -> Result<Vec<FusablePair>> {
+    type Halves<'a> = (
+        Option<&'a UniquePtr<MlxArray>>,
+        Option<&'a UniquePtr<MlxArray>>,
+    );
+
+    let mut halves: HashMap<&str, Halves<'_>> = HashMap::new();
+    let mut violations: Vec<String> = Vec::new();
+
+    for (name, weight) in adapter_weights {
+        if let Some(layer) = name.strip_suffix(".lora_a") {
+            halves.entry(layer).or_default().0 = Some(weight);
+        } else if let Some(layer) = name.strip_suffix(".lora_b") {
+            halves.entry(layer).or_default().1 = Some(weight);
+        } else {
+            violations.push(format!(
+                "{name}: not a LoRA tensor (expected .lora_a or .lora_b)"
+            ));
+        }
+    }
+
+    let mut pairs: Vec<FusablePair> = Vec::with_capacity(halves.len());
+    for (layer, (lora_a, lora_b)) in halves {
+        let (Some(lora_a), Some(lora_b)) = (lora_a, lora_b) else {
+            let (present, missing) = if lora_a.is_some() {
+                ("lora_a", "lora_b")
+            } else {
+                ("lora_b", "lora_a")
+            };
+            violations.push(format!(
+                "{layer}.{present}: incomplete pair (missing {layer}.{missing})"
+            ));
+            continue;
+        };
+        let Some(base_weight_name) = find_base_weight_name(layer, base_weights) else {
+            violations.push(format!(
+                "{layer}.lora_a: no base weight (tried {})",
+                base_weight_candidates(layer).join(", ")
+            ));
+            continue;
+        };
+        pairs.push(FusablePair {
+            layer: layer.to_string(),
+            base_weight_name,
+            lora_a: mlxcel_core::copy(lora_a),
+            lora_b: mlxcel_core::copy(lora_b),
+        });
+    }
+
+    if !violations.is_empty() {
+        violations.sort();
+        let count = violations.len();
+        let noun = if count == 1 { "tensor" } else { "tensors" };
+        anyhow::bail!(
+            "{count} adapter {noun} cannot be applied to this model:\n  {}\n\
+             Every tensor in a fusable adapter has to be one half of a <layer>.lora_a / \
+             <layer>.lora_b pair whose base weight this checkpoint holds; skipping the rest \
+             would serve weights that match neither the base model nor the fine-tune.",
+            violations.join("\n  "),
+        );
+    }
+
+    pairs.sort_by(|a, b| {
+        a.base_weight_name
+            .cmp(&b.base_weight_name)
+            .then_with(|| a.layer.cmp(&b.layer))
+    });
+    Ok(pairs)
+}
+
 /// Fuse LoRA weights into base model weights
 ///
 /// LoRA formula: W_fused = W_base + scale * (lora_b @ lora_a)
@@ -74,12 +250,28 @@ pub fn fuse_lora_weights(
     adapter_weights: &WeightMap,
     scale: f32,
 ) -> Result<WeightMap> {
+    let (fused_weights, _) = fuse_lora_weights_counted(base_weights, adapter_weights, scale)?;
+    Ok(fused_weights)
+}
+
+/// [`fuse_lora_weights`] with the number of pairs that were actually applied.
+///
+/// Only [`apply_lora_adapters_scaled`] needs the count, and it needs it to be
+/// the fused total rather than an adapter key count, so this stays private
+/// instead of widening the public surface.
+///
+/// Used by: [`fuse_lora_weights`], [`apply_lora_adapters_scaled`]
+fn fuse_lora_weights_counted(
+    base_weights: &WeightMap,
+    adapter_weights: &WeightMap,
+    scale: f32,
+) -> Result<(WeightMap, usize)> {
     let mut fused_weights: WeightMap = base_weights
         .iter()
         .map(|(k, v)| (k.clone(), mlxcel_core::copy(v)))
         .collect();
-    fuse_lora_weights_into(&mut fused_weights, adapter_weights, scale)?;
-    Ok(fused_weights)
+    let fused_count = fuse_lora_weights_into(&mut fused_weights, adapter_weights, scale)?;
+    Ok((fused_weights, fused_count))
 }
 
 /// Fuse LoRA adapter weights into an existing base [`WeightMap`] in place.
@@ -91,8 +283,12 @@ pub fn fuse_lora_weights(
 /// allocation of a second weight map).
 ///
 /// If the adapter weight map is stage-filtered, only the layers covered by
-/// the filter will produce fusion updates — `base_weights` entries that are
+/// the filter will produce fusion updates. `base_weights` entries that are
 /// not referenced by any `lora_a` / `lora_b` pair are left untouched.
+///
+/// Returns the number of pairs that were applied. That is the count callers
+/// must log: counting `.lora_a` keys instead reported tensors that had been
+/// skipped as if they had been fused (issue #1328).
 ///
 /// # Layout
 ///
@@ -107,69 +303,51 @@ pub fn fuse_lora_weights(
 ///
 /// # Errors
 ///
-/// Returns an error, leaving `base_weights` untouched, when the base weight map
-/// stores its projections transposed, or when a resolved base weight and its
-/// delta disagree on shape.
+/// Returns an error when any adapter tensor cannot be applied to this base
+/// weight map (see [`validate_adapter_tensors`]) or when the base weight map
+/// stores its projections transposed. Both verdicts are taken before the first
+/// write, so `base_weights` is untouched. A per-pair shape disagreement is
+/// found later, with the computed delta in hand, so it can leave the pairs
+/// sorted ahead of it applied.
 ///
-/// Used by: [`fuse_lora_weights`], [`apply_stage_lora_adapter`]
+/// Used by: [`fuse_lora_weights_counted`], [`apply_stage_lora_adapter`]
 pub fn fuse_lora_weights_into(
     base_weights: &mut WeightMap,
     adapter_weights: &WeightMap,
     scale: f32,
-) -> Result<()> {
-    // Group adapter weights by their base layer name
-    // LoRA weights are typically named like:
-    // - layers.0.self_attn.q_proj.lora_a (rank, in_features)
-    // - layers.0.self_attn.q_proj.lora_b (out_features, rank)
-    let mut lora_pairs: std::collections::HashMap<
-        String,
-        (Option<UniquePtr<MlxArray>>, Option<UniquePtr<MlxArray>>),
-    > = std::collections::HashMap::new();
-
-    for (name, weight) in adapter_weights {
-        if name.ends_with(".lora_a") {
-            let base_name = name.trim_end_matches(".lora_a").to_string();
-            lora_pairs.entry(base_name).or_insert((None, None)).0 = Some(mlxcel_core::copy(weight));
-        } else if name.ends_with(".lora_b") {
-            let base_name = name.trim_end_matches(".lora_b").to_string();
-            lora_pairs.entry(base_name).or_insert((None, None)).1 = Some(mlxcel_core::copy(weight));
-        }
-        // Ignore other weights (like scales for DoRA)
-    }
+) -> Result<usize> {
+    // Pair the adapter tensors up and resolve each pair's base weight before
+    // anything is written. Adapter tensor names look like
+    // `layers.0.self_attn.q_proj.lora_a` / `.lora_b`, and anything that is not
+    // one half of such a pair, or that resolves to no base weight, fails the
+    // whole load here rather than being skipped.
+    let pairs = validate_adapter_tensors(base_weights, adapter_weights)?;
 
     // Refuse up front if the base weight map still stores its projections
     // transposed. This has to be a whole-map verdict taken before the first
     // `add`, because the square `attn.c_proj` is precisely the case where the
     // two shapes agree and the corruption would be silent.
-    if !lora_pairs.is_empty() {
-        let adapter_layers: Vec<&str> = lora_pairs.keys().map(String::as_str).collect();
-        reject_conv1d_layout_fusion(base_weights, &adapter_layers)?;
-    }
+    reject_conv1d_layout_fusion(base_weights, &pairs)?;
 
     // Fuse each LoRA pair with the corresponding base weight
-    for (base_name, (lora_a_opt, lora_b_opt)) in lora_pairs {
-        let (Some(lora_a), Some(lora_b)) = (lora_a_opt, lora_b_opt) else {
-            tracing::warn!(
-                "Incomplete LoRA pair for {}: missing lora_a or lora_b",
-                base_name
-            );
-            continue;
-        };
+    let mut fused_count = 0usize;
+    for pair in &pairs {
+        let FusablePair {
+            layer: base_name,
+            base_weight_name,
+            lora_a,
+            lora_b,
+        } = pair;
 
-        // Find the corresponding base weight
-        let base_weight_name = find_base_weight_name(&base_name, base_weights)?;
-
-        let Some(base_weight) = base_weights.get(&base_weight_name) else {
-            tracing::warn!(
-                "Base weight not found for LoRA layer {}: tried {}",
-                base_name,
-                base_weight_name
+        let Some(base_weight) = base_weights.get(base_weight_name) else {
+            anyhow::bail!(
+                "internal error: base weight {base_weight_name} for adapter layer {base_name} \
+                 was resolved during validation but is no longer in the weight map"
             );
-            continue;
         };
 
         // Compute the LoRA delta: scale * (lora_b @ lora_a)
-        let delta = compute_lora_delta(&lora_a, &lora_b, scale)?;
+        let delta = compute_lora_delta(lora_a, lora_b, scale)?;
 
         // Never hand mismatched operands to `mlxcel_core::add`. MLX broadcasts,
         // so a mismatch is not reliably an error: a base weight that is one
@@ -202,10 +380,11 @@ pub fn fuse_lora_weights_into(
         // Fuse: W_fused = W_base + delta
         let fused = mlxcel_core::add(base_weight, &delta);
 
-        base_weights.insert(base_weight_name, fused);
+        base_weights.insert(base_weight_name.clone(), fused);
+        fused_count += 1;
     }
 
-    Ok(())
+    Ok(fused_count)
 }
 
 /// Suffixes of the transformer-block projections that a HuggingFace GPT-2
@@ -306,31 +485,36 @@ fn detect_conv1d_projection_layout(base_weights: &WeightMap) -> Option<Conv1dLay
 /// Refuse to fuse into a base weight map whose projections are still stored
 /// transposed, before any operand reaches MLX.
 ///
-/// `adapter_layers` are the layer paths the adapter targets, i.e. the
-/// `lora_a` / `lora_b` key stems. Only targets that resolve to a projection
-/// actually stored in `Conv1D` layout are reported; an adapter that touches
-/// nothing transposed (an embedding-only adapter, say) fuses as before.
+/// `pairs` are the adapter pairs [`validate_adapter_tensors`] already resolved
+/// against this map, so every `base_weight_name` is known to exist. Only
+/// targets that land on a projection actually stored in `Conv1D` layout are
+/// reported; an adapter that touches nothing transposed (an embedding-only
+/// adapter, say) fuses as before.
 ///
 /// This deliberately does not repair anything. Transposing the delta would fix
 /// the non-square projections and leave the square `attn.c_proj` just as wrong,
 /// because a square weight gives no evidence about which orientation was
 /// intended. Reporting is the only honest outcome.
-fn reject_conv1d_layout_fusion(base_weights: &WeightMap, adapter_layers: &[&str]) -> Result<()> {
+fn reject_conv1d_layout_fusion(base_weights: &WeightMap, pairs: &[FusablePair]) -> Result<()> {
+    if pairs.is_empty() {
+        return Ok(());
+    }
     let Some(evidence) = detect_conv1d_projection_layout(base_weights) else {
         return Ok(());
     };
 
-    let mut affected: Vec<String> = Vec::new();
-    for layer in adapter_layers {
-        let resolved = find_base_weight_name(layer, base_weights)?;
-        if conv1d_projection_suffix(&resolved).is_some() && base_weights.contains_key(&resolved) {
-            affected.push(resolved);
-        }
-    }
+    let mut affected: Vec<&str> = pairs
+        .iter()
+        .filter(|pair| conv1d_projection_suffix(&pair.base_weight_name).is_some())
+        .map(|pair| pair.base_weight_name.as_str())
+        .collect();
     if affected.is_empty() {
         return Ok(());
     }
-    affected.sort();
+    // Two adapter layers can resolve to one base weight (a `.base_layer`
+    // spelling next to a plain one), so the list is deduplicated as well.
+    affected.sort_unstable();
+    affected.dedup();
 
     let Conv1dLayoutEvidence { key, shape } = evidence;
     anyhow::bail!(
@@ -347,28 +531,6 @@ fn reject_conv1d_layout_fusion(base_weights: &WeightMap, adapter_layers: &[&str]
          the model without the adapter.",
         affected.join(", "),
     );
-}
-
-/// Find the base weight name that corresponds to a LoRA layer name
-pub(crate) fn find_base_weight_name(lora_name: &str, base_weights: &WeightMap) -> Result<String> {
-    // Common patterns to try:
-    // 1. Direct match with .weight suffix
-    // 2. Replace specific LoRA naming conventions
-    let candidates = vec![
-        format!("{}.weight", lora_name),
-        lora_name.to_string(),
-        // HuggingFace PEFT format uses base_layer
-        lora_name.replace(".base_layer", ".weight"),
-    ];
-
-    for candidate in &candidates {
-        if base_weights.contains_key(candidate) {
-            return Ok(candidate.clone());
-        }
-    }
-
-    // If no direct match, return the most likely candidate
-    Ok(format!("{}.weight", lora_name))
 }
 
 /// Compute the LoRA delta: scale * (lora_b @ lora_a)
@@ -462,12 +624,7 @@ pub fn apply_lora_adapters_scaled(
         config.fine_tune_type
     );
 
-    if !config.is_lora() {
-        anyhow::bail!(
-            "Adapter is not LoRA type: {:?}. Full fine-tuning adapters should be loaded directly.",
-            config.fine_tune_type
-        );
-    }
+    reject_unsupported_fine_tune_type(&config, adapter_path)?;
 
     // Load adapter weights
     let adapter_weights = load_adapter_weights(adapter_path)?;
@@ -475,19 +632,26 @@ pub fn apply_lora_adapters_scaled(
     tracing::info!("Loaded {} adapter weight tensors", adapter_weights.len());
 
     // Fuse weights
-    let fused = fuse_lora_weights(
+    let (fused, fused_count) = fuse_lora_weights_counted(
         base_weights,
         &adapter_weights,
         config.effective_scale() * user_scale,
-    )?;
+    )
+    .map_err(|err| anyhow::anyhow!("Adapter at {}: {err}", adapter_path.display()))?;
 
-    // Count how many weights were modified
-    let modified_count = adapter_weights
-        .keys()
-        .filter(|k| k.ends_with(".lora_a"))
-        .count();
+    // An adapter that applies nothing is the failure this path exists to
+    // report: the model would load and serve the base weights unchanged while
+    // every log line said the adapter was in place. The pipeline-stage entry
+    // point deliberately does not take this check, because a stage that owns
+    // none of the adapter's layers applies zero pairs by design.
+    if fused_count == 0 {
+        anyhow::bail!(
+            "Adapter at {} applied no tensors to this model: it holds no lora_a / lora_b pair",
+            adapter_path.display()
+        );
+    }
 
-    tracing::info!("Fused LoRA adapters into {} layers", modified_count);
+    tracing::info!("Fused LoRA adapters into {fused_count} layers");
 
     Ok(fused)
 }
@@ -508,12 +672,18 @@ pub fn apply_lora_adapters_scaled(
 /// `load_model_with_adapter`, but it shares [`fuse_lora_weights_into`], so it
 /// inherits the same layout and shape guards.
 ///
+/// Returns the number of pairs this stage applied. Zero is a valid result and
+/// is never an error here: an adapter may target a subset of the model's
+/// layers, and a stage that owns none of them has nothing to apply. The
+/// whole-model entry point ([`apply_lora_adapters_scaled`]) is the one that
+/// treats zero as a failed load.
+///
 /// Used by: pipeline stage initialization (family stage executors)
 pub fn apply_stage_lora_adapter(
     base_weights: &mut WeightMap,
     adapter_path: &Path,
     filter: &crate::distributed::pipeline::LayerFilter,
-) -> Result<()> {
+) -> Result<usize> {
     let config = AdapterConfig::load(adapter_path)?;
 
     tracing::info!(
@@ -525,34 +695,23 @@ pub fn apply_stage_lora_adapter(
         filter.layer_range.end,
     );
 
-    if !config.is_lora() {
-        anyhow::bail!(
-            "Adapter is not LoRA type: {:?}. Full fine-tuning adapters should be loaded directly.",
-            config.fine_tune_type
-        );
-    }
+    reject_unsupported_fine_tune_type(&config, adapter_path)?;
 
     let adapter_weights =
         crate::distributed::pipeline::load_stage_adapter_weights(adapter_path, filter)?;
-
-    let modified_count = adapter_weights
-        .keys()
-        .filter(|k| k.ends_with(".lora_a"))
-        .count();
 
     tracing::info!(
         "Loaded {} adapter tensors for stage (skipped out-of-range adapter layers)",
         adapter_weights.len(),
     );
 
-    fuse_lora_weights_into(base_weights, &adapter_weights, config.effective_scale())?;
+    let fused_count =
+        fuse_lora_weights_into(base_weights, &adapter_weights, config.effective_scale())
+            .map_err(|err| anyhow::anyhow!("Adapter at {}: {err}", adapter_path.display()))?;
 
-    tracing::info!(
-        "Fused stage-local LoRA adapters into {} layers",
-        modified_count,
-    );
+    tracing::info!("Fused stage-local LoRA adapters into {fused_count} layers");
 
-    Ok(())
+    Ok(fused_count)
 }
 
 #[cfg(test)]

--- a/src/lora/loader.rs
+++ b/src/lora/loader.rs
@@ -144,8 +144,10 @@ fn find_base_weight_name(lora_name: &str, base_weights: &WeightMap) -> Option<St
 /// the base weight in place:
 ///
 /// 1. Every tensor is one half of a `<layer>.lora_a` / `<layer>.lora_b` pair.
-///    A DoRA magnitude vector, a stray `.weight`, and the HuggingFace PEFT
-///    `.lora_A.weight` spelling this build does not read all land here.
+///    A DoRA magnitude vector and a stray `.weight` land here. The HuggingFace
+///    PEFT `.lora_A.weight` spelling this build does not read gets its own
+///    single aggregated line, because reporting it per tensor would be one
+///    line per layer per module for an adapter that has exactly one problem.
 /// 2. Both halves of every pair are present.
 /// 3. Every pair resolves to a base weight this checkpoint actually holds.
 ///
@@ -172,12 +174,20 @@ pub(super) fn validate_adapter_tensors(
 
     let mut halves: HashMap<&str, Halves<'_>> = HashMap::new();
     let mut violations: Vec<String> = Vec::new();
+    // A HuggingFace PEFT export spells every tensor `<layer>.lora_A.weight` /
+    // `.lora_B.weight`, so reporting it per tensor would bury the one thing the
+    // user needs to know under a line per layer per module. Counted here and
+    // reported once below.
+    let mut peft_named: Option<(usize, &str)> = None;
 
     for (name, weight) in adapter_weights {
         if let Some(layer) = name.strip_suffix(".lora_a") {
             halves.entry(layer).or_default().0 = Some(weight);
         } else if let Some(layer) = name.strip_suffix(".lora_b") {
             halves.entry(layer).or_default().1 = Some(weight);
+        } else if name.ends_with(".lora_A.weight") || name.ends_with(".lora_B.weight") {
+            let (count, example) = peft_named.unwrap_or((0, name.as_str()));
+            peft_named = Some((count + 1, example.min(name.as_str())));
         } else {
             violations.push(format!(
                 "{name}: not a LoRA tensor (expected .lora_a or .lora_b)"
@@ -185,7 +195,19 @@ pub(super) fn validate_adapter_tensors(
         }
     }
 
-    let mut pairs: Vec<FusablePair> = Vec::with_capacity(halves.len());
+    if let Some((count, example)) = peft_named {
+        violations.push(format!(
+            "{example}: HuggingFace PEFT tensor naming (.lora_A.weight / .lora_B.weight) is not \
+             read by this build, which expects the mlx-lm .lora_a / .lora_b spelling ({count} \
+             tensors in this adapter); convert the adapter with mlx-lm first"
+        ));
+    }
+
+    // Resolved without copying any tensor, because a wrong-architecture adapter
+    // fails on every layer and would otherwise materialize a full set of copies
+    // only to drop them at the bail below.
+    let mut resolved: Vec<(&str, String, &UniquePtr<MlxArray>, &UniquePtr<MlxArray>)> =
+        Vec::with_capacity(halves.len());
     for (layer, (lora_a, lora_b)) in halves {
         let (Some(lora_a), Some(lora_b)) = (lora_a, lora_b) else {
             let (present, missing) = if lora_a.is_some() {
@@ -205,12 +227,7 @@ pub(super) fn validate_adapter_tensors(
             ));
             continue;
         };
-        pairs.push(FusablePair {
-            layer: layer.to_string(),
-            base_weight_name,
-            lora_a: mlxcel_core::copy(lora_a),
-            lora_b: mlxcel_core::copy(lora_b),
-        });
+        resolved.push((layer, base_weight_name, lora_a, lora_b));
     }
 
     if !violations.is_empty() {
@@ -226,6 +243,15 @@ pub(super) fn validate_adapter_tensors(
         );
     }
 
+    let mut pairs: Vec<FusablePair> = resolved
+        .into_iter()
+        .map(|(layer, base_weight_name, lora_a, lora_b)| FusablePair {
+            layer: layer.to_string(),
+            base_weight_name,
+            lora_a: mlxcel_core::copy(lora_a),
+            lora_b: mlxcel_core::copy(lora_b),
+        })
+        .collect();
     pairs.sort_by(|a, b| {
         a.base_weight_name
             .cmp(&b.base_weight_name)

--- a/src/lora/loader_tests.rs
+++ b/src/lora/loader_tests.rs
@@ -24,6 +24,7 @@
 //! classification before exercising fusion.
 
 use super::*;
+use crate::lora::test_support::{adapter_pair_tensors, ones_tensor, temp_dir, write_adapter_dir};
 use crate::models::gpt2::Gpt2Layout;
 use crate::models::gpt2::tests::{mlx_converted_weights, raw_hf_weights, tiny_args};
 
@@ -46,6 +47,17 @@ fn lora_pair(layer: &str, in_features: i32, rank: i32, out_features: i32) -> Wei
         mlxcel_core::ones(&[rank, out_features], mlxcel_core::dtype::FLOAT32),
     );
     adapter
+}
+
+/// The error text of a call that must fail.
+///
+/// `Result::expect_err` needs `T: Debug`, and a [`WeightMap`] holds
+/// `UniquePtr<MlxArray>`, which is not `Debug`.
+fn fusion_error<T>(result: Result<T>, what: &str) -> String {
+    match result {
+        Ok(_) => panic!("{what}"),
+        Err(err) => err.to_string(),
+    }
 }
 
 fn tensor_sum(weight: &MlxArray) -> f32 {
@@ -258,7 +270,7 @@ fn conv1d_checkpoint_rejects_every_non_square_projection_without_aborting() {
         let adapter = lora_pair(layer, in_features, 2, out_features);
 
         let err = match fuse_lora_weights_into(&mut base, &adapter, 0.5) {
-            Ok(()) => panic!("{layer} must not fuse"),
+            Ok(fused) => panic!("{layer} must not fuse ({fused} applied)"),
             Err(err) => err.to_string(),
         };
         assert!(err.contains("Conv1D"), "{layer}: {err}");
@@ -382,4 +394,227 @@ fn a_mismatch_that_is_not_a_transpose_omits_the_transpose_hint() {
         .to_string();
     assert!(err.contains("[8, 4]") && err.contains("[4, 4]"), "{err}");
     assert!(!err.contains("transposes"), "{err}");
+}
+
+// ---------------------------------------------------------------------------
+// Adapter tensor validation (issue #1328)
+//
+// Every case below used to be a `warn!` and a `continue`: the load succeeded,
+// the "fused into N layers" line counted the skipped tensors anyway, and the
+// server answered from base weights under the adapter's name.
+// ---------------------------------------------------------------------------
+
+/// A base weight map holding one `[out, in]` projection per named layer.
+fn base_map(layers: &[(&str, i32, i32)]) -> WeightMap {
+    let mut base = WeightMap::new();
+    for (layer, out_features, in_features) in layers {
+        base.insert(
+            format!("{layer}.weight"),
+            mlxcel_core::ones(&[*out_features, *in_features], mlxcel_core::dtype::FLOAT32),
+        );
+    }
+    base
+}
+
+#[test]
+fn adapter_pair_without_base_weight_is_an_error() {
+    let base = base_map(&[("layer", 3, 4)]);
+    let adapter = lora_pair("other", 4, 2, 3);
+
+    let err = fusion_error(
+        fuse_lora_weights(&base, &adapter, 1.0),
+        "an adapter layer the model does not have must not load",
+    );
+    assert!(err.contains("other.lora_a"), "{err}");
+    assert!(err.contains("no base weight"), "{err}");
+    assert!(err.contains("tried other.weight"), "{err}");
+}
+
+#[test]
+fn adapter_with_unknown_leaf_is_an_error() {
+    // A DoRA magnitude vector next to a well-formed pair: the pair alone would
+    // fuse cleanly and produce weights that are neither base nor fine-tune.
+    let base = base_map(&[("layer", 3, 4)]);
+    let mut adapter = lora_pair("layer", 4, 2, 3);
+    adapter.insert(
+        "layer.m".to_string(),
+        mlxcel_core::ones(&[3], mlxcel_core::dtype::FLOAT32),
+    );
+
+    let err = fusion_error(
+        fuse_lora_weights(&base, &adapter, 1.0),
+        "an unrecognised adapter tensor must not be dropped",
+    );
+    assert!(err.contains("layer.m"), "{err}");
+    assert!(err.contains("not a LoRA tensor"), "{err}");
+}
+
+#[test]
+fn incomplete_pair_is_an_error() {
+    let base = base_map(&[("layer", 3, 4)]);
+    let mut adapter = WeightMap::new();
+    adapter.insert(
+        "layer.lora_a".to_string(),
+        mlxcel_core::ones(&[4, 2], mlxcel_core::dtype::FLOAT32),
+    );
+
+    let err = fusion_error(
+        fuse_lora_weights(&base, &adapter, 1.0),
+        "half a pair cannot be applied",
+    );
+    assert!(err.contains("layer.lora_a"), "{err}");
+    assert!(err.contains("layer.lora_b"), "{err}");
+    assert!(err.contains("incomplete pair"), "{err}");
+
+    // The mirror case: a lone `lora_b` names the missing `lora_a`.
+    let mut adapter = WeightMap::new();
+    adapter.insert(
+        "layer.lora_b".to_string(),
+        mlxcel_core::ones(&[2, 3], mlxcel_core::dtype::FLOAT32),
+    );
+    let err = fusion_error(
+        fuse_lora_weights(&base, &adapter, 1.0),
+        "half a pair cannot be applied",
+    );
+    assert!(err.contains("layer.lora_b: incomplete pair"), "{err}");
+    assert!(err.contains("missing layer.lora_a"), "{err}");
+}
+
+#[test]
+fn all_violations_are_reported_together() {
+    // An adapter built for another architecture fails on every layer it
+    // carries. Reporting one at a time would need as many load attempts as the
+    // model has layers, so the report is exhaustive and sorted (`WeightMap` is
+    // a `HashMap`, so an unsorted report would reorder run to run).
+    let base = base_map(&[("kept", 3, 4)]);
+    let mut adapter = lora_pair("missing_one", 4, 2, 3);
+    adapter.extend(lora_pair("missing_two", 4, 2, 3));
+    adapter.insert(
+        "kept.stray".to_string(),
+        mlxcel_core::ones(&[3], mlxcel_core::dtype::FLOAT32),
+    );
+
+    let err = fusion_error(fuse_lora_weights(&base, &adapter, 1.0), "must not load");
+    assert!(err.contains("3 adapter tensors cannot be applied"), "{err}");
+
+    let kept = err.find("kept.stray").expect("stray leaf reported");
+    let one = err
+        .find("missing_one.lora_a")
+        .expect("first layer reported");
+    let two = err
+        .find("missing_two.lora_a")
+        .expect("second layer reported");
+    assert!(kept < one && one < two, "report must be sorted: {err}");
+}
+
+#[test]
+fn fused_count_reports_applied_pairs() {
+    let mut base = base_map(&[("a", 3, 4), ("b", 5, 6)]);
+    let mut adapter = lora_pair("a", 4, 2, 3);
+    adapter.extend(lora_pair("b", 6, 2, 5));
+
+    let fused = fuse_lora_weights_into(&mut base, &adapter, 1.0).expect("both pairs apply");
+    assert_eq!(fused, 2);
+}
+
+#[test]
+fn a_peft_base_layer_pair_resolves_to_the_wrapped_weight() {
+    // HuggingFace PEFT wraps the frozen projection, so `<layer>.base_layer`
+    // has to resolve to `<layer>.weight`. Dropping the no-match fallback must
+    // not lose that.
+    let mut base = base_map(&[("model.layers.0.self_attn.q_proj", 3, 4)]);
+    let before = tensor_sum(base.get("model.layers.0.self_attn.q_proj.weight").unwrap());
+
+    let adapter = lora_pair("model.layers.0.self_attn.q_proj.base_layer", 4, 2, 3);
+    let fused = fuse_lora_weights_into(&mut base, &adapter, 0.5).expect("PEFT naming resolves");
+    assert_eq!(fused, 1);
+
+    let after = tensor_sum(base.get("model.layers.0.self_attn.q_proj.weight").unwrap());
+    let expected = before + 0.5 * 2.0 * (3 * 4) as f32;
+    assert!(
+        (after - expected).abs() < 1e-3,
+        "after={after}, expected={expected}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Adapter directory acceptance (`apply_lora_adapters`)
+// ---------------------------------------------------------------------------
+
+#[test]
+fn dora_adapter_is_refused() {
+    // The pair itself is valid, so nothing but the declared type can catch
+    // this: applying it would drop the magnitude vectors the checkpoint's own
+    // tooling folds in, and the result matches neither base nor fine-tune.
+    let dir = temp_dir("dora");
+    write_adapter_dir(&dir, "dora", 2, adapter_pair_tensors("layer", 4, 2, 3));
+
+    let base = base_map(&[("layer", 3, 4)]);
+    let err = fusion_error(
+        apply_lora_adapters(&base, &dir),
+        "a DoRA adapter must not be applied as LoRA",
+    );
+    assert!(err.contains("DoRA"), "{err}");
+    assert!(err.contains("dora"), "{err}");
+
+    let _ = std::fs::remove_dir_all(&dir);
+}
+
+#[test]
+fn full_fine_tune_adapter_is_refused() {
+    let dir = temp_dir("full");
+    write_adapter_dir(&dir, "full", 2, adapter_pair_tensors("layer", 4, 2, 3));
+
+    let base = base_map(&[("layer", 3, 4)]);
+    let err = fusion_error(
+        apply_lora_adapters(&base, &dir),
+        "a full fine-tune is not an adapter",
+    );
+    assert!(err.contains("not LoRA type"), "{err}");
+
+    let _ = std::fs::remove_dir_all(&dir);
+}
+
+#[test]
+fn an_adapter_that_applies_nothing_is_refused() {
+    // Every tensor is either applied or reported, so an empty file is the one
+    // way to reach zero. It is still a failed load: the model would serve base
+    // weights while the startup log said an adapter was in place.
+    let dir = temp_dir("empty");
+    write_adapter_dir(&dir, "lora", 2, std::collections::HashMap::new());
+
+    let base = base_map(&[("layer", 3, 4)]);
+    let err = fusion_error(
+        apply_lora_adapters(&base, &dir),
+        "an adapter with no pairs must not load",
+    );
+    assert!(err.contains("applied no tensors"), "{err}");
+    assert!(err.contains(&dir.display().to_string()), "{err}");
+
+    let _ = std::fs::remove_dir_all(&dir);
+}
+
+#[test]
+fn a_valid_adapter_directory_still_applies_and_names_its_directory_on_failure() {
+    let dir = temp_dir("valid");
+    let mut tensors = adapter_pair_tensors("layer", 4, 2, 3);
+    tensors.insert("layer.m".to_string(), ones_tensor(3, 1));
+    write_adapter_dir(&dir, "lora", 2, tensors);
+
+    let base = base_map(&[("layer", 3, 4)]);
+    let err = fusion_error(
+        apply_lora_adapters(&base, &dir),
+        "the stray magnitude tensor fails the load",
+    );
+    assert!(err.contains(&dir.display().to_string()), "{err}");
+    assert!(err.contains("layer.m"), "{err}");
+
+    // The same directory without the stray tensor loads and applies one pair.
+    write_adapter_dir(&dir, "lora", 2, adapter_pair_tensors("layer", 4, 2, 3));
+    let fused = apply_lora_adapters(&base, &dir).expect("a well-formed adapter applies");
+    let after = tensor_sum(fused.get("layer.weight").unwrap());
+    // 12 base entries of 1.0 plus a delta of scale (1.0) * rank (2) everywhere.
+    assert!((after - 36.0).abs() < 1e-3, "unexpected fused sum: {after}");
+
+    let _ = std::fs::remove_dir_all(&dir);
 }

--- a/src/lora/loader_tests.rs
+++ b/src/lora/loader_tests.rs
@@ -24,7 +24,7 @@
 //! classification before exercising fusion.
 
 use super::*;
-use crate::lora::test_support::{adapter_pair_tensors, ones_tensor, temp_dir, write_adapter_dir};
+use crate::lora::test_support::{adapter_pair_tensors, ones_vector, temp_dir, write_adapter_dir};
 use crate::models::gpt2::Gpt2Layout;
 use crate::models::gpt2::tests::{mlx_converted_weights, raw_hf_weights, tiny_args};
 
@@ -598,7 +598,7 @@ fn an_adapter_that_applies_nothing_is_refused() {
 fn a_valid_adapter_directory_still_applies_and_names_its_directory_on_failure() {
     let dir = temp_dir("valid");
     let mut tensors = adapter_pair_tensors("layer", 4, 2, 3);
-    tensors.insert("layer.m".to_string(), ones_tensor(3, 1));
+    tensors.insert("layer.m".to_string(), ones_vector(3));
     write_adapter_dir(&dir, "lora", 2, tensors);
 
     let base = base_map(&[("layer", 3, 4)]);
@@ -617,4 +617,43 @@ fn a_valid_adapter_directory_still_applies_and_names_its_directory_on_failure() 
     assert!((after - 36.0).abs() < 1e-3, "unexpected fused sum: {after}");
 
     let _ = std::fs::remove_dir_all(&dir);
+}
+
+#[test]
+fn a_peft_named_adapter_is_reported_once_with_the_conversion_hint() {
+    // A HuggingFace PEFT export spells every tensor `.lora_A.weight` /
+    // `.lora_B.weight`, which this build does not read. Reporting that per
+    // tensor would be one line per layer per module, so the whole adapter gets
+    // a single line that names the spelling and how many tensors carry it.
+    let base = base_map(&[("model.layers.0.self_attn.q_proj", 3, 4)]);
+    let mut adapter = WeightMap::new();
+    for layer in 0..3 {
+        for half in ["lora_A", "lora_B"] {
+            adapter.insert(
+                format!("base_model.model.model.layers.{layer}.self_attn.q_proj.{half}.weight"),
+                mlxcel_core::ones(&[2, 4], mlxcel_core::dtype::FLOAT32),
+            );
+        }
+    }
+
+    let err = fusion_error(
+        fuse_lora_weights(&base, &adapter, 1.0),
+        "PEFT tensor naming is not read by this build",
+    );
+    assert!(
+        err.contains("1 adapter tensor cannot be applied"),
+        "the whole adapter must collapse to one line: {err}"
+    );
+    assert!(err.contains("HuggingFace PEFT tensor naming"), "{err}");
+    assert!(err.contains("(6 tensors in this adapter)"), "{err}");
+    assert!(
+        err.contains("convert the adapter with mlx-lm first"),
+        "{err}"
+    );
+    // The example names the lexicographically smallest offender, so the report
+    // does not depend on `WeightMap`'s hash order.
+    assert!(
+        err.contains("base_model.model.model.layers.0.self_attn.q_proj.lora_A.weight"),
+        "{err}"
+    );
 }

--- a/src/lora/mod.rs
+++ b/src/lora/mod.rs
@@ -24,6 +24,8 @@ mod config;
 mod loader;
 pub mod multi;
 pub mod runtime;
+#[cfg(test)]
+mod test_support;
 
 pub use config::{AdapterConfig, LoRAParameters};
 pub use loader::{

--- a/src/lora/runtime.rs
+++ b/src/lora/runtime.rs
@@ -42,7 +42,9 @@ use mlxcel_core::runtime_lora::{PendingLoraTerm, SharedLoraScale};
 use mlxcel_core::weights::WeightMap;
 
 use super::config::AdapterConfig;
-use super::loader::{find_base_weight_name, load_adapter_weights};
+use super::loader::{
+    load_adapter_weights, reject_unsupported_fine_tune_type, validate_adapter_tensors,
+};
 use super::multi::LoraAdapterSpec;
 
 /// One adapter's serving state.
@@ -84,14 +86,7 @@ impl RuntimeLoraSet {
             let config = AdapterConfig::load(&spec.path).map_err(|e| {
                 anyhow::anyhow!("LoRA adapter {} failed to load: {e}", spec.path.display())
             })?;
-            if !config.is_lora() {
-                anyhow::bail!(
-                    "Adapter {} is not LoRA type: {:?}. Full fine-tuning adapters should be \
-                     loaded directly.",
-                    spec.path.display(),
-                    config.fine_tune_type
-                );
-            }
+            reject_unsupported_fine_tune_type(&config, &spec.path)?;
             adapters.push(RuntimeLoraAdapter {
                 base_scale: config.effective_scale(),
                 handle: SharedLoraScale::new(spec.reported_scale()),
@@ -230,7 +225,13 @@ fn validate_pair_shapes(
     out_features: i32,
 ) -> Result<()> {
     let Some(base) = base_weights.get(base_weight_name) else {
-        return Ok(()); // caller already warned; nothing to validate against
+        // `validate_adapter_tensors` resolved this key against the same map,
+        // so reaching this arm means the two disagree, not that the adapter
+        // targets something absent.
+        anyhow::bail!(
+            "internal error: base weight {base_weight_name} for LoRA adapter layer {layer} was \
+             resolved during validation but is no longer in the weight map"
+        );
     };
     let base_shape = mlxcel_core::array_shape(base);
     if base_shape.len() != 2 {
@@ -274,61 +275,52 @@ fn validate_pair_shapes(
 
 /// Load every adapter in `set` and stage its per-layer terms for the model
 /// construction about to run on this thread (see
-/// [`mlxcel_core::runtime_lora::stage`]). Unmatched tensors warn with the
-/// same posture as the fused path (#1328 owns making both strict); shape
-/// mismatches are hard errors, as they are when fusing.
+/// [`mlxcel_core::runtime_lora::stage`]).
+///
+/// Tensor validation is the fused path's, shared verbatim through
+/// [`validate_adapter_tensors`]: an unpaired tensor, a leaf that is not a
+/// `lora_a` / `lora_b` half, or a pair with no base weight fails the load with
+/// every offender listed. Both paths used to `warn!` and continue here, which
+/// served the base model under an adapter's name (issue #1328). Shape
+/// mismatches remain hard errors, as they are when fusing.
 pub fn stage_runtime_adapters(base_weights: &WeightMap, set: &RuntimeLoraSet) -> Result<()> {
     use std::collections::HashMap;
 
     let mut pending: HashMap<String, Vec<PendingLoraTerm>> = HashMap::new();
     for adapter in &set.adapters {
         let adapter_weights = load_adapter_weights(&adapter.spec.path)?;
-        // Group `.lora_a` / `.lora_b` tensors by their base layer name,
-        // the same grouping the fused path applies.
-        let mut pairs: HashMap<String, (Option<&_>, Option<&_>)> = HashMap::new();
-        for (name, weight) in &adapter_weights {
-            if let Some(base) = name.strip_suffix(".lora_a") {
-                pairs.entry(base.to_string()).or_default().0 = Some(weight);
-            } else if let Some(base) = name.strip_suffix(".lora_b") {
-                pairs.entry(base.to_string()).or_default().1 = Some(weight);
-            }
-        }
+        let pairs = validate_adapter_tensors(base_weights, &adapter_weights)
+            .map_err(|err| anyhow::anyhow!("Adapter at {}: {err}", adapter.spec.path.display()))?;
         let mut staged_layers = 0usize;
-        for (layer, (a, b)) in pairs {
-            let (Some(a), Some(b)) = (a, b) else {
-                tracing::warn!(
-                    "Incomplete LoRA pair for {layer}: missing lora_a or lora_b (adapter {})",
-                    adapter.spec.path.display()
-                );
-                continue;
-            };
-            let base_weight_name = find_base_weight_name(&layer, base_weights)?;
-            if !base_weights.contains_key(&base_weight_name) {
-                tracing::warn!(
-                    "Base weight not found for LoRA layer {layer}: tried {base_weight_name} \
-                     (adapter {})",
-                    adapter.spec.path.display()
-                );
-                continue;
-            }
-            let a_shape = mlxcel_core::array_shape(a);
-            let b_shape = mlxcel_core::array_shape(b);
+        for pair in &pairs {
+            let layer = pair.layer.as_str();
+            let a_shape = mlxcel_core::array_shape(&pair.lora_a);
+            let b_shape = mlxcel_core::array_shape(&pair.lora_b);
             let (orientation, in_features, out_features) =
-                detect_orientation(&layer, &a_shape, &b_shape)?;
+                detect_orientation(layer, &a_shape, &b_shape)?;
             validate_pair_shapes(
-                &layer,
+                layer,
                 base_weights,
-                &base_weight_name,
+                &pair.base_weight_name,
                 in_features,
                 out_features,
             )?;
-            let prefix = base_weight_name.trim_end_matches(".weight").to_string();
+            let prefix = pair
+                .base_weight_name
+                .trim_end_matches(".weight")
+                .to_string();
             // Normalize both on-disk orientations into the forward
             // orientation the layers consume: a_t = [in, rank],
             // b_t = [rank, out].
             let (a_t, b_t) = match orientation {
-                PairOrientation::MlxLm => (mlxcel_core::copy(a), mlxcel_core::copy(b)),
-                PairOrientation::Peft => (mlxcel_core::transpose(a), mlxcel_core::transpose(b)),
+                PairOrientation::MlxLm => (
+                    mlxcel_core::copy(&pair.lora_a),
+                    mlxcel_core::copy(&pair.lora_b),
+                ),
+                PairOrientation::Peft => (
+                    mlxcel_core::transpose(&pair.lora_a),
+                    mlxcel_core::transpose(&pair.lora_b),
+                ),
             };
             pending.entry(prefix).or_default().push(PendingLoraTerm {
                 handle: adapter.handle.clone(),
@@ -337,6 +329,12 @@ pub fn stage_runtime_adapters(base_weights: &WeightMap, set: &RuntimeLoraSet) ->
                 b_t,
             });
             staged_layers += 1;
+        }
+        if staged_layers == 0 {
+            anyhow::bail!(
+                "Adapter at {} applied no tensors to this model: it holds no lora_a / lora_b pair",
+                adapter.spec.path.display()
+            );
         }
         tracing::info!(
             "Staged runtime LoRA adapter {} for {} layers (rank scale {:.3}, user scale {:.2})",
@@ -360,3 +358,7 @@ pub fn finish_runtime_staging() {
         );
     }
 }
+
+#[cfg(test)]
+#[path = "runtime_tests.rs"]
+mod tests;

--- a/src/lora/runtime_tests.rs
+++ b/src/lora/runtime_tests.rs
@@ -1,0 +1,118 @@
+// Copyright 2025-2026 Lablup Inc. and Jeongkyu Shin
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Unit tests for the runtime (unfused) adapter staging path.
+//!
+//! The runtime path shares `validate_adapter_tensors` with fusion, so these
+//! tests cover the wiring rather than re-testing every rule: that the shared
+//! validator is reached, that its report names the adapter directory, and that
+//! a well-formed adapter still stages (issue #1328).
+
+use super::*;
+use crate::lora::test_support::{adapter_pair_tensors, ones_tensor, temp_dir, write_adapter_dir};
+
+/// A base weight map holding one `[out, in]` projection per named layer.
+fn base_map(layers: &[(&str, i32, i32)]) -> WeightMap {
+    let mut base = WeightMap::new();
+    for (layer, out_features, in_features) in layers {
+        base.insert(
+            format!("{layer}.weight"),
+            mlxcel_core::ones(&[*out_features, *in_features], mlxcel_core::dtype::FLOAT32),
+        );
+    }
+    base
+}
+
+fn spec_for(dir: &std::path::Path) -> LoraAdapterSpec {
+    LoraAdapterSpec {
+        path: dir.to_path_buf(),
+        scale: 1.0,
+        apply: true,
+    }
+}
+
+#[test]
+fn runtime_staging_refuses_a_pair_with_no_base_weight() {
+    // Serving unfused has exactly the fused path's failure mode: a term whose
+    // base weight does not exist is never claimed by any layer, so the model
+    // answers from base weights while the adapter is reported as loaded.
+    let dir = temp_dir("runtime_missing");
+    write_adapter_dir(&dir, "lora", 2, adapter_pair_tensors("other", 4, 2, 3));
+
+    let set = RuntimeLoraSet::from_specs(&[spec_for(&dir)]).expect("a lora adapter config");
+    let base = base_map(&[("layer", 3, 4)]);
+
+    let err = stage_runtime_adapters(&base, &set)
+        .expect_err("an adapter that maps onto nothing must not stage")
+        .to_string();
+    assert!(err.contains(&dir.display().to_string()), "{err}");
+    assert!(err.contains("other.lora_a"), "{err}");
+    assert!(err.contains("no base weight"), "{err}");
+
+    let _ = std::fs::remove_dir_all(&dir);
+}
+
+#[test]
+fn runtime_staging_refuses_an_unknown_adapter_tensor() {
+    let dir = temp_dir("runtime_leaf");
+    let mut tensors = adapter_pair_tensors("layer", 4, 2, 3);
+    tensors.insert("layer.m".to_string(), ones_tensor(3, 1));
+    write_adapter_dir(&dir, "lora", 2, tensors);
+
+    let set = RuntimeLoraSet::from_specs(&[spec_for(&dir)]).expect("a lora adapter config");
+    let base = base_map(&[("layer", 3, 4)]);
+
+    let err = stage_runtime_adapters(&base, &set)
+        .expect_err("a magnitude vector must not be dropped on this path either")
+        .to_string();
+    assert!(err.contains("layer.m"), "{err}");
+    assert!(err.contains("not a LoRA tensor"), "{err}");
+
+    let _ = std::fs::remove_dir_all(&dir);
+}
+
+#[test]
+fn runtime_set_refuses_a_dora_adapter() {
+    let dir = temp_dir("runtime_dora");
+    write_adapter_dir(&dir, "dora", 2, adapter_pair_tensors("layer", 4, 2, 3));
+
+    let err = RuntimeLoraSet::from_specs(&[spec_for(&dir)])
+        .expect_err("DoRA is refused before any serving state is built")
+        .to_string();
+    assert!(err.contains("DoRA"), "{err}");
+
+    let _ = std::fs::remove_dir_all(&dir);
+}
+
+#[test]
+fn a_well_formed_runtime_adapter_still_stages() {
+    // Positive control for the shared validator: the happy path must reach
+    // `runtime_lora::stage`. The staging slot is thread-local, so this drains
+    // it again rather than leaving terms for the next test on this thread.
+    let dir = temp_dir("runtime_ok");
+    write_adapter_dir(&dir, "lora", 2, adapter_pair_tensors("layer", 4, 2, 3));
+
+    let set = RuntimeLoraSet::from_specs(&[spec_for(&dir)]).expect("a lora adapter config");
+    let base = base_map(&[("layer", 3, 4)]);
+
+    stage_runtime_adapters(&base, &set).expect("a well-formed adapter stages");
+    let unclaimed = mlxcel_core::runtime_lora::drain_unclaimed();
+    assert_eq!(
+        unclaimed,
+        vec!["layer".to_string()],
+        "the pair must have been staged under its base weight prefix"
+    );
+
+    let _ = std::fs::remove_dir_all(&dir);
+}

--- a/src/lora/runtime_tests.rs
+++ b/src/lora/runtime_tests.rs
@@ -20,7 +20,7 @@
 //! a well-formed adapter still stages (issue #1328).
 
 use super::*;
-use crate::lora::test_support::{adapter_pair_tensors, ones_tensor, temp_dir, write_adapter_dir};
+use crate::lora::test_support::{adapter_pair_tensors, ones_vector, temp_dir, write_adapter_dir};
 
 /// A base weight map holding one `[out, in]` projection per named layer.
 fn base_map(layers: &[(&str, i32, i32)]) -> WeightMap {
@@ -67,7 +67,7 @@ fn runtime_staging_refuses_a_pair_with_no_base_weight() {
 fn runtime_staging_refuses_an_unknown_adapter_tensor() {
     let dir = temp_dir("runtime_leaf");
     let mut tensors = adapter_pair_tensors("layer", 4, 2, 3);
-    tensors.insert("layer.m".to_string(), ones_tensor(3, 1));
+    tensors.insert("layer.m".to_string(), ones_vector(3));
     write_adapter_dir(&dir, "lora", 2, tensors);
 
     let set = RuntimeLoraSet::from_specs(&[spec_for(&dir)]).expect("a lora adapter config");
@@ -107,7 +107,10 @@ fn a_well_formed_runtime_adapter_still_stages() {
     let base = base_map(&[("layer", 3, 4)]);
 
     stage_runtime_adapters(&base, &set).expect("a well-formed adapter stages");
-    let unclaimed = mlxcel_core::runtime_lora::drain_unclaimed();
+    // `drain_unclaimed` drains a `HashMap`, so sort before comparing: this
+    // fixture has one layer today and would be order-flaky with two.
+    let mut unclaimed = mlxcel_core::runtime_lora::drain_unclaimed();
+    unclaimed.sort();
     assert_eq!(
         unclaimed,
         vec!["layer".to_string()],

--- a/src/lora/test_support.rs
+++ b/src/lora/test_support.rs
@@ -1,0 +1,117 @@
+// Copyright 2025-2026 Lablup Inc. and Jeongkyu Shin
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! On-disk adapter fixtures shared by the LoRA unit tests.
+//!
+//! The loader's entry points (`apply_lora_adapters`, `stage_runtime_adapters`)
+//! read an adapter *directory*, not a [`WeightMap`], so the tests that cover
+//! adapter acceptance have to write real `adapter_config.json` and
+//! `adapters.safetensors` files. This module holds that writer once so the
+//! fused-path tests and the runtime-path tests do not each carry a copy.
+//!
+//! Used by: `loader_tests.rs`, `runtime_tests.rs`
+
+use std::collections::HashMap;
+use std::path::{Path, PathBuf};
+
+/// A safetensors view over an owned little-endian f32 buffer.
+///
+/// The impl is on `&OwnedTensor` because `serialize_to_file` is handed a
+/// `&HashMap`, which yields borrowed values.
+pub(crate) struct OwnedTensor {
+    shape: Vec<usize>,
+    data: Vec<u8>,
+}
+
+impl safetensors::View for &OwnedTensor {
+    fn dtype(&self) -> safetensors::tensor::Dtype {
+        safetensors::tensor::Dtype::F32
+    }
+    fn shape(&self) -> &[usize] {
+        &self.shape
+    }
+    fn data(&self) -> std::borrow::Cow<'_, [u8]> {
+        self.data.as_slice().into()
+    }
+    fn data_len(&self) -> usize {
+        self.data.len()
+    }
+}
+
+/// An all-ones `[rows, cols]` f32 tensor, so a fused sum stays predictable.
+pub(crate) fn ones_tensor(rows: usize, cols: usize) -> OwnedTensor {
+    let mut data = Vec::with_capacity(rows * cols * 4);
+    for _ in 0..rows * cols {
+        data.extend_from_slice(&1.0f32.to_le_bytes());
+    }
+    OwnedTensor {
+        shape: vec![rows, cols],
+        data,
+    }
+}
+
+/// A unique temporary directory for one test case.
+///
+/// The PID disambiguates parallel `cargo test` processes and the counter
+/// disambiguates cases inside one process, so two tests cannot collide on the
+/// same nanosecond timestamp.
+pub(crate) fn temp_dir(name: &str) -> PathBuf {
+    use std::sync::atomic::{AtomicUsize, Ordering};
+    static COUNTER: AtomicUsize = AtomicUsize::new(0);
+    let nanos = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .expect("system clock is after the unix epoch")
+        .as_nanos();
+    let pid = std::process::id();
+    let seq = COUNTER.fetch_add(1, Ordering::Relaxed);
+    std::env::temp_dir().join(format!("mlxcel_lora_{name}_{pid}_{nanos}_{seq}"))
+}
+
+/// Write an adapter directory holding `tensors` and an `adapter_config.json`
+/// that declares `fine_tune_type`.
+///
+/// The tensor map is passed in rather than derived from a layer name so a test
+/// can write exactly the malformed shape it is about: an unpaired half, an
+/// unknown leaf, or a pair whose layer path no base weight answers to.
+pub(crate) fn write_adapter_dir(
+    dir: &Path,
+    fine_tune_type: &str,
+    rank: usize,
+    tensors: HashMap<String, OwnedTensor>,
+) {
+    std::fs::create_dir_all(dir).expect("create adapter dir");
+    std::fs::write(
+        dir.join("adapter_config.json"),
+        format!(
+            r#"{{"fine_tune_type": "{fine_tune_type}", "lora_parameters": {{"rank": {rank}, "scale": 1.0}}}}"#
+        ),
+    )
+    .expect("write adapter config");
+    safetensors::serialize_to_file(&tensors, None, &dir.join("adapters.safetensors"))
+        .expect("write adapter safetensors");
+}
+
+/// An mlx-lm-convention pair for `layer`: `lora_a` is `[in, rank]`, `lora_b` is
+/// `[rank, out]`, both all ones.
+pub(crate) fn adapter_pair_tensors(
+    layer: &str,
+    in_features: usize,
+    rank: usize,
+    out_features: usize,
+) -> HashMap<String, OwnedTensor> {
+    let mut tensors = HashMap::new();
+    tensors.insert(format!("{layer}.lora_a"), ones_tensor(in_features, rank));
+    tensors.insert(format!("{layer}.lora_b"), ones_tensor(rank, out_features));
+    tensors
+}

--- a/src/lora/test_support.rs
+++ b/src/lora/test_support.rs
@@ -61,6 +61,21 @@ pub(crate) fn ones_tensor(rows: usize, cols: usize) -> OwnedTensor {
     }
 }
 
+/// An all-ones 1-D f32 tensor of length `n`.
+///
+/// A real DoRA magnitude vector is 1-D, so the fixtures that stand one in use
+/// this rather than a degenerate `[n, 1]`.
+pub(crate) fn ones_vector(n: usize) -> OwnedTensor {
+    let mut data = Vec::with_capacity(n * 4);
+    for _ in 0..n {
+        data.extend_from_slice(&1.0f32.to_le_bytes());
+    }
+    OwnedTensor {
+        shape: vec![n],
+        data,
+    }
+}
+
 /// A unique temporary directory for one test case.
 ///
 /// The PID disambiguates parallel `cargo test` processes and the counter


### PR DESCRIPTION
## Summary

Loading a LoRA adapter used to skip every tensor it could not apply and carry on. A pair whose base weight was missing hit a `warn!` and a `continue`, a leaf that was neither `.lora_a` nor `.lora_b` was dropped as "other weights", and the `Fused LoRA adapters into N layers` line counted `.lora_a` keys in the file rather than pairs that had actually been applied. The load succeeded, the log said the adapter was in place, and the model answered from base weights. A DoRA adapter went the same way: `is_lora()` answered true for it, its magnitude vectors were dropped, and the result matched neither the base model nor the fine-tune. Adapter tensors are now validated against the base weight map before anything is written, every offender is reported in one error, the logged count is the number of pairs applied, and DoRA is refused by name.

## What changed

- `src/lora/loader.rs`: new `validate_adapter_tensors` pairs every adapter tensor up, resolves each pair through the `find_base_weight_name` candidates, and collects every violation into one error instead of failing on the first. An adapter built for the wrong architecture fails on every layer it carries, so one-at-a-time reporting would need as many load attempts as the model has layers. Violations and applied pairs are both sorted, so neither the diagnostic nor the fusion order depends on `WeightMap`'s hash order.
- `src/lora/loader.rs`: `find_base_weight_name` returns `Option<String>` and lost its "most likely candidate" fallback, which is what made "resolved" and "exists" indistinguishable to its caller. `reject_conv1d_layout_fusion` now takes the already-resolved pairs rather than re-resolving layer names.
- `src/lora/loader.rs`: `fuse_lora_weights_into` returns the number of pairs it applied. `apply_lora_adapters_scaled` logs that number, treats zero applied pairs as a failed load, and prefixes fusion failures with the adapter directory. `apply_stage_lora_adapter` returns the count but deliberately does not take the zero check.
- `src/lora/config.rs`: `is_lora()` is replaced by `is_fusable_lora()`, true for plain LoRA only. The DoRA and full fine-tune refusals move into one shared `reject_unsupported_fine_tune_type` in the loader.
- `src/lora/runtime.rs`: the runtime (unfused) staging path shares the same validator and the same fine-tune-type refusal. It carried the identical `warn!`-and-continue posture with a source comment assigning the fix to this issue, and it is the default channel for the b10621 `--lora` spellings, so an adapter that maps onto nothing there produced exactly the same silently-base-weights server.
- `src/distributed/pipeline/stage_executor/llama.rs`: binds and logs the applied count with the stage index, and records in a comment why zero is valid here and must never be gated on. An adapter may target a subset of the model's layers, so a stage that owns none of them applies nothing by design.
- `src/loading/mod.rs`: dropped the `LoRA adapter {} failed to fuse` wrapper, which now printed the adapter directory twice.
- `src/lora/test_support.rs` (new): one adapter-directory writer shared by the fused-path and runtime-path tests, so neither carries its own copy.
- `docs/server-features.md`: documents the acceptance rule, the DoRA refusal, and the pipeline-stage exception.

## Changes during review

- `src/loading/mod.rs`: `reject_adapter_unsupported_family` hoists the family capability gate ahead of fusion in both single-process entry points. The ~20 families carrying an `adapter_unsupported_message` had that verdict taken inside `load_model_from_weights`, which runs after fusion, so making an unmapped tensor fatal would have answered with a line per adapter tensor instead of the one sentence saying the family takes no adapters. Checking first also stops the base weights being read for a load that cannot succeed. The original check stays where it is as the backstop.
- `src/lora/config.rs`: `AdapterConfig::load`'s JSON-parse context now names the config path. That arm runs before the wrapper that adds the adapter directory, so with several `--lora` entries a malformed `adapter_config.json` used to report which line failed but not which adapter.
- `src/lora/loader.rs`: HuggingFace PEFT `<layer>.lora_A.weight` / `.lora_B.weight` tensors, which this build does not read, collapse into one violation naming the spelling, the tensor count, and the conversion step, instead of one line per layer per module (roughly 200 lines for a 32-layer adapter). The example names the lexicographically smallest offender so the report does not depend on hash order.
- `src/lora/loader.rs`: pairs are resolved without copying any tensor, so a wrong-architecture adapter no longer materializes a full set of `mlxcel_core::copy` nodes it immediately drops.
- `src/lib/mlxcel-core/src/runtime_lora.rs`: two comments assigned strict refusal of *unclaimed terms* to #1328 and were wrong. #1328 covers an adapter tensor that maps onto no base weight. An unclaimed term is a different hole, where the tensor did map onto a real base weight but no layer constructor reads runtime terms for that prefix, so those layers serve base weights after a load that succeeded. Issue #1577 now owns that, and records the adjacent case where a term is claimed and still never reaches the forward pass.
- Tests: the runtime test sorts `drain_unclaimed` before comparing, since it drains a `HashMap`; the DoRA magnitude stand-in is 1-D, as a real one is.

## Known residuals, filed rather than fixed here

- Issue #1577: unclaimed runtime terms are still only logged. Turning that into a load failure is a hard-failure change to the default `--lora` channel that cannot be validated without real checkpoints across many families, and it is outside this issue's tensor-to-base-weight scope.
- Issue #1577 also records that the fused single-process path validates against the raw checkpoint while the pipeline-stage path validates against a `sanitize_tied_embeddings`-processed map, so an `lm_head` pair on a tied-embeddings checkpoint now fails on one path and applies on the other. Stock `mlx_lm.lora` only wraps modules inside `model.layers`, so this is latent. Neither direction is obviously right, since applying an `lm_head` adapter on a tied model breaks the tie.
- MoE LoRA is unsupported on both paths: `mlx-lm`'s `LoRASwitchLinear` writes 3-D `lora_a` / `lora_b`, which `compute_lora_delta` has always rejected with "Expected 2D LoRA matrices". Not a regression, now recorded in #1577.

## Test plan

- [x] `cargo test --profile test-fast --features metal,accelerate --lib lora` (62 passed)
- [x] `cargo test --profile test-fast --features metal,accelerate --lib distributed::pipeline` (323 passed)
- [x] `cargo test --profile test-fast --features metal,accelerate --lib loading::` (312 passed)
- [x] `cargo clippy --profile test-fast --lib --tests --features metal,accelerate -- -D warnings`
- [x] `cargo fmt --all -- --check`

New unit tests cover a pair with no base weight, an unknown leaf, both halves of an incomplete pair, several violations reported together in sorted order, the applied-pair count, a HuggingFace PEFT `.base_layer` pair still resolving to the wrapped `.weight`, a PEFT-named adapter collapsing to one violation, DoRA and full fine-tune refusal, an adapter that applies nothing, a pipeline stage that owns none of the adapter's layers, and the same acceptance rules on the runtime staging path.

The full `cargo test --workspace --profile test-fast --features metal,accelerate` gate and the real-checkpoint smoke below were left to CI and to the merge step rather than run here.

## Real-checkpoint smoke

One correction to the issue's plan first, measured against the pre-change `target/release/mlxcel`. The fused `--adapter` path cannot be smoke-tested on a quantized checkpoint at all, and that is unrelated to this change: a 4-bit base stores `model.layers.0.self_attn.q_proj.weight` as packed `U32` of shape `[2048, 128]`, while the delta is `[2048, 1024]`, so `models/mlx/qwen3-0.6b-4bit` with the matching `models/lora-runtime-test` already fails today with `LoRA shape mismatch fusing adapter layer model.layers.10.self_attn.k_proj into base weight model.layers.10.self_attn.k_proj.weight: base is [1024, 128], delta is [1024, 1024]`. The fused smoke therefore runs against `models/mlx/qwen2.5-0.5b-bf16` (qwen2, hidden 896, 24 layers, bf16), which is the exact match for `models/lora-dense-test` (24 layers, q/k/v_proj, rank 8). The quantized pair belongs to the unfused `--lora` server channel.

Positive control, must keep working and must report 72 applied pairs (24 layers x 3 projections):

```
RUST_LOG=info ./target/release/mlxcel generate -m models/mlx/qwen2.5-0.5b-bf16 --adapter models/lora-dense-test -p "Hello" -n 12
```

Expect exit 0, `Fused LoRA adapters into 72 layers`, and generation that differs from the same prompt without `--adapter`. This is the before/after equality control: measured on the pre-change binary it loads and generates `Hello! How can I assist you today?`, and the post-change run must produce the same tokens, because the set of applied pairs is unchanged for a valid adapter.

Unmapped layers, the case the issue is about. `models/lora-runtime-test` carries 28 layers, so layers 24 to 27 have no base weight in a 24-layer model:

```
./target/release/mlxcel generate -m models/mlx/qwen2.5-0.5b-bf16 --adapter models/lora-runtime-test -p "Hello" -n 12
```

Expect a non-zero exit naming all 12 unmapped pairs, headed `Adapter at models/lora-runtime-test: 12 adapter tensors cannot be applied to this model:` and listing lines of the form `model.layers.24.self_attn.k_proj.lora_a: no base weight (tried model.layers.24.self_attn.k_proj.weight, model.layers.24.self_attn.k_proj)`. Before this change those 12 pairs were warn-skipped and the run continued to a later `LoRA shape mismatch` on layers 0 to 23, so the offending layer names were never reported.

The two silent cases, which need a mutated copy of an otherwise perfect adapter. Both of these load and generate on the pre-change binary, which is the defect:

```
mkdir -p /tmp/mlxcel-1328
python3 - <<'PY'
import json, struct, shutil, pathlib
sb = pathlib.Path("/tmp/mlxcel-1328")
src = pathlib.Path("models/lora-dense-test")
with open(src / "adapters.safetensors", "rb") as f:
    n = struct.unpack("<Q", f.read(8))[0]
    header = json.loads(f.read(n))
    data = f.read()
bogus = sb / "lora-dense-bogus"
bogus.mkdir(parents=True, exist_ok=True)
shutil.copy(src / "adapter_config.json", bogus / "adapter_config.json")
old = "model.layers.0.self_attn.q_proj.lora_a"
header[old + ".bogus"] = header.pop(old)
blob = json.dumps(header, separators=(",", ":")).encode()
blob += b" " * ((8 - len(blob) % 8) % 8)
with open(bogus / "adapters.safetensors", "wb") as f:
    f.write(struct.pack("<Q", len(blob)))
    f.write(blob)
    f.write(data)
dora = sb / "lora-dense-dora"
dora.mkdir(parents=True, exist_ok=True)
cfg = json.loads((src / "adapter_config.json").read_text())
cfg["fine_tune_type"] = "dora"
(dora / "adapter_config.json").write_text(json.dumps(cfg, indent=2))
shutil.copy(src / "adapters.safetensors", dora / "adapters.safetensors")
PY

./target/release/mlxcel generate -m models/mlx/qwen2.5-0.5b-bf16 --adapter /tmp/mlxcel-1328/lora-dense-bogus -p "Hello" -n 8
./target/release/mlxcel generate -m models/mlx/qwen2.5-0.5b-bf16 --adapter /tmp/mlxcel-1328/lora-dense-dora -p "Hello" -n 8
```

The renamed-tensor run must exit non-zero with `2 adapter tensors cannot be applied to this model:` naming `model.layers.0.self_attn.q_proj.lora_a.bogus: not a LoRA tensor (expected .lora_a or .lora_b)` and `model.layers.0.self_attn.q_proj.lora_b: incomplete pair (missing model.layers.0.self_attn.q_proj.lora_a)`. Measured before this change: it fused the other 71 pairs, warned once, and generated normally.

The DoRA run must exit non-zero with `DoRA adapters are not supported: /tmp/mlxcel-1328/lora-dense-dora declares fine_tune_type dora; fuse it with its own tooling first`. Measured before this change: it loaded and generated as if it were plain LoRA.

Server equivalents of the same three cases, which take the identical fused channel because `--adapter` is set:

```
./target/release/mlxcel-server -m models/mlx/qwen2.5-0.5b-bf16 --adapter models/lora-dense-test --port 8080
./target/release/mlxcel-server -m models/mlx/qwen2.5-0.5b-bf16 --adapter models/lora-runtime-test --port 8080
./target/release/mlxcel-server -m models/mlx/qwen2.5-0.5b-bf16 --adapter /tmp/mlxcel-1328/lora-dense-dora --port 8080
```

The first must serve; the other two must fail the model load with the errors above rather than serving base weights.

Unfused runtime channel, where the quantized checkpoint belongs. `models/lora-runtime-test` matches `models/mlx/qwen3-0.6b-4bit` (hidden 1024, 28 layers) for 84 staged pairs (28 layers x 3 projections):

```
./target/release/mlxcel-server -m models/mlx/qwen3-0.6b-4bit --lora models/lora-runtime-test --port 8080
./target/release/mlxcel-server -m models/mlx/qwen3-0.6b-4bit --lora models/lora-dense-test --port 8080
```

The first must start and report `Staged runtime LoRA adapter models/lora-runtime-test for 84 layers`. The second is the deliberate mismatch and must fail startup: `models/lora-dense-test` was trained at hidden 896 against a 24-layer model, so its pairs resolve to base weights that exist but disagree on shape, and the runtime path refuses it with `LoRA adapter layer model.layers.0.self_attn.q_proj: the pair produces 896 output features but the base weight model.layers.0.self_attn.q_proj.weight has 1024 rows`.

Closes #1328
