### PR TITLE
refactor(server): remove unused build_failed_response helper

### DIFF
--- a/src/server/responses_translator.rs
+++ b/src/server/responses_translator.rs
@@ -762,42 +762,6 @@ pub(crate) fn short_uuid() -> String {
     raw.chars().take(16).collect()
 }
 
-/// Convenience entry point for the route layer: build a response object
-/// representing an error that occurred mid-generation.
-#[allow(dead_code)]
-pub fn build_failed_response(
-    id: String,
-    model: String,
-    created_at: f64,
-    error_code: &str,
-    error_message: &str,
-    request: &CreateResponseRequest,
-) -> ResponseObject {
-    let ctx = OutboundContext {
-        response_id: id,
-        model_id: model,
-        created_at,
-        completed_at: created_at,
-        status: ResponseStatus::Failed,
-        prompt_tokens: 0,
-        completion_tokens: 0,
-        cached_tokens: 0,
-        reasoning_tokens: 0,
-        text: String::new(),
-        reasoning_text: None,
-        parsed_tool_calls: None,
-        max_tool_calls: None,
-        request,
-        error: Some(ResponseErrorBody {
-            code: error_code.to_string(),
-            message: error_message.to_string(),
-        }),
-        incomplete_reason: None,
-        finish_reason: "error".to_string(),
-    };
-    build_response_object(ctx)
-}
-
 #[cfg(test)]
 mod tests {
     use std::collections::HashMap;


### PR DESCRIPTION
## Summary

Removes the never-called `build_failed_response` helper from `src/server/responses_translator.rs`, taking the "delete" branch of #1226. The `/v1/responses` route layer already reports mid-generation failures as HTTP `ErrorResponse`s via `generation_error_to_response`, so there is no place a failed `ResponseObject` builder would be used without changing the endpoint's error contract.

## Related issues

Closes #1226

## Type of change

- [x] `refactor` — internal restructuring without behavior change

## Test plan

- [x] `cargo fmt --all -- --check`
- [x] `cargo check --workspace --all-targets --features metal,accelerate` (initially on a CPU-only MLX build via `MLXCEL_BUILD_METAL=OFF`; superseded by the Metal gate below). No new warnings, so no import went stale.
- [x] `cargo test --features metal,accelerate -p mlxcel --lib server::responses_translator` (24 passed)
- [x] `grep -rn build_failed_response src/ docs/` returns nothing
- [x] Full local gate from CONTRIBUTING.md on a Metal MLX build, run on a local branch that merges all eight re-implementation PRs (#1583, #1584, #1585, #1586, #1587, #1589, #1590, #1591) onto `main`: `cargo clippy --workspace --all-targets --features metal,accelerate -- -D warnings` (clean) and `cargo test --workspace --profile test-fast --features metal,accelerate --no-fail-fast -- --test-threads=1` (114 test binaries, 10385 passed, 0 failed, 326 ignored)

## Notes for reviewers

This re-implements the closed PR #1246 against current `main`. If a failed `ResponseObject` shape is wanted on `/v1/responses` in the future, it is a five-line `OutboundContext` construction with `status: ResponseStatus::Failed` and `error: Some(..)`, and should be added together with the route change and a test rather than kept as an uncalled helper.
