### PR TITLE
docs: replace opaque (A4)/(B11) task codes in code comments

### DIFF
--- a/src/bin/mlx_server.rs
+++ b/src/bin/mlx_server.rs
@@ -2108,7 +2108,7 @@ fn build_startup_input(mut args: ServerArgs) -> anyhow::Result<ServerStartupInpu
     env_fallback_apc_num_blocks(&mut args.apc_num_blocks);
     env_fallback_apc_hash(&mut args.apc_hash);
 
-    // (B11): env-var fallbacks for KV cache type split flags.
+    // Env-var fallbacks for KV cache type split flags.
     // LLAMA_ARG_CACHE_TYPE_K / LLAMA_ARG_CACHE_TYPE_V are the canonical env
     // vars matching llama.cpp; the clap `env = "..."` attribute on the arg
     // also reads them directly, so these helpers are only needed when the CLI
@@ -2617,7 +2617,7 @@ fn build_startup_input(mut args: ServerArgs) -> anyhow::Result<ServerStartupInpu
         apc_block_size: args.apc_block_size,
         apc_num_blocks: args.apc_num_blocks,
         apc_hash: args.apc_hash,
-        // (B11): KV cache type split flags already resolved via
+        // KV cache type split flags already resolved via
         // env-var fallbacks (and clap `env = "..."`) above.
         cache_type_k: args.turbo.cache_type_k,
         cache_type_v: args.turbo.cache_type_v,
@@ -2647,7 +2647,7 @@ fn build_startup_input(mut args: ServerArgs) -> anyhow::Result<ServerStartupInpu
         conversation_store_max_entries: args.conversation_store_max_entries,
         conversation_store_max_bytes: args.conversation_store_max_bytes,
         conversation_store_ttl_secs: args.conversation_store_ttl_secs,
-        // (A4): forward the surgery YAML path. clap reads
+        // Forward the surgery YAML path. clap reads
         // `MLXCEL_SURGERY` directly via the `env = ...` attribute on
         // the flag, so no separate env-fallback helper is needed.
         #[cfg(feature = "surgery")]

--- a/src/cli/turbo_args.rs
+++ b/src/cli/turbo_args.rs
@@ -182,7 +182,7 @@ impl TurboKvCacheArgs {
     }
 }
 
-// ── (B11)   KV cache type split flags ─────────────────────────────
+// ── KV cache type split flags ────────────────────────────────────
 // (Comment kept in non-doc form for code-archeology only; the user-facing
 // help text intentionally omits closed-repo issue numbers.)
 

--- a/src/commands/generate_tests.rs
+++ b/src/commands/generate_tests.rs
@@ -616,7 +616,7 @@ fn sample_generate_args(model_path: PathBuf) -> crate::GenerateArgs {
         },
         lang_bias: mlxcel::lang_bias::LangBiasCliArgs::default(),
         speculative: mlxcel::cli::speculative_args::SpeculativeArgs::default(),
-        // (A4): default to None so existing tests stay on
+        // Default to None so existing tests stay on
         // the bit-exact baseline load path; tests that need surgery
         // override this field explicitly.
         #[cfg(feature = "surgery")]

--- a/src/commands/serve.rs
+++ b/src/commands/serve.rs
@@ -440,7 +440,7 @@ fn build_startup_input(mut args: crate::ServeArgs) -> anyhow::Result<ServerStart
     env_fallback_apc_block_size(&mut args.apc_block_size);
     env_fallback_apc_num_blocks(&mut args.apc_num_blocks);
     env_fallback_apc_hash(&mut args.apc_hash);
-    // (B11): env-var fallbacks for KV cache type split flags.
+    // Env-var fallbacks for KV cache type split flags.
     // The clap `env = "..."` attribute already reads these env vars; the
     // explicit calls below maintain the warn-on-conflict pattern used by
     // other LLAMA_ARG_* pairs.
@@ -739,7 +739,7 @@ fn build_startup_input(mut args: crate::ServeArgs) -> anyhow::Result<ServerStart
         apc_block_size: args.apc_block_size,
         apc_num_blocks: args.apc_num_blocks,
         apc_hash: args.apc_hash,
