### PR TITLE
perf(server): pack structured-output masks as u32 bitmasks

### DIFF
--- a/TECHNICAL_REPORTS/1578-packed-structured-output-mask-20260902.en.md
+++ b/TECHNICAL_REPORTS/1578-packed-structured-output-mask-20260902.en.md
@@ -1,0 +1,353 @@
+# Technical Report: PR #1578 - perf(server): pack structured-output masks as u32 bitmasks
+
+**Date**: 2026-09-02
+**Author**: mlxcel maintainers
+**Reviewer**: n/a
+**Status**: Completed
+**Languages**: Rust
+**Risk Level**: Medium
+
+---
+
+## Executive Summary
+
+Constrained decoding expanded the grammar engine's packed token bitmask into a `Vec<bool>` the width of the vocabulary, walked the logits axis a second time to turn that into a `Vec<f32>` bias, uploaded the bias and added it to the logits, once per token per constrained sequence, on the scheduler thread between the forward pass and sampling. This PR keeps the mask packed all the way to the device and expands it there with a broadcast shift. At the Qwen3.8-27B geometry the scheduler-thread cost of preparing and uploading the mask falls from 711 us to 7.4 us per step, and the per-step host-to-device copy falls from 970 KiB to 30 KiB. The output array is unchanged, verified elementwise against the implementation it replaces.
+
+---
+
+## 1. Problem Statement
+
+### 1.1 Background
+
+An OpenAI-style `response_format: {"type": "json_schema", ...}` request compiles its schema into an `llguidance` grammar and attaches a `StructuredOutputConstraint` to the sequence. Before sampling each token, the scheduler asks the matcher which token ids keep the partial output conforming and masks every other logit to negative infinity, so the sampler cannot emit a token that breaks the schema.
+
+`llguidance` answers that question in the form it computes it: a `SimpleVob`, a bitset with one bit per token id, 32 ids per `u32` word. The mask application then had to get that answer onto the GPU as something MLX can combine with a logits row.
+
+### 1.2 Existing Issues
+
+- **The bitset was expanded twice on the host.** `compute_mask` resized `mask_buf` to `vocab_size` and ran `iter_set_entries` to write one `bool` per allowed id. `apply_structured_mask_to_logits` then resized `bias_buf` to `vocab_size_hint` and walked it entry by entry, writing `0.0` at allowed positions and `f32::NEG_INFINITY` everywhere else. For a 248320-row head that is two loops of roughly a quarter million iterations each, per token, per constrained sequence.
+- **The upload was 32 times larger than the information it carried.** An f32 bias whose only two values are `0.0` and `-inf` is one bit of information per token stored in 32 bits. At 248320 rows that is a 970 KiB host-to-device copy per step, against the 30 KiB the packed form needs.
+- **All of it sat on the scheduler thread.** `apply_structured_mask` is called from `decode_tick` and `prefill` between the forward pass and sampling, once per constrained sequence per tick, so with B concurrent constrained sequences the cost is paid B times per tick and serializes against the batch's own progress.
+- **The `mask_buf` / `bias_buf` reuse only removed the allocator cost.** Pre-allocating both buffers at construction avoided a fresh `Vec` per token but did nothing about the two walks or the copy, and cost about 1 MB of resident host memory per constrained sequence at that vocabulary.
+
+### 1.3 Risk Assessment
+
+| Risk | Impact | Likelihood |
+|------|--------|------------|
+| Constrained decode throughput degrades as vocabulary grows, with no bound in sight | Medium | High |
+| Cost scales linearly with concurrent constrained sequences, so structured output degrades exactly under load | Medium | High |
+| A rewrite of the mask path silently changes which token the sampler selects | High | Low |
+| A rewrite drops the padded-head masking rule and lets an unnameable row be sampled | High | Low |
+
+The last two are the risks this change itself introduces; sections 2 and 3 describe how they are constrained.
+
+---
+
+## 2. Technical Review
+
+### 2.1 Security
+
+The mask is the only thing standing between a constrained request and non-conforming output, so a mask that is too permissive is a correctness and a trust problem, not merely a performance one. Two rules had to survive the rewrite and both are now covered by explicit tests:
+
+- A logits row past the matcher's vocabulary must stay masked. Qwen3.5 and Qwen3.8 pad `lm_head` beyond the tokenizer: 248320 rows against 248077 tokenizer entries. Those 243 rows name no token, so the grammar has never seen them and they can never satisfy it. In the packed form they read a zero word and are therefore disallowed by construction.
+- The matcher's own bitset has excess bits. `SimpleVob` stores `ceil(size / 32)` words, so a vocabulary of 248077 leaves 19 bits in the final word that name no token. `toktrie` clears them on some paths (`set_all`, `negated`) but the invariant is not guaranteed at the API boundary, so `pack_mask_words` masks the final partial word to its valid bit range rather than trusting it.
+
+No input parsing, authentication, or logging surface changed. The public error message for an empty mask is byte-identical to the previous one.
+
+### 2.2 Performance
+
+This is the point of the change; the measurements are in section 8 and Appendix B. The short version: the host work is gone, the copy is 1/32 the size, and the device-side expansion is four elementwise ops over the vocabulary that fuse into the same graph as the selection.
+
+### 2.3 Compatibility and Dependencies
+
+No new dependencies. Every MLX op used (`from_slice_u32`, `right_shift`, `bitwise_and`, `reshape`, `slice`, `astype`, `where_cond`) was already bound in the cxx bridge, so `src/lib/mlxcel-core` is untouched and no CUDA kernel is added, which keeps `make verify-kernel-dtype-keys` trivially green.
+
+`apply_structured_mask_to_logits` keeps its exact signature, so the call site in `src/server/batch/scheduler/run_loop.rs` and its three callers in `decode_tick.rs` and `prefill.rs` are unchanged. `compute_mask` is kept as the `Vec<bool>` accessor; nine call sites in `tests/structured_outputs.rs` depend on it, and it remains the readable way to inspect individual entries. It is simply no longer on the hot path.
+
+### 2.4 Code Quality
+
+The bit algebra is factored into `pack_mask_words`, a pure function over slices with no matcher and no device involved, which is what makes the randomized equivalence tests possible at all. The device expansion is `expand_packed_mask`, also free-standing. `apply_structured_mask_to_logits` is now short enough to read as a policy statement: gate check, pack, emptiness check, select.
+
+`cargo clippy --profile test-fast --lib --tests --features metal,accelerate -- -D warnings` and `cargo fmt --all -- --check` are clean.
+
+---
+
+## 3. Technical Decisions
+
+### 3.1 Broadcast the bit positions instead of gathering per-token index tables
+
+Issue #1316 proposed precomputing two device arrays per constraint, `word_idx = i32[V]` holding `i >> 5` and `bit_idx = u32[V]` holding `i & 31`, and expanding with `bitwise_and(right_shift(take(words, word_idx, 0), bit_idx), 1)`.
+
+The implementation broadcasts instead. The packed words go up as a `u32[n_words, 1]` column and the 32 bit positions as a `u32[1, 32]` row, so a single `right_shift` broadcasts to `[n_words, 32]` where element `(w, b)` is bit `b` of word `w`. Row-major, that flat index is `w * 32 + b`, which is exactly the token id. A reshape to `[1, n_words * 32]` and a trim to the logits width recover the mask in token order.
+
+Why this rather than the plan:
+
+- **No per-constraint index tables.** The gather design needed `2 * 4 * V` bytes of device memory per constrained sequence, about 2 MB at 248320, allocated for the constraint's lifetime. The broadcast needs a 32-element row.
+- **No gather.** `take` over `V` indices reads a `V`-element index array and writes a `V`-element result before the shift even starts. The broadcast reads `n_words` words, 1/32 as much.
+- **No cached state keyed on width.** The plan's arrays had to be rebuilt when `vocab_size_hint` or the logits dtype changed, which is why its validation list includes `packed_apply_rebuilds_index_arrays_on_width_change`. Nothing here depends on the width, so that failure mode does not exist; the corresponding test became `packed_apply_handles_a_width_change_between_calls`, which drives six widths through one buffer and checks each.
+- **It is MLX's own idiom.** `dequantize` unpacks non-power-of-two quantized weights with literally `bitwise_and(right_shift(w, arange(32, uint32)), 1)`. Reusing a shape MLX exercises on every quantized forward is a better bet than a novel one.
+
+### 3.2 Do not cache the device constants on the constraint
+
+The plan also stored `neg_inf` and the index arrays on `StructuredOutputConstraint` as `Option<UniquePtr<MlxArray>>`. That does not compile, and the reason is worth recording because it is not obvious from reading the struct.
+
+`StructuredOutputConstraint` lives in `SequenceInfo` as `Arc<Mutex<StructuredOutputConstraint>>` and is moved onto the scheduler thread, so it must be `Send`. cxx does not derive `Send` for an opaque `extern "C++"` type, and `mlxcel-core` declares no `unsafe impl Send for MlxArray`, so `UniquePtr<MlxArray>` is not `Send`:
+
+```
+error[E0277]: `*const cxx::void` cannot be sent between threads safely
+   = help: within `MlxArray`, the trait `Send` is not implemented for `*const cxx::void`
+   = note: required for `UniquePtr<MlxArray>` to implement `Send`
+```
+
+Adding such a field would have required an `unsafe impl Send` wrapper of the kind `src/server/prompt_cache/entry.rs` uses for `DetachedKvSetHolder`, with a real safety argument about MLX array handles crossing threads. The three constants this design needs (32 bit positions, the scalar `1`, the scalar `-inf`) total 152 bytes, so they are simply constructed per call. The measurement in section 8 is of the whole prepare-and-upload phase including those three constructions, at 7.4 us, so the decision costs nothing observable.
+
+### 3.3 Select with `where_cond` rather than adding a bias
+
+The previous code added an f32 array of `0.0` and `-inf`. The new code selects between the logit and a scalar `-inf`. The reason the output is identical rather than merely equivalent:
+
+- `mlx::core::where` computes `promote_types(b.dtype(), c.dtype())` and casts both operands to it, exactly as `add` does. Pairing f16 or bf16 logits with an f32 `-inf` therefore yields the same f32 output the f32 bias produced. No dtype behavior changed for any logits precision.
+- `where` broadcasts through `broadcast_arrays`, the same rules `add` used, so `[1, V]` from prefill and `[1, 1, V]` from the decode tick both come back with the shape they had before.
+- At an allowed position the logit is passed through instead of having `0.0` added to it. For IEEE floats `x + 0.0 == x`, so this is the same value, and it is one fewer rounding opportunity rather than one more.
+
+### 3.4 Test the packing algebra without a matcher
+
+The unit test module has only `MlxcelTokenizer::stub()`, whose vocabulary is empty, so a matcher-driven unit test cannot produce an interesting mask. Rather than duplicating the 80-line inline `tokenizer.json` from `tests/structured_outputs.rs`, the packing was factored into a pure function and tested against explicitly constructed bitsets.
+
+That turned out to be the stronger option, not the cheaper one: it allows randomized allow sets over thirteen width pairs, all-ones sources that expose excess-bit leakage, and a direct elementwise comparison against the old bias routine kept as a test-only reference. A matcher-driven test can only assert what that particular grammar happens to allow. The matcher-driven behavior stays covered by the twenty-one runnable tests in `tests/structured_outputs.rs`, which pass unchanged.
+
+### 3.5 Compute emptiness from the packed words
+
+The old code counted allowed entries in `[0, vocab_size_hint)` over the `Vec<bool>` and raised `StructuredOutputError::Matcher` when the count was zero. The new code tests whether every packed word is zero. Because `compute_packed_mask` packs to exactly the logits width and zeroes everything outside it, "all words zero" is precisely "no matcher-allowed token is reachable in the model's logits vocabulary", so no separate bound is needed and the error message is unchanged. A stopped matcher returns an empty slice, and `[].iter().all(...)` is `true`, so it takes the same error path it did before.
+
+---
+
+## 4. Implementation Details
+
+### 4.1 Architecture Changes
+
+The per-step path before this change:
+
+```
+matcher.compute_mask_or_eos() -> SimpleVob (packed u32)
+  -> iter_set_entries        -> Vec<bool>, vocab_size entries      [host loop 1]
+  -> bias fill               -> Vec<f32>, vocab_size_hint entries  [host loop 2]
+  -> from_slice_f32          -> 970 KiB upload
+  -> add(logits, bias)
+```
+
+and after:
+
+```
+matcher.compute_mask_or_eos() -> SimpleVob (packed u32)
+  -> pack_mask_words         -> Vec<u32>, ceil(V / 32) words       [word copy]
+  -> from_slice_u32          -> 30 KiB upload
+  -> right_shift / bitwise_and / reshape+slice / astype -> bool[1, V] on device
+  -> where_cond(allowed, logits, -inf)
+```
+
+### 4.2 Key Code Changes
+
+`StructuredOutputConstraint::compute_packed_mask(vocab_size_hint)` drives the matcher exactly as `compute_mask` does, including the `get_error` check, then packs instead of expanding. It takes the width as a parameter, unlike the `compute_mask` it parallels, because the padding width is a property of the model's logits axis and not of the matcher.
+
+The bit that decides what survives:
+
+```rust
+let matcher_vocab = self.vocab_size.min(vob.len());
+pack_mask_words(vob.as_slice(), matcher_vocab, vocab_size_hint, &mut self.packed_buf);
+```
+
+`compute_mask` dropped every entry at or past `self.vocab_size`, and a bitset shorter than that has no bit to read; taking the smaller of the two reproduces that rule in one expression.
+
+`pack_mask_words` is the whole packing rule:
+
+```rust
+let n_words = vocab_size_hint.div_ceil(32);
+out.clear();
+out.resize(n_words, 0);
+
+let valid_bits = matcher_vocab.min(vocab_size_hint).min(src.len() * 32);
+let full_words = valid_bits / 32;
+let rem = valid_bits % 32;
+
+out[..full_words].copy_from_slice(&src[..full_words]);
+if rem != 0 {
+    out[full_words] = src[full_words] & ((1u32 << rem) - 1);
+}
+```
+
+The triple `min` is the safety argument as well as the semantics: `full_words <= n_words` follows from `valid_bits <= vocab_size_hint`, and `full_words < src.len()` in the `rem != 0` branch follows from `valid_bits <= src.len() * 32` plus `valid_bits` not being a word multiple. Both indexing sites are therefore in bounds without a runtime check.
+
+`expand_packed_mask` is the device half:
+
+```rust
+let packed  = from_slice_u32(words, &[n_words, 1]);
+let bit_pos = from_slice_u32(&PACKED_MASK_BIT_POSITIONS, &[1, 32]);
+let bits    = bitwise_and(&right_shift(&packed, &bit_pos), &one);
+let flat    = reshape(&bits, &[1, n_words * 32]);
+let trimmed = if flat_len as usize == vocab_size { flat } else { slice(&flat, &[0, 0], &[1, vocab_size as i32]) };
+astype(&trimmed, dtype::BOOL)
+```
+
+A `debug_assert_eq!` pins `words.len() == vocab_size.div_ceil(32)`, the invariant the trim depends on, so a future caller that packs to one width and expands to another fails loudly in debug rather than slicing past the flat length.
+
+`apply_structured_mask_to_logits` reduces to the policy:
+
+```rust
+if constraint.is_gated() { return Ok(copy(logits)); }
+let words = constraint.compute_packed_mask(vocab_size_hint)?;
+if words.iter().all(|word| *word == 0) { return Err(StructuredOutputError::Matcher(...)); }
+Ok(apply_packed_mask_to_logits(words, vocab_size_hint, logits))
+```
+
+### 4.3 Data Model Changes
+
+`StructuredOutputConstraint::bias_buf: Vec<f32>` is removed and `packed_buf: Vec<u32>` takes its place. At a 248320-entry vocabulary that is about 1 MB less resident host memory per constrained sequence, and the constructor reserves 1/32 as much as before. `mask_buf` is unchanged and still backs `compute_mask`.
+
+---
+
+## 5. Learning Points
+
+### 5.1 A mask is one bit per token; anything wider is a transport choice
+
+The bias array was carrying one bit of information per token in 32 bits, and the two host loops existed only to perform that widening. Once the question is framed as "what is the narrowest thing that answers this", the answer is the form the producer already computed, and both loops turn out to be pure overhead rather than necessary work. The matcher never stopped producing a bitset; the code just kept unpacking it because the consumer wanted floats.
+
+The general shape: when a producer and a consumer disagree about representation, check whether the consumer can be taught the producer's form before you write a converter that runs per token.
+
+### 5.2 Broadcast beats gather when the index pattern is affine
+
+The natural way to expand a bitset to one entry per token is to look up, for each token, the word it lives in. That is a gather, and it needs an index array as wide as the output. But the mapping token to (word, bit) is not arbitrary, it is `(i >> 5, i & 31)`, which is exactly what a 2-D reshape expresses for free. Laying the words along one axis and the bit positions along the other makes the index table implicit in the shape.
+
+This is worth recognising on sight: an index array whose contents are an arithmetic function of its position is usually a reshape in disguise. MLX arrives at the same conclusion in `dequantize` for the same reason.
+
+### 5.3 `UniquePtr<MlxArray>` is not `Send`, so it cannot be cached on a per-sequence struct
+
+Anything reachable from `SequenceInfo` crosses to the scheduler thread and must be `Send`. cxx does not derive `Send` for opaque `extern "C++"` types and `mlxcel-core` declares no manual impl, so an MLX array handle cannot be stored on a per-request struct without an explicit `unsafe impl Send` wrapper and the safety argument that goes with it (`src/server/prompt_cache/entry.rs` has two such wrappers for exactly this reason). Any design that wants to keep a device-side lookup table alive across steps runs into this first. It is a compile error rather than a subtle bug, but it invalidates a plan late if it is discovered during implementation instead of during design.
+
+### 5.4 An A/B against the code you are deleting is worth keeping as a test
+
+The old bias routine was preserved as a test-only reference, which made two things possible at once: an elementwise equivalence assertion across randomized allow sets and seven vocabulary geometries, and a microbenchmark that times both arms in one process under identical conditions. Neither is available once the old path is gone, and reconstructing it later from the diff is strictly worse because the reconstruction is untested. The reference costs 25 lines.
+
+---
+
+## 6. Further Learning
+
+### Key Terms
+
+- **`SimpleVob`**: `toktrie`'s bitset over token ids, `Vec<u32>` plus a size. Bit `i % 32` of word `i / 32` is token `i`, and `as_slice()` exposes the words directly. The backing store can be wider than the declared size, so the excess bits are not guaranteed to be clear.
+- **Padded `lm_head`**: a model whose output projection has more rows than the tokenizer has tokens. Qwen3.8-27B declares `vocab_size: 248320` against 248077 tokenizer entries, leaving 243 rows that no token id names.
+- **`vocab_size_hint`**: the model's logits width, as read from the logits array's last axis at the call site. It is deliberately not the matcher's vocabulary, because the mask has to broadcast onto the logits.
+- **Broadcast shift**: `right_shift` on `[n, 1]` against `[1, 32]`, producing `[n, 32]`. MLX's binary ops broadcast under NumPy rules, so no explicit `broadcast_to` is needed.
+
+### Related Technologies and Frameworks
+
+- `llguidance` 1.7 / `toktrie` 1.8, the grammar engine behind `response_format`, chosen upstream in Blaizzy/mlx-vlm#1047 and shared by mlxcel.
+- MLX's `Select` primitive, which backs `where_cond` and promotes its value operands to their common dtype.
+- MLX `dequantize`, the in-tree precedent for the broadcast bit-unpack shape: https://github.com/ml-explore/mlx/blob/main/mlx/ops.cpp
+
+### Related PRs and Issues
+
+- #1316, the issue this PR closes.
+- Blaizzy/mlx-vlm#1805, the upstream analogue of the padded-`lm_head` sizing rule that `apply_mask_covers_the_qwen3_8_padded_lm_head` pins.
+
+---
+
+## 7. Change Summary
+
+### Statistics
+
+| Metric | Value |
+|--------|-------|
+| Files changed | 2 |
+| Lines added | 698 |
+| Lines removed | 65 |
+| New unit tests | 6 plus 1 ignored benchmark |
+| Crates touched | `mlxcel` only |
+
+### Changes by Category
+
+| File | Change |
+|------|--------|
+| `src/server/structured.rs` | +218 / -65. Adds `compute_packed_mask`, `pack_mask_words`, `expand_packed_mask`, `apply_packed_mask_to_logits` and `PACKED_MASK_BIT_POSITIONS`; rewrites `apply_structured_mask_to_logits`; replaces `bias_buf` with `packed_buf`. |
+| `src/server/structured_tests.rs` | +480. Six unit tests, the test-only bias reference, a deterministic xorshift, array readback and argmax helpers, and the ignored microbenchmark. |
+
+### Related Commits
+
+- `ff3d8bd` perf(server): pack structured-output masks as u32 bitmasks
+
+---
+
+## 8. Follow-up Actions
+
+### Required
+
+- Run the live-server check in the PR body against `models/mlx/qwen3-4b-4bit`: a `response_format: json_schema` request must return a schema-conforming object with `finish_reason: stop`, and at `temperature: 0` the completion must be token-identical to the pre-change binary, with an unconstrained control unchanged.
+- Run the whole-workspace gate. This change was validated with narrow commands (`--lib server::structured`, `--test structured_outputs`, `clippy --lib --tests`); `cargo test --workspace --profile test-fast --features metal,accelerate` and `cargo clippy --workspace --all-targets -- -D warnings` have not been run here.
+
+### Monitoring Required
+
+- Constrained decode throughput on a wide-vocabulary checkpoint under concurrency. The removed cost scaled with the number of concurrent constrained sequences, so the gain should be most visible there, and that is also where a regression would show first.
+
+### Future Improvements
+
+- Issue #1316 lists a fused kernel, `logits[i] = (words[i >> 5] >> (i & 31)) & 1 ? logits[i] : -inf`, as an optional follow-up if the four-op expansion ever dominates. The measurement below says it does not: the whole prepare-and-upload phase is 7.4 us at a 248k vocabulary, so the remaining cost is the elementwise pass over the logits, which any implementation has to pay.
+- The issue's own out-of-scope list still stands: a fused masked-argmax sampler for greedy constrained decoding, and sharing one mask upload across sequences that hold the same grammar state.
+
+---
+
+## Appendix
+
+### A. Test Results
+
+```
+cargo test --profile test-fast --features metal,accelerate --lib server::structured
+  21 passed, 0 failed, 1 ignored (the microbenchmark)
+
+cargo test --profile test-fast --features metal,accelerate --test structured_outputs
+  21 passed, 0 failed, 2 ignored (require local model weights)
+
+cargo clippy --profile test-fast --lib --tests --features metal,accelerate -- -D warnings
+  clean
+
+cargo fmt --all -- --check
+  clean
+```
+
+New unit tests:
+
+| Test | What it pins |
+|------|--------------|
+| `packed_mask_matches_bool_mask` | Thirteen width pairs, randomized allow sets. Every bit matches the boolean mask, and every lane past the logits width is zero. |
+| `packed_mask_trims_the_matchers_own_excess_bits` | An all-ones source with a 77-token matcher: the 19 bits naming no token must not survive. |
+| `packed_mask_zero_pads_past_the_matcher_vocabulary` | The padded-head direction, 40 tokens into a 200-wide axis. |
+| `packed_mask_of_an_empty_allow_set_is_all_zero` | The exact predicate the empty-mask error reads, plus a lone allowed token in the final partial word. |
+| `packed_apply_matches_bias_apply` | Seven geometries: the packed output equals the f32 bias output under IEEE equality at every position, an allowed position carries the exact input logit, a disallowed one is `-inf`, and `argmax` agrees. |
+| `packed_apply_handles_the_all_allowed_and_single_allowed_edges` | An all-allowed mask is a no-op; a single allowed token in the last partial word wins greedy decoding at any logit value. |
+| `packed_apply_handles_a_width_change_between_calls` | Six widths driven through one buffer, each checked in full. |
+
+### B. Performance Benchmarks
+
+```
+cargo test --profile test-fast --features metal,accelerate --lib \
+  server::structured::tests::bench_packed_mask_apply -- --ignored --nocapture
+```
+
+M1 Ultra, Time Machine stopped, 248320 logits rows against 248077 tokenizer entries, min-of-60 per trial, median of four runs:
+
+| Arm | Prepare + upload | With eval | Upload |
+|-----|------------------|-----------|--------|
+| f32 bias (before) | 711 us | 1002 us | 970 KiB |
+| packed u32 (after) | 7.4 us | 322 us | 30 KiB |
+
+Observed spread across the four runs: 707 to 714 us, 6.7 to 8.9 us, 986 to 1009 us, 300 to 326 us.
+
+"Prepare + upload" is the scheduler-thread cost: mask preparation plus the host-to-device copy, up to having the output graph node. "With eval" adds a forced `mlxcel_core::eval` of the result. The packed arm's eval figure sits at the known MLX single-shot eval floor of roughly 300 us, so it understates the device-side saving rather than overstating it; the honest claim from this measurement is the roughly 0.7 ms per token per constrained sequence removed from the scheduler thread, which is inside the 0.5 to 1.5 ms the issue predicted.
+
+Both arms are timed in the same process under identical conditions, with the reference arm being the code this PR deletes.
+
+### C. References
+
+- Issue #1316, which specifies the change and its acceptance criteria.
+- `src/server/structured.rs`, `compute_packed_mask` / `pack_mask_words` / `expand_packed_mask`.
+- `tests/structured_outputs.rs`, `apply_mask_covers_the_qwen3_8_padded_lm_head`, the production-magnitude partial-word case.
+- MLX `dequantize`, the in-tree precedent for the broadcast bit-unpack: https://github.com/ml-explore/mlx/blob/main/mlx/ops.cpp
+- `docs/code-guidelines.md` for the shared-function convention; no shared function was widened here.

