### PR TITLE
fix(server): define tools only when the request sends them

### DIFF
--- a/TECHNICAL_REPORTS/1598-tools-undefined-template-context-20260903.en.md
+++ b/TECHNICAL_REPORTS/1598-tools-undefined-template-context-20260903.en.md
@@ -1,0 +1,220 @@
+# Technical Report: PR #1598 - fix(server): define tools only when the request sends them
+
+**Date**: 2026-09-03
+**Author**: mlxcel maintainers
+**Reviewer**: implementation and security review cycle
+**Status**: Completed (weight-free template parity verified against both shipped checkpoints; the HTTP gate on real weights is run centrally)
+**Languages**: Rust, Markdown
+**Risk Level**: Medium (changes the rendered prompt, and therefore the prompt-cache prefix, for every checkpoint whose template guards on `tools is defined` or `tools is not none`)
+
+---
+
+## Executive Summary
+
+`build_template_context` inserted the `tools` key into the minijinja context unconditionally, and both render paths substituted an empty `Vec<Tool>` when the request carried no tools. Any chat template that decides its tool branch with `tools is defined` or `tools is not none` therefore saw a defined, non-none, empty list and rendered its tool-calling preamble with an empty function list on every plain chat request. Two shipped families do exactly that: DeepSeek V3 derivatives (Youtu-LLM) and Llama 3.1 / 3.2 / 3.3 / 4, which includes the project's base transformer reference checkpoint.
+
+PR #1598 changes `build_template_context` to take `tools: Option<minijinja::Value>` and to insert the key only for `Some`, and normalizes both "no tools" and an explicit `"tools": []` to `None` inside `apply_raw_inner` and `apply_inner`. Undefined rather than `none` is required, not preferred: minijinja's `iterable` test succeeds for `none` while `| length` of `none` errors, so a `none` would abort the Nemotron and MiMo family's renders and silently degrade their prompts to the plain-chat fallback. The result matches transformers (`tools=None`) and llama-server (key unset) for every guard shape in the local corpus.
+
+---
+
+## 1. Problem Statement
+
+### 1.1 Background
+
+Chat templates published on HuggingFace are written against `transformers`, where `apply_chat_template` passes `tools=None` when the caller supplies none. llama-server reaches the same state by a different route: `common_chat_tools_to_json_oaicompat` answers a null JSON value for an empty tool array, and minja's `chat-template.hpp` sets the context key only when that value is non-null. Both engines therefore render a tools-less request against a context where `tools` is absent or `None`, and template authors write their guards on that assumption.
+
+mlxcel did not. `src/server/chat_template.rs` inserted `tools` unconditionally, and the two inner render functions turned `None` into `minijinja::Value::from_serialize(Vec::<Tool>::new())`. The comment beside both call sites explained the empty list as a workaround for `{% if tools is iterable and tools | length > 0 %}`, saying minijinja "still tries to compute `| length` of `none`" despite the short circuit. That reasoning was half right and the conclusion was wrong: minijinja 2.24 does compile `and` as a short circuit (`BinOpKind::ScAnd`), but its `iterable` test is `Value::try_iter().is_ok()`, which succeeds for `none`, so the right-hand side is reached anyway. The workaround fixed that one guard by breaking every `is defined` and `is not none` guard instead.
+
+### 1.2 Measured impact
+
+Measured on `POST /apply-template` with `{"messages":[{"role":"user","content":"The Fibonacci sequence begins with"}]}` and no `tools` key:
+
+| Checkpoint | Guard shape | Rendered before | Oracle (transformers / jinja2 with `tools` undefined) |
+|---|---|---|---|
+| `models/mlx/youtu-llm-2b-4bit` | `tools is defined and tools is not none` | 76 tokens, with an empty `<\|begin_of_tool_description\|>` block between "available:" and "For tool call returns" | 8 tokens |
+| `models/mlx/llama-3.2-1b-4bit` | `{%- if not tools is defined %}{%- set tools = none %}{%- endif %}` then `tools is not none` | 97 tokens, with `Environment: ipython` and the "Given the following functions" user preamble | 40 tokens |
+
+Rendering each checkpoint's own template with Python jinja2 reproduced mlxcel's long output byte for byte only when `tools=[]` was passed, which is the direct confirmation that the empty list, not any other context difference, was the cause. An explicit `"tools": []` in the request body produced the same phantom block, because `effective_tools` forwards the empty slice unchanged.
+
+### 1.3 Consequences
+
+- **Prompt inflation.** The preamble costs 68 tokens on Youtu and 57 on Llama 3.2 for a one-line message, on every request.
+- **Wrong steering.** The model is told it may call functions and given the call syntax, with no functions to call. Greedy output diverged from the mlx-lm oracle after 12 tokens on one Youtu prompt and 5 on another; feeding the 8-token oracle prompt through raw `/completion` matched the oracle 32 of 32.
+- **Cache pollution.** The preamble sits in `tokens[..prefix_len]` of every prompt-cache key for these models and in the history-boundary render the cache snapshots on, so every entry for an affected model was keyed on a prompt the model should never have seen.
+- **Silent.** The rendered prompt is fluent and the request succeeds, so nothing in the logs or the response shape reports the divergence. It is only visible against an external oracle or in `usage.prompt_tokens`.
+
+---
+
+## 2. Technical Review
+
+### 2.1 Root cause
+
+One line: `ctx.insert("tools", tools);` in `build_template_context`, fed by two `match tools { None => Vec::<Tool>::new() }` substitutions. The key's *definedness*, not its value, is what three of the seven guard families in the local corpus branch on, and the code had no way to express "absent".
+
+### 2.2 The guard-shape corpus
+
+Probing the local templates with the pinned minijinja version for each candidate value of `tools` gives the decision table this fix is built on:
+
+| Guard shape | Representative checkpoints | `[]` (before) | `none` | undefined (after) |
+|---|---|---|---|---|
+| `tools is defined and tools is not none` | youtu-llm-2b-4bit | phantom block | ok | ok |
+| `set tools = none` when undefined, then `tools is not none` | meta-llama-3.1-8b-instruct-4bit, llama-3.2-1b-4bit, llama-4-scout-17b-4bit | phantom block | ok | ok |
+| `set tools = []` when undefined, then `tools is iterable and tools \| length > 0` | nemotron-3-nano-omni-30b-a3b-reasoning-4bit, nemotron-h-30b-4bit, mimo-v2-flash-4bit | ok | render error | ok |
+| `not tools is defined or tools is none` sets `[]`, then the same iterable guard | seed-oss-36b-instruct-4bit | ok | ok | ok |
+| `if tools` / `tools and tools is iterable and tools is not mapping` | Qwen 2.5 / 3 / 3.5 and later | ok | ok | ok |
+| `tools is defined and tools is not none and tools\|length > 0` | ministral-3b-4bit, mistral-small-4-119b-2603-4bit | ok | ok | ok |
+| `tools is defined and tools` | apertus-8b-instruct-2509-4bit, exaone4-1.2b-4bit | ok | ok | ok |
+
+Only the undefined column is clean across every row. The `none` column is the reason this is not a one-character change from an empty vector to `Value::from(())`.
+
+### 2.3 Compatibility and dependencies
+
+No dependency moved. `effective_tools` in `src/server/chat_request.rs` is untouched, which also keeps this PR clear of the in-flight tool_choice work in PR #1581, which edits the same file. `tool_choice: "none"` still reaches the template as no tools, through the same path it always did.
+
+### 2.4 Code quality
+
+The two stale comments that misattributed the empty-list workaround to minijinja short-circuiting are replaced by the actual `iterable` and `length` semantics, the three guard shapes, and a pointer to the issue. `build_template_context` gains a comment stating the invariant that decides which keys may be inserted unconditionally, so the next key added to that block has a rule to be checked against rather than a precedent to be copied.
+
+---
+
+## 3. Technical Decisions
+
+### 3.1 Undefined, not `none`, not an empty list
+
+The decision is forced by the corpus rather than chosen. An empty list breaks the two `is defined` families. `none` breaks the Nemotron and MiMo family, and it breaks it in the worst available way: `render_simple_fallback` catches the render error and substitutes a generic `User:` / `Assistant:` prompt, so the failure surfaces as a quality regression rather than an error. Undefined is the only value that leaves all seven rows on their intended path, and it is also what both reference implementations produce.
+
+A note on the residual risk this leaves: a template that computes `tools | length` with no preceding definedness guard would now error where it previously worked. Such a template cannot ship, because it would raise under transformers' `tools=None` for the same reason, and a static audit of the 196 chat templates under `models/` confirms that all 8 templates computing `tools | length` guard it first.
+
+### 3.2 An explicit empty list means no tools
+
+`"tools": []` is normalized to undefined rather than passed through as a defined empty list. This is llama-server's rule (an empty array becomes a null JSON value before the context is built) and the OpenAI reading of the field. Passing it through would preserve exactly the bug for clients that send the key unconditionally, which is a common SDK shape.
+
+### 3.3 Normalize in the two inner functions, not at the callers
+
+Every render in the tree funnels through `apply_raw_inner` or `apply_inner`: the chat, messages, responses, apply-template and both input_tokens routes, the Muse ATEM stream path, the prompt cache's history-boundary render, and the offline `generate` and `chat` commands. Normalizing at that choke point covers all of them in one place and leaves no caller that can forget the rule. The alternative, a shared helper each caller invokes, reintroduces exactly the per-caller drift the choke point removes.
+
+### 3.4 `enable_thinking` stays defined
+
+The audit the issue asked for covered every key the builder inserts. `enable_thinking` is the one other unconditional key that a template could in principle test with `is defined`, and the Youtu template does read it that way (`enable_thinking is defined and enable_thinking is false`). It stays unconditional anyway, because its definedness is the tested per-request override contract from #686 and #1114, and no shipped template was found where `enable_thinking is defined` alone flips a branch that transformers would not flip. Widening this fix to cover it would trade one measured defect for an unmeasured change to a contract with tests on it.
+
+### 3.5 `tools` stays in `RESERVED_KEYS`
+
+The empty tool set is the server-managed answer to "what tools does this request carry", so a `chat_template_kwargs` entry must not be able to define the key the request deliberately left undefined. Under minijinja's default lenient undefined mode, `test_kwargs_cannot_override_reserved_tools_key` keeps passing without modification: iterating an undefined `tools` yields nothing, which is the same observable result the empty list produced.
+
+---
+
+## 4. Implementation Details
+
+### 4.1 The context builder
+
+```rust
+// before
+    tools: minijinja::Value,
+    ...
+    ctx.insert("tools", tools);
+
+// after
+    tools: Option<minijinja::Value>,
+    ...
+    if let Some(tools) = tools {
+        ctx.insert("tools", tools);
+    }
+```
+
+### 4.2 Both render paths
+
+```rust
+// before, in apply_raw_inner and apply_inner alike
+let tools_val = match tools {
+    Some(t) => minijinja::Value::from_serialize(t),
+    None => minijinja::Value::from_serialize(Vec::<Tool>::new()),
+};
+
+// after
+let tools_val = tools
+    .filter(|t| !t.is_empty())
+    .map(minijinja::Value::from_serialize);
+```
+
+The tests-module render helper, which exists to reproduce the production context on a freshly compiled environment, carries the same expression with a comment saying it must stay identical.
+
+### 4.3 The invariant comment
+
+The insert block in `build_template_context` now states the rule that decides conditional against unconditional: insert a key unconditionally only when no shipped template can branch on its mere definedness. It names each key and its verdict, so a future addition is checked rather than copied.
+
+---
+
+## 5. Validation
+
+| Check | Result |
+|---|---|
+| `cargo test --profile test-fast --features metal,accelerate --lib server::chat_template` | 154 passed, 3 ignored |
+| `cargo test ... --lib server::chat_request` | 104 passed |
+| `cargo test ... --lib server::routes` / `server::tool` / `server::prompt_cache` | 387 / 384 / 173 passed |
+| `cargo test ... --lib server::reasoning_effort_tests` / `server::anthropic_translator` / `server::muse_atem_roundtrip_tests` / `server::muse_glimmer_template_tests` | 28 / 33 / 5 / 6 passed |
+| `cargo test ... --lib server::chat_template::tests::local_checkpoint_templates_render -- --ignored` | passed: both checkpoints render the transformers oracle byte for byte |
+| `cargo clippy --profile test-fast --lib --tests --features metal,accelerate -- -D warnings` | clean |
+| `cargo fmt --all -- --check` | clean |
+| `python3 scripts/ci/check_cross_repo_refs.py` | clean |
+| Static audit of 196 local chat templates | all 8 templates computing `tools \| length` guard it with a definedness or none test first |
+| `cargo test --test apply_template_tools_parity -- --ignored` (real weights, HTTP) | pending, run centrally |
+
+### 5.1 The weight-free gate, and what it caught
+
+`ChatTemplateProcessor::from_model_path` reads only the template files, so both shipped checkpoints can be rendered and compared against the oracle with no weights, no GPU and no server. That test is worth more than its size: its first version asserted a prompt the server does not produce, because the Youtu template primes an empty `<think></think>` block when `enable_thinking` is defined and false, and `server::startup` sets that default to true from the tokenizer's think markers. The test now mirrors that derivation per checkpoint. Without it, the discrepancy would have surfaced only in the real-checkpoint HTTP gate.
+
+### 5.2 New tests
+
+Four checkpoint-free unit tests cover the three guard shapes plus the history-boundary render, in both the typed and the raw-JSON path, for `None`, `Some(&[])` and one real tool. `tests/apply_template_tools_parity.rs` asserts the exact prompt strings and the 8 and 40 token counts over HTTP against real weights, and that a request carrying one tool still renders its tool block on both checkpoints. It starts the two servers one after the other inside a single test, because the suite shares one Metal device and two concurrently resident checkpoints is the shape that aborts runs.
+
+---
+
+## 6. Change Summary
+
+### Statistics
+
+| Metric | Value |
+|---|---|
+| Files changed | 3 |
+| Lines added | 557 |
+| Lines removed | 27 |
+| Commits | 2 |
+
+### Changes by category
+
+| File | Change |
+|---|---|
+| `src/server/chat_template.rs` | `build_template_context` takes `Option<minijinja::Value>` and inserts conditionally; both inner render functions normalize empty to `None`; stale comments replaced; invariant comment added; five new tests |
+| `tests/apply_template_tools_parity.rs` | New gated HTTP parity test over both shipped checkpoints |
+| `docs/llama-server-compat.md` | New subsection under "Chat templates, reasoning, and output parsing" |
+
+### Related commits
+
+- `7d5d80d42` fix(server): leave tools undefined when a request sends none
+- `4d66e8c1d` test(server): gate the tools-less prompt without loading weights
+
+### Related issues and PRs
+
+- Closes #1597
+- Adjacent, deliberately not touched: #1581 (tool_choice enforcement, issue #1319), which edits `src/server/chat_request.rs`
+- Context keys whose contracts this fix leaves alone: #686 and #1114 (`enable_thinking`), #512 (`thinking`), #775 and #819 (`thinking_mode`)
+
+---
+
+## 7. Follow-up Actions
+
+### 7.1 Operational note
+
+The rendered prefix changes for affected models, so the first request per model after upgrading misses in the prompt cache once and rebuilds it. That is a cold miss, not a compatibility break: no key digest version changes and no migration is needed.
+
+### 7.2 Out of scope, filed separately if a checkpoint needs it
+
+- Aligning minijinja's `iterable` test and `length` filter with Python for `none` and undefined. A template that defaults an undefined `tools` to `none` and then uses the iterable guard would still error and fall back; no template in the local corpus does this.
+- The definedness of `enable_thinking`, unless a concrete template divergence is found.
+- The remaining bf16-tie drift on the second Youtu prompt after the fix, which is not this defect.
+
+### 7.3 Broader lesson
+
+The bug was a workaround whose stated rationale was checkable and wrong. The comment asserted a minijinja behavior ("short-circuit evaluation still tries to compute `| length` of `none`") that a two-line probe against the pinned version disproves, and the fix it justified traded one broken guard family for two. When a comment explains a value choice by citing an engine behavior, the cheap move is to run the engine.
+
+The second lesson is about where the gate lives. The byte-exact prompt for these two checkpoints is verifiable without weights, without a GPU and without a server, because the template files are the whole input. Putting that gate at the unit level made the assertion runnable in milliseconds and caught a wrong expectation before any real-checkpoint run.

