### PR TITLE
docs: fix garbled comments left by issue-reference scrubbing

### DIFF
--- a/src/cli/speculative_args.rs
+++ b/src/cli/speculative_args.rs
@@ -182,10 +182,11 @@ pub fn user_selectable_kinds() -> Vec<&'static str> {
 pub fn default_block_size_for_kind(kind: DrafterKind) -> u32 {
     match kind {
         DrafterKind::Mtp => DEFAULT_MTP_BLOCK_SIZE,
-        // DFlash and the future InternalMtp variant both share the
-        // upstream-published 16-token default. InternalMtp's user-facing
-        // override surface lands in for now its CLI knob
-        // shares the DFlash default.
+        // DFlash and InternalMtp both share the upstream-published
+        // 16-token default. InternalMtp is auto-detected rather than
+        // selectable via `--draft-kind` and has no user-facing override
+        // surface of its own yet, so for now its `--draft-block-size`
+        // default shares the DFlash value.
         DrafterKind::Dflash | DrafterKind::InternalMtp => DEFAULT_DFLASH_BLOCK_SIZE,
         // `DrafterKind` is `#[non_exhaustive]` so future variants force a
         // CI failure. Until a new variant lands the wildcard is

--- a/src/cli/speculative_args_tests.rs
+++ b/src/cli/speculative_args_tests.rs
@@ -107,8 +107,9 @@ fn default_block_size_for_dflash_is_16() {
 
 #[test]
 fn default_block_size_for_internal_mtp_shares_dflash_default() {
-    // InternalMtp's CLI surface lands in for now we share the
-    // DFlash 16-token default to keep the helper exhaustive.
+    // InternalMtp has no CLI surface of its own yet; for now it shares the
+    // DFlash 16-token default so the helper stays exhaustive over every
+    // variant.
     assert_eq!(
         default_block_size_for_kind(DrafterKind::InternalMtp),
         DEFAULT_DFLASH_BLOCK_SIZE

--- a/src/server/config.rs
+++ b/src/server/config.rs
@@ -846,9 +846,12 @@ pub struct ServerConfig {
     ///
     /// Defaults to the baseline policy (enabled with 2 GiB / 1024 entries /
     /// 1-hour TTL). When `enabled = false` the store is skipped entirely at
-    /// startup so no memory is reserved. CLI/env parsing for the individual
-    /// fields is tracked separately in for now operators set
-    /// the policy via the Rust API or keep the default.
+    /// startup so no memory is reserved. The individual fields are parsed
+    /// from the `--prompt-cache-*` flags of `mlxcel serve` and
+    /// `mlxcel-server` (with `MLXCEL_PROMPT_CACHE_*` environment fallbacks)
+    /// plus the llama-server `--cache-prompt` / `--cache-ram` spellings in
+    /// [`crate::cli::cache_args`]; embedders that build a [`ServerConfig`]
+    /// directly set the policy via the Rust API or keep the default.
     pub prompt_cache: crate::server::prompt_cache::PromptCacheConfig,
 
     /// (B11): server-wide KV cache mode.

--- a/src/server/config.rs
+++ b/src/server/config.rs
@@ -846,12 +846,13 @@ pub struct ServerConfig {
     ///
     /// Defaults to the baseline policy (enabled with 2 GiB / 1024 entries /
     /// 1-hour TTL). When `enabled = false` the store is skipped entirely at
-    /// startup so no memory is reserved. The individual fields are parsed
-    /// from the `--prompt-cache-*` flags of `mlxcel serve` and
-    /// `mlxcel-server` (with `MLXCEL_PROMPT_CACHE_*` environment fallbacks)
-    /// plus the llama-server `--cache-prompt` / `--cache-ram` spellings in
-    /// [`crate::cli::cache_args`]; embedders that build a [`ServerConfig`]
-    /// directly set the policy via the Rust API or keep the default.
+    /// startup so no memory is reserved. The policy fields are parsed from
+    /// the `--prompt-cache-*` flags of `mlxcel serve` and `mlxcel-server`
+    /// (with `MLXCEL_PROMPT_CACHE_*` environment fallbacks) plus the
+    /// llama-server `--cache-prompt` / `--cache-ram` spellings in
+    /// [`crate::cli::cache_args`], and the nested APC sub-config from the
+    /// `--apc-*` flags; embedders that build a [`ServerConfig`] themselves
+    /// set the policy via the Rust API or keep the default.
     pub prompt_cache: crate::server::prompt_cache::PromptCacheConfig,
 
     /// (B11): server-wide KV cache mode.

--- a/src/server/prompt_cache/key.rs
+++ b/src/server/prompt_cache/key.rs
@@ -242,9 +242,10 @@ pub struct PromptCacheKey<'a> {
     pub model_id: &'a str,
     /// LoRA adapter identifier; `None` for the base model.
     pub lora_id: Option<&'a str>,
-    /// Chat-template signature. Full wiring is; for now any stable
-    /// digest of the template + tool-schema inputs is acceptable and will
-    /// simply slot into this field.
+    /// Chat-template signature: the [`template_sig`] digest of the template
+    /// source, merged chat-template kwargs, tool choice, tool schemas and
+    /// assistant-prefill flag, so two requests whose prompts would render
+    /// differently never share a bucket.
     pub template_sig: &'a str,
     /// Caller-supplied tenancy / conversation scope. `None` means global.
     pub session_key: Option<&'a str>,

--- a/src/server/prompt_cache/key.rs
+++ b/src/server/prompt_cache/key.rs
@@ -242,10 +242,11 @@ pub struct PromptCacheKey<'a> {
     pub model_id: &'a str,
     /// LoRA adapter identifier; `None` for the base model.
     pub lora_id: Option<&'a str>,
-    /// Chat-template signature: the [`template_sig`] digest of the template
-    /// source, merged chat-template kwargs, tool choice, tool schemas and
-    /// assistant-prefill flag, so two requests whose prompts would render
-    /// differently never share a bucket.
+    /// Chat-template signature. Chat routes fill it with the [`template_sig`]
+    /// digest of the template source, merged chat-template kwargs, tool
+    /// choice, tool schemas and assistant-prefill flag, so two requests whose
+    /// prompts would render differently do not share a bucket; raw-prompt
+    /// routes carry a fixed sentinel (`RAW_PROMPT_TEMPLATE_SIG`) instead.
     pub template_sig: &'a str,
     /// Caller-supplied tenancy / conversation scope. `None` means global.
     pub session_key: Option<&'a str>,


### PR DESCRIPTION
## Summary

Four doc and code comments lost their sentence structure when private issue references were scrubbed from the tree, leaving fragments such as "is tracked separately in for now operators set". This PR rewrites each of the four sites listed in #1218 as a complete sentence. Two of them had also gone stale in substance, not only in grammar, so restoring the pre-scrub wording would have produced a grammatical but false comment; those two now describe the code as it is today.

## What changed

- `src/server/config.rs` (`ServerConfig::prompt_cache`): the old text said CLI/env parsing for the individual fields was pending and operators had to use the Rust API. Both server binaries now parse `--prompt-cache-*` flags with `MLXCEL_PROMPT_CACHE_*` fallbacks (`src/bin/mlx_server.rs`, `src/main.rs`), `src/cli/cache_args.rs` adds the llama-server `--cache-prompt` / `--cache-ram` spellings, and the nested `PromptCacheConfig::apc` sub-config comes from the separate `--apc-*` flag group via `build_prompt_cache_config`. The doc now says exactly that and keeps the Rust API note for embedders that build a `ServerConfig` themselves.
- `src/server/prompt_cache/key.rs` (`PromptCacheKey::template_sig`): the old text described the field as a placeholder awaiting "full wiring". For chat routes, `template_sig()` in the same module already produces the digest and `src/server/routes/chat.rs` fills the field with it; the raw-prompt routes (`/v1/completions`, `/completion`) fill it with the fixed `RAW_PROMPT_TEMPLATE_SIG` sentinel. The doc now names the function, the inputs it covers, and the sentinel case.
- `src/cli/speculative_args.rs` (`default_block_size_for_kind`): rewritten to say InternalMtp is auto-detected rather than selectable via `--draft-kind`, has no override surface of its own yet, and therefore shares the DFlash `--draft-block-size` default. The claim still holds (`SpeculativeArgs::parse_kind` rejects `internal-mtp`); the words "the future InternalMtp variant" were dropped because the variant exists.
- `src/cli/speculative_args_tests.rs` (`default_block_size_for_internal_mtp_shares_dflash_default`): the same statement, rewritten as a sentence.

No bare `#NNN` references were added, so there is nothing new for the cross-repo reference check to flag.

## Changes during review

The correctness review found that the two newly authored claims were true for the main code path but over-broad: the `apc` sub-config is not a `--prompt-cache-*` knob, and the raw-prompt routes do not use the `template_sig` digest. The second commit narrows both sentences accordingly. Still comment-only.

## Out of scope

`src/server/prompt_cache/mod.rs` carries a `## Sub-issues` list whose bullets were emptied by the same scrub (each bullet now starts with a bare dash and no reference). It is not one of the four sites the issue lists, so it is left for a follow-up rather than widening this PR.

## Type of change

- [x] `docs`: documentation only (comment-only, zero behavior change)

## Test plan

- [x] `cargo fmt --all -- --check`
- [x] `cargo check --profile test-fast --features metal,accelerate --lib --tests` (exit 0, zero warnings, run on the final head)
- [ ] `cargo clippy`, `cargo test`, `cargo deny`: not run locally; the diff touches only comment lines, so there is nothing new for them to exercise. CI's `cargo-clippy` and `cargo-deny` jobs pass on this PR.
- [ ] Real-checkpoint validation: not applicable to a comment-only change.

Closes #1218