-        // (B11): KV cache type split flags already resolved via
+        // KV cache type split flags already resolved via
         // env-var fallbacks (and clap `env = "..."`) above.
         cache_type_k: args.turbo.cache_type_k,
         cache_type_v: args.turbo.cache_type_v,
@@ -770,7 +770,7 @@ fn build_startup_input(mut args: crate::ServeArgs) -> anyhow::Result<ServerStart
         conversation_store_max_entries: args.conversation_store_max_entries,
         conversation_store_max_bytes: args.conversation_store_max_bytes,
         conversation_store_ttl_secs: args.conversation_store_ttl_secs,
-        // (A4): forward the surgery YAML path. clap reads
+        // Forward the surgery YAML path. clap reads
         // `MLXCEL_SURGERY` directly via the `env = ...` attribute on
         // the flag, so no separate env-fallback helper is needed.
         #[cfg(feature = "surgery")]

--- a/src/commands/serve_tests.rs
+++ b/src/commands/serve_tests.rs
@@ -212,7 +212,7 @@ fn sample_args() -> crate::ServeArgs {
         conversation_store_max_bytes:
             mlxcel::server::conversation_store::DEFAULT_CONVERSATION_STORE_MAX_BYTES,
         conversation_store_ttl_secs: 3600,
-        // (A4): keep tests on the baseline path by default.
+        // Keep tests on the baseline path by default.
         #[cfg(feature = "surgery")]
         surgery: None,
         // serve-level diffusion knobs (#217 phase 3): engine defaults in tests.

--- a/src/lib/mlxcel-surgery/src/config.rs
+++ b/src/lib/mlxcel-surgery/src/config.rs
@@ -234,7 +234,7 @@ pub fn parse_config_str(
 /// [`SurgeryPipeline`]. Relative `source*` paths in the YAML are
 /// resolved against the file's parent directory.
 ///
-/// Used by: future CLI wiring (A4), `mlxcel surgery validate` (A4),
+/// Used by: the `--surgery` CLI wiring, `mlxcel surgery validate`,
 /// integration tests in this crate
 pub fn parse_config_file<P: AsRef<Path>>(path: P) -> Result<SurgeryPipeline, SurgeryError> {
     let path = path.as_ref();

--- a/src/lib/mlxcel-surgery/tests/interpolate_integration.rs
+++ b/src/lib/mlxcel-surgery/tests/interpolate_integration.rs
@@ -143,7 +143,7 @@ operations:
     fs::write(&yaml_path, yaml).expect("write yaml");
 
     // 3. Parse the YAML — this is the exact entry point the CLI
-    //    flag (A4) will invoke.
+    //    flag will invoke.
     let pipeline: SurgeryPipeline = parse_config_file(&yaml_path).expect("parse_config_file");
     assert_eq!(pipeline.len(), 1);
 

--- a/src/loading/vlm.rs
+++ b/src/loading/vlm.rs
@@ -219,7 +219,7 @@ pub(super) fn require_object_mut<'a>(
 /// remap which runs in the caller after we return). Surgery operations
 /// inspecting dtype therefore see the dtype the model graph will see.
 ///
-/// ## Active-pipeline fallback (— A4)
+/// ## Active-pipeline fallback
 ///
 /// When the explicit `transform` argument is `None` *and* the
 /// `surgery` feature is enabled *and* the CLI has installed an active
@@ -319,7 +319,7 @@ fn finish_vlm_weights_common(
     // surgery slot are absent, the hook is bypassed entirely and the
     // load path matches the earlier baseline bit-for-bit.
     //
-    // Resolution order (A4) mirrors `load_text_weights`:
+    // Resolution order mirrors `load_text_weights`:
     //   1. Explicit `transform` argument (test fixtures, programmatic).
     //   2. CLI-installed active pipeline (--surgery flag).
     //   3. Baseline — no transform applied.

--- a/src/main_tests.rs
+++ b/src/main_tests.rs
@@ -403,7 +403,7 @@ fn generate_command_parses_tensor_parallel_flags() {
     assert_eq!(args.tensor_parallel.tp_lm_head_mode, "replicated");
 }
 
-// (A4): CLI argument-parsing tests for the `--surgery <FILE>`
+// CLI argument-parsing tests for the `--surgery <FILE>`
 // flag on the `generate` and `serve` subcommands. These tests only cover
 // the clap surface — they do not invoke the surgery pipeline or touch
 // any model weights. The end-to-end behavior is exercised by the

--- a/src/models/sanitize.rs
+++ b/src/models/sanitize.rs
@@ -1577,7 +1577,7 @@ pub fn load_and_sanitize_weights<P: AsRef<std::path::Path>>(
 /// see them. When `transform` is `None` the call is bit-exact identical
 /// to the pre-refactor `load_and_sanitize_weights` path.
 ///
-/// ## Active-pipeline fallback (— A4)
+/// ## Active-pipeline fallback
 ///
 /// When the explicit `transform` parameter is `None` *and* the
 /// `surgery` feature is enabled *and* the CLI has installed an active
@@ -1649,7 +1649,7 @@ pub fn load_text_weights<P: AsRef<std::path::Path>>(
     // and before precision conversion so transforms observe weights in
     // their final tied/dequantized layout.
     //
-    // Resolution order (A4):
+    // Resolution order:
     //   1. Explicit `transform` argument — used as-is (test fixtures and
     //      future programmatic callers that want to bypass the global slot).
     //   2. `surgery` feature active + CLI-installed active pipeline —

--- a/src/models/sanitize_tests.rs
+++ b/src/models/sanitize_tests.rs
@@ -748,7 +748,7 @@ fn load_text_weights_with_none_transform_matches_legacy_path() {
     // doubles as a regression guard against accidental divergence
     // between the alias and the new entry point.
     //
-    // (A4): the `load_text_weights(_, None)` call below
+    // The `load_text_weights(_, None)` call below
     // reads the process-global active-pipeline slot. Acquire
     // `env_lock` so a parallel test in `surgery_integration` can't
     // install a pipeline mid-test and leak it into the consolidated
@@ -832,7 +832,7 @@ fn load_text_weights_invokes_transform_when_supplied() {
     // transform the produced `WeightMap` must match the `None` path
     // bit-for-bit.
     //
-    // (A4): baseline call reads the active-pipeline slot,
+    // The baseline call reads the active-pipeline slot,
     // so we need the same `env_lock` discipline as the other tests
     // touching `load_text_weights(_, None)`.
     #[cfg(feature = "surgery")]
@@ -944,7 +944,7 @@ mod surgery_integration {
         // really does implement A1's `WeightTransform` trait at the
         // type level (the call would not type-check otherwise).
         //
-        // (A4): `load_text_weights(_, None)` reads the
+        // `load_text_weights(_, None)` reads the
         // process-global active-pipeline slot, so any test that calls
         // it must serialise on the same `env_lock` as the tests that
         // mutate the slot — otherwise a parallel mutator can leak a
@@ -1287,7 +1287,7 @@ operations:
         }
     }
 
-    /// (A4): when the CLI installs an active pipeline via
+    /// When the CLI installs an active pipeline via
     /// `crate::surgery::set_active_pipeline`, the consolidated loader
     /// must pick it up for `load_text_weights(_, None)` callers. This
     /// is the integration glue that lets `mlxcel generate --surgery
@@ -1341,7 +1341,7 @@ operations:
         std::fs::remove_dir_all(&dir_with_slot).unwrap();
     }
 
-    /// (A4): explicit `transform` argument takes precedence
+    /// The explicit `transform` argument takes precedence
     /// over the active-pipeline slot. This is the contract callers
     /// (e.g. future programmatic users and the existing integration tests) rely on to bypass the global slot.
     #[test]

--- a/src/server/cli_input.rs
+++ b/src/server/cli_input.rs
@@ -368,7 +368,7 @@ pub struct ServerStartupInput {
     /// consistently.
     pub chat_template_kwargs: Option<String>,
 
-    // (B11): llama-server-compatible K/V cache type split flags.
+    // llama-server-compatible K/V cache type split flags.
     //
     // These hold the raw CLI strings from `--cache-type-k` / `--cache-type-v`
     // (and their env var aliases `LLAMA_ARG_CACHE_TYPE_K` /
@@ -559,7 +559,7 @@ pub struct ServerStartupInput {
     /// `--conversation-store-ttl-secs` value (`0` disables TTL).
     pub conversation_store_ttl_secs: u64,
 
-    /// (A4): path to a YAML weight-load surgery configuration.
+    /// Path to a YAML weight-load surgery configuration.
     ///
     /// `None` (the default) keeps the server on the bit-exact baseline
     /// weight-load path — no surgery crate work, no observable
@@ -845,7 +845,7 @@ impl ServerStartupInput {
         )
         .map_err(|e| anyhow::anyhow!("--apc-hash: {e}"))?;
 
-        // (B11): resolve the effective KV cache mode from split flags,
+        // Resolve the effective KV cache mode from split flags,
         // legacy shorthand, or the default (FP16).
         let kv_cache_mode = resolve_kv_cache_mode(
             self.cache_type_k.as_deref(),
@@ -1168,7 +1168,7 @@ impl ServerStartupInput {
             conversation_store_max_entries: self.conversation_store_max_entries,
             conversation_store_max_bytes: self.conversation_store_max_bytes,
             conversation_store_ttl_secs: self.conversation_store_ttl_secs,
-            // (A4): forward the surgery YAML path verbatim.
+            // Forward the surgery YAML path verbatim.
             // start_server() parses the YAML and installs the pipeline
             // exactly once before spawning the model worker.
             #[cfg(feature = "surgery")]

--- a/src/server/cli_input_tests.rs
+++ b/src/server/cli_input_tests.rs
@@ -198,7 +198,7 @@ fn sample_input() -> ServerStartupInput {
         apc_block_size: None,
         apc_num_blocks: None,
         apc_hash: None,
-        // (B11): KV cache type split flags — default to None (FP16).
+        // KV cache type split flags — default to None (FP16).
         cache_type_k: None,
         cache_type_v: None,
         kv_cache_mode_legacy: None,
@@ -224,7 +224,7 @@ fn sample_input() -> ServerStartupInput {
         conversation_store_max_bytes:
             crate::server::conversation_store::DEFAULT_CONVERSATION_STORE_MAX_BYTES,
         conversation_store_ttl_secs: 3600,
-        // (A4): default to None for baseline-path tests.
+        // Surgery config path defaults to None for baseline-path tests.
         #[cfg(feature = "surgery")]
         surgery_config_path: None,
         // serve-level diffusion knobs (#217 phase 3): engine defaults in tests.
@@ -1353,7 +1353,7 @@ fn prompt_cache_e2e_cli_capacity_bytes_flows_to_startup_config() {
 }
 
 // ─────────────────────────────────────────────────────────────────────────────
-// (B11) — resolve_kv_cache_mode tests
+// resolve_kv_cache_mode tests
 //
 // These tests cover the K/V-to-KVCacheMode mapping logic: all supported pairs,
 // unsupported combinations, and legacy/split flag interaction.
@@ -1567,7 +1567,7 @@ fn into_startup_config_kv_cache_mode_unsupported_pair_errors() {
 }
 
 // ─────────────────────────────────────────────────────────────────────────────
-// (B11) — env-var fallback tests for LLAMA_ARG_CACHE_TYPE_K/V
+// env-var fallback tests for LLAMA_ARG_CACHE_TYPE_K/V
 // ─────────────────────────────────────────────────────────────────────────────
 
 /// `LLAMA_ARG_CACHE_TYPE_K` is applied when the CLI flag is absent.

--- a/src/server/config.rs
+++ b/src/server/config.rs
@@ -851,7 +851,7 @@ pub struct ServerConfig {
     /// the policy via the Rust API or keep the default.
     pub prompt_cache: crate::server::prompt_cache::PromptCacheConfig,
 
-    /// (B11): server-wide KV cache mode.
+    /// Server-wide KV cache mode.
     ///
     /// Resolved from `--cache-type-k`/`--cache-type-v` (llama-server split
     /// flags) or the legacy `--kv-cache-mode` shorthand.  Defaults to

--- a/src/server/model_worker.rs
+++ b/src/server/model_worker.rs
@@ -108,7 +108,7 @@ pub(crate) struct WorkerSchedulerConfig {
     /// scheduler can adopt detached prefixes on cache hits and donate-back
     /// finished sequences.
     pub prompt_cache: Option<Arc<crate::server::prompt_cache::PromptCacheStore>>,
-    /// (B11) / server-wide KV cache quantization mode.
+    /// Server-wide KV cache quantization mode.
     ///
     /// Defaults to [`mlxcel_core::cache::KVCacheMode::Fp16`] (bit-exact
     /// baseline). When a Turbo4 variant is configured, the scheduler

--- a/src/server/startup.rs
+++ b/src/server/startup.rs
@@ -437,7 +437,7 @@ pub struct ServerStartupConfig {
     /// (enabled, 2 GiB cap, 1024 entries, 3600 s TTL, 32 token min).
     pub prompt_cache: super::prompt_cache::PromptCacheConfig,
 
-    /// (B11): resolved KV cache mode for per-sequence cache
+    /// Resolved KV cache mode for per-sequence cache
     /// construction.
     ///
     /// Resolved from `--cache-type-k`/`--cache-type-v` (split flags,
@@ -527,7 +527,7 @@ pub struct ServerStartupConfig {
     /// disables TTL.
     pub conversation_store_ttl_secs: u64,
 
-    /// (A4): resolved path to a YAML weight-load surgery
+    /// Resolved path to a YAML weight-load surgery
     /// configuration. `None` keeps the bit-exact baseline load path.
     ///
     /// The path is parsed into a [`mlxcel_surgery::SurgeryPipeline`]
@@ -1572,7 +1572,7 @@ pub(super) fn build_server_config(
         // wire the CLI/env-resolved policy through instead of
         // always using the compiled-in default.
         prompt_cache: startup.prompt_cache.clone(),
-        // (B11): wire the resolved KV cache mode through so the
+        // Wire the resolved KV cache mode through so the
         // model worker can apply it when constructing per-sequence generators.
         kv_cache_mode: startup.kv_cache_mode,
         // wire the resolved batch KV quant config through so

--- a/src/surgery.rs
+++ b/src/surgery.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//! Axis A "weight-load surgery" CLI integration glue (— A4).
+//! Axis A "weight-load surgery" CLI integration glue.
 //!
 //! This module owns the **active-pipeline slot**: a process-wide
 //! `Option<Arc<SurgeryPipeline>>` set by the CLI/server entry points


### PR DESCRIPTION
## Summary

Removes the internal `(A4)` and `(B11)` task codes from doc comments and inline comments so the rendered rustdoc reads as plain sentences. `A4` was the `--surgery` CLI wiring and `B11` the llama-server `--cache-type-k/--cache-type-v` split flags; the commits that introduced them had their issue references scrubbed, so there is no public `(issue #NNN)` to substitute and the prefixes are simply dropped.

## Related issues

Closes #1234

## Type of change

- [x] `docs` — documentation only

## Test plan

- [x] `cargo fmt --all -- --check`
- [x] `cargo check --workspace --all-targets --features metal,accelerate` (initially on a CPU-only MLX build via `MLXCEL_BUILD_METAL=OFF`; superseded by the Metal gate below)
- [x] `grep -rnE '\((— )?(A4|B11)\)|\((A4|B11):' src/` returns nothing
- [x] Full local gate from CONTRIBUTING.md on a Metal MLX build, run on a local branch that merges all eight re-implementation PRs (#1583, #1584, #1585, #1586, #1587, #1589, #1590, #1591) onto `main`: `cargo clippy --workspace --all-targets --features metal,accelerate -- -D warnings` (clean) and `cargo test --workspace --profile test-fast --features metal,accelerate --no-fail-fast -- --test-threads=1` (114 test binaries, 10385 passed, 0 failed, 326 ignored)

## Notes for reviewers

This re-implements the closed PR #1240 against current `main`. The issue listed six sites; a full grep found 23 parenthesized occurrences across 17 files (`src/server`, `src/bin/mlx_server.rs`, `src/commands/serve.rs`, `src/cli/turbo_args.rs`, `src/loading`, `src/models`, `mlxcel-surgery`), all handled here. Bare narrative mentions such as "once A4's `--surgery` flag lands" in the `mlxcel-surgery` integration-test module docs are left alone: they are stale in a different way (the flag has landed) and deserve their own rewrite rather than a mechanical prefix drop.
