### PR TITLE
docs: sync PR template clippy and test commands with CONTRIBUTING.md

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -34,8 +34,8 @@ For inference changes, real-checkpoint validation is required — synthetic-only
 -->
 
 - [ ] `cargo fmt --all -- --check` (enforced by CI — violations block merge)
-- [ ] `cargo clippy --workspace --all-targets -- -D warnings`
-- [ ] `cargo test --workspace --profile test-fast`
+- [ ] `cargo clippy --workspace --all-targets --features metal,accelerate -- -D warnings`
+- [ ] `cargo test --workspace --profile test-fast --features metal,accelerate --no-fail-fast -- --test-threads=1`
 - [ ] `cargo deny check`
 - [ ] Validated with a real checkpoint (specify which, e.g. `mlx-community/Qwen3.5-0.8B-OptiQ-4bit`): ...
 - [ ] If the change moves the numbers (quantization, kernel selection, fused ops, block widths), traced it: disagreement at decided positions, and the width and context it was traced at. See [Judging a change that moves the numbers](../docs/benchmarks.md#judging-a-change-that-moves-the-numbers).


### PR DESCRIPTION
## Summary

Copies the clippy and test commands from the CONTRIBUTING.md local quality gates into the PR template's checklist, so a contributor who follows the template runs the same `--features metal,accelerate` build and the same serialized (`--no-fail-fast -- --test-threads=1`) test run that the contributor guide requires.

## Related issues

Closes #1232

## Type of change

- [x] `docs` — documentation only

## Test plan

- [x] Verified with `grep -F` that both template lines are byte-identical to the corresponding lines in `CONTRIBUTING.md`
- [x] `cargo fmt --all -- --check`
- [x] Full local gate from CONTRIBUTING.md on a Metal MLX build, run on a local branch that merges all eight re-implementation PRs (#1583, #1584, #1585, #1586, #1587, #1589, #1590, #1591) onto `main`: `cargo clippy --workspace --all-targets --features metal,accelerate -- -D warnings` (clean) and `cargo test --workspace --profile test-fast --features metal,accelerate --no-fail-fast -- --test-threads=1` (114 test binaries, 10385 passed, 0 failed, 326 ignored)

## Notes for reviewers

This re-implements the closed PR #1238 against current `main`. The template still lists `cargo clippy` and `cargo test` as checkboxes even though CONTRIBUTING.md notes they are not gated at PR time; that is intentional, since CONTRIBUTING.md asks contributors to run them locally before pushing.
