### PR TITLE
fix(qwen2_5_vl): normalize the raw HF patch-embed layout at load

### DIFF
--- a/TECHNICAL_REPORTS/1582-qwen2-5-vl-patch-embed-layout-20260902.en.md
+++ b/TECHNICAL_REPORTS/1582-qwen2-5-vl-patch-embed-layout-20260902.en.md
@@ -1,0 +1,236 @@
+# Technical Report: PR #1582 - fix(qwen2_5_vl): normalize the raw HF patch-embed layout at load
+
+**Date**: 2026-09-02
+**Author**: mlxcel maintainers
+**Reviewer**: implementation review cycle
+**Status**: Completed (unit level verified locally; the shipped-binary gates are listed in the PR and remain open)
+**Languages**: Rust
+**Risk Level**: Medium (touches the load path of three Qwen-VL consumers; the conversion path is a proven no-op)
+
+---
+
+## Executive Summary
+
+A raw HuggingFace export of Qwen2.5-VL could not be served by `mlxcel generate` or `mlxcel-server`. The vision tower is stored under `visual.*` rather than `vision_tower.*`, so the loader raised `Missing vision_tower.patch_embed.proj.weight`, and even with the names corrected the patch-embedding filter is in `Conv3d`'s native `[out, in, kT, kH, kW]` layout while the encoder accepts only the mlx-vlm conversion's channels-last `[out, kT, kH, kW, in]`. The two have the same element count, so the reshape downstream succeeds and the tower reads scrambled filters without any error. PR #1414 fixed the layout half on the ColQwen2.5 retrieval path only. This PR moves that one normalizer into the encoder module whose contract it protects, parameterizes it by weight prefix, calls it from both consumers, and adds the missing key remap to the generation loader.
+
+---
+
+## 1. Problem Statement
+
+### 1.1 Background
+
+`Qwen25VLVisionEncoder::from_weights` builds its patch embedding through `PatchEmbed::from_weights` (`src/vision/encoders/qwen2_5_vl.rs`), which accepts a 5-D weight, permutes it with `[0, 1, 4, 2, 3]`, and reshapes to `[out, in * kT * kH * kW]`. That permutation is only correct for the mlx-vlm conversion's channels-last layout. `transformers` writes the PyTorch `Conv3d` parameter directly, which puts `in_channels` on axis 1.
+
+PR #1414 discovered this while porting ColQwen2.5, whose published checkpoint (`vidore/colqwen2.5-base`) is a raw export. It added `normalize_patch_embed_layout` to `src/models/colqwen2_5.rs`, hardcoded to that module's `VISION_PREFIX`. The measured cost of the unfixed path was a retrieval misranking: the unrelated page scored MaxSim 7.83 against the matching page's 8.04.
+
+The generation loader `load_qwen2_5_vl` (`src/loading/vlm_qwen.rs`) never received either half of that fix. It ran `strip_language_model_prefix`, which strips only a leading `language_model.`, then handed the map straight to the encoder under the prefix `vision_tower`.
+
+### 1.2 Existing Issues
+
+- **A raw export could not load at all.** The `Qwen/Qwen2.5-VL-3B-Instruct` snapshot on this host carries exactly two top-level prefixes, `model` and `visual`. Nothing named `vision_tower.*` exists, so `PatchEmbed::from_weights` failed with `Missing vision_tower.patch_embed.proj.weight` before any layout question could arise.
+- **Fixing only the names would have produced a silent wrong answer.** A hand-renamed export, or the remap on its own, gets past the missing-key error and then reads `[1280, 3, 2, 14, 14]` as if it were `[1280, 2, 14, 14, 3]`. The reshape succeeds because both hold 1505280 elements. Nothing throws, and the model still emits fluent text.
+- **The fix already existed but was scoped to one caller.** `normalize_patch_embed_layout` sat in the ColQwen2.5 module as `pub(crate)` with the prefix baked in, so the generation loader could not reuse it without duplicating the detection rule.
+- **The naming precedent was already in the same file.** `load_qwen3_vl` performs exactly this class of remap for its own family, so the Qwen2.5-VL loader was the outlier rather than the norm.
+
+### 1.3 Risk Assessment
+
+| Risk | Impact | Likelihood |
+|------|--------|------------|
+| Raw HuggingFace Qwen2.5-VL checkpoints unusable for generation and serving | High | Certain before this change |
+| A renamed raw checkpoint generating from scrambled vision filters with no error | High | High, and undetectable from output fluency |
+| The detection rule drifting between two copies once a second caller needs it | Medium | Medium |
+
+---
+
+## 2. Technical Review
+
+### 2.1 Root cause
+
+Two independent gaps on the same load path, both invisible from the model's output.
+
+The first is naming. `strip_language_model_prefix` handles the mlx-vlm shape (`language_model.model.*` becomes `model.*`) and nothing else. A `transformers` export uses `visual.*` with a bare `model.*` decoder (older exports) or `model.visual.*` with `model.language_model.*` (newer ones). Neither is reachable from that one strip.
+
+The second is layout. The channel axis is what separates the two 5-D shapes: the raw layout has `in_channels` on axis 1 and a spatial extent (`patch_size`) on axis 4, and the converted layout has `in_channels` on axis 4. `in_channels` is 3 and `patch_size` is 14 for every published Qwen2.5-VL, so the test is unambiguous in practice, but it is a shape heuristic and the code should say so.
+
+### 2.2 Compatibility & Dependencies
+
+- **Breaking changes**: none. Both new steps are no-ops on an mlx-community conversion, whose keys are already `vision_tower.*` and `language_model.*` and whose filter is already `[1280, 2, 14, 14, 3]`.
+- **New dependencies**: none.
+- **Encoder contract**: unchanged. `PatchEmbed::from_weights` still accepts exactly one 5-D layout. This matters because Qwen2-VL and ColQwen2.5 consume the same code and rely on that.
+- **Quantized checkpoints**: `patch_embed.proj.weight` stays float in a 4-bit conversion, so the same detection and transpose apply to it unchanged.
+
+### 2.3 Code Quality
+
+- The normalizer now lives beside the code whose invariant it enforces, and carries the repository's `Used by:` line naming its two callers.
+- Its detection rule and its tests exist in one place instead of two.
+- Test coverage grew from one test (in the ColQwen2.5 module) to four in the encoder module plus two loader-remap tests and one real-checkpoint gate.
+- `src/loading/vlm_qwen.rs` gained a `#[path]` test file (`vlm_qwen_tests.rs`) rather than another inline `mod`, which keeps an already long file from growing further.
+
+---
+
+## 3. Technical Decisions
+
+### 3.1 Where the layout normalization belongs
+
+**Context:** `PatchEmbed::from_weights` could detect the layout itself and accept both, which would fix every consumer at once with no loader changes.
+
+**Alternatives considered:**
+
+| Option | Pros | Cons |
+|--------|------|------|
+| Detect inside `PatchEmbed::from_weights` | One place, fixes Qwen2-VL and ColQwen2.5 automatically | Silently accepts two layouts in a module whose three consumers all assume one; a future checkpoint with a genuinely wrong filter would be reshaped rather than rejected |
+| Duplicate the ColQwen2.5 helper into the loader | Smallest diff | Two copies of a shape heuristic that must stay identical |
+| **Chosen: move the helper into the encoder module, parameterized by prefix, called from both loaders** | The rule lives with the contract it guards, tested once, and the encoder's accepted layout stays a single documented shape | Every new consumer must remember to call it |
+
+**Rationale:** the loader is the layer that has `in_channels` on hand and the only layer that knows which flavour of checkpoint it opened. Keeping the encoder strict means a genuinely malformed filter still fails loudly there.
+
+**Trade-offs:** a future Qwen2.5-VL-family loader that forgets the call gets the pre-fix silent-corruption behaviour. The `Used by:` line and the shared location are the mitigation; a hard guard inside `PatchEmbed` would trade that for the ambiguity this decision rejects.
+
+### 3.2 What to do when the two layouts are indistinguishable
+
+**Context:** detection is by the channel axis. If `in_channels` equalled `patch_size`, both axis 1 and axis 4 would carry `in_channels` and shape alone could not tell the layouts apart.
+
+The original condition (`shape.len() != 5 || shape[1] != channels || shape[4] == channels`) already fell through to "leave it alone" in that case, but only as a side effect of ordering. The rewritten form names `leading_is_channel` and `trailing_is_channel` and documents the refusal to guess as deliberate. Behaviour is identical; the intent is now readable, which is what makes the next reader trust the fall-through instead of "fixing" it.
+
+---
+
+## 4. Implementation Details
+
+### 4.1 Key code changes
+
+**File: `src/vision/encoders/qwen2_5_vl.rs`**
+
+```rust
+pub(crate) fn normalize_patch_embed_layout(
+    weights: &mut WeightMap,
+    prefix: &str,
+    in_channels: usize,
+) -> bool {
+    let key = format!("{prefix}.patch_embed.proj.weight");
+    let channels = in_channels as i32;
+    let converted = {
+        let Some(weight) = weights.get(&key) else {
+            return false;
+        };
+        let shape = mlxcel_core::array_shape(weight);
+        if shape.len() != 5 {
+            return false;
+        }
+        let leading_is_channel = shape[1] == channels;
+        let trailing_is_channel = shape[4] == channels;
+        if !leading_is_channel || trailing_is_channel {
+            return false;
+        }
+        // [out, in, kT, kH, kW] -> [out, kT, kH, kW, in].
+        mlxcel_core::transpose_axes(weight, &[0, 2, 3, 4, 1])
+    };
+    weights.insert(key, converted);
+    true
+}
+```
+
+**File: `src/loading/vlm_qwen.rs`**
+
+```rust
+fn rewrite_qwen2_5_vl_native_key(key: &str) -> String {
+    if let Some(rest) = key.strip_prefix("model.visual.") {
+        format!("vision_tower.{rest}")
+    } else if let Some(rest) = key.strip_prefix("model.language_model.") {
+        format!("model.{rest}")
+    } else if let Some(rest) = key.strip_prefix("visual.") {
+        format!("vision_tower.{rest}")
+    } else {
+        key.to_string()
+    }
+}
+```
+
+and, inside `load_qwen2_5_vl`:
+
+```rust
+let mut weights = remap_qwen2_5_vl_native_keys(strip_language_model_prefix(
+    load_vlm_weights_common(model_path, None)?,
+));
+models::sanitize_tied_embeddings(&mut weights, &full_config);
+
+if normalize_patch_embed_layout(&mut weights, "vision_tower", vision_config.in_channels) {
+    tracing::debug!(
+        "Qwen2.5-VL: converted patch_embed.proj.weight from the PyTorch Conv3d layout"
+    );
+}
+```
+
+**File: `src/models/colqwen2_5.rs`**
+
+The local copy is deleted; the call becomes `normalize_patch_embed_layout(&mut weights, VISION_PREFIX, vision_config.in_channels)`.
+
+### 4.2 Ordering
+
+The remap runs after `strip_language_model_prefix`, not before. That ordering matters for the mlx-vlm shape: `language_model.model.layers.*` has to become `model.layers.*` first, or the `model.language_model.` rule would never see it, and a checkpoint carrying `language_model.visual.*` (none is known) would be handled the same way. The normalizer runs after both, so it sees the final `vision_tower.` prefix regardless of which flavour the checkpoint used.
+
+---
+
+## 5. Validation
+
+The permutation is checked against the real converter, not only against itself. Reading the bf16 `visual.patch_embed.proj.weight` from the local `Qwen/Qwen2.5-VL-3B-Instruct` snapshot (`[1280, 3, 2, 14, 14]`), transposing it with axes `[0, 2, 3, 4, 1]`, and comparing 20000 randomly sampled elements at f16 resolution against `mlx-community/Qwen2.5-VL-3B-Instruct-4bit`'s `vision_tower.patch_embed.proj.weight` (`[1280, 2, 14, 14, 3]`, f16) gives 20000/20000 exact matches, max absolute difference 0.0. Reading the same buffer without permuting, which is what the pre-fix loader effectively did, is off by up to 1.09e-01. That is the numerical statement the issue was making, measured rather than assumed.
+
+Test commands run on this branch:
+
+```
+cargo fmt --all -- --check
+cargo clippy --profile test-fast --lib --tests --features metal,accelerate -- -D warnings
+cargo test --profile test-fast --features metal,accelerate --lib vision::encoders::qwen2_5_vl   # 4 passed
+cargo test --profile test-fast --features metal,accelerate --lib loading::vlm::qwen             # 6 passed, 1 ignored
+cargo test --profile test-fast --features metal,accelerate --lib models::colqwen2_5             # 6 passed
+```
+
+The `#[ignore]`d gate `qwen2_5_vl_raw_export_matches_mlx_conversion` normally looks up `Qwen/Qwen2.5-VL-3B-Instruct` and `mlx-community/Qwen2.5-VL-3B-Instruct-bf16` through the usual store lookup and soft-skips when either is absent. The bf16 conversion is not present on this host, so the gate was instead pointed at two locally present raw 3B exports through its `MLXCEL_TEST_QWEN25VL_RAW_DIR` / `MLXCEL_TEST_QWEN25VL_MLX_DIR` overrides. Both loaded through the generation path and produced identical, non-empty greedy output in 7.6 seconds. That does not test the raw-versus-converted differential, but it does prove the thing the pre-fix loader could not do at all: open a raw `transformers` export and generate from it.
+
+### Not verified here
+
+Three checks belong to the shipped binary and are listed as open boxes in the PR body: a coherent image description from `mlxcel generate -m <raw dir> --image ...`; byte-identical output from the 4-bit conversion before and after this change; and the ColQwen2.5 real-checkpoint gate with its checkpoint present. The differential gate against `mlx-community/Qwen2.5-VL-3B-Instruct-bf16` also remains unrun for lack of that checkpoint.
+
+---
+
+## 6. Change Summary
+
+### Statistics
+
+| Metric | Value |
+|--------|-------|
+| Files changed | 6 |
+| Lines added | 520 |
+| Lines removed | 84 |
+| New test files | 2 |
+| New tests | 7 (6 unit, 1 ignored real-checkpoint gate) |
+
+### Changes by Category
+
+| Category | Files |
+|----------|-------|
+| Shared normalizer relocated and parameterized | `src/vision/encoders/qwen2_5_vl.rs`, `src/models/colqwen2_5.rs` |
+| Generation loader fix | `src/loading/vlm_qwen.rs` |
+| Tests | `src/vision/encoders/qwen2_5_vl_tests.rs`, `src/loading/vlm_qwen_tests.rs`, `src/models/colqwen2_5_tests.rs` |
+
+### Related Commits
+
+| Hash | Type | Message |
+|------|------|---------|
+| `0ea8233f6` | fix(qwen2_5_vl) | normalize the raw HF patch-embed layout at load |
+
+### Related PRs/Issues
+
+- Issue #1423: the issue this PR closes.
+- PR #1414: added the original ColQwen2.5-scoped normalizer and measured the 7.83 against 8.04 misranking that motivated it.
+- Issue #1367: vision-stripped Qwen2.5-VL checkpoints, which edits the same `load_qwen2_5_vl` body and is expected to land after this.
+- Epic #1348: the parent epic this follow-up belongs to.
+
+---
+
+## 7. Follow-up Actions
+
+### Broader lesson
+
+The interesting property of this defect class is that both halves fail differently. The missing key remap fails loudly, at load, and is trivially diagnosed. The layout mismatch fails silently, at inference, and produces fluent output from scrambled filters, so no smoke test built around "does it say something sensible" catches it. What separated them was a numerical comparison against an independent reference, which is the same method PR #1414 used to find it in the first place and the same method used here to prove the permutation.
+
+The practical rule is narrower than "always diff against a reference". It is that when a tensor's element count is invariant under the layout confusion, shape checks and reshape success carry no information at all, and only values do. `[1280, 3, 2, 14, 14]` and `[1280, 2, 14, 14, 3]` both hold 1505280 elements, which is exactly why the pre-fix path never raised anything.

