### PR TITLE
refactor(loading): remove dead is_special_weight_model_type wrapper

### DIFF
--- a/src/loading/special.rs
+++ b/src/loading/special.rs
@@ -100,11 +100,6 @@ fn special_weight_loader_kind(model_type: ModelType) -> Option<SpecialWeightLoad
     }
 }
 
-#[allow(dead_code)]
-pub(crate) fn is_special_weight_model_type(model_type: ModelType) -> bool {
-    model_metadata::is_special_weight_model_type(model_type)
-}
-
 pub(crate) fn try_load_special_model_from_weights(
     model_type: ModelType,
     model_path: &Path,


### PR DESCRIPTION
## Summary

Deletes the dead `is_special_weight_model_type` pass-through wrapper in `src/loading/special.rs`, together with the `#[allow(dead_code)]` that kept it compiling. The only consumer of the predicate, `src/model_metadata_tests.rs`, already calls the `model_metadata` original.

## Related issues

Closes #1225

## Type of change

- [x] `refactor` — internal restructuring without behavior change

## Test plan

- [x] `cargo fmt --all -- --check`
- [x] `cargo check --workspace --all-targets --features metal,accelerate` (initially on a CPU-only MLX build via `MLXCEL_BUILD_METAL=OFF`; superseded by the Metal gate below)
- [x] `cargo test --features metal,accelerate -p mlxcel --lib model_metadata_tests` (7 passed)
- [x] `grep -rn is_special_weight_model_type src/` now matches only `src/model_metadata.rs` and `src/model_metadata_tests.rs`
- [x] Full local gate from CONTRIBUTING.md on a Metal MLX build, run on a local branch that merges all eight re-implementation PRs (#1583, #1584, #1585, #1586, #1587, #1589, #1590, #1591) onto `main`: `cargo clippy --workspace --all-targets --features metal,accelerate -- -D warnings` (clean) and `cargo test --workspace --profile test-fast --features metal,accelerate --no-fail-fast -- --test-threads=1` (114 test binaries, 10385 passed, 0 failed, 326 ignored)

## Notes for reviewers

This re-implements the closed PR #1237 against current `main`. Not an inference change, so no real-checkpoint validation applies.
