### PR TITLE
feat: add JSON inspect output

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,9 +75,14 @@ mlxcel generate -m Qwen3.5-0.8B-4bit -p "Hello, world!" -n 100
 # Read-only memory estimate before loading.
 mlxcel inspect -m Qwen3.5-0.8B-4bit --max-tokens 32768
 
+# Emit the same estimate as machine-readable bytes for recipe builders or schedulers.
+mlxcel inspect --json -m Qwen3.5-0.8B-4bit --max-tokens 32768 | python3 -m json.tool
+
 # Abort before generation if the estimated model and KV cache do not fit.
 mlxcel generate -m Qwen3.5-0.8B-4bit -p "Hello" -n 32768 --estimate-memory
 ```
+
+`mlxcel inspect --json` prints a single JSON object with byte-exact `weights_bytes`, `kv_bytes_total`, `activation_bytes`, `headroom_bytes`, `budget_bytes`, `total_bytes`, `fits`, input flags, and per-token FP16/INT8 KV rates when the model config exposes KV geometry. TurboQuant per-token sizing is reported as `null` until the estimator models those widths directly.
 
 ### Start a server
 

--- a/TECHNICAL_REPORTS/1605-json-inspect-output-20260903.en.md
+++ b/TECHNICAL_REPORTS/1605-json-inspect-output-20260903.en.md
@@ -1,0 +1,197 @@
+# Technical Report: PR #1605 - feat: add JSON inspect output
+
+**Date**: 2026-09-03
+**Author**: mlxcel maintainers
+**Reviewer**: implementation review cycle
+**Status**: Completed (CLI, library, clippy, and local real-checkpoint smoke are recorded in the PR; merge and broader integrated gates remain on the normal PR path)
+**Languages**: Rust, Markdown
+**Risk Level**: Medium (`mlxcel inspect` gains a new machine-readable contract, and resolver behavior now differs between text and JSON modes on cache misses)
+
+---
+
+## Executive Summary
+
+Recipe builders and schedulers needed the existing memory estimator as stable byte fields, but `mlxcel inspect` only exposed a human-readable banner. Any consumer had to scrape prose, infer units, and stay in lock-step with a CLI format that was written for operators rather than tooling.
+
+PR #1605 adds `mlxcel inspect --json` as a structured contract. The new path reuses the same estimator state as the banner, emits one JSON object with exact byte totals and effective inputs, derives `family` from the same registry-facing classifier mapping instead of raw `config.json` names, and resolves models quietly in offline mode so stdout stays machine-readable.
+
+---
+
+## 1. Problem Statement
+
+### 1.1 Background
+
+The repository already had a unified memory estimator behind `mlxcel inspect`, `generate --estimate-memory`, and `serve --estimate-memory`. That solved the sizing problem for humans, but not for automation. External recipe tooling needed byte-exact fields such as model weights, KV cache totals, activation reserve, headroom, and budget, while the CLI only printed a formatted text report.
+
+### 1.2 Existing issues
+
+- Tooling had to scrape human prose instead of reading a stable schema.
+- The raw `model_type` string in `config.json` did not always match public registry identifiers, so a consumer could not reliably join inspect output with the architecture catalog.
+- The normal model resolver prints expansion and downloader notices to stdout, which corrupts any command that promises "one JSON object" output.
+
+### 1.3 Risk of leaving it unfixed
+
+Without a structured surface, every downstream integration would have to duplicate fragile parsing logic and would break on presentation-only CLI changes. More importantly, a partially machine-readable command is worse than none at all: once stdout carries both data and resolver chatter, automation cannot safely distinguish success from noise.
+
+---
+
+## 2. Technical Review
+
+### 2.1 New contract
+
+`src/execution/memory_estimate.rs` now defines `InspectReport`, `InspectReportInputs`, and `InspectKvBytesPerToken`, and `InspectReport::from_estimate()` copies the same `MemoryEstimate` values the text banner already prints. The schema carries:
+
+- version and resolved model path
+- raw `model_type` and best-effort `family`
+- effective inputs: `max_tokens`, `batch`, `kv_cache_mode`, `quant`
+- byte fields: `weights_bytes`, `kv_bytes_total`, `activation_bytes`, `headroom_bytes`, `budget_bytes`, `total_bytes`
+- optional fields serialized as `null` when geometry is unavailable: per-token KV rates, paged per-slot overhead, family/model type
+
+This is the correct seam: the report is built from the estimator state rather than re-parsing rendered text, so the text and JSON forms cannot silently diverge.
+
+### 2.2 Resolver behavior
+
+`src/commands/inspect.rs` switches JSON mode onto `resolve_model_source_quietly_with_options()` and sets `offline: args.json`. That does two things deliberately:
+
+- cache hits stay silent, so stdout is exactly one JSON object
+- cache misses fail through stderr instead of auto-downloading with progress output
+
+The human-readable banner path keeps the previous reuse-or-download behavior, so the PR widens the CLI surface without changing the interactive operator workflow.
+
+### 2.3 Registry alignment
+
+The initial JSON branch would have slugified the raw `model_type`, but that would have drifted from public registry ids such as `qwen3_5` versus `qwen3-5`. The fix commit moves `family` onto `inspect_family_slug()`, which derives the value through `get_model_type()` and the same registry-id mapping the architecture catalog uses. Raw `model_type` remains present as a separate field.
+
+### 2.4 Compatibility and dependencies
+
+- No new dependency is introduced.
+- Existing `mlxcel inspect` banner output remains intact.
+- The change is additive at the CLI level: `--json` is new, not a behavior change for existing invocations.
+- JSON mode intentionally changes cache-miss semantics to offline failure, which should be treated as part of the contract, not an incidental implementation detail.
+
+---
+
+## 3. Technical Decisions
+
+### 3.1 Build JSON from the estimator, not from the banner
+
+The estimator already encoded the authoritative totals and fit decision. Reusing that state avoids dual logic and guarantees that the machine-readable and human-readable paths answer the same sizing question.
+
+The rejected alternative was parsing or reformatting the existing banner. That would have left two sources of truth and made wording-only text changes risky for automation.
+
+### 3.2 Keep stdout pure by making JSON mode quiet and offline
+
+Machine-readable CLI output is only trustworthy if stdout contains the payload and nothing else. The PR therefore treats resolver chatter as a correctness bug for `--json`, not a cosmetic issue. Quiet resolution alone was not enough because a cache miss could still invoke the downloader; forcing offline behavior closes that gap.
+
+The trade-off is that `mlxcel inspect --json -m <repo-id>` no longer auto-downloads on a miss. That is an acceptable constraint for automation, because scripts can now depend on a deterministic success shape and a deterministic failure channel.
+
+### 3.3 Separate `family` from raw `model_type`
+
+The contract exposes both fields because they solve different problems:
+
+- `model_type` preserves the checkpoint's raw metadata
+- `family` provides the registry-facing join key recipe tooling actually needs
+
+Collapsing them into one field would either lose raw metadata or leak internal naming drift into public tooling.
+
+### 3.4 Prefer nullable fields over invented defaults
+
+The PR serializes unavailable geometry-dependent fields as `null` instead of `0` or placeholder strings. That makes absence explicit and prevents downstream code from mistaking "not computable" for a real zero-cost value.
+
+---
+
+## 4. Implementation Details
+
+### 4.1 CLI surface
+
+`src/main.rs` adds `json: bool` to `InspectArgs`, documenting that `mlxcel inspect --json` emits the same estimate as one JSON object.
+
+### 4.2 Command flow
+
+`src/commands/inspect.rs` now:
+
+- resolves the model path through the quiet resolver when `--json` is set
+- preserves effective KV-cache-mode resolution, so the report matches what `generate` and `serve` would actually build
+- prints `serde_json::to_string_pretty(&report)` and returns early
+
+The text banner path remains unchanged, including the over-budget note for non-fitting configurations.
+
+### 4.3 Estimator extensions
+
+`src/execution/memory_estimate.rs` adds the JSON structs plus helpers for:
+
+- raw model-type extraction from `config.json`
+- best-effort family classification aligned with registry ids
+- paged per-slot overhead reporting for families that default to paged decode
+
+The unit tests cover contract copying, stable key order, null serialization, raw-versus-classified family values, and known registry edge cases such as `qwen3_5` and `gemma3_text`.
+
+### 4.4 Documentation
+
+- `README.md` adds a `mlxcel inspect --json` example and enumerates the key byte fields.
+- `docs/environment-variables.md` clarifies that `MLXCEL_MEMORY_LIMIT` also feeds the inspect and estimate-memory preflight figures through the same parser.
+
+---
+
+## 5. Validation
+
+The PR body records these checks:
+
+| Check | Result |
+|---|---|
+| `cargo fmt --check` | passed |
+| `cargo check --lib --tests` | passed |
+| `cargo test --lib -- memory_estimate` | passed |
+| `cargo clippy --lib --tests -- -D warnings` | passed |
+| Real checkpoint smoke on `/home/inureyes/models/mlx/qwen3-4b-4bit` | text banner preserved; JSON mode emitted one stdout object with empty stderr |
+| Cache-miss smoke on `definitely-missing-model-for-pr1605` | stdout stayed empty; failure surfaced on stderr |
+
+The validation is well matched to the change: it exercises the estimator unit boundary, the CLI integration path, and the structured-output cleanliness guarantee on both cache-hit and cache-miss branches.
+
+---
+
+## 6. Learning Points
+
+**Structured CLI output is a separate product surface.** Once a command promises machine readability, resolver messages and downloader progress are no longer harmless UX details; they are contract violations.
+
+**Raw metadata and public identifiers are not interchangeable.** `config.json` is useful provenance, but automation often needs a stable join key aligned with a curated catalog. Exposing both fields keeps those responsibilities separate.
+
+**Nullable beats fake certainty.** Returning `null` for unavailable geometry communicates the real state of the estimator and keeps consumers from baking in incorrect assumptions about unsupported paths such as TurboQuant sizing.
+
+---
+
+## 7. Change Summary
+
+### Statistics
+
+| Metric | Value |
+|---|---|
+| Files changed | 7 |
+| Lines added | 561 |
+| Lines removed | 20 |
+| Commits | 3 |
+
+### Related commits
+
+- `f8d670e` feat: add JSON inspect output
+- `c142dbd` fix: align inspect family with registry ids
+- `85eea20` fix: keep inspect JSON stdout machine-readable
+
+### Files of interest
+
+| File | Change |
+|---|---|
+| `src/main.rs` | Adds `--json` to `inspect` |
+| `src/commands/inspect.rs` | Routes JSON mode through quiet offline resolution and report serialization |
+| `src/execution/memory_estimate.rs` | Adds the JSON contract and contract-focused tests |
+| `src/downloader/resolver.rs` | Exposes quiet model resolution for structured-output callers |
+| `README.md` | Documents the new JSON form |
+| `docs/environment-variables.md` | Clarifies memory-limit interaction with inspect/preflight |
+
+---
+
+## 8. Follow-up Actions
+
+- Replace the local `inspect_family_slug()` fallback with the canonical `mlxcel arch --json` registry id once issue `#1508` lands on `main`.
+- If external tooling begins depending on the JSON shape, promote the schema to an explicit documentation page or compatibility note so future additions remain additive.
+- Consider whether other structured CLI surfaces should adopt the same "quiet stdout, stderr on failure" rule, to keep automation semantics consistent across commands.