--- a/TECHNICAL_REPORTS/1582-qwen2-5-vl-patch-embed-layout-20260902.ko.md
+++ b/TECHNICAL_REPORTS/1582-qwen2-5-vl-patch-embed-layout-20260902.ko.md
@@ -1,0 +1,236 @@
+# 기술 보고서: PR #1582 - fix(qwen2_5_vl): normalize the raw HF patch-embed layout at load
+
+**작성일**: 2026-09-02
+**작성자**: mlxcel maintainers
+**리뷰어**: implementation review cycle
+**상태**: 완료 (단위 수준은 로컬에서 검증했고, 실제 바이너리 게이트는 PR에 미체크 항목으로 남겨 둠)
+**언어**: Rust
+**위험도**: Medium (Qwen-VL 계열 세 소비자의 로드 경로를 건드리지만, 변환 체크포인트 경로는 no-op임이 증명됨)
+
+---
+
+## 요약
+
+HuggingFace 원본 Qwen2.5-VL 체크포인트는 `mlxcel generate`로도 `mlxcel-server`로도 서빙할 수 없었다. 비전 타워가 `vision_tower.*`가 아니라 `visual.*`에 저장돼 있어서 로더가 `Missing vision_tower.patch_embed.proj.weight`로 실패했고, 이름을 맞춰 준다 해도 패치 임베딩 필터가 `Conv3d`의 원래 레이아웃인 `[out, in, kT, kH, kW]`인 반면 인코더는 mlx-vlm 변환본의 채널 마지막 배치 `[out, kT, kH, kW, in]`만 받는다. 두 텐서의 원소 수가 같으므로 이후 reshape는 그냥 성공하고, 타워는 아무 오류 없이 뒤섞인 필터를 읽는다. PR #1414는 레이아웃 쪽만, 그것도 ColQwen2.5 검색 경로에서만 고쳤다. 이번 PR은 그 정규화 함수를 자신이 지키는 계약이 있는 인코더 모듈로 옮기고, 가중치 prefix를 인자로 받게 하고, 두 소비자 모두에서 호출하며, 생성 로더에 빠져 있던 키 리맵을 추가한다.
+
+---
+
+## 1. 문제 정의
+
+### 1.1 배경
+
+`Qwen25VLVisionEncoder::from_weights`는 패치 임베딩을 `PatchEmbed::from_weights`(`src/vision/encoders/qwen2_5_vl.rs`)로 만든다. 이 함수는 5차원 가중치를 받아 `[0, 1, 4, 2, 3]`으로 치환한 뒤 `[out, in * kT * kH * kW]`로 reshape한다. 이 치환은 mlx-vlm 변환본의 채널 마지막 레이아웃에서만 옳다. `transformers`는 PyTorch `Conv3d` 파라미터를 그대로 쓰므로 `in_channels`가 축 1에 온다.
+
+PR #1414는 ColQwen2.5를 포팅하다가 이 문제를 찾았다. 공개 체크포인트 `vidore/colqwen2.5-base`가 원본 export이기 때문이다. 그때 `src/models/colqwen2_5.rs`에 `normalize_patch_embed_layout`을 추가했지만, 해당 모듈의 `VISION_PREFIX`를 함수 안에 박아 넣은 형태였다. 고치지 않았을 때의 실측 대가는 검색 순위 역전이었다. 무관한 페이지가 MaxSim 7.83, 정답 페이지가 8.04였다.
+
+생성 로더 `load_qwen2_5_vl`(`src/loading/vlm_qwen.rs`)에는 그 수정의 어느 쪽도 들어오지 않았다. 선행 `language_model.`만 떼는 `strip_language_model_prefix`를 돌린 뒤, 맵을 그대로 `vision_tower` prefix로 인코더에 넘겼다.
+
+### 1.2 기존 문제점
+
+- **원본 export는 아예 로드되지 않았다.** 이 호스트의 `Qwen/Qwen2.5-VL-3B-Instruct` 스냅샷은 최상위 prefix가 정확히 `model`과 `visual` 둘뿐이다. `vision_tower.*`라는 이름 자체가 없으니, 레이아웃 문제를 따지기도 전에 `PatchEmbed::from_weights`가 `Missing vision_tower.patch_embed.proj.weight`로 죽었다.
+- **이름만 고쳤다면 조용히 틀린 답이 나왔을 것이다.** 손으로 이름을 바꾼 export나 리맵만 단독으로 들어간 경우, 키 없음 오류는 통과하고 그다음에 `[1280, 3, 2, 14, 14]`를 `[1280, 2, 14, 14, 3]`인 양 읽는다. 둘 다 원소가 1505280개라 reshape는 성공한다. 예외도 없고, 모델은 여전히 매끄러운 문장을 뱉는다.
+- **고칠 코드는 이미 있었지만 호출자 하나에 묶여 있었다.** `normalize_patch_embed_layout`은 prefix를 상수로 박은 채 ColQwen2.5 모듈 안에 `pub(crate)`로 있었고, 생성 로더가 재사용하려면 판별 규칙을 복제하는 수밖에 없었다.
+- **명명 규칙의 선례는 같은 파일 안에 이미 있었다.** `load_qwen3_vl`은 자기 계열에 대해 정확히 이 부류의 리맵을 한다. 즉 예외였던 쪽은 Qwen2.5-VL 로더다.
+
+### 1.3 위험성
+
+| 위험 | 영향 | 발생 가능성 |
+|------|------|------------|
+| HuggingFace 원본 Qwen2.5-VL 체크포인트를 생성/서빙에 쓸 수 없음 | High | 이번 변경 전에는 확정 |
+| 이름만 맞춘 원본 체크포인트가 뒤섞인 비전 필터로 오류 없이 생성 | High | High, 출력이 매끄러워 탐지 불가 |
+| 두 번째 호출자가 생기는 순간 판별 규칙 사본이 서로 어긋남 | Medium | Medium |
+
+---
+
+## 2. 기술적 검토 사항
+
+### 2.1 근본 원인
+
+같은 로드 경로에 서로 독립적인 구멍이 둘 있었고, 둘 다 모델 출력만 봐서는 보이지 않는다.
+
+첫째는 이름이다. `strip_language_model_prefix`는 mlx-vlm 형태(`language_model.model.*` → `model.*`)만 처리하고 나머지는 손대지 않는다. `transformers` export는 `visual.*` + 맨 `model.*` 디코더(구형)이거나 `model.visual.*` + `model.language_model.*`(신형)인데, 어느 쪽도 그 한 번의 strip으로는 닿지 않는다.
+
+둘째는 레이아웃이다. 두 5차원 shape를 가르는 것은 채널 축이다. 원본 레이아웃은 `in_channels`가 축 1에, 공간 크기(`patch_size`)가 축 4에 있고, 변환본은 `in_channels`가 축 4에 있다. 공개된 Qwen2.5-VL은 모두 `in_channels`가 3, `patch_size`가 14라 실무적으로는 애매함이 없지만, 이것은 어디까지나 shape 휴리스틱이므로 코드가 그렇게 말해야 한다.
+
+### 2.2 호환성/의존성 관점
+
+- **호환성 파괴**: 없음. 새로 들어간 두 단계 모두 mlx-community 변환본에서는 no-op이다. 키가 이미 `vision_tower.*` / `language_model.*`이고 필터도 이미 `[1280, 2, 14, 14, 3]`이다.
+- **새 의존성**: 없음.
+- **인코더 계약**: 그대로다. `PatchEmbed::from_weights`는 여전히 5차원 레이아웃 하나만 받는다. Qwen2-VL과 ColQwen2.5가 같은 코드를 쓰면서 그 전제에 기대고 있으므로 이 점이 중요하다.
+- **양자화 체크포인트**: 4비트 변환본에서도 `patch_embed.proj.weight`는 float로 남으므로, 같은 판별과 치환이 그대로 적용된다.
+
+### 2.3 코드 품질 관점
+
+- 정규화 함수가 자신이 강제하는 불변식이 있는 코드 옆으로 옮겨졌고, 저장소 규약대로 두 호출자를 적은 `Used by:` 줄을 달았다.
+- 판별 규칙과 그 테스트가 두 곳이 아니라 한 곳에 있다.
+- 테스트는 ColQwen2.5 모듈의 1개에서 인코더 모듈 4개 + 로더 리맵 2개 + 실제 체크포인트 게이트 1개로 늘었다.
+- `src/loading/vlm_qwen.rs`에는 인라인 `mod`를 또 추가하는 대신 `#[path]` 테스트 파일(`vlm_qwen_tests.rs`)을 붙였다. 이미 긴 파일을 더 늘리지 않기 위해서다.
+
+---
+
+## 3. 기술적 선택과 그 이유
+
+### 3.1 레이아웃 정규화를 어디에 둘 것인가
+
+**맥락:** `PatchEmbed::from_weights`가 스스로 레이아웃을 판별해 둘 다 받아 주면, 로더를 건드리지 않고 모든 소비자를 한 번에 고칠 수 있다.
+
+**검토한 대안:**
+
+| 선택지 | 장점 | 단점 |
+|--------|------|------|
+| `PatchEmbed::from_weights` 안에서 판별 | 한 곳에서 Qwen2-VL과 ColQwen2.5까지 자동으로 해결 | 세 소비자가 모두 하나의 레이아웃을 전제하는 모듈이 두 레이아웃을 조용히 받아들이게 됨. 진짜로 잘못된 필터가 들어와도 거부가 아니라 reshape가 됨 |
+| ColQwen2.5의 헬퍼를 로더에 복제 | diff가 가장 작음 | 완전히 같아야 하는 shape 휴리스틱 사본이 둘 |
+| **채택: 헬퍼를 인코더 모듈로 옮기고 prefix를 인자로 받아 두 로더에서 호출** | 규칙이 자신이 지키는 계약 옆에 있고, 테스트도 한 번이며, 인코더가 받는 레이아웃은 문서화된 하나로 유지됨 | 새 소비자가 생길 때마다 호출을 잊지 말아야 함 |
+
+**근거:** `in_channels`를 손에 쥔 계층이 로더고, 어떤 종류의 체크포인트를 열었는지 아는 것도 로더뿐이다. 인코더를 엄격하게 두면 진짜로 망가진 필터는 거기서 크게 실패한다.
+
+**트레이드오프:** 앞으로 Qwen2.5-VL 계열 로더가 호출을 빠뜨리면 수정 전의 조용한 손상 동작이 그대로 돌아온다. `Used by:` 줄과 공유 위치가 그 완화책이고, `PatchEmbed` 안의 강제 가드는 이 결정이 거부한 모호함과 맞바꾸는 선택이 된다.
+
+### 3.2 두 레이아웃을 구별할 수 없을 때 무엇을 할 것인가
+
+**맥락:** 판별은 채널 축으로 한다. 만약 `in_channels`가 `patch_size`와 같다면 축 1과 축 4가 모두 `in_channels`를 담게 되고, shape만으로는 구별할 수 없다.
+
+기존 조건(`shape.len() != 5 || shape[1] != channels || shape[4] == channels`)도 그 경우 "건드리지 않음"으로 떨어지긴 했지만, 그건 순서에 따른 부수 효과였다. 새로 쓴 형태는 `leading_is_channel`과 `trailing_is_channel`에 이름을 붙이고, 추측하지 않겠다는 결정을 명시한다. 동작은 동일하고, 의도가 읽힌다는 점이 다르다. 다음 사람이 이 fall-through를 "버그"로 보고 고치는 일을 막는 것이 요점이다.
+
+---
+
+## 4. 구현 상세
+
+### 4.1 주요 코드 변경
+
+**파일: `src/vision/encoders/qwen2_5_vl.rs`**
+
+```rust
+pub(crate) fn normalize_patch_embed_layout(
+    weights: &mut WeightMap,
+    prefix: &str,
+    in_channels: usize,
+) -> bool {
+    let key = format!("{prefix}.patch_embed.proj.weight");
+    let channels = in_channels as i32;
+    let converted = {
+        let Some(weight) = weights.get(&key) else {
+            return false;
+        };
+        let shape = mlxcel_core::array_shape(weight);
+        if shape.len() != 5 {
+            return false;
+        }
+        let leading_is_channel = shape[1] == channels;
+        let trailing_is_channel = shape[4] == channels;
+        if !leading_is_channel || trailing_is_channel {
+            return false;
+        }
+        // [out, in, kT, kH, kW] -> [out, kT, kH, kW, in].
+        mlxcel_core::transpose_axes(weight, &[0, 2, 3, 4, 1])
+    };
+    weights.insert(key, converted);
+    true
+}
+```
+
+**파일: `src/loading/vlm_qwen.rs`**
+
+```rust
+fn rewrite_qwen2_5_vl_native_key(key: &str) -> String {
+    if let Some(rest) = key.strip_prefix("model.visual.") {
+        format!("vision_tower.{rest}")
+    } else if let Some(rest) = key.strip_prefix("model.language_model.") {
+        format!("model.{rest}")
+    } else if let Some(rest) = key.strip_prefix("visual.") {
+        format!("vision_tower.{rest}")
+    } else {
+        key.to_string()
+    }
+}
+```
+
+그리고 `load_qwen2_5_vl` 안:
+
+```rust
+let mut weights = remap_qwen2_5_vl_native_keys(strip_language_model_prefix(
+    load_vlm_weights_common(model_path, None)?,
+));
+models::sanitize_tied_embeddings(&mut weights, &full_config);
+
+if normalize_patch_embed_layout(&mut weights, "vision_tower", vision_config.in_channels) {
+    tracing::debug!(
+        "Qwen2.5-VL: converted patch_embed.proj.weight from the PyTorch Conv3d layout"
+    );
+}
+```
+
+**파일: `src/models/colqwen2_5.rs`**
+
+로컬 사본을 지우고, 호출을 `normalize_patch_embed_layout(&mut weights, VISION_PREFIX, vision_config.in_channels)`로 바꿨다.
+
+### 4.2 순서
+
+리맵은 `strip_language_model_prefix` 앞이 아니라 뒤에서 돈다. mlx-vlm 형태에서 이 순서가 중요하다. `language_model.model.layers.*`가 먼저 `model.layers.*`가 돼야 하고, 그렇지 않으면 `model.language_model.` 규칙이 그 키를 볼 일이 없다. `language_model.visual.*`를 담은 체크포인트(알려진 것은 없다)도 같은 방식으로 처리된다. 정규화는 둘 다 끝난 뒤에 돌기 때문에, 체크포인트가 어느 형태였든 최종 `vision_tower.` prefix를 본다.
+
+---
+
+## 5. 검증
+
+치환은 자기 자신이 아니라 실제 변환기 결과와 맞춰 확인했다. 로컬 `Qwen/Qwen2.5-VL-3B-Instruct` 스냅샷의 bf16 `visual.patch_embed.proj.weight`(`[1280, 3, 2, 14, 14]`)를 축 `[0, 2, 3, 4, 1]`로 치환한 뒤, 무작위 20000개 원소를 f16 해상도에서 `mlx-community/Qwen2.5-VL-3B-Instruct-4bit`의 `vision_tower.patch_embed.proj.weight`(`[1280, 2, 14, 14, 3]`, f16)와 비교하면 20000/20000이 정확히 일치하고 최대 절대 오차는 0.0이다. 치환 없이 같은 버퍼를 읽으면, 즉 수정 전 로더가 사실상 하던 일을 하면 최대 1.09e-01까지 어긋난다. 이슈가 주장하던 수치를 가정이 아니라 측정으로 확인한 것이다.
+
+이 브랜치에서 실행한 명령:
+
+```
+cargo fmt --all -- --check
+cargo clippy --profile test-fast --lib --tests --features metal,accelerate -- -D warnings
+cargo test --profile test-fast --features metal,accelerate --lib vision::encoders::qwen2_5_vl   # 4 passed
+cargo test --profile test-fast --features metal,accelerate --lib loading::vlm::qwen             # 6 passed, 1 ignored
+cargo test --profile test-fast --features metal,accelerate --lib models::colqwen2_5             # 6 passed
+```
+
+`#[ignore]`가 붙은 게이트 `qwen2_5_vl_raw_export_matches_mlx_conversion`은 평소에는 `Qwen/Qwen2.5-VL-3B-Instruct`와 `mlx-community/Qwen2.5-VL-3B-Instruct-bf16`을 표준 저장소 탐색으로 찾고, 어느 한쪽이 없으면 실패가 아니라 skip한다. 이 호스트에는 bf16 변환본이 없어서, 대신 `MLXCEL_TEST_QWEN25VL_RAW_DIR` / `MLXCEL_TEST_QWEN25VL_MLX_DIR` 오버라이드로 로컬에 있는 원본 3B export 두 개를 가리켜 돌렸다. 둘 다 생성 경로로 로드됐고 7.6초 만에 동일한 비어 있지 않은 greedy 출력을 냈다. 원본과 변환본 사이의 차분을 검증한 것은 아니지만, 수정 전 로더가 아예 못 하던 일, 즉 `transformers` 원본 export를 열어 거기서 생성하는 것은 증명한다.
+
+### 여기서 검증하지 않은 것
+
+세 가지는 실제 바이너리의 몫이고 PR 본문에 미체크 항목으로 남겼다. `mlxcel generate -m <원본 디렉터리> --image ...`가 이미지에 맞는 설명을 내놓는지, 4비트 변환본 출력이 변경 전후로 바이트 단위 동일한지, 그리고 체크포인트가 있는 상태에서 ColQwen2.5 실제 체크포인트 게이트가 통과하는지다. `mlx-community/Qwen2.5-VL-3B-Instruct-bf16`을 상대로 한 차분 게이트도 그 체크포인트가 없어 실행하지 못했다.
+
+---
+
+## 6. 변경 요약
+
+### 통계
+
+| 항목 | 값 |
+|------|-----|
+| 변경 파일 | 6 |
+| 추가 라인 | 520 |
+| 삭제 라인 | 84 |
+| 신규 테스트 파일 | 2 |
+| 신규 테스트 | 7 (단위 6, ignore된 실제 체크포인트 게이트 1) |
+
+### 카테고리별 변경
+
+| 카테고리 | 파일 |
+|----------|------|
+| 공용 정규화 함수 이전 및 파라미터화 | `src/vision/encoders/qwen2_5_vl.rs`, `src/models/colqwen2_5.rs` |
+| 생성 로더 수정 | `src/loading/vlm_qwen.rs` |
+| 테스트 | `src/vision/encoders/qwen2_5_vl_tests.rs`, `src/loading/vlm_qwen_tests.rs`, `src/models/colqwen2_5_tests.rs` |
+
+### 관련 커밋
+
+| 해시 | 유형 | 메시지 |
+|------|------|--------|
+| `0ea8233f6` | fix(qwen2_5_vl) | normalize the raw HF patch-embed layout at load |
+
+### 관련 PR/이슈
+
+- 이슈 #1423: 이 PR이 닫는 이슈.
+- PR #1414: ColQwen2.5 범위의 원래 정규화 함수를 추가했고, 동기가 된 7.83 대 8.04 순위 역전을 측정했다.
+- 이슈 #1367: 비전이 제거된 Qwen2.5-VL 체크포인트. 같은 `load_qwen2_5_vl` 본문을 수정하며 이 PR 다음에 들어갈 예정이다.
+- 에픽 #1348: 이 후속 작업이 속한 상위 에픽.
+
+---
+
+## 7. 후속 조치
+
+### 더 넓은 교훈
+
+이 결함 부류에서 흥미로운 점은 두 절반이 서로 다르게 실패한다는 것이다. 키 리맵 누락은 로드 시점에 크게 실패하고 진단도 쉽다. 레이아웃 불일치는 추론 시점에 조용히 실패하면서 뒤섞인 필터로도 매끄러운 문장을 만들어 내므로, "그럴듯한 말을 하는가"로 만든 스모크 테스트는 절대 잡지 못한다. 둘을 갈라낸 것은 독립적인 기준과의 수치 비교였다. PR #1414이 애초에 이 문제를 찾은 방법이고, 여기서 치환을 증명한 방법도 같다.
+
+실무 규칙은 "항상 레퍼런스와 비교하라"보다 좁다. 레이아웃 혼동에도 텐서의 원소 수가 불변이면 shape 검사와 reshape 성공은 아무 정보도 주지 않으며, 값만이 정보다. `[1280, 3, 2, 14, 14]`와 `[1280, 2, 14, 14, 3]`은 모두 1505280개를 담고, 수정 전 경로가 아무것도 던지지 않은 이유가 정확히 그것이다.

