### PR TITLE
fix: include RT-DETRv2 in arch JSON registry

### DIFF
--- a/README.md
+++ b/README.md
@@ -231,7 +231,7 @@ mlxcel arch
 mlxcel arch --json
 ```
 
-for the architecture catalog compiled into the current binary. The `--json` form emits the stable recipes registry snapshot used by downstream site builds and automation. [Supported models](docs/supported-models.md) maintains the family table, quantization support, distributed coverage, checkpoint qualifications, and known caveats.
+for the architecture catalog compiled into the current binary. The `--json` form emits the stable recipes registry snapshot used by downstream site builds and automation, including standalone runtime families such as detector-only checkpoints. [Supported models](docs/supported-models.md) maintains the family table, quantization support, distributed coverage, checkpoint qualifications, and known caveats.
 
 ## Python
 

--- a/TECHNICAL_REPORTS/1608-rtdetr-detection-registry-20260903.en.md
+++ b/TECHNICAL_REPORTS/1608-rtdetr-detection-registry-20260903.en.md
@@ -1,0 +1,152 @@
+# Technical Report: PR #1608 - fix: include RT-DETRv2 in arch JSON registry
+
+**Date**: 2026-09-03
+**Author**: mlxcel maintainers
+**Reviewer**: implementation, security, and finalization review cycle
+**Status**: Completed (focused Rust checks and hosted CI passed)
+**Languages**: Rust, JSON, Markdown
+**Risk Level**: Medium (the registry is a downstream recipes contract, and an inaccurate runtime claim can generate unusable commands)
+
+---
+
+## Executive Summary
+
+PR #1608 corrects a coverage gap left by PR #1606. The initial `mlxcel arch --json` registry was derived only from `ALL_MODEL_TYPES`, which represents text, VLM, embedding, reranking, speech, and audio model loaders. RT-DETRv2 is supported through the separate `mlxcel detect` command, so that derivation silently omitted a real runtime surface.
+
+The correction adds a deterministic extension point for standalone architecture families and registers `rt_detr_v2` with exactly the capabilities the command implements: `detect` runtime, `image` input, `boxes` output, and `detection` category. It deliberately does not advertise generation, serving, distributed execution, or speculative decoding. A security-review follow-up also adds invariants that prevent standalone entries from colliding with loadable family IDs or model-type keys.
+
+---
+
+## 1. Problem Statement
+
+### 1.1 Background
+
+The recipes catalog consumes the versioned architecture registry to decide which modes and command forms it may offer. PR #1606 made that data machine-readable, but its one-entry-per-`ALL_MODEL_TYPES` construction assumed every supported runtime was represented by the main model loader enum.
+
+RT-DETRv2 violates that assumption by design. Object detection has a dedicated predictor and CLI handler because it accepts images and emits bounding boxes rather than tokens. Treating it as a normal generation model would be misleading, but leaving it out makes the registry incomplete.
+
+### 1.2 User-visible impact
+
+- Recipe builders could not discover any `detect` runtime.
+- No registry entry exposed the `detection` category or `boxes` output.
+- A valid RT-DETRv2 recipe could not be validated against the exported capability catalog.
+- Adding RT-DETRv2 to `ModelType` merely to satisfy the registry would risk false `generate` or `serve` support.
+
+---
+
+## 2. Change Summary
+
+### 2.1 Standalone architecture families
+
+`src/models/registry.rs` now defines a small standalone-family descriptor for command runtimes that do not pass through the text/VLM model loader. `build_architecture_registry()` preserves the existing `ALL_MODEL_TYPES` order, then appends standalone entries in a fixed declared order.
+
+The first standalone entry is `rt_detr_v2`:
+
+| Field | Value |
+|---|---|
+| `id` | `rt_detr_v2` |
+| `model_types` | `rt_detr_v2` |
+| `runtimes` | `detect` |
+| `modalities_in` | `image` |
+| `output` | `boxes` |
+| `category` | `detection` |
+| TP / PP | disabled |
+| drafters | none |
+
+The entry does not claim `generate` or `serve`, matching the actual `mlxcel detect` boundary.
+
+### 2.2 Collision invariants
+
+The security review identified a maintenance risk in the extension point: a later standalone entry could reuse an existing family ID or detection key and silently shadow a loadable family in downstream maps. The follow-up test constructs the exported identity sets and rejects:
+
+- duplicate standalone IDs,
+- standalone IDs that collide with `ALL_MODEL_TYPES` registry IDs,
+- duplicate standalone model-type keys,
+- standalone keys that collide with loadable family keys.
+
+### 2.3 Snapshot and documentation
+
+The release CLI regenerated `recipes/registry/0.6.0.json`, adding the detector entry without changing the schema. `README.md` and `docs/supported-models.md` now state that the registry includes both loader-backed families and standalone command runtimes.
+
+---
+
+## 3. Technical Decisions
+
+### 3.1 Keep detector runtimes outside `ModelType`
+
+`ModelType` drives text/VLM loading and capability dispatch. Adding RT-DETRv2 there solely for registry enumeration would couple an image-to-box predictor to token-generation assumptions and increase the chance of false runtime advertising.
+
+The standalone descriptor keeps runtime ownership truthful while still providing one unified JSON document to recipes consumers.
+
+### 3.2 Preserve deterministic ordering
+
+The original loader-backed entries retain their `ALL_MODEL_TYPES` order. Standalone families are appended from a static slice rather than a map, so repeated builds remain byte-stable and committed snapshots stay reviewable.
+
+### 3.3 Extend counts rather than redefine loader coverage
+
+Registry family count is now the number of loader-backed families plus standalone runtime families. Tests express that formula explicitly. This preserves the useful exhaustiveness check for `ALL_MODEL_TYPES` while acknowledging supported commands outside that enum.
+
+### 3.4 Fail tests on ambiguous public identities
+
+Downstream recipe indexes commonly key by family ID and model-type key. Rejecting collisions at test time prevents last-writer-wins behavior and turns an otherwise subtle catalog corruption into an immediate development failure.
+
+---
+
+## 4. Validation
+
+| Check | Result |
+|---|---|
+| `cargo fmt --check` | passed |
+| `cargo test --lib registry --no-default-features` | passed |
+| `cargo test --bin mlxcel arch --no-default-features` | passed |
+| `cargo check --lib --tests --no-default-features` | passed |
+| `cargo clippy --lib --tests --no-default-features -- -D warnings` | passed |
+| `make recipes-registry` | passed |
+| Release JSON versus committed snapshot | byte-identical |
+| RT-DETRv2 capability assertions | passed |
+| Standalone ID/key collision assertions | passed |
+| Hosted required checks | passed |
+
+The release registry and committed snapshot shared SHA-256 `3360ff0554365c702e9eb501d85c0ec5ae8d4dd7aadddcdc4059be81efcdfddf` at finalization.
+
+---
+
+## 5. Change Statistics
+
+| Metric | Value |
+|---|---|
+| Files changed | 5 |
+| Lines added | 204 |
+| Lines removed | 35 |
+| Commits | 2 |
+
+Related commits:
+
+- `0ab5509` fix: include RT-DETRv2 in arch JSON registry
+- `9cd2806` test: guard standalone registry extension collisions
+
+Files of interest:
+
+- `src/models/registry.rs`: standalone descriptors, registry assembly, capability and collision tests
+- `src/main_tests.rs`: CLI-level family-count and detector assertions
+- `recipes/registry/0.6.0.json`: regenerated public snapshot
+- `README.md`, `docs/supported-models.md`: clarified registry scope
+
+---
+
+## 6. Learning Points
+
+**Runtime catalogs must enumerate command boundaries, not only loader enums.** A single enum is a useful source of truth only when it actually owns every supported execution path.
+
+**Truthful omission is better than capability inflation.** The detector belongs in the registry, but it must not inherit generation or serving capabilities it does not implement.
+
+**Extension points need identity invariants immediately.** Static data can still collide, and downstream JSON consumers often turn collisions into silent overwrites.
+
+---
+
+## 7. Follow-up Actions
+
+- Add future standalone runtimes through the same static descriptor and collision tests.
+- Keep recipe builders tolerant of additive families while treating existing IDs and field meanings as stable.
+- Revalidate backend support when RT-DETRv2 receives backend-specific qualification data.
+

--- a/TECHNICAL_REPORTS/1608-rtdetr-detection-registry-20260903.ko.md
+++ b/TECHNICAL_REPORTS/1608-rtdetr-detection-registry-20260903.ko.md
@@ -1,0 +1,152 @@
+# 기술 보고서: PR #1608 - fix: include RT-DETRv2 in arch JSON registry
+
+**날짜**: 2026-09-03
+**작성자**: mlxcel 유지보수자
+**검토**: 구현, 보안, 최종화 검토 사이클
+**상태**: 완료 (집중 Rust 검사와 hosted CI 통과)
+**언어**: Rust, JSON, Markdown
+**위험 수준**: 중간 (registry는 downstream recipes 계약이며, 부정확한 runtime 광고는 실행 불가능한 명령을 생성할 수 있음)
+
+---
+
+## 요약
+
+PR #1608은 PR #1606 이후 남아 있던 coverage 누락을 교정합니다. 최초 `mlxcel arch --json` registry는 `ALL_MODEL_TYPES`만으로 만들어졌습니다. 이 목록은 text, VLM, embedding, reranking, speech, audio 모델 로더를 나타내지만, RT-DETRv2는 별도 `mlxcel detect` 명령으로 지원되기 때문에 실제 runtime이 registry에서 조용히 빠졌습니다.
+
+이번 교정은 standalone architecture family를 위한 결정적 확장 지점을 추가하고, `rt_detr_v2`가 실제로 제공하는 capability만 등록합니다. 즉 `detect` runtime, `image` 입력, `boxes` 출력, `detection` category이며, 생성·서빙·분산 실행·speculative decoding은 광고하지 않습니다. 보안 검토 후속 커밋은 standalone 항목이 loader-backed family ID 또는 model-type key와 충돌하지 못하도록 invariant도 추가했습니다.
+
+---
+
+## 1. 문제 정의
+
+### 1.1 배경
+
+recipes catalog는 versioned architecture registry를 사용해 어떤 mode와 command 형식을 제공할 수 있는지 판단합니다. PR #1606은 이 정보를 기계 판독 가능하게 만들었지만, family 수집 과정은 모든 runtime이 주 모델 로더 enum에 들어 있다는 가정을 사용했습니다.
+
+RT-DETRv2는 의도적으로 이 가정의 바깥에 있습니다. 객체 검출은 image를 입력받아 bounding box를 출력하므로 token 생성과 다른 predictor와 CLI handler를 사용합니다. 일반 생성 모델처럼 취급하면 잘못된 capability가 생기고, 제외하면 registry가 불완전해집니다.
+
+### 1.2 사용자 영향
+
+- Recipe builder가 `detect` runtime을 발견할 수 없었습니다.
+- `detection` category와 `boxes` 출력을 제공하는 registry 항목이 없었습니다.
+- 유효한 RT-DETRv2 recipe를 exported capability catalog로 검증할 수 없었습니다.
+- registry 열거만을 위해 RT-DETRv2를 `ModelType`에 넣으면 거짓 `generate` 또는 `serve` 지원이 생길 위험이 있었습니다.
+
+---
+
+## 2. 변경 요약
+
+### 2.1 Standalone architecture family
+
+`src/models/registry.rs`에 text/VLM 모델 로더를 통과하지 않는 command runtime용 작은 standalone-family descriptor를 추가했습니다. `build_architecture_registry()`는 기존 `ALL_MODEL_TYPES` 순서를 유지하고, 선언된 고정 순서대로 standalone 항목을 뒤에 추가합니다.
+
+첫 standalone 항목은 `rt_detr_v2`입니다.
+
+| 필드 | 값 |
+|---|---|
+| `id` | `rt_detr_v2` |
+| `model_types` | `rt_detr_v2` |
+| `runtimes` | `detect` |
+| `modalities_in` | `image` |
+| `output` | `boxes` |
+| `category` | `detection` |
+| TP / PP | 비활성 |
+| drafters | 없음 |
+
+실제 `mlxcel detect` 경계에 맞게 `generate`와 `serve`는 포함하지 않습니다.
+
+### 2.2 충돌 invariant
+
+보안 검토에서는 확장 지점의 유지보수 위험을 발견했습니다. 이후 standalone 항목이 기존 family ID 또는 detection key를 재사용하면 downstream map에서 loader-backed family를 조용히 덮을 수 있습니다. 후속 테스트는 exported identity set을 구성해 다음을 거부합니다.
+
+- 중복 standalone ID,
+- `ALL_MODEL_TYPES` registry ID와 충돌하는 standalone ID,
+- 중복 standalone model-type key,
+- loader-backed family key와 충돌하는 standalone key.
+
+### 2.3 Snapshot과 문서
+
+Release CLI로 `recipes/registry/0.6.0.json`을 재생성해 schema 변경 없이 detector 항목을 추가했습니다. `README.md`와 `docs/supported-models.md`는 이제 registry가 loader-backed family와 standalone command runtime을 함께 포함한다고 설명합니다.
+
+---
+
+## 3. 기술적 선택과 그 이유
+
+### 3.1 Detector runtime을 `ModelType` 밖에 유지
+
+`ModelType`은 text/VLM loading과 capability dispatch를 구동합니다. Registry 열거만을 위해 RT-DETRv2를 추가하면 image-to-box predictor가 token-generation 가정에 결합되고, 잘못된 runtime 광고 가능성이 커집니다.
+
+Standalone descriptor는 runtime 소유권을 사실대로 유지하면서 recipes consumer에는 하나의 통합 JSON 문서를 제공합니다.
+
+### 3.2 결정적 순서 보존
+
+기존 loader-backed 항목은 `ALL_MODEL_TYPES` 순서를 그대로 유지합니다. Standalone family는 map이 아니라 static slice에서 추가되므로 반복 빌드 결과가 byte-stable하고 committed snapshot을 쉽게 검토할 수 있습니다.
+
+### 3.3 Loader coverage를 재정의하지 않고 count 확장
+
+Registry family 수는 이제 loader-backed family 수와 standalone runtime family 수의 합입니다. 테스트가 이 공식을 명시적으로 표현하므로, `ALL_MODEL_TYPES` exhaustiveness를 유지하면서 enum 밖의 지원 command도 인정합니다.
+
+### 3.4 모호한 공개 identity를 테스트에서 차단
+
+Downstream recipe index는 흔히 family ID와 model-type key를 키로 사용합니다. 충돌을 테스트 시점에 거부하면 last-writer-wins 형태의 조용한 catalog 손상을 즉시 개발 실패로 바꿀 수 있습니다.
+
+---
+
+## 4. 검증
+
+| 검사 | 결과 |
+|---|---|
+| `cargo fmt --check` | 통과 |
+| `cargo test --lib registry --no-default-features` | 통과 |
+| `cargo test --bin mlxcel arch --no-default-features` | 통과 |
+| `cargo check --lib --tests --no-default-features` | 통과 |
+| `cargo clippy --lib --tests --no-default-features -- -D warnings` | 통과 |
+| `make recipes-registry` | 통과 |
+| Release JSON과 committed snapshot 비교 | byte-identical |
+| RT-DETRv2 capability assertion | 통과 |
+| Standalone ID/key collision assertion | 통과 |
+| Hosted 필수 검사 | 통과 |
+
+최종화 시 release registry와 committed snapshot의 SHA-256은 모두 `3360ff0554365c702e9eb501d85c0ec5ae8d4dd7aadddcdc4059be81efcdfddf`였습니다.
+
+---
+
+## 5. 변경 통계
+
+| 지표 | 값 |
+|---|---|
+| 변경 파일 | 5 |
+| 추가 라인 | 204 |
+| 삭제 라인 | 35 |
+| 커밋 | 2 |
+
+관련 커밋:
+
+- `0ab5509` fix: include RT-DETRv2 in arch JSON registry
+- `9cd2806` test: guard standalone registry extension collisions
+
+주요 파일:
+
+- `src/models/registry.rs`: standalone descriptor, registry 조립, capability 및 collision 테스트
+- `src/main_tests.rs`: CLI 수준 family count와 detector assertion
+- `recipes/registry/0.6.0.json`: 재생성된 공개 snapshot
+- `README.md`, `docs/supported-models.md`: registry 범위 명확화
+
+---
+
+## 6. 학습 포인트
+
+**Runtime catalog는 loader enum뿐 아니라 command boundary를 열거해야 합니다.** 단일 enum은 실제로 모든 실행 경로를 소유할 때만 완전한 source of truth입니다.
+
+**과장된 capability보다 사실에 맞는 제한이 낫습니다.** Detector는 registry에 있어야 하지만 구현하지 않는 생성·서빙 capability를 물려받아서는 안 됩니다.
+
+**확장 지점에는 처음부터 identity invariant가 필요합니다.** Static data도 충돌할 수 있고 downstream JSON consumer는 이를 조용한 덮어쓰기로 바꾸기 쉽습니다.
+
+---
+
+## 7. 후속 작업
+
+- 향후 standalone runtime도 같은 static descriptor와 collision 테스트를 통해 추가합니다.
+- Recipe builder는 additive family를 허용하되 기존 ID와 field 의미는 안정적인 계약으로 다룹니다.
+- RT-DETRv2에 backend별 qualification 자료가 생기면 backend support를 다시 검증합니다.
+

--- a/docs/supported-models.md
+++ b/docs/supported-models.md
@@ -647,7 +647,7 @@ Muse Glimmer is not a speculative or DFlash target in this baseline.
 - Muse Glimmer's measured gate above is hardware-specific. CUDA allocator
   counters are unavailable on the GB10 backend, and Apple-Silicon/Metal remains
   untested; use the recorded OS memory bounds rather than extrapolating them.
-- `mlxcel arch` is the human-readable architecture catalog. `mlxcel arch --json` emits the machine-readable recipes registry with `mlxcel_version`, one `families` entry per `ALL_MODEL_TYPES` variant, stable `id` values, detection keys in `model_types`, runtime/modalities/output fields, Metal and CUDA status, tensor/pipeline parallel flags, speculative drafter support, and supported KV modes.
+- `mlxcel arch` is the human-readable architecture catalog. `mlxcel arch --json` emits the machine-readable recipes registry with `mlxcel_version`, one `families` entry per loadable `ALL_MODEL_TYPES` variant plus standalone runtime families such as `rt_detr_v2`, stable `id` values, detection keys in `model_types`, runtime/modalities/output fields, Metal and CUDA status, tensor/pipeline parallel flags, speculative drafter support, and supported KV modes.
 - The registry is still a family-level contract, not a checkpoint qualification. Use the per-family notes above before treating a model card, quantization, backend, or hardware combination as validated.
 
 ## Adding support

--- a/recipes/registry/0.6.0.json
+++ b/recipes/registry/0.6.0.json
@@ -4891,6 +4891,32 @@
       "kv_modes": [
         "fp16"
       ]
+    },
+    {
+      "id": "rt_detr_v2",
+      "display_name": "RT-DETRv2",
+      "category": "detection",
+      "model_types": [
+        "rt_detr_v2"
+      ],
+      "aliases": [],
+      "runtimes": [
+        "detect"
+      ],
+      "modalities_in": [
+        "image"
+      ],
+      "output": "boxes",
+      "backends": {
+        "metal": "supported",
+        "cuda": "supported"
+      },
+      "tensor_parallel": false,
+      "pipeline_parallel": false,
+      "drafters": [],
+      "kv_modes": [
+        "fp16"
+      ]
     }
   ]
 }

--- a/src/main_tests.rs
+++ b/src/main_tests.rs
@@ -190,7 +190,7 @@ fn arch_json_output_is_stable_registry_json() {
     let value: serde_json::Value = serde_json::from_slice(&out).unwrap();
     assert_eq!(value["mlxcel_version"], env!("CARGO_PKG_VERSION"));
     let families = value["families"].as_array().unwrap();
-    assert_eq!(families.len(), mlxcel::models::ALL_MODEL_TYPES.len());
+    assert_eq!(families.len(), mlxcel::models::ALL_MODEL_TYPES.len() + 1);
     assert_eq!(families[0]["id"], "llama");
 
     let qwen3 = families
@@ -232,6 +232,19 @@ fn arch_json_output_is_stable_registry_json() {
         .unwrap();
     assert_eq!(sequence["runtimes"], serde_json::json!(["rerank"]));
     assert_eq!(sequence["output"], "scores");
+
+    let rt_detr = families
+        .iter()
+        .find(|family| family["id"] == "rt_detr_v2")
+        .unwrap();
+    assert_eq!(rt_detr["display_name"], "RT-DETRv2");
+    assert_eq!(rt_detr["category"], "detection");
+    assert_eq!(rt_detr["model_types"], serde_json::json!(["rt_detr_v2"]));
+    assert_eq!(rt_detr["runtimes"], serde_json::json!(["detect"]));
+    assert_eq!(rt_detr["modalities_in"], serde_json::json!(["image"]));
+    assert_eq!(rt_detr["output"], "boxes");
+    assert_eq!(rt_detr["tensor_parallel"], false);
+    assert_eq!(rt_detr["pipeline_parallel"], false);
 }
 
 /// Issue #26: the dead `docs/model_implementations.md` reference was

--- a/src/models/registry.rs
+++ b/src/models/registry.rs
@@ -105,8 +105,10 @@ const EMBED: &[Runtime] = &[Runtime::Embed];
 const RERANK: &[Runtime] = &[Runtime::Rerank];
 const ASR: &[Runtime] = &[Runtime::Asr];
 const TTS: &[Runtime] = &[Runtime::Tts];
+const DETECT: &[Runtime] = &[Runtime::Detect];
 
 const TEXT: &[Modality] = &[Modality::Text];
+const IMAGE: &[Modality] = &[Modality::Image];
 const AUDIO: &[Modality] = &[Modality::Audio];
 const TEXT_IMAGE: &[Modality] = &[Modality::Text, Modality::Image];
 const TEXT_IMAGE_VIDEO: &[Modality] = &[Modality::Text, Modality::Image, Modality::Video];
@@ -127,6 +129,40 @@ const EMPTY_KEYS: &[&str] = &[];
 const QWEN35_ALIASES: &[&str] = &["Qwen 3.8"];
 const QWEN35_MOE_ALIASES: &[&str] = &["Qwen 3.6"];
 const QWEN35_VLM_ALIASES: &[&str] = &["Qwen 3.8 VL"];
+
+#[derive(Debug, Clone, Copy)]
+struct StandaloneArchitectureFamily {
+    id: &'static str,
+    display_name: &'static str,
+    category: &'static str,
+    model_types: &'static [&'static str],
+    aliases: &'static [&'static str],
+    runtimes: &'static [Runtime],
+    modalities_in: &'static [Modality],
+    output: OutputKind,
+    backends: [BackendStatus; 2],
+    tensor_parallel: bool,
+    pipeline_parallel: bool,
+    drafters: &'static [Drafter],
+    kv_modes: &'static [KvMode],
+}
+
+const STANDALONE_ARCHITECTURE_FAMILIES: &[StandaloneArchitectureFamily] =
+    &[StandaloneArchitectureFamily {
+        id: "rt_detr_v2",
+        display_name: "RT-DETRv2",
+        category: "detection",
+        model_types: &["rt_detr_v2"],
+        aliases: EMPTY_KEYS,
+        runtimes: DETECT,
+        modalities_in: IMAGE,
+        output: OutputKind::Boxes,
+        backends: [BackendStatus::Supported, BackendStatus::Supported],
+        tensor_parallel: false,
+        pipeline_parallel: false,
+        drafters: NO_DRAFTERS,
+        kv_modes: KV_FP16,
+    }];
 
 const TENSOR_PARALLEL_MODEL_TYPES: &[ModelType] = &[
     ModelType::Llama,
@@ -521,38 +557,63 @@ impl ModelType {
 }
 
 pub fn build_architecture_registry(mlxcel_version: &'static str) -> ArchitectureRegistry {
+    let mut families: Vec<ArchitectureFamily> = ALL_MODEL_TYPES
+        .iter()
+        .copied()
+        .map(|model_type| {
+            let caps = model_type.capabilities();
+            let model_types = if caps.model_types.is_empty() {
+                vec![model_type.registry_id()]
+            } else {
+                caps.model_types.to_vec()
+            };
+            ArchitectureFamily {
+                id: model_type.registry_id(),
+                display_name: model_type.display_name(),
+                category: model_type.category(),
+                model_types,
+                aliases: caps.aliases,
+                runtimes: caps.runtimes,
+                modalities_in: caps.modalities_in,
+                output: caps.output,
+                backends: BackendSupport {
+                    metal: caps.backends[0],
+                    cuda: caps.backends[1],
+                },
+                tensor_parallel: caps.tensor_parallel,
+                pipeline_parallel: caps.pipeline_parallel,
+                drafters: caps.drafters,
+                kv_modes: caps.kv_modes,
+            }
+        })
+        .collect();
+
+    families.extend(
+        STANDALONE_ARCHITECTURE_FAMILIES
+            .iter()
+            .map(|family| ArchitectureFamily {
+                id: family.id,
+                display_name: family.display_name,
+                category: family.category,
+                model_types: family.model_types.to_vec(),
+                aliases: family.aliases,
+                runtimes: family.runtimes,
+                modalities_in: family.modalities_in,
+                output: family.output,
+                backends: BackendSupport {
+                    metal: family.backends[0],
+                    cuda: family.backends[1],
+                },
+                tensor_parallel: family.tensor_parallel,
+                pipeline_parallel: family.pipeline_parallel,
+                drafters: family.drafters,
+                kv_modes: family.kv_modes,
+            }),
+    );
+
     ArchitectureRegistry {
         mlxcel_version,
-        families: ALL_MODEL_TYPES
-            .iter()
-            .copied()
-            .map(|model_type| {
-                let caps = model_type.capabilities();
-                let model_types = if caps.model_types.is_empty() {
-                    vec![model_type.registry_id()]
-                } else {
-                    caps.model_types.to_vec()
-                };
-                ArchitectureFamily {
-                    id: model_type.registry_id(),
-                    display_name: model_type.display_name(),
-                    category: model_type.category(),
-                    model_types,
-                    aliases: caps.aliases,
-                    runtimes: caps.runtimes,
-                    modalities_in: caps.modalities_in,
-                    output: caps.output,
-                    backends: BackendSupport {
-                        metal: caps.backends[0],
-                        cuda: caps.backends[1],
-                    },
-                    tensor_parallel: caps.tensor_parallel,
-                    pipeline_parallel: caps.pipeline_parallel,
-                    drafters: caps.drafters,
-                    kv_modes: caps.kv_modes,
-                }
-            })
-            .collect(),
+        families,
     }
 }
 
@@ -834,7 +895,10 @@ mod tests {
     #[test]
     fn registry_has_one_family_per_model_type_with_unique_ids() {
         let registry = build_architecture_registry("test");
-        assert_eq!(registry.families.len(), ALL_MODEL_TYPES.len());
+        assert_eq!(
+            registry.families.len(),
+            ALL_MODEL_TYPES.len() + STANDALONE_ARCHITECTURE_FAMILIES.len()
+        );
         let mut ids = BTreeSet::new();
         for family in &registry.families {
             assert!(ids.insert(family.id), "duplicate registry id {}", family.id);
@@ -854,7 +918,7 @@ mod tests {
         assert_eq!(value["mlxcel_version"], "test");
         assert_eq!(
             value["families"].as_array().unwrap().len(),
-            ALL_MODEL_TYPES.len()
+            ALL_MODEL_TYPES.len() + STANDALONE_ARCHITECTURE_FAMILIES.len()
         );
     }
 
@@ -875,6 +939,28 @@ mod tests {
         let sequence = family(ModelType::SequenceClassifier);
         assert_eq!(sequence.runtimes, RERANK);
         assert_eq!(sequence.output, OutputKind::Scores);
+    }
+
+    #[test]
+    fn standalone_detection_family_reports_detect_only_capabilities() {
+        let rt_detr = build_architecture_registry("test")
+            .families
+            .into_iter()
+            .find(|family| family.id == "rt_detr_v2")
+            .unwrap();
+
+        assert_eq!(rt_detr.display_name, "RT-DETRv2");
+        assert_eq!(rt_detr.category, "detection");
+        assert_eq!(rt_detr.model_types, ["rt_detr_v2"]);
+        assert_eq!(rt_detr.runtimes, DETECT);
+        assert!(!rt_detr.runtimes.contains(&Runtime::Generate));
+        assert!(!rt_detr.runtimes.contains(&Runtime::Serve));
+        assert_eq!(rt_detr.modalities_in, IMAGE);
+        assert_eq!(rt_detr.output, OutputKind::Boxes);
+        assert!(!rt_detr.tensor_parallel);
+        assert!(!rt_detr.pipeline_parallel);
+        assert_eq!(rt_detr.drafters, NO_DRAFTERS);
+        assert_eq!(rt_detr.kv_modes, KV_FP16);
     }
 
     #[test]

--- a/src/models/registry.rs
+++ b/src/models/registry.rs
@@ -912,6 +912,50 @@ mod tests {
     }
 
     #[test]
+    fn standalone_registry_extensions_do_not_collide_with_model_registry() {
+        let model_registry_ids: BTreeSet<_> = ALL_MODEL_TYPES
+            .iter()
+            .copied()
+            .map(ModelType::registry_id)
+            .collect();
+        let model_registry_keys: BTreeSet<_> = ALL_MODEL_TYPES
+            .iter()
+            .copied()
+            .flat_map(model_type_keys)
+            .collect();
+        let mut standalone_ids = BTreeSet::new();
+        let mut standalone_keys = BTreeSet::new();
+
+        for family in STANDALONE_ARCHITECTURE_FAMILIES {
+            assert!(
+                standalone_ids.insert(family.id),
+                "duplicate standalone registry id {}",
+                family.id
+            );
+            assert!(
+                !model_registry_ids.contains(family.id),
+                "standalone registry id {} collides with ALL_MODEL_TYPES",
+                family.id
+            );
+            assert!(
+                !family.model_types.is_empty(),
+                "{} has no model_type key",
+                family.id
+            );
+            for key in family.model_types {
+                assert!(
+                    standalone_keys.insert(*key),
+                    "duplicate standalone model_type key {key}"
+                );
+                assert!(
+                    !model_registry_keys.contains(key),
+                    "standalone model_type key {key} collides with ALL_MODEL_TYPES"
+                );
+            }
+        }
+    }
+
+    #[test]
     fn registry_json_round_trips() {
         let registry = build_architecture_registry("test");
         let value = serde_json::to_value(&registry).unwrap();


### PR DESCRIPTION
## Summary

Adds the standalone RT-DETRv2 detector to the machine-readable architecture registry without presenting it as a text/VLM generation model.

## What Changed

- Added a deterministic standalone-family extension point after the `ALL_MODEL_TYPES` registry entries.
- Registered `rt_detr_v2` with the truthful `detect` runtime, `image` input, `boxes` output, and `detection` category.
- Added collision guards so standalone registry IDs and detection keys cannot shadow loadable `ALL_MODEL_TYPES` families.
- Kept `generate`, `serve`, tensor parallelism, pipeline parallelism, and speculative decoding disabled for the detector.
- Extended registry and CLI tests and regenerated the committed `0.6.0` snapshot.
- Clarified public documentation that the JSON registry includes text/VLM model families plus standalone command runtimes.

## Validation

- [x] `cargo fmt --check`
- [x] `cargo test --lib registry --no-default-features`
- [x] `cargo test --bin mlxcel arch --no-default-features`
- [x] `cargo check --lib --tests --no-default-features`
- [x] `cargo clippy --lib --tests --no-default-features -- -D warnings`
- [x] `make recipes-registry`
- [x] Release `mlxcel arch --json` matches `recipes/registry/0.6.0.json` byte-for-byte.
- [x] The `rt_detr_v2` entry advertises only `detect`, accepts only `image`, and emits `boxes`.
- [x] Standalone registry extensions cannot collide with loadable family IDs or keys.

## Links

- Refs #1606
- Refs lablup/mlxcel-internal#1508