--- a/TECHNICAL_REPORTS/1578-packed-structured-output-mask-20260902.ko.md
+++ b/TECHNICAL_REPORTS/1578-packed-structured-output-mask-20260902.ko.md
@@ -1,0 +1,353 @@
+# 기술 보고서: PR #1578 - perf(server): pack structured-output masks as u32 bitmasks
+
+**작성일**: 2026-09-02
+**작성자**: mlxcel maintainers
+**리뷰어**: 없음
+**상태**: 완료
+**언어**: Rust
+**위험도**: Medium
+
+---
+
+## 요약
+
+제약 디코딩은 문법 엔진이 내놓은 패킹된 토큰 비트마스크를 어휘 폭만큼의 `Vec<bool>`로 펼치고, 로짓 축을 한 번 더 훑어 `Vec<f32>` 바이어스를 만든 뒤 그것을 업로드해 로짓에 더했다. 제약이 걸린 시퀀스마다, 토큰마다, 포워드 패스와 샘플링 사이의 스케줄러 스레드에서 매번 벌어지는 일이었다. 이 PR은 마스크를 패킹된 채로 디바이스까지 보내고 브로드캐스트 시프트로 그곳에서 펼친다. Qwen3.8-27B 형상에서 마스크를 준비하고 업로드하는 스케줄러 스레드 비용은 스텝당 711us에서 7.4us로, 스텝당 호스트-디바이스 복사는 970KiB에서 30KiB로 줄었다. 출력 배열은 그대로이며, 대체된 구현과 원소 단위로 대조해 확인했다.
+
+---
+
+## 1. 문제 정의
+
+### 1.1 배경
+
+OpenAI 형식의 `response_format: {"type": "json_schema", ...}` 요청은 스키마를 `llguidance` 문법으로 컴파일하고 시퀀스에 `StructuredOutputConstraint`를 붙인다. 매 토큰을 샘플링하기 전에 스케줄러는 부분 출력이 스키마를 유지하려면 어떤 토큰 id가 허용되는지 매처에 묻고, 나머지 로짓을 전부 음의 무한대로 마스킹한다. 샘플러가 스키마를 깨는 토큰을 뽑을 수 없게 만드는 장치다.
+
+`llguidance`는 그 답을 자신이 계산한 형태 그대로 돌려준다. `SimpleVob`, 즉 토큰 id 하나당 1비트, `u32` 워드 하나당 32개 id가 들어가는 비트셋이다. 마스크 적용부의 일은 그 답을 MLX가 로짓 행과 결합할 수 있는 형태로 GPU에 올리는 것이었다.
+
+### 1.2 기존 문제
+
+- **비트셋을 호스트에서 두 번 펼쳤다.** `compute_mask`가 `mask_buf`를 `vocab_size`로 resize한 뒤 `iter_set_entries`로 허용된 id마다 `bool` 하나를 썼다. 이어서 `apply_structured_mask_to_logits`가 `bias_buf`를 `vocab_size_hint`로 resize하고 한 칸씩 훑으며 허용 위치에는 `0.0`을, 나머지에는 `f32::NEG_INFINITY`를 채웠다. 248320행 헤드라면 대략 25만 회짜리 루프 두 개를, 토큰마다, 제약 시퀀스마다 돈다는 뜻이다.
+- **업로드가 실어 나르는 정보량의 32배였다.** 값이 `0.0`과 `-inf` 둘뿐인 f32 바이어스는 토큰당 1비트짜리 정보를 32비트에 담은 것이다. 248320행에서는 스텝당 970KiB 복사이고, 패킹 형태라면 30KiB면 된다.
+- **전부 스케줄러 스레드에서 벌어졌다.** `apply_structured_mask`는 `decode_tick`과 `prefill`에서 포워드 패스와 샘플링 사이에, 틱마다 제약 시퀀스 수만큼 호출된다. 동시 제약 시퀀스가 B개면 틱당 B번 지불되고, 배치 자체의 진행과 직렬화된다.
+- **`mask_buf` / `bias_buf` 재사용은 할당 비용만 없앴다.** 두 버퍼를 생성 시점에 미리 잡아두면 토큰마다 새 `Vec`을 만드는 일은 피하지만, 두 번의 순회도 복사도 그대로다. 게다가 그 어휘 크기에서 제약 시퀀스당 약 1MB의 호스트 메모리를 상주시킨다.
+
+### 1.3 위험 평가
+
+| 위험 | 영향 | 가능성 |
+|------|------|--------|
+| 어휘가 커질수록 제약 디코딩 처리량이 나빠지는데 상한이 보이지 않음 | Medium | High |
+| 비용이 동시 제약 시퀀스 수에 비례하므로, 부하가 걸릴 때 구조화 출력이 정확히 그만큼 나빠짐 | Medium | High |
+| 마스크 경로를 갈아엎으면서 샘플러가 고르는 토큰이 조용히 바뀜 | High | Low |
+| 갈아엎는 과정에서 패딩 헤드 마스킹 규칙이 빠져 이름 없는 행이 샘플링됨 | High | Low |
+
+뒤의 둘은 이 변경 자체가 들여오는 위험이며, 2절과 3절이 그것을 어떻게 묶어뒀는지 설명한다.
+
+---
+
+## 2. 기술 검토
+
+### 2.1 보안
+
+마스크는 제약 요청과 비적합 출력 사이에 서 있는 유일한 장치다. 그러니 너무 관대한 마스크는 성능 문제가 아니라 정확성과 신뢰의 문제다. 재작성에서 반드시 살아남아야 했던 규칙이 둘이고, 지금은 둘 다 전용 테스트가 붙어 있다.
+
+- 매처 어휘를 넘어선 로짓 행은 마스킹된 채로 남아야 한다. Qwen3.5와 Qwen3.8은 `lm_head`를 토크나이저보다 넓게 패딩한다. 토크나이저 항목 248077개에 대해 248320행이다. 그 243행은 어떤 토큰도 이름 붙이지 않으므로 문법이 본 적조차 없고 결코 만족시킬 수 없다. 패킹 형태에서는 0인 워드를 읽으므로 구조적으로 비허용이 된다.
+- 매처의 비트셋에는 잉여 비트가 있다. `SimpleVob`은 `ceil(size / 32)` 워드를 저장하므로 어휘 248077개면 마지막 워드에 어떤 토큰도 가리키지 않는 19비트가 남는다. `toktrie`는 일부 경로(`set_all`, `negated`)에서 이를 지우지만 API 경계에서 보장되는 불변식은 아니다. 그래서 `pack_mask_words`는 그것을 믿는 대신 마지막 부분 워드를 유효 비트 범위로 잘라낸다.
+
+입력 파싱, 인증, 로깅 표면은 바뀌지 않았다. 빈 마스크에 대한 공개 에러 메시지는 이전과 바이트 단위로 동일하다.
+
+### 2.2 성능
+
+이 변경의 목적 자체다. 측정치는 8절과 부록 B에 있다. 요지는 호스트 작업이 사라졌고, 복사가 1/32로 줄었으며, 디바이스 쪽 확장은 어휘 길이에 대한 원소별 연산 네 개로 선택 연산과 같은 그래프에 융합된다는 것이다.
+
+### 2.3 호환성 및 의존성
+
+새 의존성은 없다. 사용한 MLX 연산(`from_slice_u32`, `right_shift`, `bitwise_and`, `reshape`, `slice`, `astype`, `where_cond`)은 전부 이미 cxx 브리지에 바인딩돼 있어 `src/lib/mlxcel-core`는 손대지 않았고, CUDA 커널을 추가하지 않으므로 `make verify-kernel-dtype-keys`는 자명하게 통과한다.
+
+`apply_structured_mask_to_logits`는 시그니처를 그대로 유지하므로 `src/server/batch/scheduler/run_loop.rs`의 호출부와 `decode_tick.rs`, `prefill.rs`의 세 호출 지점은 변경이 없다. `compute_mask`는 `Vec<bool>` 접근자로 남겼다. `tests/structured_outputs.rs`의 아홉 개 호출부가 이것에 의존하고, 개별 항목을 들여다보는 읽기 좋은 방법이기도 하다. 다만 이제 핫 패스에는 없다.
+
+### 2.4 코드 품질
+
+비트 연산은 `pack_mask_words`로 분리했다. 매처도 디바이스도 끼지 않는 슬라이스 위의 순수 함수이며, 무작위 등가성 테스트가 애초에 가능해진 이유가 이것이다. 디바이스 확장은 역시 독립 함수인 `expand_packed_mask`다. 그 결과 `apply_structured_mask_to_logits`는 정책 선언처럼 읽을 만큼 짧아졌다. 게이트 확인, 패킹, 공집합 확인, 선택.
+
+`cargo clippy --profile test-fast --lib --tests --features metal,accelerate -- -D warnings`와 `cargo fmt --all -- --check`는 깨끗하다.
+
+---
+
+## 3. 기술적 선택과 그 이유
+
+### 3.1 토큰별 인덱스 테이블을 gather하는 대신 비트 위치를 브로드캐스트
+
+이슈 #1316은 제약마다 디바이스 배열 두 개를 미리 만들어 두자고 했다. `i >> 5`를 담는 `word_idx = i32[V]`와 `i & 31`을 담는 `bit_idx = u32[V]`를 두고 `bitwise_and(right_shift(take(words, word_idx, 0), bit_idx), 1)`로 펼치는 안이다.
+
+구현은 대신 브로드캐스트한다. 패킹된 워드는 `u32[n_words, 1]` 열로, 32개 비트 위치는 `u32[1, 32]` 행으로 올라가므로 `right_shift` 한 번이 `[n_words, 32]`로 브로드캐스트되고 원소 `(w, b)`가 워드 `w`의 비트 `b`가 된다. 행 우선으로 보면 그 평탄 인덱스는 `w * 32 + b`, 정확히 토큰 id다. `[1, n_words * 32]`로 reshape하고 로짓 폭으로 잘라내면 토큰 순서의 마스크가 그대로 복원된다.
+
+계획 대신 이 형태를 고른 이유는 이렇다.
+
+- **제약별 인덱스 테이블이 없다.** gather 설계는 제약 시퀀스마다 `2 * 4 * V` 바이트, 248320이면 약 2MB의 디바이스 메모리를 제약의 수명 내내 붙들고 있어야 한다. 브로드캐스트에 필요한 것은 32개짜리 행 하나다.
+- **gather가 없다.** `V`개 인덱스에 대한 `take`는 시프트가 시작되기도 전에 `V`개짜리 인덱스 배열을 읽고 `V`개짜리 결과를 쓴다. 브로드캐스트는 `n_words`개 워드만 읽으니 1/32이다.
+- **폭에 묶인 캐시 상태가 없다.** 계획의 배열들은 `vocab_size_hint`나 로짓 dtype이 바뀔 때 다시 만들어야 했고, 그래서 검증 목록에 `packed_apply_rebuilds_index_arrays_on_width_change`가 들어 있었다. 여기서는 폭에 의존하는 것이 아무것도 없으니 그 실패 양상 자체가 존재하지 않는다. 해당 테스트는 버퍼 하나에 여섯 개 폭을 흘려보내며 각각을 확인하는 `packed_apply_handles_a_width_change_between_calls`가 되었다.
+- **MLX 자신의 관용구다.** `dequantize`는 2의 거듭제곱이 아닌 비트폭의 양자화 가중치를 문자 그대로 `bitwise_and(right_shift(w, arange(32, uint32)), 1)`로 푼다. 양자화 포워드마다 MLX가 돌리는 형태를 재사용하는 편이 새로운 형태를 만드는 것보다 안전한 내기다.
+
+### 3.2 디바이스 상수를 제약 객체에 캐시하지 않기
+
+계획은 `neg_inf`와 인덱스 배열을 `StructuredOutputConstraint`에 `Option<UniquePtr<MlxArray>>`로 두자고도 했다. 그것은 컴파일되지 않으며, 구조체만 읽어서는 드러나지 않는 이유이므로 기록해 둘 값어치가 있다.
+
+`StructuredOutputConstraint`는 `SequenceInfo` 안에 `Arc<Mutex<StructuredOutputConstraint>>`로 살면서 스케줄러 스레드로 옮겨지므로 `Send`여야 한다. cxx는 불투명 `extern "C++"` 타입에 `Send`를 자동으로 붙이지 않고 `mlxcel-core`에도 수동 impl이 없으므로, `UniquePtr<MlxArray>`는 `Send`가 아니다.
+
+```
+error[E0277]: `*const cxx::void` cannot be sent between threads safely
+   = help: within `MlxArray`, the trait `Send` is not implemented for `*const cxx::void`
+   = note: required for `UniquePtr<MlxArray>` to implement `Send`
+```
+
+그런 필드를 넣으려면 `src/server/prompt_cache/entry.rs`가 `DetachedKvSetHolder`에 쓰는 식의 `unsafe impl Send` 래퍼와, MLX 배열 핸들이 스레드를 넘나드는 데 대한 실제 안전성 논증이 필요했을 것이다. 이 설계가 필요로 하는 상수 셋(비트 위치 32개, 스칼라 `1`, 스칼라 `-inf`)은 합쳐서 152바이트라, 그냥 호출마다 만든다. 8절의 측정은 그 세 번의 생성을 포함한 준비-업로드 구간 전체를 7.4us로 잰 것이므로, 이 결정은 관측 가능한 비용이 없다.
+
+### 3.3 바이어스를 더하는 대신 `where_cond`로 선택
+
+이전 코드는 `0.0`과 `-inf`로 채운 f32 배열을 더했다. 새 코드는 로짓과 스칼라 `-inf` 사이에서 고른다. 출력이 단지 동등한 것이 아니라 동일한 이유는 이렇다.
+
+- `mlx::core::where`는 `promote_types(b.dtype(), c.dtype())`를 계산해 두 피연산자를 그 타입으로 캐스팅한다. `add`가 하던 것과 똑같다. 따라서 f16이나 bf16 로짓을 f32 `-inf`와 짝지으면 f32 바이어스가 내던 것과 같은 f32 출력이 나온다. 어떤 로짓 정밀도에서도 dtype 거동은 바뀌지 않았다.
+- `where`는 `add`가 쓰던 것과 같은 규칙으로 `broadcast_arrays`를 통해 브로드캐스트하므로, prefill의 `[1, V]`와 decode 틱의 `[1, 1, V]` 둘 다 이전과 같은 shape로 돌아온다.
+- 허용 위치에서는 `0.0`을 더하는 대신 로짓이 그대로 통과한다. IEEE 부동소수점에서 `x + 0.0 == x`이므로 같은 값이고, 반올림 기회가 하나 늘어나는 것이 아니라 하나 줄어드는 쪽이다.
+
+### 3.4 매처 없이 패킹 연산을 테스트
+
+단위 테스트 모듈에는 `MlxcelTokenizer::stub()`밖에 없고 그 어휘는 비어 있어서, 매처를 구동하는 단위 테스트로는 의미 있는 마스크를 만들 수 없다. `tests/structured_outputs.rs`의 80줄짜리 인라인 `tokenizer.json`을 복제하는 대신, 패킹을 순수 함수로 분리하고 명시적으로 구성한 비트셋에 대해 테스트했다.
+
+이 선택은 더 싼 쪽이 아니라 더 강한 쪽으로 드러났다. 열세 가지 폭 조합에 대한 무작위 허용 집합, 잉여 비트 누출을 드러내는 전부 1인 소스, 그리고 테스트 전용 참조로 남겨둔 옛 바이어스 루틴과의 직접적인 원소 단위 비교가 가능해진다. 매처를 구동하는 테스트는 그 특정 문법이 마침 허용하는 것만 단언할 수 있다. 매처 구동 거동은 변경 없이 통과하는 `tests/structured_outputs.rs`의 실행 가능한 21개 테스트가 계속 담당한다.
+
+### 3.5 공집합 판정을 패킹된 워드에서 계산
+
+옛 코드는 `Vec<bool>` 위에서 `[0, vocab_size_hint)` 구간의 허용 항목을 세고 그 수가 0이면 `StructuredOutputError::Matcher`를 냈다. 새 코드는 모든 패킹 워드가 0인지를 본다. `compute_packed_mask`가 정확히 로짓 폭으로 패킹하고 그 바깥을 모두 0으로 만들기 때문에, "모든 워드가 0"은 곧 "모델의 로짓 어휘 안에 매처가 허용하는 도달 가능한 토큰이 없다"와 정확히 같다. 따로 경계를 둘 필요가 없고 에러 메시지도 그대로다. 멈춘 매처는 빈 슬라이스를 돌려주는데 `[].iter().all(...)`은 `true`이므로 이전과 같은 에러 경로를 탄다.
+
+---
+
+## 4. 구현 상세
+
+### 4.1 아키텍처 변경
+
+변경 전의 스텝당 경로:
+
+```
+matcher.compute_mask_or_eos() -> SimpleVob (패킹된 u32)
+  -> iter_set_entries        -> Vec<bool>, vocab_size 항목        [호스트 루프 1]
+  -> 바이어스 채우기          -> Vec<f32>, vocab_size_hint 항목    [호스트 루프 2]
+  -> from_slice_f32          -> 970KiB 업로드
+  -> add(logits, bias)
+```
+
+변경 후:
+
+```
+matcher.compute_mask_or_eos() -> SimpleVob (패킹된 u32)
+  -> pack_mask_words         -> Vec<u32>, ceil(V / 32) 워드       [워드 복사]
+  -> from_slice_u32          -> 30KiB 업로드
+  -> right_shift / bitwise_and / reshape+slice / astype -> 디바이스 위의 bool[1, V]
+  -> where_cond(allowed, logits, -inf)
+```
+
+### 4.2 주요 코드 변경
+
+`StructuredOutputConstraint::compute_packed_mask(vocab_size_hint)`는 `get_error` 확인까지 포함해 `compute_mask`와 똑같이 매처를 구동한 뒤, 펼치는 대신 패킹한다. 짝을 이루는 `compute_mask`와 달리 폭을 인자로 받는데, 패딩 폭은 매처가 아니라 모델 로짓 축의 성질이기 때문이다.
+
+무엇이 살아남는지를 정하는 부분:
+
+```rust
+let matcher_vocab = self.vocab_size.min(vob.len());
+pack_mask_words(vob.as_slice(), matcher_vocab, vocab_size_hint, &mut self.packed_buf);
+```
+
+`compute_mask`는 `self.vocab_size` 이상의 항목을 전부 버렸고, 그보다 짧은 비트셋에는 읽을 비트 자체가 없다. 둘 중 작은 쪽을 취하면 그 규칙이 한 표현식으로 재현된다.
+
+`pack_mask_words`가 패킹 규칙의 전부다:
+
+```rust
+let n_words = vocab_size_hint.div_ceil(32);
+out.clear();
+out.resize(n_words, 0);
+
+let valid_bits = matcher_vocab.min(vocab_size_hint).min(src.len() * 32);
+let full_words = valid_bits / 32;
+let rem = valid_bits % 32;
+
+out[..full_words].copy_from_slice(&src[..full_words]);
+if rem != 0 {
+    out[full_words] = src[full_words] & ((1u32 << rem) - 1);
+}
+```
+
+세 겹의 `min`은 의미론이면서 동시에 안전성 논증이다. `valid_bits <= vocab_size_hint`에서 `full_words <= n_words`가 따라오고, `rem != 0` 분기에서는 `valid_bits <= src.len() * 32`에 `valid_bits`가 워드 배수가 아니라는 사실이 더해져 `full_words < src.len()`이 따라온다. 두 인덱싱 지점 모두 런타임 검사 없이 범위 안이다.
+
+`expand_packed_mask`가 디바이스 쪽 절반이다:
+
+```rust
+let packed  = from_slice_u32(words, &[n_words, 1]);
+let bit_pos = from_slice_u32(&PACKED_MASK_BIT_POSITIONS, &[1, 32]);
+let bits    = bitwise_and(&right_shift(&packed, &bit_pos), &one);
+let flat    = reshape(&bits, &[1, n_words * 32]);
+let trimmed = if flat_len as usize == vocab_size { flat } else { slice(&flat, &[0, 0], &[1, vocab_size as i32]) };
+astype(&trimmed, dtype::BOOL)
+```
+
+`debug_assert_eq!`가 자르기 연산이 의존하는 불변식인 `words.len() == vocab_size.div_ceil(32)`를 못박는다. 한 폭으로 패킹해 다른 폭으로 펼치려는 미래의 호출자는 평탄 길이 밖을 자르는 대신 디버그 빌드에서 크게 실패한다.
+
+`apply_structured_mask_to_logits`는 정책만 남는다:
+
+```rust
+if constraint.is_gated() { return Ok(copy(logits)); }
+let words = constraint.compute_packed_mask(vocab_size_hint)?;
+if words.iter().all(|word| *word == 0) { return Err(StructuredOutputError::Matcher(...)); }
+Ok(apply_packed_mask_to_logits(words, vocab_size_hint, logits))
+```
+
+### 4.3 데이터 모델 변경
+
+`StructuredOutputConstraint::bias_buf: Vec<f32>`가 제거되고 그 자리를 `packed_buf: Vec<u32>`가 대신한다. 어휘 248320개 기준으로 제약 시퀀스당 약 1MB의 호스트 상주 메모리가 줄고, 생성자가 잡아두는 용량도 이전의 1/32이다. `mask_buf`는 그대로이며 여전히 `compute_mask`를 뒷받침한다.
+
+---
+
+## 5. 학습 포인트
+
+### 5.1 마스크는 토큰당 1비트다. 그보다 넓은 것은 전송 방식의 선택일 뿐이다
+
+바이어스 배열은 토큰당 1비트짜리 정보를 32비트에 실어 나르고 있었고, 호스트 루프 두 개는 오직 그 넓히기를 수행하려고 존재했다. 질문을 "이 답을 담을 수 있는 가장 좁은 형태는 무엇인가"로 바꿔 놓으면 답은 생산자가 이미 계산해 둔 그 형태이고, 두 루프는 필요한 작업이 아니라 순수한 오버헤드로 드러난다. 매처는 비트셋 생산을 멈춘 적이 없다. 소비자가 부동소수점을 원했기 때문에 코드가 계속 그것을 풀고 있었을 뿐이다.
+
+일반화하면 이렇다. 생산자와 소비자의 표현이 어긋날 때, 토큰마다 도는 변환기를 쓰기 전에 소비자에게 생산자의 형태를 가르칠 수 있는지부터 확인하라.
+
+### 5.2 인덱스 패턴이 아핀이면 gather보다 브로드캐스트다
+
+비트셋을 토큰당 한 항목으로 펼치는 자연스러운 방법은 토큰마다 그것이 사는 워드를 찾아보는 것이다. 그것이 gather이고, 출력만큼 넓은 인덱스 배열이 필요하다. 그런데 토큰에서 (워드, 비트)로 가는 사상은 임의가 아니라 `(i >> 5, i & 31)`이고, 이것이야말로 2차원 reshape가 공짜로 표현해 주는 것이다. 워드를 한 축에, 비트 위치를 다른 축에 놓으면 인덱스 테이블이 shape 안에 암묵적으로 들어간다.
+
+이건 눈에 익혀 둘 만하다. 내용이 자기 위치의 산술 함수인 인덱스 배열은 대개 변장한 reshape다. MLX도 같은 이유로 `dequantize`에서 같은 결론에 도달했다.
+
+### 5.3 `UniquePtr<MlxArray>`는 `Send`가 아니므로 시퀀스별 구조체에 캐시할 수 없다
+
+`SequenceInfo`에서 닿는 것은 전부 스케줄러 스레드를 건너가므로 `Send`여야 한다. cxx는 불투명 `extern "C++"` 타입에 `Send`를 유도하지 않고 `mlxcel-core`에도 수동 impl이 없으므로, MLX 배열 핸들은 명시적인 `unsafe impl Send` 래퍼와 그에 딸린 안전성 논증 없이는 요청별 구조체에 저장할 수 없다(`src/server/prompt_cache/entry.rs`에 정확히 이 이유로 두 개의 래퍼가 있다). 디바이스 쪽 조회 테이블을 스텝 사이에 살려 두려는 설계는 모두 여기에 먼저 부딪힌다. 미묘한 버그가 아니라 컴파일 에러이긴 하지만, 설계가 아니라 구현 도중에 발견되면 계획을 늦게 뒤집는다.
+
+### 5.4 지우려는 코드와의 A/B는 테스트로 남길 값어치가 있다
+
+옛 바이어스 루틴을 테스트 전용 참조로 보존했고, 그 덕에 두 가지가 동시에 가능해졌다. 무작위 허용 집합과 일곱 가지 어휘 형상에 걸친 원소 단위 등가성 단언, 그리고 두 경로를 한 프로세스 안에서 동일한 조건으로 재는 마이크로벤치마크다. 옛 경로가 사라진 뒤에는 둘 다 불가능하고, 나중에 diff에서 복원하는 것은 그 복원 자체가 검증되지 않았다는 점에서 확실히 더 나쁘다. 참조 구현의 비용은 25줄이다.
+
+---
+
+## 6. 추가 학습
+
+### 핵심 용어
+
+- **`SimpleVob`**: 토큰 id에 대한 `toktrie`의 비트셋으로, `Vec<u32>`와 크기로 이뤄진다. 워드 `i / 32`의 비트 `i % 32`가 토큰 `i`이고 `as_slice()`가 워드를 그대로 노출한다. 백킹 스토어가 선언된 크기보다 넓을 수 있어 잉여 비트가 0이라는 보장은 없다.
+- **패딩된 `lm_head`**: 출력 프로젝션의 행 수가 토크나이저의 토큰 수보다 많은 모델. Qwen3.8-27B는 토크나이저 항목 248077개에 대해 `vocab_size: 248320`을 선언하며, 어떤 토큰 id도 이름 붙이지 않는 243행이 남는다.
+- **`vocab_size_hint`**: 호출부에서 로짓 배열의 마지막 축으로 읽은 모델의 로짓 폭. 마스크가 로짓 위로 브로드캐스트돼야 하므로 의도적으로 매처의 어휘가 아니다.
+- **브로드캐스트 시프트**: `[n, 1]`에 대한 `right_shift`를 `[1, 32]`와 짝지어 `[n, 32]`를 만드는 것. MLX의 이항 연산은 NumPy 규칙으로 브로드캐스트하므로 명시적 `broadcast_to`가 필요 없다.
+
+### 관련 기술/프레임워크
+
+- `llguidance` 1.7 / `toktrie` 1.8. `response_format` 뒤의 문법 엔진으로, Blaizzy/mlx-vlm#1047에서 상류가 선택했고 mlxcel도 공유한다.
+- MLX의 `Select` 프리미티브. `where_cond`를 뒷받침하며 값 피연산자를 공통 dtype으로 승격한다.
+- MLX `dequantize`. 브로드캐스트 비트 언팩 형태의 인트리 선례다: https://github.com/ml-explore/mlx/blob/main/mlx/ops.cpp
+
+### 관련 PR/이슈
+
+- #1316. 이 PR이 닫는 이슈.
+- Blaizzy/mlx-vlm#1805. `apply_mask_covers_the_qwen3_8_padded_lm_head`가 못박는 패딩 `lm_head` 크기 규칙의 상류 대응물.
+
+---
+
+## 7. 변경 요약
+
+### 통계
+
+| 항목 | 값 |
+|------|-----|
+| 변경 파일 | 2 |
+| 추가 줄 | 698 |
+| 삭제 줄 | 65 |
+| 신규 단위 테스트 | 6개와 ignore된 벤치마크 1개 |
+| 영향받은 크레이트 | `mlxcel`만 |
+
+### 카테고리별 변경
+
+| 파일 | 변경 |
+|------|------|
+| `src/server/structured.rs` | +218 / -65. `compute_packed_mask`, `pack_mask_words`, `expand_packed_mask`, `apply_packed_mask_to_logits`, `PACKED_MASK_BIT_POSITIONS` 추가. `apply_structured_mask_to_logits` 재작성. `bias_buf`를 `packed_buf`로 교체. |
+| `src/server/structured_tests.rs` | +480. 단위 테스트 6개, 테스트 전용 바이어스 참조, 결정론적 xorshift, 배열 읽기와 argmax 헬퍼, ignore된 마이크로벤치마크. |
+
+### 관련 커밋
+
+- `ff3d8bd` perf(server): pack structured-output masks as u32 bitmasks
+
+---
+
+## 8. 후속 조치
+
+### 필수
+
+- PR 본문의 라이브 서버 확인을 `models/mlx/qwen3-4b-4bit`에 대해 실행할 것. `response_format: json_schema` 요청이 스키마에 맞는 객체를 `finish_reason: stop`과 함께 돌려줘야 하고, `temperature: 0`에서 완성 결과가 변경 이전 바이너리와 토큰 단위로 동일해야 하며, 제약 없는 대조군은 변화가 없어야 한다.
+- 워크스페이스 전체 게이트를 실행할 것. 이번 변경은 좁은 명령(`--lib server::structured`, `--test structured_outputs`, `clippy --lib --tests`)으로 검증했고, `cargo test --workspace --profile test-fast --features metal,accelerate`와 `cargo clippy --workspace --all-targets -- -D warnings`는 여기서 실행하지 않았다.
+
+### 모니터링 필요
+
+- 동시성 하에서 넓은 어휘 체크포인트의 제약 디코딩 처리량. 제거된 비용은 동시 제약 시퀀스 수에 비례했으므로 이득이 가장 잘 보이는 곳이 거기이고, 회귀가 가장 먼저 드러날 곳도 거기다.
+
+### 향후 개선
+
+- 이슈 #1316은 네 연산짜리 확장이 지배적이 될 경우의 선택적 후속으로 `logits[i] = (words[i >> 5] >> (i & 31)) & 1 ? logits[i] : -inf` 융합 커널을 적어 두었다. 아래 측정은 그렇지 않다고 말한다. 248k 어휘에서 준비-업로드 구간 전체가 7.4us이므로 남은 비용은 로짓에 대한 원소별 순회이고, 그것은 어떤 구현이든 지불해야 한다.
+- 이슈 자신의 범위 밖 목록도 그대로 유효하다. 그리디 제약 디코딩용 융합 masked-argmax 샘플러, 그리고 같은 문법 상태를 가진 시퀀스들이 마스크 업로드 하나를 공유하는 것.
+
+---
+
+## 부록
+
+### A. 테스트 결과
+
+```
+cargo test --profile test-fast --features metal,accelerate --lib server::structured
+  21 passed, 0 failed, 1 ignored (마이크로벤치마크)
+
+cargo test --profile test-fast --features metal,accelerate --test structured_outputs
+  21 passed, 0 failed, 2 ignored (로컬 모델 가중치 필요)
+
+cargo clippy --profile test-fast --lib --tests --features metal,accelerate -- -D warnings
+  clean
+
+cargo fmt --all -- --check
+  clean
+```
+
+신규 단위 테스트:
+
+| 테스트 | 못박는 것 |
+|--------|-----------|
+| `packed_mask_matches_bool_mask` | 열세 가지 폭 조합, 무작위 허용 집합. 모든 비트가 불리언 마스크와 일치하고 로짓 폭 너머의 모든 레인이 0이다. |
+| `packed_mask_trims_the_matchers_own_excess_bits` | 전부 1인 소스에 77토큰 매처. 어떤 토큰도 가리키지 않는 19비트가 살아남으면 안 된다. |
+| `packed_mask_zero_pads_past_the_matcher_vocabulary` | 패딩 헤드 방향. 200폭 축에 40토큰. |
+| `packed_mask_of_an_empty_allow_set_is_all_zero` | 빈 마스크 에러가 읽는 바로 그 술어, 그리고 마지막 부분 워드에 홀로 있는 허용 토큰. |
+| `packed_apply_matches_bias_apply` | 일곱 가지 형상. 패킹 출력이 모든 위치에서 IEEE 동등성으로 f32 바이어스 출력과 같고, 허용 위치는 입력 로짓을 정확히 그대로 담으며, 비허용 위치는 `-inf`이고, `argmax`가 일치한다. |
+| `packed_apply_handles_the_all_allowed_and_single_allowed_edges` | 전부 허용인 마스크는 무연산이고, 마지막 부분 워드의 단 하나뿐인 허용 토큰은 로짓 값과 무관하게 그리디 디코딩에서 이긴다. |
+| `packed_apply_handles_a_width_change_between_calls` | 버퍼 하나에 여섯 가지 폭을 흘려보내며 각각을 전부 확인. |
+
+### B. 성능 벤치마크
+
+```
+cargo test --profile test-fast --features metal,accelerate --lib \
+  server::structured::tests::bench_packed_mask_apply -- --ignored --nocapture
+```
+
+M1 Ultra, Time Machine 중지, 토크나이저 항목 248077개에 대한 로짓 248320행, 시행당 min-of-60, 네 번 실행의 중앙값:
+
+| 경로 | 준비 + 업로드 | eval 포함 | 업로드 |
+|------|---------------|-----------|--------|
+| f32 바이어스 (이전) | 711us | 1002us | 970KiB |
+| 패킹 u32 (이후) | 7.4us | 322us | 30KiB |
+
+네 번의 실행에서 관측된 범위: 707에서 714us, 6.7에서 8.9us, 986에서 1009us, 300에서 326us.
+
+"준비 + 업로드"는 스케줄러 스레드 비용이다. 마스크 준비와 호스트-디바이스 복사를 거쳐 출력 그래프 노드를 손에 넣기까지다. "eval 포함"은 결과에 대한 강제 `mlxcel_core::eval`을 더한 것이다. 패킹 경로의 eval 수치는 알려진 MLX 단발 eval 바닥값 약 300us에 걸려 있으므로, 디바이스 쪽 이득을 과장하는 것이 아니라 축소해서 보여준다. 이 측정에서 정직하게 주장할 수 있는 것은 스케줄러 스레드에서 제거된 제약 시퀀스당 토큰당 약 0.7ms이고, 이는 이슈가 예상한 0.5에서 1.5ms 안에 있다.
+
+두 경로는 같은 프로세스에서 동일한 조건으로 측정했으며, 참조 경로는 이 PR이 삭제하는 코드 그 자체다.
+
+### C. 참고 자료
+
+- 이슈 #1316. 변경 내용과 인수 기준을 규정한다.
+- `src/server/structured.rs`의 `compute_packed_mask` / `pack_mask_words` / `expand_packed_mask`.
+- `tests/structured_outputs.rs`의 `apply_mask_covers_the_qwen3_8_padded_lm_head`. 실제 크기의 부분 워드 사례다.
+- MLX `dequantize`. 브로드캐스트 비트 언팩의 인트리 선례: https://github.com/ml-explore/mlx/blob/main/mlx/ops.cpp
+- 공유 함수 관례는 `docs/code-guidelines.md`. 여기서는 어떤 공유 함수도 넓히지 않았다.