--- a/src/loading/vlm_qwen.rs
+++ b/src/loading/vlm_qwen.rs
@@ -25,6 +25,7 @@
 //! about Qwen family details.
 
 use anyhow::Result;
+use mlxcel_core::weights::WeightMap;
 use std::path::Path;
 
 use crate::LoadedModel;
@@ -202,9 +203,46 @@ pub(crate) fn load_qwen2_vl_iree_host_preprocessor(
     )
 }
 
+/// Rewrite one raw-HuggingFace Qwen2.5-VL weight key into the names this tree
+/// loads the model under.
+///
+/// A `transformers` export of Qwen2.5-VL names the vision tower `visual.*`
+/// (older exports) or `model.visual.*` (the nested layout newer exports use,
+/// which pairs it with `model.language_model.*`), while the encoder here reads
+/// `vision_tower.*` and the decoder reads `model.*`. mlx-community conversions
+/// already carry both target names, so every rule below misses on them and the
+/// map comes back unchanged.
+///
+/// `lm_head.*` and `vision_tower.merger.*` are deliberately untouched: the head
+/// is already at its final name, and the merger is inside the tower that the
+/// `visual.` rule renames as a whole.
+fn rewrite_qwen2_5_vl_native_key(key: &str) -> String {
+    if let Some(rest) = key.strip_prefix("model.visual.") {
+        format!("vision_tower.{rest}")
+    } else if let Some(rest) = key.strip_prefix("model.language_model.") {
+        format!("model.{rest}")
+    } else if let Some(rest) = key.strip_prefix("visual.") {
+        format!("vision_tower.{rest}")
+    } else {
+        key.to_string()
+    }
+}
+
+/// Apply [`rewrite_qwen2_5_vl_native_key`] to a whole weight map. A no-op on an
+/// mlx-community conversion.
+fn remap_qwen2_5_vl_native_keys(raw_weights: WeightMap) -> WeightMap {
+    let mut weights = WeightMap::new();
+    for (key, value) in raw_weights {
+        weights.insert(rewrite_qwen2_5_vl_native_key(&key), value);
+    }
+    weights
+}
+
 /// Load a Qwen2.5-VL model (windowed ViT + Qwen2 language model with MRoPE)
 pub(crate) fn load_qwen2_5_vl(model_path: &Path) -> Result<LoadedModel> {
-    use vision::encoders::qwen2_5_vl::{Qwen25VLVisionConfig, Qwen25VLVisionEncoder};
+    use vision::encoders::qwen2_5_vl::{
+        Qwen25VLVisionConfig, Qwen25VLVisionEncoder, normalize_patch_embed_layout,
+    };
 
     let (config_str, full_config) = read_sanitized_vlm_config(model_path)?;
 
@@ -216,8 +254,18 @@ pub(crate) fn load_qwen2_5_vl(model_path: &Path) -> Result<LoadedModel> {
 
     inherit_qwen_vision_quantization(&mut vision_config, &full_config);
 
-    let mut weights = strip_language_model_prefix(load_vlm_weights_common(model_path, None)?);
+    let mut weights = remap_qwen2_5_vl_native_keys(strip_language_model_prefix(
+        load_vlm_weights_common(model_path, None)?,
+    ));
     models::sanitize_tied_embeddings(&mut weights, &full_config);
+
+    // A raw `transformers` export keeps `Conv3d`'s native filter layout, which
+    // the encoder would reshape without complaint and then read scrambled.
+    if normalize_patch_embed_layout(&mut weights, "vision_tower", vision_config.in_channels) {
+        tracing::debug!(
+            "Qwen2.5-VL: converted patch_embed.proj.weight from the PyTorch Conv3d layout"
+        );
+    }
 
     let text_model = models::Qwen2VLModel::from_weights(&weights, &text_config)
         .map_err(|e| anyhow::anyhow!("Failed to load Qwen2.5VL text model: {}", e))?;
@@ -952,6 +1000,10 @@ pub fn load_qwen3_omni_speech(
     Qwen3OmniSpeech::from_weights(&weights, cfg)
         .map_err(|e| anyhow::anyhow!("Failed to load Qwen3-Omni speech stack: {e}"))
 }
+
+#[cfg(test)]
+#[path = "vlm_qwen_tests.rs"]
+mod tests;
 
 #[cfg(test)]
 mod qwen3_omni_speech_loader_tests {

--- a/src/loading/vlm_qwen_tests.rs
+++ b/src/loading/vlm_qwen_tests.rs
@@ -1,0 +1,222 @@
+// Copyright 2025-2026 Lablup Inc. and Jeongkyu Shin
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Qwen-VL family loader tests.
+//!
+//! The synthetic half asserts the key remap that lets `mlxcel generate` and
+//! `mlxcel-server` read a raw `transformers` export of Qwen2.5-VL. The real
+//! half is one `#[ignore]`d differential gate that runs the generation path
+//! on both a raw export and its mlx conversion and requires the same tokens
+//! out of each; it soft-skips when either checkpoint is absent.
+
+use super::{remap_qwen2_5_vl_native_keys, rewrite_qwen2_5_vl_native_key};
+
+#[test]
+fn native_key_remap_renames_the_tower_and_unwraps_the_language_model() {
+    // Older exports: `visual.*` beside a bare `model.*` decoder. Newer ones:
+    // `model.visual.*` beside `model.language_model.*`. Both reach this path
+    // because `strip_language_model_prefix` only handles a leading
+    // `language_model.`.
+    assert_eq!(
+        rewrite_qwen2_5_vl_native_key("visual.blocks.0.attn.qkv.weight"),
+        "vision_tower.blocks.0.attn.qkv.weight"
+    );
+    assert_eq!(
+        rewrite_qwen2_5_vl_native_key("model.visual.patch_embed.proj.weight"),
+        "vision_tower.patch_embed.proj.weight"
+    );
+    assert_eq!(
+        rewrite_qwen2_5_vl_native_key("model.language_model.layers.0.mlp.up_proj.weight"),
+        "model.layers.0.mlp.up_proj.weight"
+    );
+    assert_eq!(
+        rewrite_qwen2_5_vl_native_key("lm_head.weight"),
+        "lm_head.weight"
+    );
+}
+
+#[test]
+fn native_key_remap_maps_a_whole_export_and_leaves_a_conversion_alone() {
+    let dummy = || mlxcel_core::from_slice_f32(&[0.0], &[1]);
+    let mut raw = mlxcel_core::weights::WeightMap::new();
+    for key in [
+        "visual.blocks.0.attn.qkv.weight",
+        "model.visual.patch_embed.proj.weight",
+        "model.language_model.layers.0.mlp.up_proj.weight",
+        "lm_head.weight",
+    ] {
+        raw.insert(key.to_string(), dummy());
+    }
+
+    let remapped = remap_qwen2_5_vl_native_keys(raw);
+    let mut keys: Vec<&str> = remapped.keys().map(String::as_str).collect();
+    keys.sort_unstable();
+    assert_eq!(
+        keys,
+        vec![
+            "lm_head.weight",
+            "model.layers.0.mlp.up_proj.weight",
+            "vision_tower.blocks.0.attn.qkv.weight",
+            "vision_tower.patch_embed.proj.weight",
+        ]
+    );
+
+    // An mlx-community conversion already carries the target names, the
+    // merger included, so every rule misses and the map comes back unchanged.
+    let mut converted = mlxcel_core::weights::WeightMap::new();
+    for key in [
+        "vision_tower.patch_embed.proj.weight",
+        "vision_tower.merger.mlp.0.weight",
+        "model.layers.0.mlp.up_proj.weight",
+        "model.embed_tokens.weight",
+    ] {
+        converted.insert(key.to_string(), dummy());
+    }
+    let before: Vec<String> = {
+        let mut keys: Vec<String> = converted.keys().cloned().collect();
+        keys.sort_unstable();
+        keys
+    };
+    let after = {
+        let mut keys: Vec<String> = remap_qwen2_5_vl_native_keys(converted)
+            .keys()
+            .cloned()
+            .collect();
+        keys.sort_unstable();
+        keys
+    };
+    assert_eq!(before, after);
+}
+
+// Real-checkpoint gate. `#[ignore]`d because it loads two 3B checkpoints, and
+// it soft-skips (rather than failing) when either directory is absent.
+
+/// Repo ids the gate looks for through the usual store lookup.
+const RAW_EXPORT: &str = "Qwen/Qwen2.5-VL-3B-Instruct";
+const MLX_CONVERSION: &str = "mlx-community/Qwen2.5-VL-3B-Instruct-bf16";
+
+/// Environment overrides for a checkout that keeps these two snapshots
+/// somewhere the store lookup does not reach, for example a shared
+/// `models/mlx/...` tree. Each names a model directory.
+const RAW_EXPORT_DIR_ENV: &str = "MLXCEL_TEST_QWEN25VL_RAW_DIR";
+const MLX_CONVERSION_DIR_ENV: &str = "MLXCEL_TEST_QWEN25VL_MLX_DIR";
+
+/// The prompt both checkpoints get, already in Qwen2.5-VL chat-template form
+/// so the gate does not depend on the tokenizer's template rendering.
+const IMAGE_PROMPT: &str = "<|im_start|>user\n<|vision_start|><|image_pad|><|vision_end|>Describe the image.<|im_end|>\n<|im_start|>assistant\n";
+
+/// A deterministic image. The gate asserts two checkpoints agree on the same
+/// input, so the picture only has to be identical between the two runs.
+fn gate_image() -> image::DynamicImage {
+    let mut buffer = image::RgbImage::new(112, 112);
+    for (x, y, pixel) in buffer.enumerate_pixels_mut() {
+        *pixel = image::Rgb([(x * 2) as u8, (y * 2) as u8, ((x + y) % 256) as u8]);
+    }
+    image::DynamicImage::ImageRgb8(buffer)
+}
+
+fn gate_checkpoint(repo_id: &str, env_key: &str) -> Option<std::path::PathBuf> {
+    if let Ok(dir) = std::env::var(env_key) {
+        let dir = std::path::PathBuf::from(dir);
+        if dir.join("config.json").is_file() {
+            return Some(dir);
+        }
+        eprintln!(
+            "skipping real-checkpoint gate: {env_key}={} has no config.json",
+            dir.display()
+        );
+        return None;
+    }
+    crate::models::embedding_test_support::local_checkpoint(repo_id)
+}
+
+/// Greedy tokens for one checkpoint, through the same calls `mlxcel generate
+/// --image` makes: `load_model`, the shared VLM embedding preparation, and a
+/// backend session seeded with those embeddings.
+fn greedy_image_tokens(model_dir: &std::path::Path, max_tokens: usize) -> Vec<i32> {
+    let (model, tokenizer) =
+        crate::loading::load_model(model_dir).expect("the Qwen2.5-VL checkpoint loads");
+    let mut prompt_tokens: Vec<i32> = tokenizer
+        .encode_with_special(IMAGE_PROMPT, false, true)
+        .expect("the chat-template prompt tokenizes")
+        .iter()
+        .map(|&id| id as i32)
+        .collect();
+
+    let prepared = crate::vlm_runtime::prepare_and_compute_vlm_embeddings(
+        &model,
+        &mut prompt_tokens,
+        IMAGE_PROMPT,
+        &[gate_image()],
+        |text, add_special| {
+            tokenizer
+                .encode(text, add_special)
+                .unwrap_or_default()
+                .iter()
+                .map(|&id| id as i32)
+                .collect()
+        },
+    )
+    .expect("the image request prepares")
+    .expect("a Qwen2.5-VL image request must produce vision embeddings");
+
+    let (input_embeds, mask) = crate::vlm_runtime::prepared_embedding_refs(&prepared.embeddings)
+        .expect("prepared embeddings expose an input tensor");
+    let mut session = crate::backend::select_backend()
+        .create_session(
+            model_dir,
+            mlxcel_core::generate::LanguageModel::num_layers(&model),
+            mlxcel_core::cache::KVCacheMode::Fp16,
+            mlxcel_core::sampling::TokenBiasMap::new(),
+        )
+        .expect("a generation session is created");
+
+    session.generate_streaming_with_embeddings(
+        &model,
+        &prompt_tokens,
+        Some(input_embeds),
+        mask,
+        max_tokens,
+        &mlxcel_core::generate::SamplingConfig::greedy(),
+        |_| true,
+    )
+}
+
+/// A raw `transformers` export and its mlx conversion are the same weights
+/// under different names and a different `Conv3d` filter layout, so the
+/// generation path must produce the same greedy tokens from both. Before the
+/// remap and the layout normalization landed, the raw export did not load at
+/// all, and a hand-renamed one generated from scrambled filters.
+#[test]
+#[ignore = "loads two 3B Qwen2.5-VL checkpoints"]
+fn qwen2_5_vl_raw_export_matches_mlx_conversion() {
+    let _guard = crate::models::embedding_test_support::mlx_test_guard();
+    let (Some(raw_dir), Some(mlx_dir)) = (
+        gate_checkpoint(RAW_EXPORT, RAW_EXPORT_DIR_ENV),
+        gate_checkpoint(MLX_CONVERSION, MLX_CONVERSION_DIR_ENV),
+    ) else {
+        return;
+    };
+
+    let raw_tokens = greedy_image_tokens(&raw_dir, 24);
+    let mlx_tokens = greedy_image_tokens(&mlx_dir, 24);
+    assert!(
+        !raw_tokens.is_empty(),
+        "the raw export generated no tokens at all"
+    );
+    assert_eq!(
+        raw_tokens, mlx_tokens,
+        "the raw export and its mlx conversion must decode to the same tokens"
+    );
+}

--- a/src/models/colqwen2_5.rs
+++ b/src/models/colqwen2_5.rs
@@ -47,8 +47,10 @@
 //! The raw HuggingFace export stores the vision tower under `visual.*` and
 //! keeps `Conv3d`'s native `[out, in, kT, kH, kW]` patch-embedding layout,
 //! while the encoder in this tree expects the mlx-converted names and the
-//! channels-last filter; [`rewrite_colqwen25_key`] and
-//! [`normalize_patch_embed_layout`] bridge both.
+//! channels-last filter; [`rewrite_colqwen25_key`] and the encoder module's
+//! [`normalize_patch_embed_layout`] bridge both. The layout normalizer is
+//! shared with the Qwen2.5-VL generation loader, which needs it for the same
+//! reason.
 
 use std::path::Path;
 
@@ -69,7 +71,9 @@ use crate::models::col_late_interaction::{
 use crate::models::qwen2_vl::{Qwen2VLConfig, Qwen2VLModel};
 use crate::multimodal::qwen_vl::insert_qwen_vl_image_tokens;
 use crate::vision::Qwen25VLModel;
-use crate::vision::encoders::qwen2_5_vl::{Qwen25VLVisionConfig, Qwen25VLVisionEncoder};
+use crate::vision::encoders::qwen2_5_vl::{
+    Qwen25VLVisionConfig, Qwen25VLVisionEncoder, normalize_patch_embed_layout,
+};
 use crate::vision::processors::qwen2_vl::Qwen2VLProcessor;
 
 /// Checkpoint key of the 128-dimension projection after sanitization.
@@ -130,7 +134,7 @@ impl ColQwen25Model {
         }
 
         let mut weights = sanitize_colqwen25_weights(load_embedding_weights(model_dir, config)?);
-        normalize_patch_embed_layout(&mut weights, vision_config.in_channels);
+        normalize_patch_embed_layout(&mut weights, VISION_PREFIX, vision_config.in_channels);
         apply_dense_projection_override(&mut weights, PROJECTION_PREFIX);
         weights.retain(|key, _| !key.starts_with("lm_head."));
 
@@ -353,38 +357,6 @@ pub(crate) fn sanitize_colqwen25_weights(weights: WeightMap) -> WeightMap {
         .into_iter()
         .map(|(key, value)| (rewrite_colqwen25_key(&key), value))
         .collect()
-}
-
-/// Put the vision patch-embedding convolution into the channels-last layout
-/// the Qwen2.5-VL encoder expects, when the checkpoint stores the PyTorch
-/// one.
-///
-/// `Qwen25VLVisionEncoder` assumes the mlx-vlm conversion's
-/// `[out, kT, kH, kW, in]` and permutes it once more itself. A raw
-/// HuggingFace export (which is what `vidore/colqwen2.5-base` is) stores
-/// `Conv3d`'s native `[out, in, kT, kH, kW]` instead, so it has to be
-/// converted here or the tower silently reads scrambled filters and every
-/// page embeds to nearly the same vectors.
-///
-/// The two layouts are told apart by the channel axis: `in_channels` is 3
-/// and the patch size is 14, so the trailing axis is the channel one only
-/// in the converted layout. Returns `true` when a conversion was applied.
-pub(crate) fn normalize_patch_embed_layout(weights: &mut WeightMap, in_channels: usize) -> bool {
-    let key = format!("{VISION_PREFIX}.patch_embed.proj.weight");
-    let channels = in_channels as i32;
-    let converted = {
-        let Some(weight) = weights.get(&key) else {
-            return false;
-        };
-        let shape = mlxcel_core::array_shape(weight);
-        if shape.len() != 5 || shape[1] != channels || shape[4] == channels {
-            return false;
-        }
-        // [out, in, kT, kH, kW] -> [out, kT, kH, kW, in].
-        mlxcel_core::transpose_axes(weight, &[0, 2, 3, 4, 1])
-    };
-    weights.insert(key, converted);
-    true
 }
 
 /// Build the dynamic-resolution processor, honoring the checkpoint's pixel

--- a/src/models/colqwen2_5_tests.rs
+++ b/src/models/colqwen2_5_tests.rs
@@ -32,8 +32,8 @@ use mlxcel_core::{MlxArray, UniquePtr};
 use serde_json::json;
 
 use super::{
-    ColQwen25Model, IMAGE_DOCUMENT_PROMPT, normalize_patch_embed_layout, rewrite_colqwen25_key,
-    sanitize_colqwen25_weights, text_input_embeddings, token_vectors,
+    ColQwen25Model, IMAGE_DOCUMENT_PROMPT, rewrite_colqwen25_key, sanitize_colqwen25_weights,
+    text_input_embeddings, token_vectors,
 };
 use crate::embeddings::model::EmbeddingModel;
 use crate::models::col_late_interaction::QUERY_AUGMENTATION_TOKENS;
@@ -228,50 +228,6 @@ fn sanitize_rewrites_every_key_of_a_native_map() {
             "vision_tower.merger.ln_q.weight"
         ]
     );
-}
-
-#[test]
-fn patch_embed_layout_is_converted_from_the_pytorch_conv3d_form() {
-    let _guard = mlx_test_guard();
-    // Raw HuggingFace: [out, in, kT, kH, kW]. The encoder wants the mlx
-    // conversion's [out, kT, kH, kW, in], so this must be permuted.
-    let (out, channels, kt, k) = (4i32, 3i32, 2i32, 2i32);
-    let count = (out * channels * kt * k * k) as usize;
-    let values: Vec<f32> = (0..count).map(|i| i as f32).collect();
-    let mut weights = WeightMap::new();
-    weights.insert(
-        "vision_tower.patch_embed.proj.weight".to_string(),
-        mlxcel_core::from_slice_f32(&values, &[out, channels, kt, k, k]),
-    );
-    assert!(normalize_patch_embed_layout(&mut weights, 3));
-    let converted = &weights["vision_tower.patch_embed.proj.weight"];
-    assert_eq!(
-        mlxcel_core::array_shape(converted),
-        vec![out, kt, k, k, channels]
-    );
-    // Element count is preserved and the permutation is the transpose, not a
-    // reinterpretation: element [0, 0, 0, 0, 1] of the output is element
-    // [0, 1, 0, 0, 0] of the input, which is `kt * k * k` = 8.
-    mlxcel_core::eval(converted);
-    let flat = to_vec(converted);
-    assert_eq!(flat.len(), count);
-    assert_eq!(flat[1], 8.0);
-
-    // An mlx conversion is already channels-last and is left untouched.
-    let mut already = WeightMap::new();
-    already.insert(
-        "vision_tower.patch_embed.proj.weight".to_string(),
-        mlxcel_core::from_slice_f32(&values, &[out, kt, k, k, channels]),
-    );
-    assert!(!normalize_patch_embed_layout(&mut already, 3));
-    assert_eq!(
-        mlxcel_core::array_shape(&already["vision_tower.patch_embed.proj.weight"]),
-        vec![out, kt, k, k, channels]
-    );
-
-    // A checkpoint without the tower is not an error.
-    let mut empty = WeightMap::new();
-    assert!(!normalize_patch_embed_layout(&mut empty, 3));
 }
 
 #[test]

--- a/src/vision/encoders/qwen2_5_vl.rs
+++ b/src/vision/encoders/qwen2_5_vl.rs
@@ -98,6 +98,67 @@ fn default_fullatt_block_indexes() -> Vec<usize> {
     vec![7, 15, 23, 31]
 }
 
+/// Put the vision patch-embedding convolution under `prefix` into the
+/// channels-last layout `PatchEmbed::from_weights` expects, when the
+/// checkpoint stores PyTorch's instead. Returns `true` when a conversion was
+/// applied.
+///
+/// Used by: Qwen2.5-VL generation loader (`load_qwen2_5_vl`), ColQwen2.5
+/// (`ColQwen25Model::load`)
+///
+/// `PatchEmbed::from_weights` accepts exactly one 5-D layout, the mlx-vlm
+/// conversion's `[out, kT, kH, kW, in]`, and permutes it once more itself.
+/// A raw HuggingFace export stores `Conv3d`'s native `[out, in, kT, kH, kW]`,
+/// which has the same element count, so the reshape downstream succeeds and
+/// nothing fails: the tower simply reads scrambled filters. PR #1414 measured
+/// what that costs on the retrieval path, where the unrelated page outranked
+/// the matching one (MaxSim 7.83 against 8.04).
+///
+/// Normalizing here rather than inside `PatchEmbed` is deliberate. The encoder
+/// contract stays "channels-last only" for all three of its consumers
+/// (Qwen2-VL, Qwen2.5-VL, ColQwen2.5), and the loader is the layer that has
+/// `in_channels` on hand to tell the layouts apart.
+///
+/// Detection is by the channel axis: the raw layout has `in_channels` on axis
+/// 1 and a spatial extent on axis 4, the converted layout has `in_channels` on
+/// axis 4. When both axes carry `in_channels` the two layouts are
+/// indistinguishable from shape alone (it would take `in_channels == patch_size`,
+/// which no published Qwen2.5-VL checkpoint has: `in_channels` is 3 and
+/// `patch_size` is 14), so the function refuses to guess and leaves the map
+/// untouched. A 2-D already-flattened weight and a missing weight are both
+/// no-ops as well, the latter so `PatchEmbed::from_weights` still reports the
+/// missing key itself.
+pub(crate) fn normalize_patch_embed_layout(
+    weights: &mut WeightMap,
+    prefix: &str,
+    in_channels: usize,
+) -> bool {
+    let key = format!("{prefix}.patch_embed.proj.weight");
+    let channels = in_channels as i32;
+    let converted = {
+        let Some(weight) = weights.get(&key) else {
+            return false;
+        };
+        let shape = mlxcel_core::array_shape(weight);
+        if shape.len() != 5 {
+            return false;
+        }
+        let leading_is_channel = shape[1] == channels;
+        let trailing_is_channel = shape[4] == channels;
+        if !leading_is_channel || trailing_is_channel {
+            return false;
+        }
+        // [out, in, kT, kH, kW] -> [out, kT, kH, kW, in].
+        mlxcel_core::transpose_axes(weight, &[0, 2, 3, 4, 1])
+    };
+    weights.insert(key, converted);
+    true
+}
+
+#[cfg(test)]
+#[path = "qwen2_5_vl_tests.rs"]
+mod tests;
+
 // RMSNorm for vision encoder.
 struct VisionRMSNorm {
     weight: UniquePtr<MlxArray>,

--- a/src/vision/encoders/qwen2_5_vl_tests.rs
+++ b/src/vision/encoders/qwen2_5_vl_tests.rs
@@ -1,0 +1,173 @@
+// Copyright 2025-2026 Lablup Inc. and Jeongkyu Shin
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Qwen2.5-VL vision encoder tests.
+//!
+//! The patch-embedding layout normalizer is tested here rather than in a
+//! consumer's module because it guards the encoder's own contract: both the
+//! `mlxcel generate` loader and ColQwen2.5 call it with their own prefix, and
+//! the detection rule should be stated once.
+//!
+//! Every test that drives MLX takes
+//! [`crate::models::embedding_test_support::mlx_test_guard`].
+
+use mlxcel_core::weights::WeightMap;
+
+use super::normalize_patch_embed_layout;
+use crate::models::embedding_test_support::{mlx_test_guard, to_vec};
+
+/// A `[out, a, b, c, d]` tensor filled with `0..count`, so a permutation is
+/// distinguishable from a reinterpretation of the same buffer.
+fn ramp(shape: &[i32]) -> (mlxcel_core::UniquePtr<mlxcel_core::MlxArray>, usize) {
+    let count: i32 = shape.iter().product();
+    let values: Vec<f32> = (0..count).map(|i| i as f32).collect();
+    (mlxcel_core::from_slice_f32(&values, shape), count as usize)
+}
+
+#[test]
+fn patch_embed_layout_is_converted_from_the_pytorch_conv3d_form() {
+    let _guard = mlx_test_guard();
+    // Raw HuggingFace: [out, in, kT, kH, kW]. The encoder wants the mlx
+    // conversion's [out, kT, kH, kW, in], so this must be permuted.
+    let (out, channels, kt, k) = (4i32, 3i32, 2i32, 2i32);
+    let (weight, count) = ramp(&[out, channels, kt, k, k]);
+    let mut weights = WeightMap::new();
+    weights.insert("vision_tower.patch_embed.proj.weight".to_string(), weight);
+
+    assert!(normalize_patch_embed_layout(
+        &mut weights,
+        "vision_tower",
+        3
+    ));
+    let converted = &weights["vision_tower.patch_embed.proj.weight"];
+    assert_eq!(
+        mlxcel_core::array_shape(converted),
+        vec![out, kt, k, k, channels]
+    );
+    // Element count is preserved and the permutation is the transpose, not a
+    // reinterpretation: element [0, 0, 0, 0, 1] of the output is element
+    // [0, 1, 0, 0, 0] of the input, which is `kt * k * k` = 8.
+    mlxcel_core::eval(converted);
+    let flat = to_vec(converted);
+    assert_eq!(flat.len(), count);
+    assert_eq!(flat[1], 8.0);
+
+    // Idempotent: a second call sees the converted layout and declines.
+    assert!(!normalize_patch_embed_layout(
+        &mut weights,
+        "vision_tower",
+        3
+    ));
+    assert_eq!(
+        mlxcel_core::array_shape(&weights["vision_tower.patch_embed.proj.weight"]),
+        vec![out, kt, k, k, channels]
+    );
+}
+
+#[test]
+fn patch_embed_layout_leaves_the_mlx_conversion_untouched() {
+    let _guard = mlx_test_guard();
+    let (out, channels, kt, k) = (4i32, 3i32, 2i32, 2i32);
+    let (weight, count) = ramp(&[out, kt, k, k, channels]);
+    let before = {
+        mlxcel_core::eval(&weight);
+        to_vec(&weight)
+    };
+    let mut weights = WeightMap::new();
+    weights.insert("vision_tower.patch_embed.proj.weight".to_string(), weight);
+
+    assert!(!normalize_patch_embed_layout(
+        &mut weights,
+        "vision_tower",
+        3
+    ));
+    let untouched = &weights["vision_tower.patch_embed.proj.weight"];
+    assert_eq!(
+        mlxcel_core::array_shape(untouched),
+        vec![out, kt, k, k, channels]
+    );
+    mlxcel_core::eval(untouched);
+    let after = to_vec(untouched);
+    assert_eq!(after.len(), count);
+    assert_eq!(before, after, "an mlx conversion must load bit-identically");
+}
+
+#[test]
+fn patch_embed_layout_normalizer_is_prefix_parameterized() {
+    let _guard = mlx_test_guard();
+    let (out, channels, kt, k) = (4i32, 3i32, 2i32, 2i32);
+    let (weight, _) = ramp(&[out, channels, kt, k, k]);
+    let mut weights = WeightMap::new();
+    // ColQwen2.5 and the generation loader both pass "vision_tower" today, but
+    // the prefix is an argument, so a tower stored anywhere else converts too
+    // and a tower under a different prefix is not touched by mistake.
+    weights.insert("visual.patch_embed.proj.weight".to_string(), weight);
+
+    assert!(!normalize_patch_embed_layout(
+        &mut weights,
+        "vision_tower",
+        3
+    ));
+    assert_eq!(
+        mlxcel_core::array_shape(&weights["visual.patch_embed.proj.weight"]),
+        vec![out, channels, kt, k, k]
+    );
+
+    assert!(normalize_patch_embed_layout(&mut weights, "visual", 3));
+    assert_eq!(
+        mlxcel_core::array_shape(&weights["visual.patch_embed.proj.weight"]),
+        vec![out, kt, k, k, channels]
+    );
+}
+
+#[test]
+fn patch_embed_layout_passes_through_shapes_it_cannot_classify() {
+    let _guard = mlx_test_guard();
+    // A checkpoint without the tower is not an error: the encoder reports the
+    // missing key itself.
+    let mut empty = WeightMap::new();
+    assert!(!normalize_patch_embed_layout(&mut empty, "vision_tower", 3));
+
+    // An already-flattened 2-D weight is the encoder's other accepted form.
+    let (flat, _) = ramp(&[4, 3 * 2 * 2 * 2]);
+    let mut flattened = WeightMap::new();
+    flattened.insert("vision_tower.patch_embed.proj.weight".to_string(), flat);
+    assert!(!normalize_patch_embed_layout(
+        &mut flattened,
+        "vision_tower",
+        3
+    ));
+    assert_eq!(
+        mlxcel_core::array_shape(&flattened["vision_tower.patch_embed.proj.weight"]),
+        vec![4, 24]
+    );
+
+    // Both candidate axes carrying `in_channels` makes the two layouts
+    // indistinguishable from shape alone, so the normalizer refuses to guess.
+    let (ambiguous, _) = ramp(&[4, 3, 2, 3, 3]);
+    let mut ambiguous_map = WeightMap::new();
+    ambiguous_map.insert(
+        "vision_tower.patch_embed.proj.weight".to_string(),
+        ambiguous,
+    );
+    assert!(!normalize_patch_embed_layout(
+        &mut ambiguous_map,
+        "vision_tower",
+        3
+    ));
+    assert_eq!(
+        mlxcel_core::array_shape(&ambiguous_map["vision_tower.patch_embed.proj.weight"]),
+        vec![4, 3, 2, 3, 3]
+    );
+}


### PR DESCRIPTION
## Summary

A raw HuggingFace Qwen2.5-VL export stores the vision `patch_embed.proj.weight` in `Conv3d`'s native `[out, in, kT, kH, kW]` layout, while `Qwen25VLVisionEncoder` accepts only the mlx-vlm conversion's channels-last `[out, kT, kH, kW, in]`. PR #1414 fixed that on the ColQwen2.5 embedding path only. The generation loader behind `mlxcel generate` and `mlxcel-server` had the same blind spot and no key remap either, so a raw `transformers` export failed with `Missing vision_tower.patch_embed.proj.weight`, and a checkpoint whose keys had been renamed by hand loaded without complaint and generated from scrambled filters.

This moves the one layout normalizer into the encoder module whose contract it guards, parameterizes it by weight prefix, and calls it from both consumers. `load_qwen2_5_vl` also gains the `visual.` / `model.visual.` key remap that the Qwen3-VL loader already does for its family. Both steps are no-ops on an mlx-community conversion.

## What changed

- `src/vision/encoders/qwen2_5_vl.rs`: new `pub(crate) normalize_patch_embed_layout(weights, prefix, in_channels) -> bool`, moved from `src/models/colqwen2_5.rs` with the prefix as a parameter. Same detection rule and same `[0, 2, 3, 4, 1]` transpose, with the ambiguous case (both candidate axes carrying `in_channels`) now spelled out as a deliberate refusal to guess rather than a side effect of the condition order. Carries the `Used by:` line for its two callers.
- `src/vision/encoders/qwen2_5_vl_tests.rs` (new): the normalizer's tests, moved here from `colqwen2_5_tests.rs` and extended. Covers the conversion, the element-level proof that it is a transpose and not a reinterpretation, idempotency, an mlx conversion left bit-identical, prefix parameterization, and the three pass-through shapes (missing key, 2-D flattened, ambiguous 5-D).
- `src/loading/vlm_qwen.rs`: new `rewrite_qwen2_5_vl_native_key` / `remap_qwen2_5_vl_native_keys` (`model.visual.` and `visual.` to `vision_tower.`, `model.language_model.` to `model.`, everything else untouched), applied in `load_qwen2_5_vl` after `strip_language_model_prefix`; then `normalize_patch_embed_layout(&mut weights, "vision_tower", vision_config.in_channels)` before the encoder is built, logging at `debug` when it converted.
- `src/loading/vlm_qwen_tests.rs` (new): the remap's unit tests, plus the `#[ignore]`d real-checkpoint differential gate `qwen2_5_vl_raw_export_matches_mlx_conversion`.
- `src/models/colqwen2_5.rs` / `src/models/colqwen2_5_tests.rs`: local copy removed, now calls the shared function with `VISION_PREFIX`; the moved test is gone from this module.
- `TECHNICAL_REPORTS/1582-qwen2-5-vl-patch-embed-layout-20260902.{en,ko}.md`: the bilingual technical report for this change, committed because this repository carries the `TECHNICAL_REPORTS/.keep-reports` marker.

`PatchEmbed::from_weights` is deliberately unchanged. Making it sniff the layout would silently accept both shapes in a module whose other consumers (Qwen2-VL, ColQwen2.5) depend on exactly one, so the normalization stays at the loader boundary, which is also where `in_channels` is available.

## Validation

The permutation is checked against the real converter rather than only asserted against itself. Sampling 20000 elements of `Qwen/Qwen2.5-VL-3B-Instruct`'s bf16 `visual.patch_embed.proj.weight` transposed with axes `[0, 2, 3, 4, 1]`, against `mlx-community/Qwen2.5-VL-3B-Instruct-4bit`'s f16 `vision_tower.patch_embed.proj.weight`, gives 20000/20000 exact matches at f16 resolution (max abs diff 0.0). Reading the same buffer without permuting is off by up to 1.09e-01, which is the pre-fix behaviour.

Run locally on this branch:

```
cargo fmt --all -- --check
cargo clippy --profile test-fast --lib --tests --features metal,accelerate -- -D warnings
cargo test --profile test-fast --features metal,accelerate --lib vision::encoders::qwen2_5_vl   # 4 passed
cargo test --profile test-fast --features metal,accelerate --lib loading::vlm::qwen             # 6 passed, 1 ignored
cargo test --profile test-fast --features metal,accelerate --lib models::colqwen2_5             # 6 passed
```

The `#[ignore]`d gate was additionally run against two locally present raw 3B exports through the `MLXCEL_TEST_QWEN25VL_RAW_DIR` / `MLXCEL_TEST_QWEN25VL_MLX_DIR` overrides: both loaded through the generation path and produced identical, non-empty greedy output in 7.6s. The pre-fix loader could not load either one at all.

## Test plan

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --profile test-fast --lib --tests --features metal,accelerate -- -D warnings`
- [x] `cargo test --profile test-fast --features metal,accelerate --lib vision::encoders::qwen2_5_vl`
- [x] `cargo test --profile test-fast --features metal,accelerate --lib loading::vlm::qwen`
- [x] `cargo test --profile test-fast --features metal,accelerate --lib models::colqwen2_5`
- [ ] Raw export loads and describes an image coherently through the shipped binary: `./target/release/mlxcel generate -m models/mlx/qwen2.5-vl-3b-hf --image <image> -p "Describe the image." -n 64 --temp 0`. Expect a coherent description of the image, not the pre-fix load failure (`Missing vision_tower.patch_embed.proj.weight`) and not unrelated text.
- [ ] The mlx conversion is unaffected: run `./target/release/mlxcel generate -m models/mlx/qwen2.5-vl-3b-4bit --image <image> -p "Describe the image." -n 64 --temp 0` with a binary built from `main` and with one built from this branch, and diff the two outputs. Expect them byte-identical, since both the remap and the normalizer are no-ops on `vision_tower.*` keys whose filter is already `[1280, 2, 14, 14, 3]`.
- [ ] ColQwen2.5 is unaffected: `cargo test --profile test-fast --features metal,accelerate --lib models::colqwen2_5` still passes with the ColQwen2.5 checkpoint present, so the moved normalizer keeps working through `ColQwen25Model::load`.
- [ ] Optional, needs `mlx-community/Qwen2.5-VL-3B-Instruct-bf16`, which is not present on this host: `cargo test --profile test-fast --features metal,accelerate --lib -- --ignored qwen2_5_vl_raw_export_matches_mlx_conversion`. Expect identical greedy tokens for the raw export and its bf16 conversion, or a printed skip when either directory is absent.

Closes #1423