--- a/TECHNICAL_REPORTS/1598-tools-undefined-template-context-20260903.ko.md
+++ b/TECHNICAL_REPORTS/1598-tools-undefined-template-context-20260903.ko.md
@@ -1,0 +1,220 @@
+# 기술 보고서: PR #1598 - fix(server): define tools only when the request sends them
+
+**작성일**: 2026-09-03
+**작성자**: mlxcel maintainers
+**리뷰어**: implementation and security review cycle
+**상태**: 완료 (가중치 없이 두 체크포인트의 템플릿 렌더 일치를 검증함. 실제 가중치를 쓰는 HTTP 게이트는 중앙에서 실행)
+**언어**: Rust, Markdown
+**위험도**: Medium (`tools is defined` 또는 `tools is not none`으로 분기하는 모든 체크포인트에서 렌더된 프롬프트가, 따라서 프롬프트 캐시 접두어가 바뀐다)
+
+---
+
+## 요약
+
+`build_template_context`는 minijinja 컨텍스트에 `tools` 키를 무조건 넣었고, 두 렌더 경로 모두 요청에 도구가 없으면 빈 `Vec<Tool>`을 대신 넣었다. 그래서 `tools is defined`나 `tools is not none`으로 도구 분기를 결정하는 채팅 템플릿은 정의돼 있고 none이 아닌 빈 리스트를 보게 되고, 평범한 대화 요청마다 빈 함수 목록이 붙은 도구 호출 프리앰블을 렌더했다. 실제로 두 계열이 이 모양이다. DeepSeek V3 파생(Youtu-LLM)과 Llama 3.1 / 3.2 / 3.3 / 4이며, 후자에는 프로젝트의 기준 트랜스포머 참조 체크포인트가 들어간다.
+
+PR #1598은 `build_template_context`가 `tools: Option<minijinja::Value>`를 받아 `Some`일 때만 키를 넣도록 바꾸고, "도구 없음"과 명시적 `"tools": []`를 모두 `apply_raw_inner` / `apply_inner` 안에서 `None`으로 정규화한다. 여기서 `none`이 아니라 정의되지 않은 상태여야 하는 것은 취향이 아니라 필수다. minijinja의 `iterable` 테스트는 `none`에 대해 참인데 `none`에 `| length`를 적용하면 오류가 나므로, `none`을 넣으면 Nemotron / MiMo 계열의 렌더가 중단되고 프롬프트가 조용히 단순 폴백으로 대체된다. 결과적으로 로컬 코퍼스의 모든 가드 형태에서 transformers(`tools=None`) 및 llama-server(키 미설정)와 동일해진다.
+
+---
+
+## 1. 문제 정의
+
+### 1.1 배경
+
+HuggingFace에 공개된 채팅 템플릿은 `transformers` 기준으로 작성된다. 거기서는 호출자가 도구를 주지 않으면 `apply_chat_template`이 `tools=None`을 넘긴다. llama-server는 경로는 다르지만 같은 상태에 도달한다. `common_chat_tools_to_json_oaicompat`이 빈 도구 배열에 대해 null JSON 값을 돌려주고, minja의 `chat-template.hpp`는 그 값이 non-null일 때만 컨텍스트 키를 설정한다. 두 엔진 모두 도구 없는 요청을 `tools`가 없거나 `None`인 컨텍스트에서 렌더하고, 템플릿 작성자는 그 전제 위에 가드를 쓴다.
+
+mlxcel은 그렇지 않았다. `src/server/chat_template.rs`는 `tools`를 무조건 넣었고, 두 내부 렌더 함수가 `None`을 `minijinja::Value::from_serialize(Vec::<Tool>::new())`로 바꿨다. 두 호출 지점 옆의 주석은 이 빈 리스트를 `{% if tools is iterable and tools | length > 0 %}`에 대한 우회책으로 설명하면서, minijinja가 단축 평가에도 불구하고 "`none`의 `| length`를 계산하려 든다"고 적어 두었다. 절반만 맞았고 결론은 틀렸다. minijinja 2.24는 `and`를 실제로 단축 평가(`BinOpKind::ScAnd`)로 컴파일하지만, `iterable` 테스트가 `Value::try_iter().is_ok()`라 `none`에 대해 성공하므로 우변에 어차피 도달한다. 이 우회책은 그 가드 하나를 고치는 대신 모든 `is defined` / `is not none` 가드를 망가뜨렸다.
+
+### 1.2 측정된 영향
+
+`{"messages":[{"role":"user","content":"The Fibonacci sequence begins with"}]}`를 `tools` 키 없이 `POST /apply-template`에 보낸 결과다.
+
+| 체크포인트 | 가드 형태 | 수정 전 렌더 | 오라클 (transformers / `tools` 미정의 jinja2) |
+|---|---|---|---|
+| `models/mlx/youtu-llm-2b-4bit` | `tools is defined and tools is not none` | 76 토큰, "available:"과 "For tool call returns" 사이에 빈 `<\|begin_of_tool_description\|>` 블록 | 8 토큰 |
+| `models/mlx/llama-3.2-1b-4bit` | `{%- if not tools is defined %}{%- set tools = none %}{%- endif %}` 이후 `tools is not none` | 97 토큰, `Environment: ipython`과 "Given the following functions" 사용자 프리앰블 포함 | 40 토큰 |
+
+각 체크포인트의 템플릿을 Python jinja2로 직접 렌더했을 때 mlxcel의 긴 출력과 바이트 단위로 일치한 것은 `tools=[]`를 넘겼을 때뿐이었다. 다른 컨텍스트 차이가 아니라 빈 리스트가 원인임을 직접 확인해 준 지점이다. 요청 본문에 `"tools": []`를 명시해도 같은 유령 블록이 나왔는데, `effective_tools`가 빈 슬라이스를 그대로 넘기기 때문이다.
+
+### 1.3 결과
+
+- **프롬프트 팽창.** 한 줄짜리 메시지에서도 프리앰블이 Youtu에서 68토큰, Llama 3.2에서 57토큰을 매 요청마다 잡아먹는다.
+- **잘못된 유도.** 호출할 함수가 하나도 없는데 모델에게 함수를 호출해도 된다고 알려 주고 호출 문법까지 준다. Youtu의 한 프롬프트에서는 12토큰 뒤, 다른 프롬프트에서는 5토큰 뒤에 그리디 출력이 mlx-lm 오라클과 갈라졌다. 8토큰짜리 오라클 프롬프트를 raw `/completion`에 넣으면 32/32로 일치했다.
+- **캐시 오염.** 프리앰블은 해당 모델의 모든 프롬프트 캐시 키의 `tokens[..prefix_len]`과 캐시가 스냅샷하는 히스토리 경계 렌더에 그대로 들어간다. 즉 영향받는 모델의 모든 엔트리가 모델이 애초에 보면 안 되는 프롬프트로 키잉돼 있었다.
+- **조용하다.** 렌더된 프롬프트는 자연스럽고 요청은 성공하므로 로그나 응답 형태에서 아무 신호도 나오지 않는다. 외부 오라클과 비교하거나 `usage.prompt_tokens`를 봐야만 보인다.
+
+---
+
+## 2. 기술적 검토 사항
+
+### 2.1 근본 원인
+
+한 줄이다. `build_template_context`의 `ctx.insert("tools", tools);`와 그 앞의 `match tools { None => Vec::<Tool>::new() }` 두 곳. 로컬 코퍼스의 일곱 가드 계열 중 셋은 키의 *값*이 아니라 *정의 여부*로 분기하는데, 코드에는 "없음"을 표현할 방법이 없었다.
+
+### 2.2 가드 형태 코퍼스
+
+고정된 minijinja 버전으로 `tools`의 각 후보 값에 대해 로컬 템플릿을 조사하면 이 수정이 근거로 삼은 판단표가 나온다.
+
+| 가드 형태 | 대표 체크포인트 | `[]` (수정 전) | `none` | 미정의 (수정 후) |
+|---|---|---|---|---|
+| `tools is defined and tools is not none` | youtu-llm-2b-4bit | 유령 블록 | ok | ok |
+| 미정의일 때 `set tools = none`, 이후 `tools is not none` | meta-llama-3.1-8b-instruct-4bit, llama-3.2-1b-4bit, llama-4-scout-17b-4bit | 유령 블록 | ok | ok |
+| 미정의일 때 `set tools = []`, 이후 `tools is iterable and tools \| length > 0` | nemotron-3-nano-omni-30b-a3b-reasoning-4bit, nemotron-h-30b-4bit, mimo-v2-flash-4bit | ok | 렌더 오류 | ok |
+| `not tools is defined or tools is none`에서 `[]` 설정, 이후 같은 iterable 가드 | seed-oss-36b-instruct-4bit | ok | ok | ok |
+| `if tools` / `tools and tools is iterable and tools is not mapping` | Qwen 2.5 / 3 / 3.5 이후 | ok | ok | ok |
+| `tools is defined and tools is not none and tools\|length > 0` | ministral-3b-4bit, mistral-small-4-119b-2603-4bit | ok | ok | ok |
+| `tools is defined and tools` | apertus-8b-instruct-2509-4bit, exaone4-1.2b-4bit | ok | ok | ok |
+
+모든 행에서 깨끗한 열은 미정의뿐이다. `none` 열이 있어서 이 수정이 빈 벡터를 `Value::from(())`로 바꾸는 한 글자짜리 변경이 될 수 없다.
+
+### 2.3 호환성/의존성 관점
+
+의존성 변경은 없다. `src/server/chat_request.rs`의 `effective_tools`는 손대지 않았고, 덕분에 같은 파일을 수정 중인 tool_choice 작업(PR #1581)과도 충돌하지 않는다. `tool_choice: "none"`은 예전과 동일한 경로로 템플릿에 "도구 없음"으로 도달한다.
+
+### 2.4 코드 품질 관점
+
+빈 리스트 우회책을 minijinja 단축 평가 탓으로 잘못 돌린 두 주석은 실제 `iterable` / `length` 의미론, 세 가드 형태, 이슈 링크로 교체했다. `build_template_context`에는 어떤 키를 무조건 넣어도 되는지 판단하는 불변식 주석이 추가돼서, 다음에 이 블록에 키를 추가하는 사람이 선례를 복사하는 대신 규칙에 비춰 확인할 수 있다.
+
+---
+
+## 3. 기술적 선택과 그 이유
+
+### 3.1 빈 리스트도 `none`도 아닌 미정의
+
+이 선택은 취향이 아니라 코퍼스가 강제한 것이다. 빈 리스트는 `is defined` 계열 둘을 깨뜨린다. `none`은 Nemotron / MiMo 계열을 깨뜨리는데, 하필 가장 나쁜 방식으로 깨뜨린다. `render_simple_fallback`이 렌더 오류를 잡아 일반적인 `User:` / `Assistant:` 프롬프트로 대체하므로, 오류가 아니라 품질 저하로만 드러난다. 일곱 행 모두를 의도된 경로에 남겨 두는 값은 미정의뿐이고, 이는 두 참조 구현이 만들어 내는 상태이기도 하다.
+
+남는 위험 하나는 짚어 둘 만하다. 정의 여부 가드 없이 `tools | length`를 계산하는 템플릿이 있다면 이제 오류가 난다. 그런 템플릿은 애초에 배포될 수 없다. 같은 이유로 transformers의 `tools=None`에서도 예외가 나기 때문이다. 그리고 `models/` 아래 196개 채팅 템플릿을 정적 감사한 결과, `tools | length`를 계산하는 8개 템플릿은 모두 그 앞에 가드를 두고 있다.
+
+### 3.2 명시적 빈 리스트는 도구 없음이다
+
+`"tools": []`는 정의된 빈 리스트로 통과시키지 않고 미정의로 정규화한다. llama-server의 규칙(컨텍스트를 만들기 전에 빈 배열이 null JSON 값이 된다)이자 OpenAI에서의 해석이다. 그대로 통과시키면 키를 항상 붙여 보내는 클라이언트, 즉 흔한 SDK 형태에 대해 버그가 그대로 남는다.
+
+### 3.3 호출자가 아니라 두 내부 함수에서 정규화
+
+트리의 모든 렌더는 `apply_raw_inner` 아니면 `apply_inner`를 통과한다. chat / messages / responses / apply-template와 두 input_tokens 라우트, Muse ATEM 스트림 경로, 프롬프트 캐시의 히스토리 경계 렌더, 오프라인 `generate` / `chat` 명령이 전부 여기로 모인다. 이 병목에서 정규화하면 전부를 한 곳에서 덮고, 규칙을 잊을 수 있는 호출자가 남지 않는다. 대안인 "각 호출자가 부르는 공용 헬퍼"는 병목이 없앤 호출자별 어긋남을 그대로 되살린다.
+
+### 3.4 `enable_thinking`은 정의된 채로 둔다
+
+이슈가 요구한 감사는 빌더가 넣는 모든 키를 대상으로 했다. 원리상 템플릿이 `is defined`로 검사할 수 있는 다른 무조건 키는 `enable_thinking`이고, 실제로 Youtu 템플릿이 그렇게 읽는다(`enable_thinking is defined and enable_thinking is false`). 그래도 무조건 유지한다. 그 정의 여부 자체가 #686과 #1114에서 테스트로 굳힌 요청별 오버라이드 계약이고, `enable_thinking is defined`만으로 transformers가 타지 않을 분기를 타는 배포 템플릿은 발견되지 않았다. 여기까지 수정을 넓히면 측정된 결함 하나를 테스트가 걸린 계약에 대한 측정되지 않은 변경과 맞바꾸는 셈이 된다.
+
+### 3.5 `tools`는 `RESERVED_KEYS`에 남는다
+
+"이 요청이 어떤 도구를 갖고 있는가"에 대한 서버 관리 답이 빈 도구 집합이므로, `chat_template_kwargs` 항목이 요청이 일부러 비워 둔 키를 정의할 수 있어서는 안 된다. minijinja의 기본 lenient 미정의 모드에서 `test_kwargs_cannot_override_reserved_tools_key`는 수정 없이 계속 통과한다. 미정의 `tools`를 순회하면 아무것도 나오지 않는데, 이는 빈 리스트가 만들던 관측 결과와 동일하다.
+
+---
+
+## 4. 구현 상세
+
+### 4.1 컨텍스트 빌더
+
+```rust
+// 수정 전
+    tools: minijinja::Value,
+    ...
+    ctx.insert("tools", tools);
+
+// 수정 후
+    tools: Option<minijinja::Value>,
+    ...
+    if let Some(tools) = tools {
+        ctx.insert("tools", tools);
+    }
+```
+
+### 4.2 두 렌더 경로
+
+```rust
+// 수정 전, apply_raw_inner와 apply_inner 양쪽
+let tools_val = match tools {
+    Some(t) => minijinja::Value::from_serialize(t),
+    None => minijinja::Value::from_serialize(Vec::<Tool>::new()),
+};
+
+// 수정 후
+let tools_val = tools
+    .filter(|t| !t.is_empty())
+    .map(minijinja::Value::from_serialize);
+```
+
+새로 컴파일한 환경에서 프로덕션 컨텍스트를 재현하려고 존재하는 테스트 모듈의 렌더 헬퍼도 같은 표현식을 쓰며, 동일하게 유지해야 한다는 주석을 달았다.
+
+### 4.3 불변식 주석
+
+`build_template_context`의 insert 블록에 조건부/무조건을 가르는 규칙을 적었다. 배포 템플릿이 키의 정의 여부만으로 분기할 수 없을 때에만 무조건 넣는다는 것이다. 각 키와 판단 근거를 함께 적어서, 나중에 추가되는 키는 복사가 아니라 검토를 거치게 했다.
+
+---
+
+## 5. 검증
+
+| 검사 | 결과 |
+|---|---|
+| `cargo test --profile test-fast --features metal,accelerate --lib server::chat_template` | 154 통과, 3 무시 |
+| `cargo test ... --lib server::chat_request` | 104 통과 |
+| `cargo test ... --lib server::routes` / `server::tool` / `server::prompt_cache` | 387 / 384 / 173 통과 |
+| `cargo test ... --lib server::reasoning_effort_tests` / `server::anthropic_translator` / `server::muse_atem_roundtrip_tests` / `server::muse_glimmer_template_tests` | 28 / 33 / 5 / 6 통과 |
+| `cargo test ... --lib server::chat_template::tests::local_checkpoint_templates_render -- --ignored` | 통과. 두 체크포인트 모두 transformers 오라클과 바이트 단위 일치 |
+| `cargo clippy --profile test-fast --lib --tests --features metal,accelerate -- -D warnings` | 클린 |
+| `cargo fmt --all -- --check` | 클린 |
+| `python3 scripts/ci/check_cross_repo_refs.py` | 클린 |
+| 로컬 채팅 템플릿 196개 정적 감사 | `tools \| length`를 계산하는 8개 모두 앞에 정의 여부/none 검사를 둠 |
+| `cargo test --test apply_template_tools_parity -- --ignored` (실제 가중치, HTTP) | 대기, 중앙에서 실행 |
+
+### 5.1 가중치 없는 게이트가 잡아낸 것
+
+`ChatTemplateProcessor::from_model_path`는 템플릿 파일만 읽으므로, 두 체크포인트를 가중치 없이, GPU 없이, 서버 없이 렌더해서 오라클과 비교할 수 있다. 이 테스트는 크기에 비해 값어치가 크다. 첫 버전은 서버가 만들지 않는 프롬프트를 단언하고 있었는데, Youtu 템플릿이 `enable_thinking`이 정의돼 있고 false일 때 빈 `<think></think>` 블록을 미리 채우고, `server::startup`은 토크나이저의 think 마커에서 그 기본값을 true로 설정하기 때문이었다. 지금은 테스트가 체크포인트별로 그 유도를 그대로 반영한다. 이 테스트가 없었다면 이 불일치는 실제 체크포인트 HTTP 게이트에서야 드러났을 것이다.
+
+### 5.2 추가된 테스트
+
+체크포인트 없이 도는 단위 테스트 넷이 세 가드 형태와 히스토리 경계 렌더를, 타입 경로와 raw JSON 경로 양쪽에서, `None` / `Some(&[])` / 실제 도구 하나에 대해 덮는다. `tests/apply_template_tools_parity.rs`는 실제 가중치로 HTTP를 통해 정확한 프롬프트 문자열과 8 / 40 토큰 수를 단언하고, 도구를 하나 실은 요청은 두 체크포인트 모두에서 여전히 도구 블록을 렌더하는지 확인한다. 두 서버는 한 테스트 안에서 순차로 띄운다. 스위트가 Metal 장치 하나를 공유하고, 체크포인트 둘이 동시에 상주하는 것이 실행을 중단시키는 형태이기 때문이다.
+
+---
+
+## 6. 변경 요약
+
+### 통계
+
+| 항목 | 값 |
+|---|---|
+| 변경 파일 | 3 |
+| 추가 줄 | 557 |
+| 삭제 줄 | 27 |
+| 커밋 | 2 |
+
+### 카테고리별 변경
+
+| 파일 | 변경 |
+|---|---|
+| `src/server/chat_template.rs` | `build_template_context`가 `Option<minijinja::Value>`를 받아 조건부 삽입, 두 내부 렌더 함수에서 빈 값을 `None`으로 정규화, 낡은 주석 교체, 불변식 주석 추가, 테스트 5개 추가 |
+| `tests/apply_template_tools_parity.rs` | 두 체크포인트를 대상으로 하는 게이트된 HTTP 일치 테스트 신규 |
+| `docs/llama-server-compat.md` | "Chat templates, reasoning, and output parsing" 아래 하위 절 신규 |
+
+### 관련 커밋
+
+- `7d5d80d42` fix(server): leave tools undefined when a request sends none
+- `4d66e8c1d` test(server): gate the tools-less prompt without loading weights
+
+### 관련 PR/이슈
+
+- Closes #1597
+- 인접하지만 일부러 건드리지 않음: #1581 (tool_choice 강제, 이슈 #1319). `src/server/chat_request.rs`를 수정 중이다
+- 이 수정이 계약을 그대로 둔 컨텍스트 키들: #686, #1114 (`enable_thinking`), #512 (`thinking`), #775, #819 (`thinking_mode`)
+
+---
+
+## 7. 후속 조치
+
+### 7.1 운영 참고
+
+영향받는 모델은 렌더된 접두어가 바뀌므로, 업그레이드 후 모델당 첫 요청이 프롬프트 캐시에서 한 번 미스가 나고 다시 만든다. 호환성 파괴가 아니라 콜드 미스 한 번이다. 키 다이제스트 버전은 바뀌지 않고 마이그레이션도 필요 없다.
+
+### 7.2 범위 밖, 필요한 체크포인트가 나오면 별도 등록
+
+- minijinja의 `iterable` 테스트와 `length` 필터를 `none` / 미정의에 대해 Python과 맞추는 것. 미정의 `tools`를 `none`으로 기본값 설정한 뒤 iterable 가드를 쓰는 템플릿은 여전히 오류가 나고 폴백된다. 로컬 코퍼스에는 그런 템플릿이 없다.
+- `enable_thinking`의 정의 여부. 구체적인 템플릿 불일치가 발견될 때만.
+- 수정 이후 Youtu 두 번째 프롬프트에 남는 bf16 동점 드리프트. 이 결함과는 무관하다.
+
+### 7.3 더 넓은 교훈
+
+이 버그는 근거를 확인할 수 있는데도 확인하지 않은 우회책이었다. 주석은 고정된 버전에 두 줄짜리 탐침을 돌리면 반증되는 minijinja 동작("단축 평가에도 `none`의 `| length`를 계산하려 든다")을 단언했고, 그 주석이 정당화한 수정은 깨진 가드 계열 하나를 둘로 바꿨다. 주석이 값 선택을 엔진 동작으로 설명한다면, 가장 싼 수는 엔진을 직접 돌려 보는 것이다.
+
+두 번째 교훈은 게이트를 어디에 두느냐다. 이 두 체크포인트의 바이트 단위 프롬프트는 템플릿 파일이 입력의 전부이므로 가중치 없이, GPU 없이, 서버 없이 검증할 수 있다. 그 게이트를 단위 테스트 층에 두니 단언이 밀리초 단위로 돌았고, 실제 체크포인트를 돌리기 전에 잘못된 기대치를 잡아냈다.

--- a/docs/llama-server-compat.md
+++ b/docs/llama-server-compat.md
@@ -412,6 +412,16 @@ clap gives no command-line order, so when `--chat-template-kwargs` names one of 
 
 b10621 accepts either Jinja template text or one of 54 built-in identifiers (`chatml`, `llama3`, `deepseek3`, ...). mlxcel has no built-in template library: an MLX checkpoint carries its own template in `tokenizer_config.json`, which is what mlxcel renders by default. A bare built-in name would become the template itself and every prompt would render to the literal string, so the name set is recognised and refused before the model resolves.
 
+### `tools` is defined only when the request carries tools (#1597)
+
+b10621 builds the template context's `tools` entry from `common_chat_tools_to_json_oaicompat`, which answers a null JSON value for an empty tool array, and minja's `chat-template.hpp` sets the key only when that value is non-null. A request with no `tools`, or with `"tools": []`, therefore renders against a context where `tools` is simply not there. mlxcel does the same since #1597: the key is absent unless the request carries at least one tool, and `tool_choice: "none"` reaches the template as no tools the way it always has.
+
+The definedness is load-bearing, not cosmetic. Published templates gate their tool-calling preamble in three shapes, and two of them are satisfied by a defined empty list: DeepSeek V3 derivatives test `tools is defined and tools is not none`, and Llama 3.1 / 3.2 / 3.3 / 4 default `tools` to `none` only when it is undefined and then test `tools is not none`. Rendering either family with `tools = []`, which is what mlxcel passed before #1597, emitted the whole preamble with an empty function list on every plain chat request: `Environment: ipython` plus the "Given the following functions" block on Llama 3.2, an empty `<|begin_of_tool_description|>` block on Youtu-LLM. transformers passes `tools=None`, which renders identically to undefined for every guard shape mlxcel ships against, so the mlx-lm oracle and llama-server agree with each other and now with mlxcel.
+
+Undefined rather than `none` is deliberate. The third guard shape, used by Nemotron and MiMo, defaults an undefined `tools` to `[]` itself and then tests `tools is iterable and tools | length > 0`; minijinja's `iterable` test succeeds for `none` while `| length` of `none` errors, so a `none` would abort those renders and silently degrade the prompt to the plain-chat fallback.
+
+Upgrading past #1597 changes the rendered prompt for affected models, so the first request per model misses in the prompt cache once and rebuilds it. That is a single cold miss, not a compatibility break: no key digest version changes and no migration is needed.
+
 ### What is left
 
 No entry in this shard is `deferred` any more. `--reasoning-budget-message` became `supported` with #1470's injection, and `--reasoning-format` became `by_design` on the `auto` resolution alone once the streamed delimiters landed. Every native field in this shard other than `echo` is `not_applicable`: mlxcel's `POST /completion` is a raw-prompt endpoint with no chat template and no chat parsing for them to configure.

--- a/src/server/chat_template.rs
+++ b/src/server/chat_template.rs
@@ -759,14 +759,34 @@ impl ChatTemplateProcessor {
         // Convert serde_json::Value to minijinja::Value
         let messages_val = minijinja::Value::from_serialize(messages);
 
-        // Always pass `tools` as an iterable (possibly empty) rather than
-        // `None` so that `{% if tools is iterable and tools | length > 0 %}`
-        // works under minijinja — its short-circuit evaluation still tries
-        // to compute `| length` of `none`, which raises an error.
-        let tools_val = match tools {
-            Some(t) => minijinja::Value::from_serialize(t),
-            None => minijinja::Value::from_serialize(Vec::<Tool>::new()),
-        };
+        // Leave `tools` UNDEFINED when the request carries no tools, and count
+        // an explicit empty list as no tools (issue #1597). Three guard shapes
+        // ship in the local template corpus and only an absent key satisfies
+        // all three:
+        //
+        //   1. `tools is defined and tools is not none` (DeepSeek V3 style,
+        //      Youtu-LLM) and `tools is not none` after a
+        //      `{%- if not tools is defined %}{%- set tools = none %}{%- endif %}`
+        //      default (Llama 3.1 / 3.2 / 3.3 / 4) are both TRUE for a defined
+        //      empty list, so the previous always-an-empty-list context
+        //      rendered a tool-calling preamble with an empty function list on
+        //      every plain chat request.
+        //   2. `tools is iterable and tools | length > 0` after a
+        //      `{%- set tools = [] %}` default (Nemotron, MiMo) is why the
+        //      value must not be `none` either: minijinja 2.24's `iterable`
+        //      test is `Value::try_iter().is_ok()`, which succeeds for `none`,
+        //      while `| length` of `none` errors, so the render would abort and
+        //      degrade to the simple fallback prompt. That template family
+        //      defaults an undefined `tools` to `[]` itself, so undefined is
+        //      safe for it.
+        //
+        // This is also llama-server's rule: it builds a null JSON value for an
+        // empty tool array and minja sets the context key only when that value
+        // is non-null. transformers passes `tools=None`, which renders
+        // identically to undefined for every guard shape above.
+        let tools_val = tools
+            .filter(|t| !t.is_empty())
+            .map(minijinja::Value::from_serialize);
 
         let context = build_template_context(
             messages_val,
@@ -836,16 +856,14 @@ impl ChatTemplateProcessor {
         kwargs: &ChatTemplateKwargs,
         add_generation_prompt: bool,
     ) -> Result<String> {
-        // Many templates conditionally check variables like `tools`,
-        // `enable_thinking`, etc. We must provide them with the right
-        // concrete type to avoid undefined/None errors — in particular,
-        // `tools` must be an iterable (even when empty) so that the common
-        // `{% if tools is iterable and tools | length > 0 %}` guard used by
-        // Qwen/Nemotron templates works correctly under minijinja.
-        let tools_val = match tools {
-            Some(t) => minijinja::Value::from_serialize(t),
-            None => minijinja::Value::from_serialize(Vec::<Tool>::new()),
-        };
+        // Same `tools` rule as `apply_raw_inner`: the key is absent when the
+        // request carries no tools, and an explicit empty list counts as no
+        // tools (issue #1597). See that function for why undefined rather than
+        // `none` or an empty list is the value that every shipped guard shape
+        // agrees on.
+        let tools_val = tools
+            .filter(|t| !t.is_empty())
+            .map(minijinja::Value::from_serialize);
 
         let messages_val = minijinja::Value::from_serialize(messages);
         let context = build_template_context(
@@ -882,9 +900,14 @@ fn compile_chat_template_environment(
 /// caller-provided kwargs.
 ///
 /// Standard fields (`messages`, `bos_token`, `eos_token`,
-/// `add_generation_prompt`, `tools`) are always present and are **reserved**
-/// from kwargs overlay — a request cannot overwrite the canonical conversation
-/// or tool list by smuggling those keys through `chat_template_kwargs`.
+/// `add_generation_prompt`, `tools`) are **reserved** from kwargs overlay: a
+/// request cannot overwrite the canonical conversation or tool list by
+/// smuggling those keys through `chat_template_kwargs`. Four of the five are
+/// also always present; `tools` is passed as `None` and left out of the context
+/// entirely when the request carries no tools, because shipped templates branch
+/// on whether the key is defined at all (issue #1597). It stays reserved in
+/// that case, so a kwargs `tools` entry cannot fill the slot the request left
+/// empty.
 ///
 /// `enable_thinking` defaults to `default_enable_thinking` (upstream PR #1114) — `true` when the underlying tokenizer recognizes a
 /// think marker pair, `false` otherwise.  The default is overridable through
@@ -1013,13 +1036,30 @@ fn build_template_context(
     bos_token: &str,
     eos_token: &str,
     add_generation_prompt: bool,
-    tools: minijinja::Value,
+    tools: Option<minijinja::Value>,
     kwargs: &ChatTemplateKwargs,
     default_enable_thinking: bool,
     bare_thinking_alias: bool,
     thinking_mode_sentinel: Option<&str>,
 ) -> minijinja::Value {
     // Start with the default context fields.
+    //
+    // Invariant for this block (issue #1597): insert a key unconditionally only
+    // when no shipped template can branch on its mere definedness. `messages`,
+    // `bos_token`, `eos_token` and `add_generation_prompt` qualify because
+    // templates read them for their value, never through `is defined`, and a
+    // missing one would change the rendered conversation rather than select a
+    // branch. `enable_thinking` is unconditional by contract (issues #686 and
+    // #1114): it is the tested per-request override point, and the templates
+    // that read it read its boolean value. `tools` is the exception this
+    // invariant was written for: three guard families in the local corpus
+    // select their tool-calling preamble on `tools is defined` or
+    // `tools is not none`, so a defined empty list rendered that preamble on
+    // every plain chat request. A future key that any template tests with
+    // `is defined` belongs on the conditional side as well. Below this block,
+    // `thinking` (issue #512) and `thinking_mode` (issues #775 and #819) are
+    // already conditional, and `tool_choice` and `documents` are never inserted
+    // at all.
     let mut ctx: std::collections::BTreeMap<&str, minijinja::Value> =
         std::collections::BTreeMap::new();
     ctx.insert("messages", messages);
@@ -1029,7 +1069,9 @@ fn build_template_context(
         "add_generation_prompt",
         minijinja::Value::from(add_generation_prompt),
     );
-    ctx.insert("tools", tools);
+    if let Some(tools) = tools {
+        ctx.insert("tools", tools);
+    }
     // Tokenizer-derived default: `has_thinking` for thinking models, `false`
     // otherwise (upstream PR #1114). Overridden below by any
     // matching kwarg from the request / server-default merge.
@@ -1044,6 +1086,11 @@ fn build_template_context(
     // Only `enable_thinking` (an intentional, tested override point) and any
     // non-reserved key (e.g. `preserve_thinking`, future template hints)
     // actually reach the Jinja context.
+    //
+    // `tools` stays reserved even when the request carried none and the key was
+    // therefore left out above (issue #1597): the empty tool set is the
+    // server-managed answer, so a kwargs entry must not be able to define the
+    // key the request deliberately left undefined.
     //
     // We rebuild the map with owned String keys after merging so the final
     // minijinja::Value owns all its entries.
@@ -1820,10 +1867,13 @@ mod tests {
             .with_context(|| "Failed to parse chat template")?;
 
         let tmpl = env.get_template("chat")?;
-        let tools_val = match tools {
-            Some(t) => minijinja::Value::from_serialize(t),
-            None => minijinja::Value::from_serialize(Vec::<Tool>::new()),
-        };
+        // Mirrors the production rule in `apply_raw_inner` / `apply_inner`: no
+        // tools and an explicit empty list both leave `tools` undefined in the
+        // context (issue #1597). Keep this expression identical to theirs, or
+        // these helpers stop reproducing what the server renders.
+        let tools_val = tools
+            .filter(|t| !t.is_empty())
+            .map(minijinja::Value::from_serialize);
         let context = build_template_context(
             messages_val,
             &processor.bos_token,
@@ -2494,6 +2544,131 @@ mod tests {
         }];
         let result = processor.apply(&messages, None).unwrap();
         assert!(result.contains("User: Hi"));
+    }
+
+    /// One `hi` user turn, in both the typed and the raw-JSON shape the two
+    /// render paths take. Shared by the issue #1597 guard-shape tests below.
+    fn one_user_turn() -> (Vec<ChatMessage>, serde_json::Value) {
+        (
+            vec![ChatMessage {
+                role: "user".to_string(),
+                content: "hi".to_string(),
+            }],
+            serde_json::json!([{"role": "user", "content": "hi"}]),
+        )
+    }
+
+    /// A single named function tool, enough to make any guard shape fire.
+    fn one_tool(name: &str) -> Vec<Tool> {
+        vec![Tool {
+            tool_type: "function".to_string(),
+            function: crate::server::types::request::FunctionDefinition {
+                name: name.to_string(),
+                description: Some("test".to_string()),
+                parameters: Some(serde_json::json!({"type": "object"})),
+            },
+        }]
+    }
+
+    /// Issue #1597, guard shape 1 of 3: DeepSeek V3 / Youtu-LLM.
+    ///
+    /// `tools is defined and tools is not none` is true for a defined empty
+    /// list, so passing `tools` as an always-present empty vector rendered the
+    /// tool-calling preamble with an empty function list on every plain chat
+    /// request. An absent key makes the guard false, which is what transformers
+    /// (`tools=None`) and llama-server (key unset) both produce.
+    #[test]
+    fn deepseek_style_tools_guard_stays_false_without_tools() {
+        const TEMPLATE: &str = "{% if tools is defined and tools is not none %}TOOLS{% endif %}\
+{% for m in messages %}{{ m.content }}{% endfor %}";
+        let processor = ChatTemplateProcessor::with_template(TEMPLATE.to_string());
+        let (typed, raw) = one_user_turn();
+
+        assert_eq!(processor.apply(&typed, None).unwrap(), "hi");
+        assert_eq!(processor.apply(&typed, Some(&[])).unwrap(), "hi");
+        assert_eq!(processor.apply_raw(&raw, None).unwrap(), "hi");
+        assert_eq!(processor.apply_raw(&raw, Some(&[])).unwrap(), "hi");
+
+        let tools = one_tool("get_weather");
+        assert_eq!(processor.apply(&typed, Some(&tools)).unwrap(), "TOOLShi");
+        assert_eq!(processor.apply_raw(&raw, Some(&tools)).unwrap(), "TOOLShi");
+    }
+
+    /// Issue #1597, guard shape 2 of 3: Llama 3.1 / 3.2 / 3.3 / 4.
+    ///
+    /// The template defaults `tools` to `none` only when it is undefined and
+    /// then branches on `tools is not none`, so a defined empty list took the
+    /// tool branch and prepended `Environment: ipython` plus the "Given the
+    /// following functions" user preamble to every plain chat request.
+    #[test]
+    fn llama_style_tools_guard_stays_false_without_tools() {
+        const TEMPLATE: &str = "{%- if not tools is defined %}{%- set tools = none %}{%- endif %}\
+{% if tools is not none %}TOOLS{% endif %}\
+{% for m in messages %}{{ m.content }}{% endfor %}";
+        let processor = ChatTemplateProcessor::with_template(TEMPLATE.to_string());
+        let (typed, raw) = one_user_turn();
+
+        assert_eq!(processor.apply(&typed, None).unwrap(), "hi");
+        assert_eq!(processor.apply(&typed, Some(&[])).unwrap(), "hi");
+        assert_eq!(processor.apply_raw(&raw, None).unwrap(), "hi");
+
+        let tools = one_tool("get_weather");
+        assert_eq!(processor.apply(&typed, Some(&tools)).unwrap(), "TOOLShi");
+    }
+
+    /// Issue #1597, guard shape 3 of 3: Nemotron / MiMo.
+    ///
+    /// This is the shape that forbids `none` as the no-tools value. The
+    /// template defaults an undefined `tools` to `[]` itself and then tests
+    /// `tools is iterable and tools | length > 0`; minijinja's `iterable` test
+    /// is true for `none` while `| length` of `none` errors, so a `none` would
+    /// abort the render and silently degrade the prompt to the simple
+    /// fallback. Undefined keeps this family on its normal path.
+    #[test]
+    fn nemotron_style_tools_guard_renders_without_error_when_undefined() {
+        const TEMPLATE: &str = "{%- if not tools is defined %}{%- set tools = [] %}{%- endif %}\
+{% if tools is iterable and tools | length > 0 %}TOOLS{% endif %}\
+{% for m in messages %}{{ m.content }}{% endfor %}";
+        let processor = ChatTemplateProcessor::with_template(TEMPLATE.to_string());
+        let (typed, raw) = one_user_turn();
+
+        assert_eq!(processor.apply(&typed, None).unwrap(), "hi");
+        assert_eq!(processor.apply(&typed, Some(&[])).unwrap(), "hi");
+        assert_eq!(processor.apply_raw(&raw, None).unwrap(), "hi");
+
+        let tools = one_tool("get_weather");
+        assert_eq!(processor.apply(&typed, Some(&tools)).unwrap(), "TOOLShi");
+    }
+
+    /// Issue #1597: the history-boundary render the prompt cache snapshots on
+    /// takes the same rule, so a cached boundary and the prompt it is a prefix
+    /// of cannot disagree about whether the tool preamble is there.
+    #[test]
+    fn history_render_leaves_tools_undefined_without_tools() {
+        const TEMPLATE: &str = "{% if tools is defined and tools is not none %}TOOLS{% endif %}\
+{% for m in messages %}{{ m.content }}{% endfor %}";
+        let processor = ChatTemplateProcessor::with_template(TEMPLATE.to_string());
+        let (typed, raw) = one_user_turn();
+        let kwargs = ChatTemplateKwargs::new();
+
+        assert_eq!(
+            processor
+                .apply_history_with_kwargs(&typed, None, &kwargs)
+                .unwrap(),
+            "hi"
+        );
+        assert_eq!(
+            processor
+                .apply_history_with_kwargs(&typed, Some(&[]), &kwargs)
+                .unwrap(),
+            "hi"
+        );
+        assert_eq!(
+            processor
+                .apply_raw_history_with_kwargs(&raw, None, &kwargs)
+                .unwrap(),
+            "hi"
+        );
     }
 
     #[test]

--- a/src/server/chat_template.rs
+++ b/src/server/chat_template.rs
@@ -2671,6 +2671,77 @@ mod tests {
         );
     }
 
+    /// Issue #1597 against the two shipped checkpoints, without loading a
+    /// single weight: `from_model_path` reads only the template files, so this
+    /// reproduces exactly what `/apply-template` answers, and it is the cheap
+    /// gate for the prompt strings that `tests/apply_template_tools_parity.rs`
+    /// re-checks over HTTP. Gated on the local `models/` tree.
+    ///
+    /// The Llama comparison replaces the `Today Date:` line, which the template
+    /// resolves through `strftime_now` at render time. The per-case
+    /// `enable_thinking` default is what `server::startup` derives from the
+    /// tokenizer's think markers (upstream PR #1114): true for Youtu, whose
+    /// template primes an empty `<think></think>` block when the value is
+    /// defined and false, and false for Llama 3.2, whose template never reads
+    /// the variable.
+    #[test]
+    #[ignore = "requires local models/ directory; run with --ignored"]
+    fn local_checkpoint_templates_render_the_transformers_prompt_without_tools() {
+        let models = std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("models/mlx");
+        let cases: [(&str, bool, &str); 2] = [
+            (
+                "youtu-llm-2b-4bit",
+                true,
+                "<|begin_of_text|><|User|>The Fibonacci sequence begins with<|Assistant|>",
+            ),
+            (
+                "llama-3.2-1b-4bit",
+                false,
+                "<|begin_of_text|><|start_header_id|>system<|end_header_id|>\n\nCutting Knowledge Date: December 2023\nToday Date: <DATE>\n\n<|eot_id|><|start_header_id|>user<|end_header_id|>\n\nThe Fibonacci sequence begins with<|eot_id|><|start_header_id|>assistant<|end_header_id|>\n\n",
+            ),
+        ];
+        let messages = vec![ChatMessage {
+            role: "user".to_string(),
+            content: "The Fibonacci sequence begins with".to_string(),
+        }];
+
+        for (name, enable_thinking, oracle) in cases {
+            let directory = models.join(name);
+            if !directory.exists() {
+                eprintln!("skip: {} not found", directory.display());
+                continue;
+            }
+            let mut processor = ChatTemplateProcessor::from_model_path(&directory)
+                .expect("read template")
+                .expect("checkpoint carries a chat template");
+            processor.set_default_enable_thinking(enable_thinking);
+
+            for tools in [None, Some(&[][..])] {
+                let rendered = processor.apply(&messages, tools).expect("render");
+                let normalized = rendered
+                    .split('\n')
+                    .map(|line| match line.starts_with("Today Date: ") {
+                        true => "Today Date: <DATE>".to_string(),
+                        false => line.to_string(),
+                    })
+                    .collect::<Vec<_>>()
+                    .join("\n");
+                assert_eq!(
+                    normalized, oracle,
+                    "{name} must render the transformers prompt for tools = {tools:?}"
+                );
+            }
+
+            let with_tools = processor
+                .apply(&messages, Some(&one_tool("get_weather")))
+                .expect("render with one tool");
+            assert!(
+                with_tools.contains("get_weather"),
+                "{name} must still declare a tool that was actually sent"
+            );
+        }
+    }
+
     #[test]
     fn test_apply_with_tools_passes_to_template() {
         // Template that explicitly uses tools

--- a/tests/apply_template_tools_parity.rs
+++ b/tests/apply_template_tools_parity.rs
@@ -1,0 +1,274 @@
+// Copyright 2025-2026 Lablup Inc. and Jeongkyu Shin
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Real-checkpoint parity for the rendered prompt of a tools-less chat request
+//! (issue #1597).
+//!
+//! Both checkpoints here guard their tool-calling preamble on whether `tools`
+//! is defined, in the two shapes that a defined-but-empty tool list used to
+//! satisfy: Youtu-LLM uses the DeepSeek V3 form
+//! `{% if tools is defined and tools is not none %}`, and Llama 3.2 defaults
+//! `tools` to `none` only when it is undefined and then branches on
+//! `{%- if tools is not none %}`. Rendering either one with `tools = []`
+//! produced a phantom preamble with an empty function list on every plain chat
+//! request, inflating the prompt from 8 to 76 tokens on Youtu and from 40 to 97
+//! on Llama 3.2 and steering the model toward a function-call format nobody
+//! asked for.
+//!
+//! The oracle strings below are what transformers, mlx-lm and a Python jinja2
+//! render with `tools` undefined or `tools=None` produce from the very same
+//! template files.
+//!
+//! The two servers are started one after the other inside a single test rather
+//! than in two parallel tests: the suite shares one Metal device, and two
+//! concurrently resident checkpoints is the shape that aborts runs.
+//!
+//! To run the gated test:
+//! ```text
+//! cargo test --test apply_template_tools_parity --release -- --ignored
+//! ```
+
+mod common;
+
+use std::net::TcpListener;
+use std::process::{Child, Command, Stdio};
+use std::time::{Duration, Instant};
+
+use common::{repo_binary_path, repo_model_dir};
+
+/// DeepSeek V3-style template, shipped as a standalone `chat_template.jinja`.
+const YOUTU_MODEL: &str = "mlx/youtu-llm-2b-4bit";
+
+/// Llama 3.2 template, carried in `tokenizer_config.json`.
+const LLAMA_MODEL: &str = "mlx/llama-3.2-1b-4bit";
+
+/// The one-line user turn every request below sends.
+const PROMPT: &str = "The Fibonacci sequence begins with";
+
+/// What transformers / mlx-lm render from the Youtu template with no tools.
+const YOUTU_ORACLE: &str =
+    "<|begin_of_text|><|User|>The Fibonacci sequence begins with<|Assistant|>";
+
+/// What Python jinja2 renders from the Llama 3.2 template with `tools`
+/// undefined, with the `Today Date:` line replaced by [`DATE_PLACEHOLDER`]
+/// because the template resolves it through `strftime_now` at render time.
+const LLAMA_ORACLE: &str = "<|begin_of_text|><|start_header_id|>system<|end_header_id|>\n\nCutting Knowledge Date: December 2023\nToday Date: <DATE>\n\n<|eot_id|><|start_header_id|>user<|end_header_id|>\n\nThe Fibonacci sequence begins with<|eot_id|><|start_header_id|>assistant<|end_header_id|>\n\n";
+
+const DATE_PLACEHOLDER: &str = "<DATE>";
+
+fn reserve_port() -> u16 {
+    let listener = TcpListener::bind("127.0.0.1:0").expect("bind ephemeral port");
+    let port = listener.local_addr().expect("local addr").port();
+    drop(listener);
+    port
+}
+
+async fn wait_for_health(client: &reqwest::Client, base_url: &str) {
+    let deadline = Instant::now() + Duration::from_secs(120);
+    while Instant::now() < deadline {
+        if let Ok(response) = client.get(format!("{base_url}/health")).send().await
+            && response.status().is_success()
+        {
+            return;
+        }
+        tokio::time::sleep(Duration::from_millis(200)).await;
+    }
+    panic!("mlxcel-server did not become healthy at {base_url}");
+}
+
+fn spawn_server(model_dir: &str, port: &str) -> Child {
+    Command::new(repo_binary_path("mlxcel-server"))
+        .args([
+            "--model",
+            model_dir,
+            "--host",
+            "127.0.0.1",
+            "--port",
+            port,
+            "--no-warmup",
+        ])
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .spawn()
+        .expect("spawn mlxcel-server")
+}
+
+fn stop_server(child: &mut Child) {
+    let _ = child.kill();
+    let _ = child.wait();
+}
+
+/// Replace the template-resolved `Today Date:` value with a fixed placeholder
+/// so the assertion does not depend on the day the suite runs.
+fn normalize_date(prompt: &str) -> String {
+    let mut out = String::with_capacity(prompt.len());
+    for (index, line) in prompt.split('\n').enumerate() {
+        if index > 0 {
+            out.push('\n');
+        }
+        match line.strip_prefix("Today Date: ") {
+            Some(_) => {
+                out.push_str("Today Date: ");
+                out.push_str(DATE_PLACEHOLDER);
+            }
+            None => out.push_str(line),
+        }
+    }
+    out
+}
+
+/// Body for the one-line user turn, with `tools` set only when `tools` is
+/// `Some`. `Some(json!([]))` is the explicit-empty-list case, which OpenAI and
+/// llama-server both read as "no tools".
+fn body(tools: Option<serde_json::Value>) -> serde_json::Value {
+    let mut body = serde_json::json!({
+        "messages": [{"role": "user", "content": PROMPT}]
+    });
+    if let Some(tools) = tools {
+        body["tools"] = tools;
+    }
+    body
+}
+
+fn one_tool() -> serde_json::Value {
+    serde_json::json!([{
+        "type": "function",
+        "function": {
+            "name": "get_weather",
+            "description": "Get weather",
+            "parameters": {"type": "object", "properties": {}}
+        }
+    }])
+}
+
+async fn rendered_prompt(
+    client: &reqwest::Client,
+    base_url: &str,
+    tools: Option<serde_json::Value>,
+) -> String {
+    let response = client
+        .post(format!("{base_url}/apply-template"))
+        .json(&body(tools))
+        .send()
+        .await
+        .expect("send /apply-template request");
+    assert!(
+        response.status().is_success(),
+        "/apply-template must succeed; got {}",
+        response.status()
+    );
+    let json: serde_json::Value = response.json().await.expect("parse /apply-template body");
+    json["prompt"]
+        .as_str()
+        .expect("/apply-template answers a string prompt")
+        .to_string()
+}
+
+async fn input_tokens(
+    client: &reqwest::Client,
+    base_url: &str,
+    tools: Option<serde_json::Value>,
+) -> u64 {
+    let response = client
+        .post(format!("{base_url}/v1/chat/completions/input_tokens"))
+        .json(&body(tools))
+        .send()
+        .await
+        .expect("send input_tokens request");
+    assert!(
+        response.status().is_success(),
+        "input_tokens must succeed; got {}",
+        response.status()
+    );
+    let json: serde_json::Value = response.json().await.expect("parse input_tokens body");
+    json["input_tokens"]
+        .as_u64()
+        .expect("input_tokens answers a number")
+}
+
+#[tokio::test]
+#[ignore = "requires local model weights and the mlxcel-server binary"]
+async fn apply_template_omits_the_tool_preamble_when_the_request_carries_no_tools() {
+    let youtu_dir = repo_model_dir(YOUTU_MODEL);
+    let llama_dir = repo_model_dir(LLAMA_MODEL);
+    if !youtu_dir.exists() || !llama_dir.exists() {
+        eprintln!(
+            "Skipping: need both {} and {}",
+            youtu_dir.display(),
+            llama_dir.display()
+        );
+        return;
+    }
+
+    let client = reqwest::Client::new();
+
+    // --- Youtu-LLM: `tools is defined and tools is not none` ---------------
+    let port = reserve_port().to_string();
+    let base_url = format!("http://127.0.0.1:{port}");
+    let mut child = spawn_server(&youtu_dir.to_string_lossy(), &port);
+    wait_for_health(&client, &base_url).await;
+
+    let no_tools = rendered_prompt(&client, &base_url, None).await;
+    let empty_tools = rendered_prompt(&client, &base_url, Some(serde_json::json!([]))).await;
+    let no_tools_count = input_tokens(&client, &base_url, None).await;
+    let with_tools = rendered_prompt(&client, &base_url, Some(one_tool())).await;
+    stop_server(&mut child);
+
+    assert_eq!(
+        no_tools, YOUTU_ORACLE,
+        "a tools-less request must render the transformers prompt"
+    );
+    assert_eq!(
+        empty_tools, YOUTU_ORACLE,
+        "an explicit empty tool list must render as no tools"
+    );
+    assert_eq!(
+        no_tools_count, 8,
+        "the tools-less Youtu prompt is 8 tokens, not the 76 the phantom preamble cost"
+    );
+    assert!(
+        with_tools.contains("<|begin_of_tool_description|>") && with_tools.contains("get_weather"),
+        "a request that does carry a tool must still render the tool block; got {with_tools:?}"
+    );
+
+    // --- Llama 3.2: `set tools = none` default, then `tools is not none` ---
+    let port = reserve_port().to_string();
+    let base_url = format!("http://127.0.0.1:{port}");
+    let mut child = spawn_server(&llama_dir.to_string_lossy(), &port);
+    wait_for_health(&client, &base_url).await;
+
+    let no_tools = rendered_prompt(&client, &base_url, None).await;
+    let no_tools_count = input_tokens(&client, &base_url, None).await;
+    let with_tools = rendered_prompt(&client, &base_url, Some(one_tool())).await;
+    stop_server(&mut child);
+
+    assert_eq!(
+        normalize_date(&no_tools),
+        LLAMA_ORACLE,
+        "a tools-less request must render the jinja2 tools-undefined prompt"
+    );
+    assert!(
+        !no_tools.contains("Environment: ipython")
+            && !no_tools.contains("Given the following functions"),
+        "neither tool branch may fire without tools; got {no_tools:?}"
+    );
+    assert_eq!(
+        no_tools_count, 40,
+        "the tools-less Llama 3.2 prompt is 40 tokens, not the 97 the phantom preamble cost"
+    );
+    assert!(
+        with_tools.contains("Environment: ipython") && with_tools.contains("get_weather"),
+        "a request that does carry a tool must still render the tool branch; got {with_tools:?}"
+    );
+}


### PR DESCRIPTION
## Summary

`build_template_context` inserted the `tools` key into the minijinja context unconditionally, and both render paths substituted an empty `Vec<Tool>` when the request carried no tools. Every template that selects its tool branch with `tools is defined` or `tools is not none` therefore took that branch on a plain chat request and rendered a tool-calling preamble with an empty function list. transformers passes `tools=None` and llama-server leaves the key unset, so neither of them does this. The key is now absent unless the request carries at least one tool.

Measured on the two shipped families, for `{"messages":[{"role":"user","content":"The Fibonacci sequence begins with"}]}` with no `tools` key:

| Checkpoint | Guard | Before | Oracle |
|---|---|---|---|
| `models/mlx/youtu-llm-2b-4bit` | `tools is defined and tools is not none` | 76 tokens, empty `<\|begin_of_tool_description\|>` block | 8 tokens |
| `models/mlx/llama-3.2-1b-4bit` | `set tools = none` default, then `tools is not none` | 97 tokens, `Environment: ipython` plus the functions preamble | 40 tokens |

## What changed

`src/server/chat_template.rs`: `build_template_context` takes `tools: Option<minijinja::Value>` and inserts the key only for `Some`. `apply_raw_inner` and `apply_inner` build that value as `tools.filter(|t| !t.is_empty()).map(minijinja::Value::from_serialize)`, so a request with no tools and a request with an explicit `"tools": []` both leave the key undefined. The tests-module render helper mirrors the same expression so it keeps reproducing what the server renders.

Normalizing inside the two inner functions covers every render in the tree at once: `/v1/chat/completions`, `/v1/messages`, `/v1/responses`, `/apply-template`, both `input_tokens` routes, the Muse ATEM stream path, the prompt cache's history-boundary render, and the offline `generate` and `chat` CLI commands. No caller was patched, no standalone helper was introduced, and `effective_tools` in `src/server/chat_request.rs` is untouched (it already maps `tool_choice: "none"` to `None`), so this PR does not overlap #1581.

Undefined rather than `none` is the required value, not a stylistic choice. minijinja 2.24's `iterable` test is `Value::try_iter().is_ok()`, which succeeds for `none`, while `| length` of `none` errors; the Nemotron / MiMo guard `tools is iterable and tools | length > 0` would therefore abort the render and degrade the prompt to the simple fallback. That family defaults an undefined `tools` to `[]` itself, so an absent key is the one value all three shipped guard shapes agree on. `tools` stays in `RESERVED_KEYS`, so a `chat_template_kwargs` entry still cannot fill the slot the request left empty.

The two stale comments that attributed the old empty-list workaround to minijinja short-circuiting are replaced with the actual `iterable` / `length` facts and a pointer to this issue.

`docs/llama-server-compat.md` gains a subsection under "Chat templates, reasoning, and output parsing" stating that llama-server defines `tools` only for a non-null tool array, that mlxcel now matches, that transformers' `tools=None` renders identically for every guard shape shipped, and that upgrading costs one cold prompt-cache miss per affected model.

## Context-key audit

Requested by the issue; also recorded as a comment on the insert block so the invariant travels with the code. `build_template_context` inserts exactly these keys:

- `messages`, `bos_token`, `eos_token`, `add_generation_prompt`: stay unconditional. Templates read them for their value and never test them with `is defined`; a missing one would change the rendered conversation rather than select a branch.
- `enable_thinking`: stays unconditional and stays defined. It is the tested per-request override point from #686 and #1114, and changing its definedness would change that contract. No shipped template was found where `enable_thinking is defined` alone flips a branch; if one turns up it is a follow-up issue, not a widening of this fix.
- `tools`: now conditional. This is the key the invariant was written for.
- `thinking` (#512) and `thinking_mode` (#775, #819): already conditional before this PR.
- `tool_choice` and `documents`: never inserted anywhere (`ctx.insert` / `owned.insert` in `chat_template.rs`), so there is nothing to audit.

## Prompt cache

The change alters `tokens[..prefix_len]` and the history-boundary render for affected models, so the first request per model after upgrading misses once and rebuilds. That is a one-time cold miss, not a compatibility break: no key digest version changes and no migration is needed.

## Test plan

- [x] `cargo test --profile test-fast --features metal,accelerate --lib server::chat_template` (154 passed), including four new tests: the DeepSeek/Youtu guard, the Llama guard, the Nemotron guard rendering without error, and the history-boundary render. `test_apply_with_tools_none_still_works`, `test_kwargs_cannot_override_reserved_tools_key`, `test_supports_tools_detection` and `test_supports_tools_caching` pass unchanged.
- [x] `cargo test --profile test-fast --features metal,accelerate --lib server::chat_request` (104 passed), plus `server::routes` (387), `server::tool` (384), `server::prompt_cache` (173), `server::reasoning_effort_tests` (28), `server::anthropic_translator` (33), `server::muse_atem_roundtrip_tests` (5), `server::muse_glimmer_template_tests` (6).
- [x] `cargo test --profile test-fast --features metal,accelerate --lib server::chat_template::tests::local_checkpoint_templates_render -- --ignored`: renders `models/mlx/youtu-llm-2b-4bit` and `models/mlx/llama-3.2-1b-4bit` through `from_model_path`, which reads only the template files, and both match the transformers oracle string exactly. This is the weight-free half of the gate and it runs in milliseconds; it caught that the Youtu template primes an empty `<think></think>` block unless `enable_thinking` is true, which `server::startup` derives from the tokenizer's think markers.
- [x] `cargo test --profile test-fast --features metal,accelerate --test apply_template_tools_parity` compiles and registers the gated HTTP test.
- [x] `cargo clippy --profile test-fast --lib --tests --features metal,accelerate -- -D warnings`
- [x] `cargo fmt --all -- --check`
- [x] `python3 scripts/ci/check_cross_repo_refs.py`
- [x] Static audit of the 196 chat templates under `models/`: every one of the 8 that computes `tools | length` guards it with a definedness or none test first, so no local template can error under an undefined `tools`.
- [ ] Real-checkpoint gate on `models/mlx/youtu-llm-2b-4bit` and `models/mlx/llama-3.2-1b-4bit` (`cargo test --test apply_template_tools_parity --release -- --ignored`, or the `/apply-template` and `input_tokens` curls in the issue). Run centrally; this PR did not start a server.

Closes #1597