--- a/TECHNICAL_REPORTS/1605-json-inspect-output-20260903.ko.md
+++ b/TECHNICAL_REPORTS/1605-json-inspect-output-20260903.ko.md
@@ -1,0 +1,197 @@
+# 기술 보고서: PR #1605 - feat: add JSON inspect output
+
+**작성일**: 2026-09-03
+**작성자**: mlxcel maintainers
+**리뷰어**: implementation review cycle
+**상태**: 완료 (PR 본문에 CLI, 라이브러리, clippy, 로컬 실체크포인트 스모크가 기록돼 있다. 머지와 더 넓은 통합 게이트는 일반 PR 경로에서 진행된다)
+**언어**: Rust, Markdown
+**위험도**: Medium (`mlxcel inspect`에 새로운 기계 판독 계약이 추가되고, 캐시 미스 시 resolver 동작이 텍스트 모드와 JSON 모드에서 달라진다)
+
+---
+
+## 요약
+
+레시피 빌더와 스케줄러는 기존 메모리 추정기를 안정적인 바이트 필드로 필요로 했지만, `mlxcel inspect`는 사람이 읽는 배너만 제공했다. 소비자는 전부 문장을 파싱해 단위를 추론해야 했고, 운영자를 위한 CLI 표현 형식과 강하게 결합될 수밖에 없었다.
+
+PR #1605는 `mlxcel inspect --json`을 구조화된 계약으로 추가한다. 새 경로는 배너와 같은 추정기 상태를 그대로 재사용하고, 정확한 바이트 총량과 실제 입력값을 담은 JSON 객체 하나를 출력하며, `family`는 원시 `config.json` 이름이 아니라 공개 레지스트리와 맞물리는 classifier 매핑에서 유도한다. 또한 모델 해석은 조용한 offline 경로로 보내서 stdout이 항상 기계 판독 가능한 상태를 유지한다.
+
+---
+
+## 1. 문제 정의
+
+### 1.1 배경
+
+저장소에는 이미 `mlxcel inspect`, `generate --estimate-memory`, `serve --estimate-memory`가 함께 쓰는 통합 메모리 추정기가 있었다. 사람에게는 충분했지만 자동화에는 충분하지 않았다. 외부 레시피 도구는 모델 가중치, KV 캐시 총량, activation reserve, headroom, budget 같은 바이트 단위 필드를 필요로 했고, CLI는 서술형 텍스트 보고서만 내보냈다.
+
+### 1.2 기존 문제점
+
+- 도구가 안정적인 스키마 대신 사람이 읽는 문장을 파싱해야 했다.
+- `config.json`의 원시 `model_type` 문자열은 공개 레지스트리 식별자와 항상 일치하지 않아, inspect 결과를 아키텍처 카탈로그와 안정적으로 조인할 수 없었다.
+- 일반 모델 resolver는 bare-name 확장과 다운로드 안내를 stdout에 찍기 때문에, "JSON 객체 하나"를 약속하는 명령과 양립할 수 없었다.
+
+### 1.3 방치 시 위험
+
+구조화된 표면이 없으면 모든 하위 통합이 취약한 파서 로직을 중복 구현해야 하고, 표현만 바뀌는 CLI 변경에도 깨지게 된다. 더 큰 문제는 반쯤만 기계 판독 가능한 명령은 없는 것보다 더 나쁘다는 점이다. stdout에 데이터와 resolver 잡음이 함께 섞이면 자동화는 성공과 노이즈를 안전하게 구분할 수 없다.
+
+---
+
+## 2. 기술적 검토
+
+### 2.1 새 계약
+
+`src/execution/memory_estimate.rs`는 이제 `InspectReport`, `InspectReportInputs`, `InspectKvBytesPerToken`을 정의하고, `InspectReport::from_estimate()`가 텍스트 배너가 이미 출력하던 `MemoryEstimate` 값을 그대로 복사한다. 스키마에는 다음이 들어간다.
+
+- 버전과 해석된 모델 경로
+- 원시 `model_type`과 best-effort `family`
+- 실제 입력값: `max_tokens`, `batch`, `kv_cache_mode`, `quant`
+- 바이트 필드: `weights_bytes`, `kv_bytes_total`, `activation_bytes`, `headroom_bytes`, `budget_bytes`, `total_bytes`
+- 계산 불가 시 `null`로 직렬화되는 선택 필드: 토큰당 KV 비율, paged per-slot overhead, family/model type
+
+이 경계가 맞다. 보고서는 렌더된 텍스트를 다시 파싱하는 대신 추정기 상태에서 직접 만들어지므로, 텍스트와 JSON 형식이 조용히 어긋날 수 없다.
+
+### 2.2 Resolver 동작
+
+`src/commands/inspect.rs`는 JSON 모드에서 `resolve_model_source_quietly_with_options()`를 사용하고 `offline: args.json`을 설정한다. 의도는 두 가지다.
+
+- 캐시 히트는 조용하게 지나가서 stdout이 정확히 JSON 객체 하나만 갖게 한다.
+- 캐시 미스는 자동 다운로드 대신 stderr 실패로 끝나서, 다운로더 진행 메시지가 출력물을 오염시키지 않는다.
+
+사람이 읽는 배너 경로는 이전 reuse-or-download 동작을 유지하므로, 이 PR은 대화형 운영자 경험을 바꾸지 않고 CLI 표면을 확장한다.
+
+### 2.3 레지스트리 정렬
+
+초기 JSON 경로는 raw `model_type`를 slugify하려 했지만, 그러면 `qwen3_5` 대 `qwen3-5`처럼 공개 레지스트리 id와 어긋날 수 있었다. 수정 커밋은 `family`를 `inspect_family_slug()`로 옮겨 `get_model_type()`과 아키텍처 카탈로그와 같은 registry-id 매핑을 통해 값을 유도한다. 원시 `model_type`는 별도 필드로 그대로 남긴다.
+
+### 2.4 호환성/의존성 관점
+
+- 새로운 의존성은 없다.
+- 기존 `mlxcel inspect` 배너 출력은 유지된다.
+- CLI 수준에서는 추가적 변경이다. `--json`이 새로 생겼을 뿐 기존 호출의 의미는 바뀌지 않는다.
+- JSON 모드의 캐시 미스 offline 실패는 부수 효과가 아니라 계약 일부로 다뤄야 한다.
+
+---
+
+## 3. 기술적 선택과 그 이유
+
+### 3.1 배너를 파싱하지 않고 추정기 상태에서 JSON을 만든다
+
+추정기는 이미 총량과 fit 판정을 위한 권위 있는 상태를 갖고 있었다. 그 상태를 재사용하면 이중 로직을 피하고, 기계 판독 경로와 사람이 읽는 경로가 같은 sizing 질문에 답하도록 강제할 수 있다.
+
+버린 대안은 기존 배너를 다시 파싱하거나 재포맷하는 방식이다. 그 방식은 두 개의 진실 원천을 남기고, 설명 문구만 바뀌는 텍스트 수정도 자동화에 위험하게 만든다.
+
+### 3.2 stdout을 깨끗하게 유지하기 위해 JSON 모드를 quiet + offline으로 둔다
+
+기계가 읽는 CLI 출력은 stdout에 payload만 있어야 믿을 수 있다. 이 PR은 resolver 메시지를 꾸밈 문제가 아니라 `--json`의 정확성 문제로 취급한다. 단순히 quiet resolver만 도입해서는 부족했고, 캐시 미스가 downloader를 호출할 수 있으므로 offline 강제가 필요했다.
+
+대가도 있다. `mlxcel inspect --json -m <repo-id>`는 캐시 미스에서 더 이상 자동 다운로드하지 않는다. 그러나 자동화 입장에서는 받아들일 만한 제약이다. 이제 스크립트는 성공 시의 모양과 실패 채널을 모두 결정적으로 가정할 수 있다.
+
+### 3.3 `family`와 raw `model_type`를 분리한다
+
+두 필드는 역할이 다르므로 둘 다 노출하는 편이 맞다.
+
+- `model_type`는 체크포인트의 원시 메타데이터를 보존한다.
+- `family`는 레시피 도구가 실제로 필요로 하는 레지스트리 조인 키를 제공한다.
+
+하나로 합치면 원시 메타데이터를 잃거나, 반대로 공개 도구에 내부 이름 흔들림을 그대로 새기게 된다.
+
+### 3.4 없는 값은 가짜 기본값 대신 `null`로 둔다
+
+기하 정보가 없어 계산할 수 없는 필드를 `0`이나 임의 문자열로 채우지 않고 `null`로 직렬화한다. 이렇게 해야 "계산 불가"가 드러나고, 소비자가 TurboQuant 크기처럼 아직 지원하지 않는 경로를 실제 0 비용으로 오해하지 않는다.
+
+---
+
+## 4. 구현 상세
+
+### 4.1 CLI 표면
+
+`src/main.rs`는 `InspectArgs`에 `json: bool`을 추가해 `mlxcel inspect --json`이 같은 추정치를 JSON 객체 하나로 출력한다고 문서화한다.
+
+### 4.2 명령 흐름
+
+`src/commands/inspect.rs`는 이제:
+
+- `--json`일 때 quiet resolver로 모델 경로를 해석하고
+- 실제 `generate`와 `serve`가 만들 KV 캐시 모드를 그대로 해석한 뒤
+- `serde_json::to_string_pretty(&report)`를 출력하고 조기 반환한다
+
+텍스트 배너 경로는 그대로 유지되며, fitting 실패 시의 안내 문구도 유지된다.
+
+### 4.3 추정기 확장
+
+`src/execution/memory_estimate.rs`는 JSON 구조체와 함께 다음 도우미를 추가한다.
+
+- `config.json`에서 raw model type을 추출하는 함수
+- 레지스트리 id와 정렬된 best-effort family 분류 함수
+- 기본 paged decode 계열에 대한 per-slot overhead 보고 함수
+
+단위 테스트는 계약 복사, 안정적인 키 순서, null 직렬화, raw와 classified family 값의 차이, `qwen3_5`와 `gemma3_text` 같은 레지스트리 경계 사례를 검증한다.
+
+### 4.4 문서
+
+- `README.md`는 `mlxcel inspect --json` 예시와 핵심 바이트 필드를 추가한다.
+- `docs/environment-variables.md`는 `MLXCEL_MEMORY_LIMIT`가 inspect와 estimate-memory preflight에도 같은 파서로 반영된다는 점을 명확히 한다.
+
+---
+
+## 5. 검증
+
+PR 본문에 기록된 검증은 다음과 같다.
+
+| 검사 | 결과 |
+|---|---|
+| `cargo fmt --check` | 통과 |
+| `cargo check --lib --tests` | 통과 |
+| `cargo test --lib -- memory_estimate` | 통과 |
+| `cargo clippy --lib --tests -- -D warnings` | 통과 |
+| `/home/inureyes/models/mlx/qwen3-4b-4bit` 실체크포인트 스모크 | 텍스트 배너 유지, JSON 모드는 빈 stderr와 함께 stdout JSON 객체 1개 출력 |
+| `definitely-missing-model-for-pr1605` 캐시 미스 스모크 | stdout 비어 있음, 실패는 stderr로만 노출 |
+
+이 검증은 변경 범위와 잘 맞는다. 추정기 단위 경계, CLI 통합 경로, 그리고 캐시 히트/미스 양쪽에서의 structured-output 청결성을 모두 확인한다.
+
+---
+
+## 6. 학습 포인트
+
+**구조화된 CLI 출력은 별도의 제품 표면이다.** 명령이 기계 판독을 약속하는 순간 resolver 메시지나 다운로드 진행 출력은 더 이상 무해한 UX가 아니라 계약 위반이 된다.
+
+**원시 메타데이터와 공개 식별자는 같은 것이 아니다.** `config.json`은 출처 정보로 유용하지만, 자동화는 종종 정제된 카탈로그와 맞물리는 안정적인 조인 키를 필요로 한다. 두 필드를 함께 노출하면 책임이 분리된다.
+
+**가짜 확정보다 nullable이 낫다.** 계산할 수 없는 필드를 `null`로 두면 추정기의 실제 상태가 드러나고, 아직 지원되지 않은 경로에 대해 하위 소비자가 잘못된 가정을 굳히는 일을 막을 수 있다.
+
+---
+
+## 7. 변경 요약
+
+### 통계
+
+| 항목 | 값 |
+|---|---|
+| 변경 파일 수 | 7 |
+| 추가 줄 | 561 |
+| 삭제 줄 | 20 |
+| 커밋 수 | 3 |
+
+### 관련 커밋
+
+- `f8d670e` feat: add JSON inspect output
+- `c142dbd` fix: align inspect family with registry ids
+- `85eea20` fix: keep inspect JSON stdout machine-readable
+
+### 주요 파일
+
+| 파일 | 변경 |
+|---|---|
+| `src/main.rs` | `inspect`에 `--json` 추가 |
+| `src/commands/inspect.rs` | JSON 모드를 quiet offline 해석과 report 직렬화로 연결 |
+| `src/execution/memory_estimate.rs` | JSON 계약과 계약 중심 테스트 추가 |
+| `src/downloader/resolver.rs` | structured-output 호출자를 위한 quiet model resolution 노출 |
+| `README.md` | 새 JSON 형식 문서화 |
+| `docs/environment-variables.md` | memory-limit와 inspect/preflight 연계를 명시 |
+
+---
+
+## 8. 후속 조치
+
+- 이슈 `#1508`이 `main`에 들어오면, 로컬 `inspect_family_slug()` fallback을 정식 `mlxcel arch --json` registry id로 교체한다.
+- 외부 도구가 이 JSON 형태에 의존하기 시작하면, 이후 확장이 additive로 유지되도록 전용 문서나 호환성 노트를 두는 편이 좋다.
+- 다른 structured CLI 표면도 같은 "stdout은 조용하게, 실패는 stderr" 규칙을 따를지 검토하면 자동화 의미론을 명령 간에 더 일관되게 만들 수 있다.

