### PR TITLE
chore(cli): unify error-message capitalization across CLI commands

### DIFF
--- a/src/commands/chat.rs
+++ b/src/commands/chat.rs
@@ -306,7 +306,7 @@ pub fn run_chat(mut opts: ChatOptions) -> Result<()> {
     )?;
 
     let mut editor = DefaultEditor::new()
-        .map_err(|e| anyhow!("failed to initialize the interactive line editor: {e}"))?;
+        .map_err(|e| anyhow!("Failed to initialize the interactive line editor: {e}"))?;
     let interactive = io::stdin().is_terminal();
 
     print_banner(interactive);

--- a/src/commands/detect.rs
+++ b/src/commands/detect.rs
@@ -53,11 +53,11 @@ pub(crate) fn run_detect(args: DetectArgs) -> Result<()> {
     let _runtime = initialize_runtime_checked()?;
 
     let predictor = RtDetrV2Predictor::from_pretrained(&args.model, args.threshold)
-        .map_err(|e| anyhow!("failed to load RT-DETRv2 model: {e}"))?;
+        .map_err(|e| anyhow!("Failed to load RT-DETRv2 model: {e}"))?;
 
     let result = predictor
         .predict_path(&args.image)
-        .map_err(|e| anyhow!("detection failed: {e}"))?;
+        .map_err(|e| anyhow!("Detection failed: {e}"))?;
 
     let mut detections = result.detections;
     sort_reading_order(&mut detections);

--- a/src/commands/generate.rs
+++ b/src/commands/generate.rs
@@ -509,7 +509,7 @@ fn generate_pipeline_text(
         )])?
         .into_iter()
         .next()
-        .ok_or_else(|| anyhow!("pipeline worker loop did not return a prefill output"))?
+        .ok_or_else(|| anyhow!("Pipeline worker loop did not return a prefill output"))?
         .logits;
     let prefill_elapsed = prefill_start.elapsed();
 
@@ -547,7 +547,7 @@ fn generate_pipeline_text(
             )])?
             .into_iter()
             .next()
-            .ok_or_else(|| anyhow!("pipeline worker loop did not return a decode output"))?
+            .ok_or_else(|| anyhow!("Pipeline worker loop did not return a decode output"))?
             .logits;
     }
 
@@ -647,7 +647,7 @@ pub(super) fn validate_muse_glimmer_cli_unsupported_options(
 
 fn template_rejection_cli_error(err: &anyhow::Error) -> Option<anyhow::Error> {
     template_rejection_message(err)
-        .map(|message| anyhow!("chat template rejected the request: {message}"))
+        .map(|message| anyhow!("Chat template rejected the request: {message}"))
 }
 
 fn apply_user_chat_template(
@@ -1286,7 +1286,7 @@ fn decode_xla_cli_images(paths: &[std::path::PathBuf]) -> Result<Vec<image::Dyna
     let read_limit = limits
         .max_payload_bytes
         .checked_add(1)
-        .ok_or_else(|| anyhow!("configured image payload limit overflowed"))?;
+        .ok_or_else(|| anyhow!("Configured image payload limit overflowed"))?;
     let mut payloads = Vec::with_capacity(paths.len());
     for path in paths {
         let mut bytes = Vec::new();

--- a/src/commands/generate_falcon_ocr.rs
+++ b/src/commands/generate_falcon_ocr.rs
@@ -412,7 +412,7 @@ pub(crate) fn run_falcon_ocr_layout_generation(
             .with_context(|| format!("Failed to decode image {image_path:?}"))?;
     let page = images
         .pop()
-        .ok_or_else(|| anyhow!("image decoding returned no image for {image_path:?}"))?;
+        .ok_or_else(|| anyhow!("Image decoding returned no image for {image_path:?}"))?;
 
     // Planned without cropping, then cropped one region at a time below. A crop
     // copies, so materializing the whole plan up front would hold one full-size

--- a/src/commands/generate_florence2.rs
+++ b/src/commands/generate_florence2.rs
@@ -77,7 +77,7 @@ pub(crate) fn run_florence2_generation(
             .with_context(|| format!("Failed to decode image {image_path:?}"))?;
     let image = images
         .pop()
-        .ok_or_else(|| anyhow!("image decoding returned no image for {image_path:?}"))?;
+        .ok_or_else(|| anyhow!("Image decoding returned no image for {image_path:?}"))?;
 
     print_generation_preamble(user_prompt)?;
     println!();

--- a/src/commands/generate_tests.rs
+++ b/src/commands/generate_tests.rs
@@ -312,7 +312,7 @@ fn resolve_cli_prompt_returns_template_rejections() {
 
     assert_eq!(
         err.to_string(),
-        "chat template rejected the request: unsupported caller value"
+        "Chat template rejected the request: unsupported caller value"
     );
 }
 

--- a/src/commands/models.rs
+++ b/src/commands/models.rs
@@ -566,7 +566,7 @@ fn confirm_removal(repo_id: &str, path: &str, size: &str) -> Result<bool> {
     let mut answer = String::new();
     std::io::stdin()
         .read_line(&mut answer)
-        .map_err(|e| anyhow!("failed to read confirmation: {e}"))?;
+        .map_err(|e| anyhow!("Failed to read confirmation: {e}"))?;
     let answer = answer.trim().to_ascii_lowercase();
     Ok(answer == "y" || answer == "yes")
 }


### PR DESCRIPTION
## Summary

Capitalizes the first word of the ten top-level `anyhow!` error messages in `src/commands/*.rs` that still started lowercase, so every CLI command prints errors in the same style as the majority (`Tokenization failed: ...`). One exact-match assertion in `generate_tests.rs` is updated to match.

## Related issues

Closes #1236

## Type of change

- [x] `chore` — build, CI, dependencies, release infrastructure

## Test plan

- [x] `cargo fmt --all -- --check`
- [x] `cargo check --workspace --all-targets --features metal,accelerate` (initially on a CPU-only MLX build via `MLXCEL_BUILD_METAL=OFF`; superseded by the Metal gate below)
- [x] `RUST_MIN_STACK=16777216 cargo test --features metal,accelerate -p mlxcel --bin mlxcel commands::` (169 passed; the stack bump is the dev-profile prefix CONTRIBUTING.md documents)
- [x] `grep -rnE 'anyhow!\("[a-z]' src/commands/*.rs` now matches only the one intentional site below
- [x] Full local gate from CONTRIBUTING.md on a Metal MLX build, run on a local branch that merges all eight re-implementation PRs (#1583, #1584, #1585, #1586, #1587, #1589, #1590, #1591) onto `main`: `cargo clippy --workspace --all-targets --features metal,accelerate -- -D warnings` (clean) and `cargo test --workspace --profile test-fast --features metal,accelerate --no-fail-fast -- --test-threads=1` (114 test binaries, 10385 passed, 0 failed, 326 ignored)

## Notes for reviewers

This re-implements the closed PR #1241 against current `main`. One deliberate deviation from the issue's site list: `not valid JSON: {error}` in `generate_falcon_ocr.rs::parse_layout_detections` stays lowercase because its caller prefixes it (`--layout-detections <path>: not valid JSON: ...`), so the user never sees it as the first word of a message. Capitalizing it would produce a mid-sentence capital and also break the two `contains("not valid JSON")` assertions in `generate_falcon_ocr_tests.rs`. Happy to flip it if you would rather have the mechanical rule applied everywhere. The lowercase `bail!` messages in `embed.rs`, `rerank.rs`, `tune.rs` and `generate_falcon_ocr.rs` are outside the issue's `anyhow!` scope and untouched.