--- a/src/server/structured.rs
+++ b/src/server/structured.rs
@@ -292,7 +292,7 @@ fn resolve_tok_env(serialized_bytes: &[u8]) -> Result<(TokenizerFingerprint, Tok
 /// in [`crate::server::batch::SequenceInfo::structured`] and consults it
 /// before/after sampling on every step.
 ///
-/// `mask_buf` and `bias_buf` are reusable scratch buffers — pre-allocated at
+/// `mask_buf` and `packed_buf` are reusable scratch buffers, pre-allocated at
 /// construction and reset (not reallocated) on each per-token call. With a
 /// 150k-vocab tokenizer that saves roughly 750 KiB of allocator churn per
 /// emitted token per sequence.
@@ -310,11 +310,13 @@ pub struct StructuredOutputConstraint {
     /// the per-token decode path does not allocate a fresh `Vec<bool>` of
     /// length `vocab_size` (~150 KB for a 150k-vocab tokenizer).
     mask_buf: Vec<bool>,
-    /// Scratch buffer for [`apply_structured_mask_to_logits`] — reused so
-    /// the per-token decode path does not allocate a fresh `Vec<f32>` of
-    /// length `vocab_size_hint` (~600 KB for a 150k-vocab model). Filled
-    /// in-place on every call.
-    bias_buf: Vec<f32>,
+    /// Scratch buffer for [`Self::compute_packed_mask`], holding the matcher
+    /// mask in its packed form: 32 token bits per `u32`, bit `i % 32` of word
+    /// `i / 32` for token `i`. Reused across calls so the per-token decode
+    /// path neither allocates nor walks the vocabulary. For a 248320-row
+    /// logits axis this is 31 KB against the 993 KB `Vec<f32>` bias the
+    /// previous implementation rebuilt and uploaded on every step.
+    packed_buf: Vec<u32>,
 }
 
 impl std::fmt::Debug for StructuredOutputConstraint {
@@ -395,6 +397,62 @@ impl StructuredOutputConstraint {
             }
         });
         Ok(&self.mask_buf)