--- a/docs/environment-variables.md
+++ b/docs/environment-variables.md
@@ -139,6 +139,8 @@ and `--estimate-memory` preflight reads `MLXCEL_MEMORY_LIMIT` through that same
 parser, so the availability figure it prints matches the cap the allocator will
 actually apply (issue #1317).
 
+When `mlxcel inspect --json` is used, the same availability figure is exposed as raw bytes in `budget_bytes`; `weights_bytes`, `kv_bytes_total`, `activation_bytes`, `headroom_bytes`, and `total_bytes` are also raw byte counts so downstream recipe tooling can compare model and hardware fits without scraping the text banner.
+
 ## Server context sizing
 
 `mlxcel serve` and `mlxcel-server` follow llama.cpp server semantics for the

--- a/src/commands/inspect.rs
+++ b/src/commands/inspect.rs
@@ -26,7 +26,10 @@ use anyhow::{Result, anyhow};
 
 use mlxcel::cli::turbo_args::resolve_kv_cache_mode;
 use mlxcel::downloader::resolve_model_source_with_override;
-use mlxcel::memory_estimate::{QuantHint, estimate_total_memory, format_estimate};
+use mlxcel::memory_estimate::{
+    InspectReport, QuantHint, estimate_total_memory, format_estimate, inspect_family_slug,
+    inspect_per_slot_overhead_bytes, raw_model_type_from_config,
+};
 use mlxcel_core::cache::KVCacheMode;
 
 use crate::InspectArgs;
@@ -64,6 +67,19 @@ pub(crate) fn run_inspect(mut args: InspectArgs) -> Result<()> {
     let kv_int8 = matches!(kv_cache_mode, KVCacheMode::Int8);
 
     let estimate = estimate_total_memory(&args.model, args.max_tokens, args.batch, quant, kv_int8);
+
+    if args.json {
+        let report = InspectReport::from_estimate(
+            &args.model,
+            &estimate,
+            kv_cache_mode.to_string(),
+            raw_model_type_from_config(&args.model),
+            inspect_family_slug(&args.model),
+            inspect_per_slot_overhead_bytes(&args.model, args.batch),
+        );
+        println!("{}", serde_json::to_string_pretty(&report)?);
+        return Ok(());
+    }
 
     let banner = format_estimate(&args.model, &estimate);
     println!("{banner}");

--- a/src/commands/inspect.rs
+++ b/src/commands/inspect.rs
@@ -25,7 +25,10 @@
 use anyhow::{Result, anyhow};
 
 use mlxcel::cli::turbo_args::resolve_kv_cache_mode;
-use mlxcel::downloader::resolve_model_source_with_override;
+use mlxcel::downloader::{
+    ModelSourceOptions, resolve_model_source_quietly_with_options,
+    resolve_model_source_with_options,
+};
 use mlxcel::memory_estimate::{
     InspectReport, QuantHint, estimate_total_memory, format_estimate, inspect_family_slug,
     inspect_per_slot_overhead_bytes, raw_model_type_from_config,
@@ -39,15 +42,23 @@ pub(crate) fn run_inspect(mut args: InspectArgs) -> Result<()> {
     // Resolve `-m` into a concrete model directory (epic #92, issue #94): an
     // existing path is used as-is (byte-identical to the pre-#94 behavior),
     // while an `owner/name` HuggingFace repo-id is reused from the legacy CWD /
-    // HF cache / mlxcel store or auto-downloaded into the mlxcel store. On a
-    // miss-and-error this returns a clear message; on success `args.model` is
-    // guaranteed to name an existing snapshot, so the downstream estimator
-    // path is unchanged.
-    args.model = resolve_model_source_with_override(
-        &args.model,
-        args.models_dir.as_deref(),
-        args.revision.as_deref(),
-    )?;
+    // HF cache / mlxcel store or, for the human-readable banner path, auto-
+    // downloaded into the mlxcel store. JSON mode is offline and quiet so stdout
+    // remains a single JSON object; a cache miss is reported through the normal
+    // error path instead of interleaving downloader progress with the report. On
+    // success `args.model` is guaranteed to name an existing snapshot, so the
+    // downstream estimator path is unchanged.
+    let source_options = ModelSourceOptions {
+        models_dir: args.models_dir.as_deref(),
+        revision: args.revision.as_deref(),
+        offline: args.json,
+        ..ModelSourceOptions::default()
+    };
+    args.model = if args.json {
+        resolve_model_source_quietly_with_options(&args.model, source_options)?
+    } else {
+        resolve_model_source_with_options(&args.model, source_options)?
+    };
 
     // Translate the user-facing `--quant` label into the typed hint.
     let quant = parse_quant_hint(&args.quant)?;

--- a/src/downloader/mod.rs
+++ b/src/downloader/mod.rs
@@ -105,6 +105,7 @@ pub use progress::should_show_progress;
 pub use resolver::ModelSourceOptions;
 pub use resolver::normalize_repo_id;
 pub use resolver::resolve_model_source;
+pub use resolver::resolve_model_source_quietly_with_options;
 pub use resolver::resolve_model_source_with_options;
 pub use resolver::resolve_model_source_with_override;
 pub use store::{

--- a/src/downloader/resolver.rs
+++ b/src/downloader/resolver.rs
@@ -198,6 +198,26 @@ pub fn resolve_model_source_with_options(
     value: &Path,
     opts: ModelSourceOptions<'_>,
 ) -> Result<PathBuf> {
+    resolve_model_source_with_options_inner(value, opts, false)
+}
+
+/// Quiet options-aware entry point for machine-readable command surfaces.
+///
+/// Suppresses resolver informational stdout. Callers that require stdout to
+/// carry only structured data should also set [`ModelSourceOptions::offline`]
+/// so a cache miss cannot invoke the downloader's progress output.
+pub fn resolve_model_source_quietly_with_options(
+    value: &Path,
+    opts: ModelSourceOptions<'_>,
+) -> Result<PathBuf> {
+    resolve_model_source_with_options_inner(value, opts, true)
+}
+
+fn resolve_model_source_with_options_inner(
+    value: &Path,
+    opts: ModelSourceOptions<'_>,
+    quiet: bool,
+) -> Result<PathBuf> {
     // Format gate first: a `.gguf` path exists on disk and would otherwise be
     // returned verbatim by step 1 below, then fail inside the loader with a
     // message that never mentions the format.
@@ -227,7 +247,7 @@ pub fn resolve_model_source_with_options(
     // 2. `owner/name` repo-id shape → reuse-or-download. An explicit
     //    `owner/name` always wins over the bare-name default org below.
     if is_repo_id_shape(value_str) {
-        return resolve_repo_id(value_str, opts);
+        return resolve_repo_id(value_str, opts, quiet);
     }
 
     // 3. Bare, prefix-less model name (issue #112): a single valid segment with
@@ -237,8 +257,8 @@ pub fn resolve_model_source_with_options(
     //    `mlx-community/gemma-4-e4b-it-4bit`. Steps 1 and 2 take precedence, so
     //    an existing local path and an explicit `owner/name` are unaffected.
     if is_repo_segment(value_str) {
-        let repo_id = expand_bare_name(value_str)?;
-        return resolve_repo_id(&repo_id, opts);
+        let repo_id = expand_bare_name(value_str, quiet)?;
+        return resolve_repo_id(&repo_id, opts, quiet);
     }
 
     // 4. Neither an existing path, a valid repo-id, nor a bare model name.
@@ -307,7 +327,7 @@ pub fn resolve_model_source_with_override(
 /// reuse location is still consulted in the same order, and a miss becomes
 /// [`offline_cache_miss_error`] rather than a download. `opts.token`
 /// (`--hf-token`) is forwarded to the downloader as the explicit token.
-fn resolve_repo_id(repo_id: &str, opts: ModelSourceOptions<'_>) -> Result<PathBuf> {
+fn resolve_repo_id(repo_id: &str, opts: ModelSourceOptions<'_>, quiet: bool) -> Result<PathBuf> {
     let ModelSourceOptions {
         models_dir,
         revision,
@@ -360,9 +380,12 @@ fn resolve_repo_id(repo_id: &str, opts: ModelSourceOptions<'_>) -> Result<PathBu
     match store_dest.as_deref().map(classify_snapshot) {
         Some(SnapshotState::Incomplete { missing }) => {
             // `store_dest` is Some in this arm, so the unwrap cannot panic.
-            report_incomplete_snapshot(store_dest.as_deref().unwrap_or(&cwd_models), &missing);
+            if !quiet {
+                report_incomplete_snapshot(store_dest.as_deref().unwrap_or(&cwd_models), &missing);
+            }
         }
-        _ => announce_fresh_download(repo_id),
+        _ if !quiet => announce_fresh_download(repo_id),
+        _ => {}
     }
 
     download_repo(download_options(
@@ -685,13 +708,15 @@ fn bad_default_org_error(org: &str, name: &str) -> anyhow::Error {
 /// Returns [`bad_default_org_error`] when `$MLXCEL_DEFAULT_ORG` expands the
 /// name into something that is not a valid `owner/name` repo-id (e.g. the org
 /// contains a `/` or an illegal character).
-fn expand_bare_name(name: &str) -> Result<String> {
+fn expand_bare_name(name: &str, quiet: bool) -> Result<String> {
     let org = default_org();
     let repo_id = format!("{org}/{name}");
     if !is_repo_id_shape(&repo_id) {
         return Err(bad_default_org_error(&org, name));
     }
-    println!("[mlxcel] '{name}' -> {repo_id}");
+    if !quiet {
+        println!("[mlxcel] '{name}' -> {repo_id}");
+    }
     Ok(repo_id)
 }
 
@@ -724,7 +749,7 @@ fn expand_bare_name(name: &str) -> Result<String> {
 /// invalid repo-id under a malformed `$MLXCEL_DEFAULT_ORG`.
 pub fn normalize_repo_id(value: &str) -> Result<String> {
     if is_repo_segment(value) {
-        expand_bare_name(value)
+        expand_bare_name(value, false)
     } else {
         Ok(value.to_string())
     }

--- a/src/execution/memory_estimate.rs
+++ b/src/execution/memory_estimate.rs
@@ -881,10 +881,9 @@ pub fn raw_model_type_from_config(model_dir: &Path) -> Option<String> {
 /// registry id once that contract is available on `main`.
 #[must_use]
 pub fn inspect_family_slug(model_dir: &Path) -> Option<String> {
-    if let Some(raw) = raw_model_type_from_config(model_dir) {
-        return Some(slugify_identifier(&raw));
-    }
-    get_model_type(model_dir).ok().map(slugify_model_type)
+    get_model_type(model_dir)
+        .ok()
+        .map(|model_type| inspect_registry_id(model_type).to_string())
 }
 
 /// Fused paged-decode workspace reserve for families that select the paged
@@ -919,26 +918,182 @@ fn model_type_uses_default_paged_decode(model_type: ModelType) -> bool {
     )
 }
 
-fn slugify_model_type(model_type: ModelType) -> String {
-    slugify_identifier(&format!("{model_type:?}"))
-}
-
-fn slugify_identifier(input: &str) -> String {
-    let mut out = String::new();
-    let mut prev_was_sep = true;
-    for ch in input.chars() {
-        if ch.is_ascii_alphanumeric() {
-            out.push(ch.to_ascii_lowercase());
-            prev_was_sep = false;
-        } else if !prev_was_sep {
-            out.push('-');
-            prev_was_sep = true;
-        }
+fn inspect_registry_id(model_type: ModelType) -> &'static str {
+    match model_type {
+        ModelType::Llama => "llama",
+        ModelType::IQuestCoder => "iquest_coder",
+        ModelType::Llama4 => "llama4",
+        ModelType::Llama4VLM => "llama4_vlm",
+        ModelType::MllamaVLM => "mllama_vlm",
+        ModelType::Qwen2 => "qwen2",
+        ModelType::Qwen3 => "qwen3",
+        ModelType::Qwen3Moe => "qwen3_moe",
+        ModelType::Qwen3Next => "qwen3_next",
+        ModelType::Qwen35 => "qwen3_5",
+        ModelType::Qwen35VLM => "qwen3_5_vlm",
+        ModelType::Qwen35Moe => "qwen3_5_moe",
+        ModelType::Qwen35MoeVLM => "qwen3_5_moe_vlm",
+        ModelType::Gemma => "gemma",
+        ModelType::Gemma2 => "gemma2",
+        ModelType::Gemma3 => "gemma3",
+        ModelType::Gemma4 => "gemma4",
+        ModelType::DiffusionGemma => "diffusion_gemma",
+        ModelType::Llada2Moe => "llada2_moe",
+        ModelType::Gemma3VLM => "gemma3_vlm",
+        ModelType::Gemma4VLM => "gemma4_vlm",
+        ModelType::Gemma4Unified => "gemma4_unified",
+        ModelType::LlavaVLM => "llava_vlm",
+        ModelType::GraniteVisionVLM => "granite_vision_vlm",
+        ModelType::Granite4VisionVLM => "granite4_vision_vlm",
+        ModelType::DeepSeekOcrVLM => "deepseek_ocr_vlm",
+        ModelType::DeepSeekOcr2VLM => "deepseek_ocr2_vlm",
+        ModelType::UnlimitedOcrVLM => "unlimited_ocr_vlm",
+        ModelType::DeepSeekVL2 => "deepseek_vl2",
+        ModelType::LlavaBunnyVLM => "llava_bunny_vlm",
+        ModelType::FastVLM => "fast_vlm",
+        ModelType::Ernie45MoeVLM => "ernie4_5_moe_vlm",
+        ModelType::HunyuanVLM => "hunyuan_vlm",
+        ModelType::AyaVisionVLM => "aya_vision_vlm",
+        ModelType::PaliGemmaVLM => "paligemma_vlm",
+        ModelType::PixtralVLM => "pixtral_vlm",
+        ModelType::Mistral3VLM => "mistral3_vlm",
+        ModelType::Qwen2VL => "qwen2_vl",
+        ModelType::Qwen25VL => "qwen2_5_vl",
+        ModelType::Qwen3VL => "qwen3_vl",
+        ModelType::Qwen3VLMoe => "qwen3_vl_moe",
+        ModelType::Qwen3OmniMoe => "qwen3_omni_moe",
+        ModelType::PaddleOcrVL => "paddleocr_vl",
+        ModelType::DotsOcrVL => "dots_ocr_vl",
+        ModelType::FalconOcrVL => "falcon_ocr_vl",
+        ModelType::JinaVLM => "jina_vlm",
+        ModelType::Glm4v => "glm4v",
+        ModelType::Glm4vMoe => "glm4v_moe",
+        ModelType::GlmOcr => "glm_ocr",
+        ModelType::YoutuLLM => "youtu_llm",
+        ModelType::YoutuVLM => "youtu_vlm",
+        ModelType::InternVLChatVLM => "internvl_chat_vlm",
+        ModelType::LocateAnythingVLM => "locateanything_vlm",
+        ModelType::SmolVLM => "smolvlm",
+        ModelType::Idefics2 => "idefics2",
+        ModelType::MiniCPMOVLM => "minicpmo_vlm",
+        ModelType::MiniCPMV46VLM => "minicpmv4_6_vlm",
+        ModelType::Moondream3VLM => "moondream3_vlm",
+        ModelType::Moondream2VLM => "moondream2_vlm",
+        ModelType::Florence2VLM => "florence2_vlm",
+        ModelType::Gemma3n => "gemma3n",
+        ModelType::Gemma3nVLM => "gemma3n_vlm",
+        ModelType::Phi => "phi",
+        ModelType::Phixtral => "phixtral",
+        ModelType::Phi3 => "phi3",
+        ModelType::Phi4MMVLM => "phi4_mm_vlm",
+        ModelType::Phi4SigLipVLM => "phi4_siglip_vlm",
+        ModelType::Phi3VLM => "phi3_vlm",
+        ModelType::MolmoVLM => "molmo_vlm",
+        ModelType::Molmo2VLM => "molmo2_vlm",
+        ModelType::MolmoPointVLM => "molmo_point_vlm",
+        ModelType::Phi3Small => "phi3small",
+        ModelType::PhiMoe => "phimoe",
+        ModelType::GptOss => "gpt_oss",
+        ModelType::MiniMax => "minimax",
+        ModelType::MiniMaxM3 => "minimax_m3",
+        ModelType::MiniMaxM3VL => "minimax_m3_vl",
+        ModelType::MuseGlimmerVLM => "muse_glimmer_vlm",
+        ModelType::Mixtral => "mixtral",
+        ModelType::Qwen2Moe => "qwen2_moe",
+        ModelType::OLMoE => "olmoe",
+        ModelType::Dbrx => "dbrx",
+        ModelType::DeepSeek => "deepseek",
+        ModelType::DeepSeekV2 => "deepseek_v2",
+        ModelType::DeepSeekV3 => "deepseek_v3",
+        ModelType::DeepSeekV32 => "deepseek_v32",
+        ModelType::DeepSeekV4 => "deepseek_v4",
+        ModelType::Dots1 => "dots1",
+        ModelType::Cohere => "cohere",
+        ModelType::Cohere2 => "cohere2",
+        ModelType::Cohere2Moe => "cohere2_moe",
+        ModelType::InternLM2 => "internlm2",
+        ModelType::InternLM3 => "internlm3",
+        ModelType::Baichuan => "baichuan",
+        ModelType::Glm4 => "glm4",
+        ModelType::Glm4Moe => "glm4_moe",
+        ModelType::Glm4MoeLite => "glm4_moe_lite",
+        ModelType::GlmMoeDsa => "glm_moe_dsa",
+        ModelType::Ernie45 => "ernie4_5",
+        ModelType::Ernie45Moe => "ernie4_5_moe",
+        ModelType::HunyuanMoe => "hunyuan_moe",
+        ModelType::HunyuanV1Dense => "hunyuan_v1_dense",
+        ModelType::MiMo => "mimo",
+        ModelType::BailingMoe => "bailing_moe",
+        ModelType::BailingMoeLinear => "bailing_moe_linear",
+        ModelType::Afmoe => "afmoe",
+        ModelType::Klear => "klear",
+        ModelType::Apertus => "apertus",
+        ModelType::SeedOss => "seed_oss",
+        ModelType::Granite => "granite",
+        ModelType::BitNet => "bitnet",
+        ModelType::ExaOne => "exaone",
+        ModelType::ExaOne4 => "exaone4",
+        ModelType::ExaOneMoe => "exaone_moe",
+        ModelType::SolarOpen => "solar_open",
+        ModelType::Olmo => "olmo",
+        ModelType::Olmo2 => "olmo2",
+        ModelType::Olmo3 => "olmo3",
+        ModelType::OpenElm => "openelm",
+        ModelType::Gpt2 => "gpt2",
+        ModelType::GptBigCode => "gpt_bigcode",
+        ModelType::GptNeoX => "gpt_neox",
+        ModelType::StarCoder2 => "starcoder2",
+        ModelType::Mellum => "mellum",
+        ModelType::Helium => "helium",
+        ModelType::TeleChat3 => "telechat3",
+        ModelType::MiniCPM => "minicpm",
+        ModelType::MiniCPM3 => "minicpm3",
+        ModelType::StableLM => "stablelm",
+        ModelType::SmolLM3 => "smollm3",
+        ModelType::Ministral3 => "ministral3",
+        ModelType::Mistral3 => "mistral3",
+        ModelType::Mistral4 => "mistral4",
+        ModelType::Nemotron => "nemotron",
+        ModelType::Mamba => "mamba",
+        ModelType::Mamba2 => "mamba2",
+        ModelType::Jamba => "jamba",
+        ModelType::NemotronH => "nemotron_h",
+        ModelType::NemotronHNanoOmniVLM => "nemotron_h_nano_omni_vlm",
+        ModelType::NemotronNAS => "nemotron_nas",
+        ModelType::FalconH1 => "falcon_h1",
+        ModelType::Lfm2 => "lfm2",
+        ModelType::Lfm2Moe => "lfm2_moe",
+        ModelType::Lfm2VL => "lfm2_vl",
+        ModelType::Inkling => "inkling",
+        ModelType::InklingVLM => "inkling_vlm",
+        ModelType::Plamo2 => "plamo2",
+        ModelType::GraniteMoeHybrid => "granitemoehybrid",
+        ModelType::KimiLinear => "kimi_linear",
+        ModelType::KimiVL => "kimi_vl",
+        ModelType::KimiK25 => "kimi_k25",
+        ModelType::LongcatFlash => "longcat_flash",
+        ModelType::LongcatFlashNgram => "longcat_flash_ngram",
+        ModelType::Step3p5 => "step3p5",
+        ModelType::Step3p7 => "step3p7",
+        ModelType::Rwkv7 => "rwkv7",
+        ModelType::RecurrentGemma => "recurrent_gemma",
+        ModelType::Whisper => "whisper",
+        ModelType::Kokoro => "kokoro",
+        ModelType::Bert => "bert",
+        ModelType::XlmRoberta => "xlm_roberta",
+        ModelType::ModernBert => "modernbert",
+        ModelType::SiglipText => "siglip",
+        ModelType::Gemma3Embedding => "gemma3_embedding",
+        ModelType::Qwen3Embedding => "qwen3_embedding",
+        ModelType::Qwen3VLEmbedding => "qwen3_vl_embedding",
+        ModelType::Lfm2Embedding => "lfm2_embedding",
+        ModelType::Ministral3Embedding => "ministral3_embedding",
+        ModelType::LlamaBidirec => "llama_bidirec",
+        ModelType::LlamaNemotronVLEmbedding => "llama_nemotron_vl_embedding",
+        ModelType::ColIdefics3 => "colidefics3",
+        ModelType::ColQwen25 => "colqwen2_5",
+        ModelType::SequenceClassifier => "sequence_classifier",
     }
-    if out.ends_with('-') {
-        out.pop();
-    }
-    out
 }
 
 // ── Paged KV block-budget resolution (epic #116 #122 b3) ──────────────────────
@@ -1475,6 +1630,48 @@ mod tests {
         );
         assert_eq!(report.kv_bytes_per_token.turbo4, None);
         assert!(format_estimate(tmp.path(), &est).contains(&format_bytes(report.total_bytes)));
+    }
+
+    #[test]
+    fn inspect_family_slug_matches_arch_registry_id() {
+        let tmp = tempfile::tempdir().unwrap();
+        let cfg = serde_json::json!({
+            "model_type": "qwen3_5",
+            "hidden_size": 4096,
+            "num_hidden_layers": 32,
+            "vocab_size": 32000,
+            "intermediate_size": 11008,
+            "num_attention_heads": 32,
+            "num_key_value_heads": 8,
+        });
+        write_config(tmp.path(), &cfg);
+
+        assert_eq!(
+            raw_model_type_from_config(tmp.path()).as_deref(),
+            Some("qwen3_5")
+        );
+        assert_eq!(inspect_family_slug(tmp.path()).as_deref(), Some("qwen3_5"));
+    }
+
+    #[test]
+    fn inspect_family_slug_is_classifier_derived_not_raw_model_type() {
+        let tmp = tempfile::tempdir().unwrap();
+        let cfg = serde_json::json!({
+            "model_type": "gemma3_text",
+            "hidden_size": 2048,
+            "num_hidden_layers": 18,
+            "vocab_size": 256000,
+            "intermediate_size": 8192,
+            "num_attention_heads": 8,
+            "num_key_value_heads": 4,
+        });
+        write_config(tmp.path(), &cfg);
+
+        assert_eq!(
+            raw_model_type_from_config(tmp.path()).as_deref(),
+            Some("gemma3_text")
+        );
+        assert_eq!(inspect_family_slug(tmp.path()).as_deref(), Some("gemma3"));
     }
 
     #[test]

--- a/src/execution/memory_estimate.rs
+++ b/src/execution/memory_estimate.rs
@@ -55,9 +55,11 @@ use std::path::Path;
 
 use mlxcel_core::hardware::{HardwareCapabilities, KvCacheParams, get_hardware};
 use mlxcel_core::weights::weight_footprint_bytes;
+use serde::Serialize;
 
 use super::config_fields;
 use super::quant_advisor::estimate_model_params_billions;
+use crate::models::{ModelType, get_model_type};
 
 // ── Constants ─────────────────────────────────────────────────────────────────
 
@@ -210,6 +212,26 @@ impl QuantHint {
             QuantHint::Int4 => "int4",
         }
     }
+
+    /// Stable short label used by machine-readable inspect output.
+    pub fn json_label(self) -> &'static str {
+        match self {
+            QuantHint::Default => "default",
+            QuantHint::Fp16 => "fp16",
+            QuantHint::Int8 => "int8",
+            QuantHint::Int4 => "int4",
+        }
+    }
+}
+
+impl WeightsSource {
+    fn json_label(self) -> &'static str {
+        match self {
+            WeightsSource::ExactSafetensors => "safetensors_header",
+            WeightsSource::AnalyticalConfig => "analytical_config",
+            WeightsSource::Fallback => "fallback",
+        }
+    }
 }
 
 /// How an operator asked the paged KV pool's block budget to be sized
@@ -326,6 +348,100 @@ pub struct MemoryEstimate {
     pub quant: QuantHint,
     /// True when KV bytes were computed with `int8_kv = true`.
     pub kv_dtype_int8: bool,
+}
+
+/// JSON payload emitted by `mlxcel inspect --json`.
+///
+/// The byte fields are copied from [`MemoryEstimate`] so scripts do not have
+/// to scrape the human-readable banner. Optional fields serialize as `null`
+/// when the estimator or model config cannot provide them.
+#[derive(Debug, Clone, Serialize)]
+pub struct InspectReport {
+    pub mlxcel_version: &'static str,
+    pub model: String,
+    pub model_type: Option<String>,
+    pub family: Option<String>,
+    pub inputs: InspectReportInputs,
+    pub weights_bytes: u64,
+    pub weights_source: &'static str,
+    pub kv_bytes_per_token: InspectKvBytesPerToken,
+    pub kv_bytes_total: u64,
+    pub kv_detail: String,
+    pub per_slot_overhead_bytes: Option<u64>,
+    pub activation_bytes: u64,
+    pub headroom_bytes: u64,
+    pub headroom_factor: f64,
+    pub budget_bytes: u64,
+    pub total_bytes: u64,
+    pub fits: bool,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct InspectReportInputs {
+    pub max_tokens: u64,
+    pub batch: u64,
+    pub kv_cache_mode: String,
+    pub quant: &'static str,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct InspectKvBytesPerToken {
+    pub fp16: Option<u64>,
+    pub int8: Option<u64>,
+    pub turbo4: Option<u64>,
+}
+
+impl InspectReport {
+    /// Build the machine-readable inspect report from the same estimator state
+    /// that backs the text banner.
+    #[must_use]
+    pub fn from_estimate(
+        model_dir: &Path,
+        est: &MemoryEstimate,
+        kv_cache_mode: String,
+        model_type: Option<String>,
+        family: Option<String>,
+        per_slot_overhead_bytes: Option<u64>,
+    ) -> Self {
+        let kv_bytes_per_token = if matches!(est.kv_source, KvSource::Config) {
+            InspectKvBytesPerToken {
+                fp16: Some(kv_cache_bytes_per_token(model_dir, false, 1)),
+                int8: Some(kv_cache_bytes_per_token(model_dir, true, 1)),
+                turbo4: None,
+            }
+        } else {
+            InspectKvBytesPerToken {
+                fp16: None,
+                int8: None,
+                turbo4: None,
+            }
+        };
+
+        Self {
+            mlxcel_version: env!("CARGO_PKG_VERSION"),
+            model: model_dir.display().to_string(),
+            model_type,
+            family,
+            inputs: InspectReportInputs {
+                max_tokens: est.ctx_len,
+                batch: est.batch,
+                kv_cache_mode,
+                quant: est.quant.json_label(),
+            },
+            weights_bytes: est.weights_bytes,
+            weights_source: est.weights_source.json_label(),
+            kv_bytes_per_token,
+            kv_bytes_total: est.kv_cache_bytes,
+            kv_detail: est.kv_detail.clone(),
+            per_slot_overhead_bytes,
+            activation_bytes: est.activation_bytes,
+            headroom_bytes: est.runtime_headroom_bytes,
+            headroom_factor: est.headroom_factor,
+            budget_bytes: est.available_bytes,
+            total_bytes: est.total_bytes,
+            fits: est.fits,
+        }
+    }
 }
 
 impl MemoryEstimate {
@@ -747,6 +863,82 @@ pub fn kv_cache_bytes_per_token(model_dir: &Path, int8_kv: bool, batch: u64) -> 
     crate::execution::kv_arch::estimate_kv_arch(model_dir, 1, int8_kv, batch)
         .map(|a| a.marginal_bytes_per_token)
         .unwrap_or(0)
+}
+
+/// Read the raw top-level `model_type` string from `config.json`.
+#[must_use]
+pub fn raw_model_type_from_config(model_dir: &Path) -> Option<String> {
+    let config = read_model_config(model_dir)?;
+    config
+        .get("model_type")
+        .and_then(serde_json::Value::as_str)
+        .map(ToOwned::to_owned)
+}
+
+/// Best-effort family slug for `mlxcel inspect --json`.
+///
+/// TODO(#1508): replace this local fallback with the `mlxcel arch --json`
+/// registry id once that contract is available on `main`.
+#[must_use]
+pub fn inspect_family_slug(model_dir: &Path) -> Option<String> {
+    if let Some(raw) = raw_model_type_from_config(model_dir) {
+        return Some(slugify_identifier(&raw));
+    }
+    get_model_type(model_dir).ok().map(slugify_model_type)
+}
+
+/// Fused paged-decode workspace reserve for families that select the paged
+/// backend by default. Families outside this set keep the field `null`.
+#[must_use]
+pub fn inspect_per_slot_overhead_bytes(model_dir: &Path, batch: u64) -> Option<u64> {
+    let model_type = get_model_type(model_dir).ok()?;
+    if !model_type_uses_default_paged_decode(model_type) {
+        return None;
+    }
+    let num_layers = kv_cache_params_from_path(model_dir, DEFAULT_CTX_LEN, false, 1)?.num_layers;
+    Some(paged_v2_workspace_reserve_bytes(
+        model_dir,
+        num_layers as usize,
+        batch,
+    ))
+}
+
+fn read_model_config(model_dir: &Path) -> Option<serde_json::Value> {
+    let config_str = std::fs::read_to_string(model_dir.join("config.json")).ok()?;
+    serde_json::from_str(&config_str).ok()
+}
+
+fn model_type_uses_default_paged_decode(model_type: ModelType) -> bool {
+    matches!(
+        model_type,
+        ModelType::Llama
+            | ModelType::Llama4
+            | ModelType::Qwen3
+            | ModelType::Qwen35
+            | ModelType::Gemma3
+    )
+}
+
+fn slugify_model_type(model_type: ModelType) -> String {
+    slugify_identifier(&format!("{model_type:?}"))
+}
+
+fn slugify_identifier(input: &str) -> String {
+    let mut out = String::new();
+    let mut prev_was_sep = true;
+    for ch in input.chars() {
+        if ch.is_ascii_alphanumeric() {
+            out.push(ch.to_ascii_lowercase());
+            prev_was_sep = false;
+        } else if !prev_was_sep {
+            out.push('-');
+            prev_was_sep = true;
+        }
+    }
+    if out.ends_with('-') {
+        out.pop();
+    }
+    out
 }
 
 // ── Paged KV block-budget resolution (epic #116 #122 b3) ──────────────────────
@@ -1233,6 +1425,93 @@ mod tests {
         assert!(format_bytes(2 * 1024 * 1024 * 1024).contains("GiB"));
         assert!(format_bytes(5 * 1024 * 1024).contains("MiB"));
         assert_eq!(format_bytes(42), "42 bytes");
+    }
+
+    #[test]
+    fn inspect_report_copies_estimate_contract() {
+        let tmp = tempfile::tempdir().unwrap();
+        let cfg = serde_json::json!({
+            "model_type": "llama",
+            "hidden_size": 4096,
+            "num_hidden_layers": 32,
+            "vocab_size": 32000,
+            "intermediate_size": 11008,
+            "num_attention_heads": 32,
+            "num_key_value_heads": 8,
+        });
+        write_config(tmp.path(), &cfg);
+        write_safetensors_index(tmp.path(), 2_415_919_104);
+
+        let est = estimate_total_memory(tmp.path(), 8192, 1, QuantHint::Default, false);
+        let report = InspectReport::from_estimate(
+            tmp.path(),
+            &est,
+            "fp16".to_string(),
+            raw_model_type_from_config(tmp.path()),
+            inspect_family_slug(tmp.path()),
+            None,
+        );
+
+        assert_eq!(report.model_type.as_deref(), Some("llama"));
+        assert_eq!(report.family.as_deref(), Some("llama"));
+        assert_eq!(
+            report.weights_bytes + report.kv_bytes_total + report.headroom_bytes,
+            report.total_bytes
+        );
+        assert_eq!(report.budget_bytes, est.available_bytes);
+        assert_eq!(report.fits, report.total_bytes <= report.budget_bytes);
+        assert_eq!(report.inputs.max_tokens, est.ctx_len);
+        assert_eq!(report.inputs.batch, est.batch);
+        assert_eq!(report.inputs.kv_cache_mode, "fp16");
+        assert_eq!(report.inputs.quant, "default");
+        assert_eq!(report.weights_source, "safetensors_header");
+        assert_eq!(
+            report.kv_bytes_per_token.fp16,
+            Some(kv_cache_bytes_per_token(tmp.path(), false, 1))
+        );
+        assert_eq!(
+            report.kv_bytes_per_token.int8,
+            Some(kv_cache_bytes_per_token(tmp.path(), true, 1))
+        );
+        assert_eq!(report.kv_bytes_per_token.turbo4, None);
+        assert!(format_estimate(tmp.path(), &est).contains(&format_bytes(report.total_bytes)));
+    }
+
+    #[test]
+    fn inspect_report_serializes_nulls_and_stable_key_order() {
+        let tmp = tempfile::tempdir().unwrap();
+        let est = MemoryEstimate {
+            weights_bytes: 100,
+            kv_cache_bytes: 0,
+            runtime_headroom_bytes: 20,
+            activation_bytes: 4,
+            total_bytes: 120,
+            available_bytes: 128,
+            fits: true,
+            weights_source: WeightsSource::Fallback,
+            kv_source: KvSource::Unavailable,
+            kv_detail: "unavailable".to_string(),
+            headroom_factor: DEFAULT_HEADROOM_FACTOR,
+            ctx_len: 256,
+            batch: 2,
+            quant: QuantHint::Int8,
+            kv_dtype_int8: true,
+        };
+        let report =
+            InspectReport::from_estimate(tmp.path(), &est, "int8".to_string(), None, None, None);
+        let json = serde_json::to_string_pretty(&report).unwrap();
+
+        assert!(json.contains(r#""model_type": null"#));
+        assert!(json.contains(r#""family": null"#));
+        assert!(json.contains(r#""turbo4": null"#));
+        assert!(json.contains(r#""per_slot_overhead_bytes": null"#));
+        assert!(json.find(r#""mlxcel_version""#).unwrap() < json.find(r#""model""#).unwrap());
+        assert!(json.find(r#""model""#).unwrap() < json.find(r#""model_type""#).unwrap());
+        assert!(
+            json.find(r#""weights_bytes""#).unwrap() < json.find(r#""kv_bytes_total""#).unwrap()
+        );
+        assert_eq!(report.kv_bytes_per_token.fp16, None);
+        assert_eq!(report.kv_bytes_per_token.int8, None);
     }
 
     #[test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -618,6 +618,11 @@ pub(crate) struct InspectArgs {
     #[arg(long, default_value = "default", value_name = "MODE")]
     pub(crate) quant: String,
 
+    /// Emit the estimate as one JSON object instead of the banner; every
+    /// number is the same the banner prints.
+    #[arg(long)]
+    pub(crate) json: bool,
+
     // Shared TurboQuant KV-cache flag group, gives `inspect` the same
     // `--cache-type-k` / `--cache-type-v` surface as `generate` so the
     // estimate matches what the loaded model would actually allocate.


### PR DESCRIPTION
## Summary

Adds `mlxcel inspect --json` so recipe tooling can consume the existing memory estimator as stable byte fields without scraping the human-readable banner.

## What Changed

- Added an `InspectReport` JSON contract with model metadata, effective input flags, estimator byte totals, nullable TurboQuant per-token sizing, and nullable paged per-slot overhead.
- Derived `family` from the same classifier-to-registry mapping used by the architecture catalog so values like `qwen3_5` and `gemma3_text` stay aligned with the public recipe registry instead of echoing raw `config.json` names.
- Routed `inspect --json` through a quiet offline resolver path so a cache hit writes exactly one JSON object to stdout and a cache miss fails on stderr without resolver or downloader notices, while the default text banner path keeps its existing resolver behavior and over-budget note.
- Documented the JSON form and `MLXCEL_MEMORY_LIMIT` byte fields in the public README and environment-variable guide.

## Validation

- [x] `cargo fmt --check`
- [x] `cargo check --lib --tests`
- [x] `cargo test --lib -- memory_estimate`
- [x] `cargo clippy --lib --tests -- -D warnings`
- [x] Real-checkpoint smoke: `./target/debug/mlxcel inspect -m /home/inureyes/models/mlx/qwen3-4b-4bit` keeps the text banner, `./target/debug/mlxcel inspect --json -m /home/inureyes/models/mlx/qwen3-4b-4bit` emits one JSON object on stdout with empty stderr, and `--max-tokens 32768 --batch 4 --cache-type-k int8 --cache-type-v int8` reports the effective `inputs` plus the expected FP16/INT8 KV ratio.
- [x] Cache-miss smoke: `./target/debug/mlxcel inspect --json -m definitely-missing-model-for-pr1605` leaves stdout empty and fails with the offline cache-miss diagnostic on stderr.

Refs lablup/mlxcel-internal#1509
