### PR TITLE
docs: correct the MLXCEL_DEVICE row in installation.md

### DIFF
--- a/docs/installation.md
+++ b/docs/installation.md
@@ -271,7 +271,7 @@ MLXCEL_CXX_MARCH=none cargo build --release --features cuda
 | `MLXCEL_CUTLASS_DIR` | Override for the bundled CUTLASS/CuTe header dir used by the CUDA NVRTC JIT for quantized matmul kernels | bundled `<exe-dir>/../include`, then build-time fallback |
 | `MLX_PTX_CACHE_DIR` | On-disk cache for JIT-compiled CUDA kernels | system temp dir |
 | `MLXCEL_QUIET_JIT` | Suppress the one-time "compiling CUDA kernels" notice on a cold first run | unset (notice shown) |
-| `MLXCEL_DEVICE` | Runtime device hint (`gpu` or `cpu`) | auto |
+| `MLXCEL_DEVICE` | Runtime device hint (`gpu`, `metal`, or `cpu`) | `gpu` |
 | `MLXCEL_WIRED_LIMIT` | Apple Silicon wired-memory ceiling, e.g. `64GB`; `0`/`none` disables it | `max` |
 | `LLAMA_ARG_*` | Environment-backed server options accepted by clap | unset |
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -48,7 +48,7 @@ use mlxcel::lang_bias::LangBiasCliArgs;
     long_about = None,
     after_help = "\
 Environment Variables:
-  MLXCEL_DEVICE          Runtime device: \"gpu\" (default), \"cpu\"
+  MLXCEL_DEVICE          Runtime device: \"gpu\" (default), \"metal\", \"cpu\"
   MLXCEL_WIRED_LIMIT     Apple Silicon wired memory limit
                            unset/\"max\", use MLX gpu_max_memory_size (default)
                            \"0\"/\"none\", disable the wired limit


### PR DESCRIPTION
## Summary

Corrects the `MLXCEL_DEVICE` row in `docs/installation.md` (default was documented as `auto`, and `metal` was missing from the accepted values) and adds `metal` to the `mlxcel --help` environment-variable line, so installation.md, environment-variables.md and the CLI help all match `parse_runtime_device` in `src/execution/runtime.rs`.

## Related issues

Closes #1223

## Type of change

- [x] `docs` — documentation only

## Test plan

- [x] `cargo fmt --all -- --check`
- [x] `cargo check --workspace --all-targets --features metal,accelerate` (initially on a CPU-only MLX build via `MLXCEL_BUILD_METAL=OFF`; superseded by the Metal gate below)
- [x] Cross-checked against `src/execution/runtime.rs`: unset resolves to `RuntimeDevice::Gpu`, and `"gpu" | "metal"` both map to `RuntimeDevice::Gpu`
- [x] Full local gate from CONTRIBUTING.md on a Metal MLX build, run on a local branch that merges all eight re-implementation PRs (#1583, #1584, #1585, #1586, #1587, #1589, #1590, #1591) onto `main`: `cargo clippy --workspace --all-targets --features metal,accelerate -- -D warnings` (clean) and `cargo test --workspace --profile test-fast --features metal,accelerate --no-fail-fast -- --test-threads=1` (114 test binaries, 10385 passed, 0 failed, 326 ignored)

## Notes for reviewers

This re-implements the closed PR #1239 against current `main`. The hint text in `src/cli/ggml_compat_args.rs` (`MLXCEL_DEVICE=gpu|cpu to choose the execution device`) was left as is since it describes the two execution choices rather than enumerating every accepted spelling; say the word if you would like `metal` added there too.