+    }
+
+    /// Compute the same allow-set as [`Self::compute_mask`], but leave it in
+    /// the matcher's packed form: bit `i % 32` of word `i / 32` is token `i`.
+    ///
+    /// This is the form the per-token decode path wants. [`Self::compute_mask`]
+    /// exists to let callers inspect individual entries and is what the
+    /// integration tests drive; it costs one host write per vocabulary entry,
+    /// which for a 248k-row head is 248320 writes that
+    /// [`apply_structured_mask_to_logits`] then reads back to build an f32
+    /// bias of the same length. Keeping the mask packed removes both walks:
+    /// the matcher already stores its answer as a bitset, so this copies
+    /// `ceil(vocab_size_hint / 32)` words straight out of it.
+    ///
+    /// `vocab_size_hint` is the model's logits width, the same value
+    /// [`apply_structured_mask_to_logits`] takes. The returned slice is
+    /// always exactly `ceil(vocab_size_hint / 32)` words long, so it expands
+    /// to a mask that broadcasts onto the model's logits: bits past the
+    /// matcher's vocabulary read zero, which keeps a padded head row masked.
+    ///
+    /// Returns an empty slice if the matcher is already stopped, matching
+    /// [`Self::compute_mask`]. Callers are expected to short-circuit on
+    /// `is_stopped()` first; this is defence in depth.
+    pub fn compute_packed_mask(
+        &mut self,
+        vocab_size_hint: usize,
+    ) -> Result<&[u32], StructuredOutputError> {
+        if self.matcher.is_stopped() {
+            self.packed_buf.clear();
+            return Ok(&self.packed_buf);
+        }
+
+        let vob = self.matcher.compute_mask_or_eos().map_err(|e| {
+            // Verbose llguidance details go to server logs only.
+            tracing::error!("structured-output compute_mask_or_eos failed: {e}");
+            StructuredOutputError::Matcher("compute_mask failed".to_string())
+        })?;
+
+        if let Some(err) = self.matcher.get_error() {
+            tracing::error!("structured-output matcher error after compute_mask: {err}");
+            return Err(StructuredOutputError::Matcher(
+                "matcher entered error state".to_string(),
+            ));
+        }
+
+        // `compute_mask` drops every entry at or past `self.vocab_size`, and a
+        // bitset shorter than that simply has no bit to read. Taking the
+        // smaller of the two reproduces that rule exactly.
+        let matcher_vocab = self.vocab_size.min(vob.len());
+        pack_mask_words(
+            vob.as_slice(),
+            matcher_vocab,
+            vocab_size_hint,
+            &mut self.packed_buf,
+        );
+        Ok(&self.packed_buf)
     }
 
     /// Advance the matcher state by the just-sampled token.
@@ -678,11 +736,12 @@ fn build_constraint(
         tok_env,
         lazy,
         mask_buf: Vec::with_capacity(vocab_size),
-        // The bias buffer is sized lazily on first call (vocab_size_hint
-        // depends on the model logits axis, which the constraint builder
-        // does not know about). Pre-reserving avoids reallocs on the
-        // first per-token call as well.
-        bias_buf: Vec::with_capacity(vocab_size),
+        // The packed buffer is sized lazily on first call: its width comes
+        // from `vocab_size_hint`, the model logits axis, which the constraint
+        // builder does not know about. Reserving the matcher's own word count
+        // covers the common case without a realloc on the first per-token
+        // call, and costs 1/32 of what the old f32 bias buffer reserved.
+        packed_buf: Vec::with_capacity(vocab_size.div_ceil(32)),
     })))
 }
 
@@ -859,6 +918,114 @@ pub fn build_constraint_from_response_format(
 // Logits-mask application
 // ---------------------------------------------------------------------------
 
+/// Bit position of each token inside its packed `u32` word, `0..32`.
+///
+/// Uploaded as a `u32[1, 32]` row and broadcast against the packed mask column
+/// so one shift expands every word into its 32 token bits at once. This is the
+/// same expansion MLX itself uses to unpack non-power-of-two quantized weights
+/// (see `bitwise_and(right_shift(w, arange(32, uint32)), 1)` in `dequantize`).
+const PACKED_MASK_BIT_POSITIONS: [u32; 32] = [
+    0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25,
+    26, 27, 28, 29, 30, 31,
+];
+
+/// Copy a matcher bitset into `out`, sized and trimmed for a logits axis of
+/// `vocab_size_hint` tokens.
+///
+/// `src` is the matcher's own packed mask: bit `i % 32` of word `i / 32` is
+/// token `i`. `matcher_vocab` is the number of leading bits in `src` that name
+/// a real token; a bit at or past it is dropped, which is what keeps a padded
+/// head row masked. `out` ends up exactly `ceil(vocab_size_hint / 32)` words
+/// long, zero past the matcher's vocabulary, with the final partial word
+/// trimmed to its valid bit range so the matcher's own excess bits cannot leak
+/// in as spuriously allowed tokens.
+///
+/// This reproduces, in packed form, what `compute_mask` plus the old f32 bias
+/// fill computed one entry at a time: token `i` is allowed exactly when
+/// `i < min(matcher_vocab, vocab_size_hint)` and `src` has its bit set.
+fn pack_mask_words(src: &[u32], matcher_vocab: usize, vocab_size_hint: usize, out: &mut Vec<u32>) {
+    let n_words = vocab_size_hint.div_ceil(32);
+    out.clear();
+    out.resize(n_words, 0);
+
+    // A bit is only meaningful when it is inside the matcher's vocabulary,
+    // inside the model's logits axis, and actually backed by a source word.
+    let valid_bits = matcher_vocab.min(vocab_size_hint).min(src.len() * 32);
+    let full_words = valid_bits / 32;
+    let rem = valid_bits % 32;
+
+    // `full_words <= n_words` because `valid_bits <= vocab_size_hint`, and
+    // `full_words <= src.len()` because `valid_bits <= src.len() * 32`.
+    out[..full_words].copy_from_slice(&src[..full_words]);
+    if rem != 0 {
+        // `valid_bits` is not a word multiple here, so `full_words` is a
+        // strict index into both slices. Keep only the bits below it.
+        out[full_words] = src[full_words] & ((1u32 << rem) - 1);
+    }
+}
+
+/// Expand a packed mask into a `bool[1, vocab_size]` array on the device.
+///
+/// The packed words go up as a `u32[n_words, 1]` column and the bit positions
+/// as a `u32[1, 32]` row, so a single broadcast shift produces `[n_words, 32]`
+/// where element `(w, b)` carries bit `b` of word `w`. Row-major that is
+/// exactly token id `w * 32 + b`, so a reshape to one row and a trim to
+/// `vocab_size` recovers the mask in token order with no host-side unpacking
+/// and no per-token index table.
+///
+/// Only `ceil(vocab_size / 32) * 4` bytes cross the bus, 31 KB for a
+/// 248320-row head against the 993 KB the f32 bias needed.
+fn expand_packed_mask(
+    words: &[u32],
+    vocab_size: usize,
+) -> mlxcel_core::UniquePtr<mlxcel_core::MlxArray> {
+    debug_assert_eq!(
+        words.len(),
+        vocab_size.div_ceil(32),
+        "the packed mask must cover exactly the logits width"
+    );
+    let n_words = words.len() as i32;
+    let packed = mlxcel_core::from_slice_u32(words, &[n_words, 1]);
+    let bit_pos = mlxcel_core::from_slice_u32(&PACKED_MASK_BIT_POSITIONS, &[1, 32]);
+    let one = mlxcel_core::from_slice_u32(&[1u32], &[1]);
+
+    // [n_words, 1] >> [1, 32] broadcasts to [n_words, 32]; masking with 1
+    // leaves the single bit that names token `w * 32 + b`.
+    let shifted = mlxcel_core::right_shift(&packed, &bit_pos);
+    let bits = mlxcel_core::bitwise_and(&shifted, &one);
+
+    let flat_len = n_words * 32;
+    let flat = mlxcel_core::reshape(&bits, &[1, flat_len]);
+    // `n_words * 32` overshoots `vocab_size` whenever the vocabulary is not a
+    // word multiple. Those trailing lanes are zero (see `pack_mask_words`), but
+    // the mask still has to match the logits width to broadcast.
+    let trimmed = if flat_len as usize == vocab_size {
+        flat
+    } else {
+        mlxcel_core::slice(&flat, &[0, 0], &[1, vocab_size as i32])
+    };
+
+    // The values here are already 0 or 1, so the cast is exact.
+    mlxcel_core::astype(&trimmed, mlxcel_core::dtype::BOOL)
+}
+
+/// Select `logits` where the packed mask allows a token and `-inf` where it
+/// does not.
+///
+/// `mlxcel_core::where_cond` promotes its two value operands to their common
+/// dtype, so pairing f16 or bf16 logits with an f32 `-inf` yields the same f32
+/// output the previous `add(logits, f32_bias)` produced, and an allowed logit
+/// passes through with the identical value it had.
+fn apply_packed_mask_to_logits(
+    words: &[u32],
+    vocab_size: usize,
+    logits: &mlxcel_core::MlxArray,
+) -> mlxcel_core::UniquePtr<mlxcel_core::MlxArray> {
+    let allowed = expand_packed_mask(words, vocab_size);
+    let neg_inf = mlxcel_core::from_slice_f32(&[f32::NEG_INFINITY], &[1]);
+    mlxcel_core::where_cond(&allowed, logits, &neg_inf)
+}
+
 /// Apply the structured-output mask to a 2-D `[1, vocab]` logits array.
 ///
 /// Returns a fresh array with `f32::NEG_INFINITY` written at every position
@@ -872,35 +1039,43 @@ pub fn build_constraint_from_response_format(
 /// the scheduler can transition the sequence to `Finished(Error)` rather
 /// than emit non-conforming output.
 ///
+/// # How the mask reaches the device
+///
+/// The matcher already answers as a bitset, so the mask stays packed all the
+/// way to the GPU: [`StructuredOutputConstraint::compute_packed_mask`] copies
+/// `ceil(vocab_size_hint / 32)` words out of it and [`expand_packed_mask`]
+/// turns those back into one bit per token with a broadcast shift, a mask and
+/// a cast. Nothing on the scheduler thread walks the vocabulary, and the
+/// per-step host-to-device copy is 1/32 of the f32 bias it replaces.
+///
+/// The result is the same array the previous additive bias produced.
+/// `where_cond` passes an allowed logit through untouched instead of adding
+/// `0.0` to it, which for IEEE floats is the same value, and writes the same
+/// `-inf` at every disallowed position.
+///
 /// # Vocab-size handling
 ///
-/// `vocab_size_hint` is the vocabulary size the model's logits axis
-/// exposes. The returned bias array has exactly `vocab_size_hint`
-/// entries so it broadcasts cleanly onto the model's logits — any other
-/// shape would trigger a hard FFI error inside `mlxcel_core::add`.
+/// `vocab_size_hint` is the vocabulary size the model's logits axis exposes.
+/// The mask is built with exactly `vocab_size_hint` entries so it broadcasts
+/// cleanly onto the model's logits; any other shape would trigger a hard FFI
+/// error inside `mlxcel_core::where_cond`.
 ///
 /// Two directions are possible:
 ///
 /// 1. `matcher_vocab >= vocab_size_hint`: the matcher carries entries
 ///    that the model cannot emit. Trailing matcher-only positions are
-///    silently dropped when building the bias; the sampler never sees
-///    them, so they cannot violate the schema.
+///    silently dropped when packing; the sampler never sees them, so they
+///    cannot violate the schema.
 /// 2. `matcher_vocab < vocab_size_hint`: rare, happens when the model
 ///    has padded its embedding table beyond the tokenizer's natural
-///    vocabulary. Positions in `[matcher_vocab, vocab_size_hint)` are
-///    conservatively masked out — an unknown token id can never satisfy
-///    the grammar.
+///    vocabulary. Positions in `[matcher_vocab, vocab_size_hint)` read a zero
+///    bit and are therefore masked out, conservatively: an unknown token id
+///    can never satisfy the grammar.
 pub fn apply_structured_mask_to_logits(
     constraint: &mut StructuredOutputConstraint,
     logits: &mlxcel_core::MlxArray,
     vocab_size_hint: usize,
 ) -> Result<mlxcel_core::UniquePtr<mlxcel_core::MlxArray>, StructuredOutputError> {
-    // Bias must broadcast onto the model's logits, so the bias length is
-    // pinned to `vocab_size_hint`. Anything the matcher allows beyond
-    // that is unreachable by the sampler (the model cannot emit a token
-    // id past its own logits axis); anything the matcher does NOT cover
-    // up to `vocab_size_hint` defaults to disallowed (conservative — an
-    // unknown id cannot satisfy the grammar).
     // A lazy grammar that has not triggered constrains nothing at all, so the
     // logits pass through untouched. This is not the same as an empty mask,
     // which below is (correctly) an error.
@@ -908,47 +1083,25 @@ pub fn apply_structured_mask_to_logits(
         return Ok(mlxcel_core::copy(logits));
     }
 
-    let vocab_size = vocab_size_hint;
-
-    // Compute the mask (borrows `constraint.mask_buf` mutably). Read out
-    // the count of in-range allowed bits, then drop the borrow before
-    // touching `constraint.bias_buf`.
-    {
-        let allowed = constraint.compute_mask()?;
-        let usable_allowed_count = allowed.iter().take(vocab_size).filter(|x| **x).count();
-        if usable_allowed_count == 0 {
-            // No legal continuation reachable by the sampler — surface
-            // as a clean error so the scheduler can stop the sequence
-            // with a 5xx-equivalent FinishReason::Error rather than
-            // silently emitting an arbitrary token.
-            return Err(StructuredOutputError::Matcher(
-                "structured-output matcher returned an empty mask: \
-                 no matcher-allowed token is reachable in the model's logits \
-                 vocabulary for the current constrained-decoding state."
-                    .to_string(),
-            ));
-        }
+    // Packed to the model's logits width, so every word this reads back is
+    // reachable by the sampler and the emptiness test below needs no separate
+    // bound. A stopped matcher yields an empty slice, which is all-zero and
+    // therefore takes the same error path.
+    let words = constraint.compute_packed_mask(vocab_size_hint)?;
+    if words.iter().all(|word| *word == 0) {
+        // No legal continuation reachable by the sampler. Surface it as a
+        // clean error so the scheduler can stop the sequence with a
+        // 5xx-equivalent FinishReason::Error rather than silently emitting an
+        // arbitrary token.
+        return Err(StructuredOutputError::Matcher(
+            "structured-output matcher returned an empty mask: \
+             no matcher-allowed token is reachable in the model's logits \
+             vocabulary for the current constrained-decoding state."
+                .to_string(),
+        ));
     }
 
-    // Build the bias from the now-populated `constraint.mask_buf`. We use
-    // the bias_buf directly (not via `bias_scratch`, which would conflict
-    // with the read of `mask_buf` since both alias `constraint`); resize
-    // in place and fill from the mask.
-    constraint.bias_buf.clear();
-    constraint.bias_buf.resize(vocab_size, 0.0);
-    let mask_len = constraint.mask_buf.len();
-    for (i, slot) in constraint.bias_buf.iter_mut().enumerate() {
-        // SAFETY of indexing: `mask_buf` was just (re-)sized to
-        // `constraint.vocab_size` by `compute_mask`, so the bounds check
-        // here matches what the previous `Vec<bool>`-returning version did.
-        let allowed = i < mask_len && constraint.mask_buf[i];
-        if !allowed {
-            *slot = f32::NEG_INFINITY;
-        }
-    }
-
-    let bias_arr = mlxcel_core::from_slice_f32(&constraint.bias_buf, &[1, vocab_size as i32]);
-    Ok(mlxcel_core::add(logits, &bias_arr))
+    Ok(apply_packed_mask_to_logits(words, vocab_size_hint, logits))
 }
 
 // ---------------------------------------------------------------------------

--- a/src/server/structured_tests.rs
+++ b/src/server/structured_tests.rs
@@ -236,3 +236,483 @@ fn invalid_request_propagates_through_helper() {
         .expect_err("json_object is not allowed in MVP");
     assert!(matches!(err, StructuredOutputError::InvalidRequest(_)));
 }
+
+// ---------------------------------------------------------------------------
+// Packed mask application (#1316)
+//
+// The matcher answers as a bitset, so the decode path keeps it packed all the
+// way to the device instead of unpacking it into a `Vec<bool>` and a `Vec<f32>`
+// bias of the vocabulary's length. These tests own the bit-level algebra and
+// the device-side equivalence; the matcher-driven behavior (mask contents,
+// padded head rows, the empty-mask error) is covered end to end against a real
+// byte-level tokenizer in `tests/structured_outputs.rs`.
+// ---------------------------------------------------------------------------
+
+/// Deterministic xorshift so the randomized cases are reproducible from the
+/// seed alone and the test needs no rng dependency.
+struct Xorshift64(u64);
+
+impl Xorshift64 {
+    fn new(seed: u64) -> Self {
+        Self(seed | 1)
+    }
+
+    fn next_u32(&mut self) -> u32 {
+        let mut x = self.0;
+        x ^= x << 13;
+        x ^= x >> 7;
+        x ^= x << 17;
+        self.0 = x;
+        (x >> 32) as u32
+    }
+
+    fn next_f32(&mut self) -> f32 {
+        // Roughly [-8, 8), the range decode logits actually live in.
+        (self.next_u32() as f32 / u32::MAX as f32) * 16.0 - 8.0
+    }
+}
+
+/// Build a matcher-shaped bitset holding exactly `allowed`.
+fn packed_source(allowed: &[bool]) -> Vec<u32> {
+    let mut words = vec![0u32; allowed.len().div_ceil(32)];
+    for (i, on) in allowed.iter().enumerate() {
+        if *on {
+            words[i / 32] |= 1u32 << (i % 32);
+        }
+    }
+    words
+}
+
+/// Read bit `i` out of a packed mask.
+fn packed_bit(words: &[u32], i: usize) -> bool {
+    words[i / 32] & (1u32 << (i % 32)) != 0
+}
+
+/// The implementation this change replaces, kept as the equivalence reference.
+///
+/// `compute_mask` unpacked the matcher bitset into one `bool` per token, and
+/// `apply_structured_mask_to_logits` then walked the logits axis a second time
+/// to build an f32 bias of `0.0` at allowed positions and `-inf` everywhere
+/// else, uploaded it, and added it to the logits.
+fn reference_bias_apply(
+    src_words: &[u32],
+    matcher_vocab: usize,
+    vocab_size_hint: usize,
+    logits: &mlxcel_core::MlxArray,
+) -> mlxcel_core::UniquePtr<mlxcel_core::MlxArray> {
+    let mut mask = vec![false; matcher_vocab];
+    for (i, slot) in mask.iter_mut().enumerate() {
+        *slot = packed_bit(src_words, i);
+    }
+
+    let mut bias = vec![0.0f32; vocab_size_hint];
+    for (i, slot) in bias.iter_mut().enumerate() {
+        if !(i < mask.len() && mask[i]) {
+            *slot = f32::NEG_INFINITY;
+        }
+    }
+
+    let bias_arr = mlxcel_core::from_slice_f32(&bias, &[1, vocab_size_hint as i32]);
+    mlxcel_core::add(logits, &bias_arr)
+}
+
+/// Evaluate a 1xN f32 array and copy it back to the host.
+fn read_f32_array(arr: &mlxcel_core::MlxArray) -> Vec<f32> {
+    mlxcel_core::eval(arr);
+    let bytes = mlxcel_core::array_to_raw_bytes(arr);
+    assert_eq!(
+        bytes.len() % 4,
+        0,
+        "f32 array bytes must be a multiple of 4"
+    );
+    bytes
+        .chunks_exact(4)
+        .map(|c| f32::from_ne_bytes([c[0], c[1], c[2], c[3]]))
+        .collect()
+}
+
+/// Index of the largest logit, the token greedy decoding would emit.
+fn argmax(values: &[f32]) -> Option<usize> {
+    values
+        .iter()
+        .enumerate()
+        .filter(|(_, v)| v.is_finite())
+        .max_by(|a, b| a.1.partial_cmp(b.1).expect("no NaN logits in these tests"))
+        .map(|(i, _)| i)
+}
+
+#[test]
+fn packed_mask_matches_bool_mask() {
+    let mut rng = Xorshift64::new(0x5175_656e_3331_3336);
+
+    // Widths that are and are not word multiples, in both directions relative
+    // to the matcher vocabulary, so the trim and the zero-pad are both live.
+    let cases: &[(usize, usize)] = &[
+        (32, 32),
+        (32, 64),
+        (33, 33),
+        (33, 96),
+        (63, 64),
+        (64, 63),
+        (100, 100),
+        (100, 137),
+        (137, 100),
+        (1000, 1024),
+        (1024, 1000),
+        (4099, 4096),
+        (4096, 4099),
+    ];
+
+    for &(matcher_vocab, vocab_size_hint) in cases {
+        let allowed: Vec<bool> = (0..matcher_vocab)
+            .map(|_| rng.next_u32().is_multiple_of(3))
+            .collect();
+        let src = packed_source(&allowed);
+
+        let mut packed = Vec::new();
+        pack_mask_words(&src, matcher_vocab, vocab_size_hint, &mut packed);
+
+        assert_eq!(
+            packed.len(),
+            vocab_size_hint.div_ceil(32),
+            "packed mask must cover exactly the logits axis for \
+             matcher_vocab={matcher_vocab} hint={vocab_size_hint}"
+        );
+
+        for i in 0..vocab_size_hint {
+            let want = allowed.get(i).copied().unwrap_or(false);
+            assert_eq!(
+                packed_bit(&packed, i),
+                want,
+                "bit {i} disagrees with the bool mask for \
+                 matcher_vocab={matcher_vocab} hint={vocab_size_hint}"
+            );
+        }
+
+        // Nothing may survive in the tail the logits axis cannot name either.
+        for i in vocab_size_hint..packed.len() * 32 {
+            assert!(
+                !packed_bit(&packed, i),
+                "lane {i} past the logits axis must be zero for \
+                 matcher_vocab={matcher_vocab} hint={vocab_size_hint}"
+            );
+        }
+    }
+}
+
+#[test]
+fn packed_mask_trims_the_matchers_own_excess_bits() {
+    // A matcher vocabulary of 77 occupies three words but only 13 valid bits
+    // in the last one. Set every bit in the source, including the 19 that name
+    // no token, and require them all to be dropped: this is the shape of the
+    // Qwen3.8 head, whose tokenizer carries 248077 entries against 248320 rows.
+    let matcher_vocab = 77usize;
+    let src = vec![u32::MAX; 3];
+
+    let mut packed = Vec::new();
+    pack_mask_words(&src, matcher_vocab, 128, &mut packed);
+
+    for i in 0..matcher_vocab {
+        assert!(packed_bit(&packed, i), "real token {i} must survive");
+    }
+    for i in matcher_vocab..128 {
+        assert!(
+            !packed_bit(&packed, i),
+            "position {i} names no token and must be masked"
+        );
+    }
+}
+
+#[test]
+fn packed_mask_zero_pads_past_the_matcher_vocabulary() {
+    // The padded-head direction: the model can emit more rows than the
+    // tokenizer has tokens, and the extra rows must come back disallowed.
+    let allowed = vec![true; 40];
+    let src = packed_source(&allowed);
+
+    let mut packed = Vec::new();
+    pack_mask_words(&src, 40, 200, &mut packed);
+
+    assert_eq!(packed.len(), 7, "200 tokens need ceil(200 / 32) = 7 words");
+    for i in 0..40 {
+        assert!(packed_bit(&packed, i), "token {i} is allowed");
+    }
+    for i in 40..200 {
+        assert!(!packed_bit(&packed, i), "padded row {i} must be masked");
+    }
+}
+
+#[test]
+fn packed_mask_of_an_empty_allow_set_is_all_zero() {
+    // `apply_structured_mask_to_logits` reads exactly this predicate to raise
+    // the empty-mask error, so pin it rather than the error string.
+    let src = vec![0u32; 4];
+    let mut packed = Vec::new();
+    pack_mask_words(&src, 100, 100, &mut packed);
+    assert!(
+        packed.iter().all(|word| *word == 0),
+        "an empty allow set must pack to all-zero words"
+    );
+
+    // A single allowed token in the final partial word must not be lost.
+    let mut src = vec![0u32; 4];
+    src[3] |= 1u32 << 3; // token 99
+    let mut packed = Vec::new();
+    pack_mask_words(&src, 100, 100, &mut packed);
+    assert!(
+        !packed.iter().all(|word| *word == 0),
+        "a lone allowed token in the last partial word must survive"
+    );
+    assert!(packed_bit(&packed, 99), "token 99 is the allowed one");
+}
+
+#[test]
+fn packed_apply_matches_bias_apply() {
+    let mut rng = Xorshift64::new(0x1316_0BAD_C0FF_EE01);
+
+    // Widths that stress the trim, the zero-pad, and both word alignments.
+    let cases: &[(usize, usize)] = &[
+        (64, 64),
+        (100, 137),
+        (137, 100),
+        (255, 256),
+        (256, 255),
+        (1000, 1024),
+        (4099, 4160),
+    ];
+
+    for &(matcher_vocab, vocab_size_hint) in cases {
+        let allowed: Vec<bool> = (0..matcher_vocab)
+            .map(|_| rng.next_u32().is_multiple_of(4))
+            .collect();
+        let src = packed_source(&allowed);
+        let values: Vec<f32> = (0..vocab_size_hint).map(|_| rng.next_f32()).collect();
+        let logits = mlxcel_core::from_slice_f32(&values, &[1, vocab_size_hint as i32]);
+
+        let mut packed = Vec::new();
+        pack_mask_words(&src, matcher_vocab, vocab_size_hint, &mut packed);
+        let got = read_f32_array(&apply_packed_mask_to_logits(
+            &packed,
+            vocab_size_hint,
+            &logits,
+        ));
+        let want = read_f32_array(&reference_bias_apply(
+            &src,
+            matcher_vocab,
+            vocab_size_hint,
+            &logits,
+        ));
+
+        assert_eq!(
+            got.len(),
+            vocab_size_hint,
+            "masked logits must keep the model's logits width for \
+             matcher_vocab={matcher_vocab} hint={vocab_size_hint}"
+        );
+        assert_eq!(got.len(), want.len(), "reference and packed widths agree");
+
+        for i in 0..vocab_size_hint {
+            // IEEE equality is the contract that matters here: it makes
+            // -inf == -inf true and would catch a sign or magnitude change at
+            // an allowed position.
+            assert!(
+                got[i] == want[i],
+                "position {i} diverges for matcher_vocab={matcher_vocab} \
+                 hint={vocab_size_hint}: packed={} bias={}",
+                got[i],
+                want[i]
+            );
+            let is_allowed = allowed.get(i).copied().unwrap_or(false);
+            if is_allowed {
+                assert!(
+                    got[i] == values[i],
+                    "allowed position {i} must pass the logit through unchanged, \
+                     got {} for input {}",
+                    got[i],
+                    values[i]
+                );
+            } else {
+                assert!(
+                    got[i].is_infinite() && got[i].is_sign_negative(),
+                    "disallowed position {i} must be -inf, got {}",
+                    got[i]
+                );
+            }
+        }
+
+        // The property the sampler actually depends on.
+        assert_eq!(
+            argmax(&got),
+            argmax(&want),
+            "greedy decoding must pick the same token for \
+             matcher_vocab={matcher_vocab} hint={vocab_size_hint}"
+        );
+    }
+}
+
+#[test]
+fn packed_apply_handles_the_all_allowed_and_single_allowed_edges() {
+    let mut rng = Xorshift64::new(0x1316_FEED_FACE_0002);
+    let vocab_size_hint = 137usize; // deliberately not a word multiple
+
+    // Every token allowed: the mask must be a no-op on the logits.
+    let allowed = vec![true; vocab_size_hint];
+    let src = packed_source(&allowed);
+    let values: Vec<f32> = (0..vocab_size_hint).map(|_| rng.next_f32()).collect();
+    let logits = mlxcel_core::from_slice_f32(&values, &[1, vocab_size_hint as i32]);
+
+    let mut packed = Vec::new();
+    pack_mask_words(&src, vocab_size_hint, vocab_size_hint, &mut packed);
+    let got = read_f32_array(&apply_packed_mask_to_logits(
+        &packed,
+        vocab_size_hint,
+        &logits,
+    ));
+    for (i, value) in values.iter().enumerate() {
+        assert!(
+            got[i] == *value,
+            "an all-allowed mask must leave logit {i} untouched, got {} for {value}",
+            got[i]
+        );
+    }
+
+    // Exactly one allowed token, sitting in the final partial word: greedy
+    // decoding must pick it no matter how small its logit is.
+    let lone = vocab_size_hint - 1;
+    let mut allowed = vec![false; vocab_size_hint];
+    allowed[lone] = true;
+    let src = packed_source(&allowed);
+    let mut values: Vec<f32> = (0..vocab_size_hint).map(|_| rng.next_f32()).collect();
+    values[lone] = -7.5;
+    let logits = mlxcel_core::from_slice_f32(&values, &[1, vocab_size_hint as i32]);
+
+    let mut packed = Vec::new();
+    pack_mask_words(&src, vocab_size_hint, vocab_size_hint, &mut packed);
+    let got = read_f32_array(&apply_packed_mask_to_logits(
+        &packed,
+        vocab_size_hint,
+        &logits,
+    ));
+    assert_eq!(
+        argmax(&got),
+        Some(lone),
+        "the only allowed token must win regardless of its logit"
+    );
+    assert!(got[lone] == -7.5, "its logit must be unchanged");
+}
+
+#[test]
+fn packed_apply_handles_a_width_change_between_calls() {
+    // Nothing the expansion caches depends on the vocabulary width, so a
+    // constraint reused across logits axes of different sizes must stay
+    // correct. Drive several widths through one buffer to prove it.
+    let matcher_vocab = 300usize;
+    let allowed: Vec<bool> = (0..matcher_vocab).map(|i| i.is_multiple_of(7)).collect();
+    let src = packed_source(&allowed);
+    let mut packed = Vec::new();
+
+    for &hint in &[64usize, 320, 137, 300, 512, 64] {
+        pack_mask_words(&src, matcher_vocab, hint, &mut packed);
+        let values: Vec<f32> = (0..hint).map(|i| i as f32 * 0.01).collect();
+        let logits = mlxcel_core::from_slice_f32(&values, &[1, hint as i32]);
+        let got = read_f32_array(&apply_packed_mask_to_logits(&packed, hint, &logits));
+
+        assert_eq!(got.len(), hint, "width {hint} must round-trip");
+        for (i, value) in got.iter().enumerate() {
+            let want_allowed = allowed.get(i).copied().unwrap_or(false);
+            if want_allowed {
+                assert!(
+                    *value == values[i],
+                    "width {hint} position {i} must pass through, got {value}"
+                );
+            } else {
+                assert!(
+                    value.is_infinite() && value.is_sign_negative(),
+                    "width {hint} position {i} must be -inf, got {value}"
+                );
+            }
+        }
+    }
+}
+
+/// Microbenchmark for the change in #1316. Not part of the gate.
+///
+/// ```text
+/// cargo test --profile test-fast --features metal,accelerate --lib \
+///   server::structured::tests::bench_packed_mask_apply -- --ignored --nocapture
+/// ```
+///
+/// Reports min-of-N per iteration for both arms at the widest vocabulary in
+/// the test set, split into the scheduler-thread cost (mask preparation plus
+/// the host-to-device upload, which is what the change removes) and the same
+/// work followed by an eval of the result.
+#[test]
+#[ignore = "microbenchmark; run explicitly with --ignored --nocapture"]
+fn bench_packed_mask_apply() {
+    use std::time::Instant;
+
+    // mlx-community/Qwen3.8-27B-4bit: 248320 lm_head rows against a
+    // tokenizer.json carrying 248077 entries.
+    const LM_HEAD_ROWS: usize = 248_320;
+    const TOKENIZER_VOCAB: usize = 248_077;
+    const TRIALS: usize = 60;
+
+    let mut rng = Xorshift64::new(0x1316_BE1C_0000_0003);
+    let allowed: Vec<bool> = (0..TOKENIZER_VOCAB)
+        .map(|_| rng.next_u32().is_multiple_of(4))
+        .collect();
+    let src = packed_source(&allowed);
+    let values: Vec<f32> = (0..LM_HEAD_ROWS).map(|_| rng.next_f32()).collect();
+    let logits = mlxcel_core::from_slice_f32(&values, &[1, LM_HEAD_ROWS as i32]);
+
+    let mut packed = Vec::new();
+
+    // Warm up both arms so neither pays first-touch allocation or JIT.
+    for _ in 0..5 {
+        pack_mask_words(&src, TOKENIZER_VOCAB, LM_HEAD_ROWS, &mut packed);
+        let out = apply_packed_mask_to_logits(&packed, LM_HEAD_ROWS, &logits);
+        mlxcel_core::eval(&out);
+        let out = reference_bias_apply(&src, TOKENIZER_VOCAB, LM_HEAD_ROWS, &logits);
+        mlxcel_core::eval(&out);
+    }
+
+    let mut packed_prepare = f64::MAX;
+    let mut packed_total = f64::MAX;
+    let mut bias_prepare = f64::MAX;
+    let mut bias_total = f64::MAX;
+
+    for _ in 0..TRIALS {
+        let t0 = Instant::now();
+        pack_mask_words(&src, TOKENIZER_VOCAB, LM_HEAD_ROWS, &mut packed);
+        let out = apply_packed_mask_to_logits(&packed, LM_HEAD_ROWS, &logits);
+        packed_prepare = packed_prepare.min(t0.elapsed().as_secs_f64());
+        mlxcel_core::eval(&out);
+        packed_total = packed_total.min(t0.elapsed().as_secs_f64());
+
+        let t0 = Instant::now();
+        let out = reference_bias_apply(&src, TOKENIZER_VOCAB, LM_HEAD_ROWS, &logits);
+        bias_prepare = bias_prepare.min(t0.elapsed().as_secs_f64());
+        mlxcel_core::eval(&out);
+        bias_total = bias_total.min(t0.elapsed().as_secs_f64());
+    }
+
+    let us = |seconds: f64| seconds * 1e6;
+    println!("vocab={LM_HEAD_ROWS} matcher_vocab={TOKENIZER_VOCAB} trials={TRIALS} (min-of-N)");
+    println!(
+        "  f32 bias   prepare+upload {:8.1} us   with eval {:8.1} us   upload {} KiB",
+        us(bias_prepare),
+        us(bias_total),
+        LM_HEAD_ROWS * 4 / 1024
+    );
+    println!(
+        "  packed u32 prepare+upload {:8.1} us   with eval {:8.1} us   upload {} KiB",
+        us(packed_prepare),
+        us(packed_total),
+        LM_HEAD_ROWS.div_ceil(32) * 4 / 1024
+    );
+    println!(
+        "  speedup    prepare+upload {:8.2}x    with eval {:8.2}x",
+        bias_prepare / packed_prepare,
+        bias_total / packed_total
+    );
+}


### PR DESCRIPTION
## Summary

Constrained decoding no longer unpacks the grammar engine's token bitmask on the host. The mask stays in its packed `u32` form from the matcher all the way to the GPU, where four graph ops expand it back to one bit per token and `where_cond` applies it. On the Qwen3.8-27B geometry that removes two 248k-element host loops and 97% of the per-step host-to-device copy from the scheduler thread, between the forward pass and sampling, for every constrained sequence on every tick.

## What changed

`src/server/structured.rs`

- `StructuredOutputConstraint::compute_packed_mask(vocab_size_hint)` is new: it drives the matcher exactly as `compute_mask` does, then copies `ceil(vocab_size_hint / 32)` words straight out of the matcher's own bitset instead of expanding them. It zero-pads past the matcher's vocabulary and trims the final partial word, so a padded head row and the matcher's own excess bits both stay masked.
- `pack_mask_words` is the pure packing step, factored out so the bit algebra is testable without a matcher. Token `i` survives exactly when `i < min(matcher_vocab, vocab_size_hint)` and the source bit is set, which is the rule `compute_mask` plus the old bias fill implemented one entry at a time.
- `expand_packed_mask` does the device-side expansion. The packed words go up as a `u32[n_words, 1]` column and the bit positions as a `u32[1, 32]` row, so one broadcast `right_shift` and a `bitwise_and` with 1 produce `[n_words, 32]` where element `(w, b)` is token id `w * 32 + b` in row-major order. A reshape to one row, a trim to the logits width and a cast give the `bool[1, vocab]` condition. This is the same expansion MLX itself uses to unpack non-power-of-two quantized weights in `dequantize`.
- `apply_structured_mask_to_logits` keeps its exact signature and now selects with `where_cond` instead of adding an f32 bias. The lazy-grammar passthrough, the empty-mask error and its message, and the `vocab_size_hint` semantics in both directions are unchanged.
- The per-constraint `bias_buf` is gone, roughly 1 MB of host memory per constrained sequence at a 248k vocabulary; `packed_buf` reserves 1/32 as much.

`src/server/structured_tests.rs`: new unit tests plus the microbenchmark below.

`TECHNICAL_REPORTS/1578-packed-structured-output-mask-20260902.{en,ko}.md` carry the bilingual technical report the repository's `.keep-reports` marker asks for.

No other file changed. `src/server/batch/scheduler/run_loop.rs` calls `apply_structured_mask_to_logits` with the same arguments as before, and `src/lib/mlxcel-core` is untouched: every MLX op used here was already bound in the cxx bridge.

## Why the output is identical

`mlxcel_core::where_cond` promotes its two value operands to their common dtype, exactly as `add` did, so pairing f16 or bf16 logits with an f32 `-inf` yields the same f32 result the previous `add(logits, f32_bias)` produced. An allowed position now passes its logit through untouched rather than having `0.0` added to it, which for IEEE floats is the same value; a disallowed position gets the same `-inf`. `where_cond` broadcasts its operands with the same rules `add` used, so every logits rank the scheduler passes in (`[1, V]` from prefill, `[1, 1, V]` from the decode tick) comes back with the shape it had before.

## Correctness evidence

`packed_apply_matches_bias_apply` keeps the old bias routine as a test-only reference and asserts, for randomized allow sets across seven vocabulary geometries, that the packed path's output equals it under IEEE equality at every position, that an allowed position still carries the exact input logit, that a disallowed position is `-inf`, and that `argmax` over the two outputs is the same token. The geometries cover word multiples and non-multiples in both directions, `matcher_vocab` above and below the logits width.

The other new tests pin the edges the issue calls out: `packed_mask_matches_bool_mask` (13 width pairs, randomized allow sets, every bit compared against the boolean mask and the tail lanes required to be zero), `packed_mask_trims_the_matchers_own_excess_bits` (all-ones source, 77-token matcher, the 19 bits naming no token must not leak), `packed_mask_zero_pads_past_the_matcher_vocabulary`, `packed_mask_of_an_empty_allow_set_is_all_zero` (the exact predicate the empty-mask error reads, plus a lone allowed token in the last partial word), `packed_apply_handles_the_all_allowed_and_single_allowed_edges`, and `packed_apply_handles_a_width_change_between_calls`.

The matcher-driven behavior is covered by `tests/structured_outputs.rs`, unchanged: all 21 runnable tests pass, including `apply_mask_covers_the_qwen3_8_padded_lm_head`, which drives the production magnitudes (248077 tokenizer entries against 248320 head rows, so a 13-bit final partial word) and `apply_mask_returns_error_when_no_reachable_token_is_allowed`.

## Performance

In-process microbenchmark at the Qwen3.8-27B geometry (248320 logits rows, 248077 tokenizer entries), min-of-60 per trial, M1 Ultra with Time Machine stopped. Both arms are timed identically in the same process; the reference arm is the code this PR replaces.

```
cargo test --profile test-fast --features metal,accelerate --lib \
  server::structured::tests::bench_packed_mask_apply -- --ignored --nocapture
```

| Arm | Prepare + upload | With eval | Upload |
|---|---|---|---|
| f32 bias (before) | 711 us | 1002 us | 970 KiB |
| packed u32 (after) | 7.4 us | 322 us | 30 KiB |

Median of four runs; the spread was 707 to 714 us, 6.7 to 8.9 us, 986 to 1009 us, and 300 to 326 us respectively. "Prepare + upload" is the scheduler-thread cost this change targets: mask preparation plus the host-to-device copy, up to having the output graph node. "With eval" adds a forced `mlxcel_core::eval` of the result; the packed arm's figure there sits at the known MLX single-shot eval floor of roughly 300 us, so it understates the device-side saving rather than overstating it.

That is a saving of about 0.7 ms per token per constrained sequence at this vocabulary, inside the 0.5 to 1.5 ms the issue predicted.

## End-to-end check still to run

This has not been run against a live server here; it is the remaining acceptance step, along with the `docs/benchmarks.md` entry the issue asks for.

```
./target/release/mlxcel-server -m models/mlx/qwen3-4b-4bit --port 8080

curl -s localhost:8080/v1/chat/completions -H 'content-type: application/json' -d '{
  "model": "q",
  "messages": [{"role": "user", "content": "Give me one European capital."}],
  "max_tokens": 128,
  "temperature": 0,
  "response_format": {
    "type": "json_schema",
    "json_schema": {
      "name": "capital",
      "schema": {
        "type": "object",
        "properties": {
          "city": {"type": "string"},
          "country": {"type": "string"},
          "population": {"type": "integer"}
        },
        "required": ["city", "country", "population"],
        "additionalProperties": false
      }
    }
  }
}' | jq -r '.choices[0].message.content' | jq .
```

Expected: HTTP 200 with an OpenAI chat-completion body whose `choices[0].message.content` is a JSON object carrying exactly `city` (string), `country` (string) and `population` (integer), so the trailing `jq .` parses it without error and `finish_reason` is `stop`, not `error`. At `temperature: 0` the completion must be token-identical to the pre-change binary, and the same request without `response_format` must be unchanged as the control.

## Test plan

- [x] `cargo test --profile test-fast --features metal,accelerate --lib server::structured` (21 passed, 1 benchmark ignored)
- [x] `cargo test --profile test-fast --features metal,accelerate --test structured_outputs` (21 passed, 2 ignored for missing local weights)
- [x] `cargo clippy --profile test-fast --lib --tests --features metal,accelerate -- -D warnings`
- [x] `cargo fmt --all -- --check`
- [x] Microbenchmark above, four runs
- [ ] Live server check above against `models/mlx/qwen3-4b-4bit`

Closes #1316

