### PR TITLE
feat(bench): dispatch speculative_bench MTP past Gemma 4 Unified

### DIFF
--- a/TECHNICAL_REPORTS/1621-speculative-bench-mtp-dispatch-20260904.en.md
+++ b/TECHNICAL_REPORTS/1621-speculative-bench-mtp-dispatch-20260904.en.md
@@ -1,0 +1,142 @@
+# Technical Report: PR #1621 - feat(bench): dispatch speculative_bench MTP past Gemma 4 Unified
+
+**Date**: 2026-09-04
+**Author**: mlxcel maintainers
+**Reviewer**: implementation review cycle
+**Status**: Completed (both previously-failing pairings measured on M1 Ultra; the M5 Max re-run is pending on that host)
+**Languages**: Rust
+**Risk Level**: Low (benchmark harness only; no inference path changes, one diagnostic helper widened to `pub`)
+
+---
+
+## Executive Summary
+
+`run_mtp` matched `LoadedModel::Gemma4Unified` and bailed on every other variant with `std::mem::discriminant`, so `speculative_bench` could produce MTP numbers for exactly one checkpoint. Every adapter it needed already existed and the server burst path already dispatched them, so the harness was the only place pretending the support was absent.
+
+The variant match now mirrors `src/server/batch/speculative_burst.rs`, and `REACHABLE_PAIRINGS` gains the Qwen 3.8 pairing. Both pairings that previously failed now produce numbers.
+
+A separate defect found on the way turned out to matter more than the one filed: `resolve_model_dir` could not find any checkpoint on a host whose store is `models/mlx/<name>`, so a full sweep there measured nothing while reporting no error.
+
+---
+
+## 1. Problem Statement
+
+### 1.1 Background
+
+`speculative_bench --sweep` walks `REACHABLE_PAIRINGS` and, for an MTP row, calls `run_mtp`. That function opened with a match that accepted one variant:
+
+```rust
+let unified = match &model {
+    LoadedModel::Gemma4Unified(u) => u,
+    other => anyhow::bail!(
+        "MTP bench currently supports a Gemma 4 Unified target; \
+         load_model returned a different variant ({:?})",
+        std::mem::discriminant(other)
+    ),
+};
+```
+
+### 1.2 What that cost
+
+Two pairings. The Gemma 4 31B MTP row failed at all three K values, not for want of a checkpoint: `models/gemma-4-31b-it-4bit` is `Gemma4ForConditionalGeneration` and loads as `LoadedModel::Gemma4VLM`, while the 12B is `Gemma4UnifiedForConditionalGeneration`. Qwen 3.8 MTP could not be measured at all, and a catalog entry alone would not have helped because the same match rejected the target.
+
+Every piece needed already existed: per-variant `&dyn LanguageModel` selection and per-variant `MtpTarget` adapter selection in `speculative_burst.rs`, the `Gemma4VLMtpTargetAdapter` the 31B target needs, the `Qwen35MtpTargetAdapter` the Qwen 3.8 target needs, `qwen3_5_mtp` drafter resolution, and `LanguageModel` on the enum itself including `release_sequence_state_by_id`.
+
+### 1.3 The defect the issue did not mention
+
+`resolve_model_dir` probed `<CARGO_MANIFEST_DIR>/models/<name>` and then `../mlxcel-internal/models/<name>`. On a host whose checkpoint store is `models/mlx/<name>`, and whose sibling checkout has the same layout, neither probe hits. Every sweep row then fell through to the "checkpoint missing on disk" skip, so the sweep completed and measured nothing while reporting no error at all. That is a worse failure mode than the one filed, because it is silent.
+
+---
+
+## 2. Technical Decisions
+
+### 2.1 One generic timed run, not one per variant
+
+`MtpGenerator` is generic over `MtpTarget`, so the warm-up burst, the timed generate, the acceptance capture and the sequence release moved into a single `run_mtp_timed` generic over `T: MtpTarget`, which each arm calls with its own adapter constructor. Only the `MtpTarget` construction is variant-specific. The drafter is bound against the enum's own `LanguageModel` impl and released through the same reference, so no arm carries its own copy of the lifecycle.
+
+### 2.2 `pub`, not `pub(crate)`, for the shared label
+
+The plan had been to widen `model_variant_label` to `pub(crate)`. That does not work: `speculative_bench` is a separate crate from the `mlxcel` library, and `pub(crate)` stops at the library boundary. The function is now `pub` with a re-export at the crate root, documented at both sites. The alternative was a second copy of the label table in the bench, which would drift from the server's.
+
+The exported surface is one `fn(&LoadedModel) -> &'static str` returning a diagnostic name, so the addition is small and non-breaking. The shared table reports anything outside the speculative-capable set as `other`, so the bench's unsupported message names the target directory alongside the label; widening that table was out of scope.
+
+### 2.3 The unsupported-variant check runs before any drafter IO
+
+As first written the match sat after `validate_target_compat`. An unsupported target with a mismatched hidden size therefore failed with a *drafter* message, and the acceptance criterion's "name the loaded variant and the supported families" message was unreachable for exactly the inputs it existed to describe. The check now runs before the drafter is loaded, the same ordering the burst path uses.
+
+### 2.4 Every failure stays a row status
+
+A drafter that loads but fails `validate_target_compat`, a missing checkpoint, `block_size < 2`, and the Metal-only guard for Qwen 3.5 MTP exactness all record a per-row status string rather than aborting the sweep. A CUDA sweep records the reason instead of emitting a number the runtime cannot vouch for.
+
+---
+
+## 3. Validation
+
+Apple M1 Ultra 128 GB, Metal, mlxcel 0.7.0-beta.1, MLX pin `9a795735`, `--kind mtp --block-size 4 --max-tokens 128`. Both of these fail on the pre-change binary.
+
+```
+gemma-4-31b-it-4bit + gemma-4-31b-it-assistant-bf16
+  tok/s=14.8  rounds=34  acceptance_rate=0.529  mean_accepted_len=1.59
+
+qwen3.8-27b-4bit + qwen3.8-27b-mtp-4bit
+  tok/s=16.9  rounds=47  acceptance_rate=0.504  mean_accepted_len=1.51
+```
+
+The full `--sweep --batch 1 --max-tokens 128` completes 16 rows: 4 baselines, 9 measured MTP rows at K=2/4/8, 3 DFlash rows still deferred on their own known blocker, and no row carrying a status beginning `MTP bench currently supports`. A `gemma-3-4b-it-4bit` target under `--kind mtp` reports the loaded variant, the target directory and the supported families as a row status rather than aborting.
+
+### 3.1 The result is a negative one, and it is the host
+
+| Pairing | Baseline | K=2 | K=4 | K=8 |
+|---|---|---|---|---|
+| Gemma 4 31B + MTP assistant | 19.9 | 18.4 | 14.9 | 14.9 |
+| Gemma 4 Unified 12B + MTP assistant | 38.4 | 36.0 | 28.5 | 29.3 |
+| Qwen 3.8 27B + MTP head | 24.9 | 22.5 | 17.2 | 9.3 |
+
+Every ratio is below 1.00x, where M5 Max reads 1.57x at K=4 for the Unified 12B pairing. Acceptance is not the explanation: the same pairing accepts *more* on M1 Ultra than on M5 Max at the same K (39.6% and mean accepted length 1.19, against 35.0% and 1.05) and still lands at 0.74x.
+
+The verify round is the difference. `docs/benchmark_results/speculative-decoding-m1ultra-2026-08-19.md` measures a block-4 verify round at 2.70 classic decode steps on M1 Ultra against 1.50 on M3 Ultra and 1.27 on M5 Max, and identifies M1 Ultra as the first host on Apple GPU generation 13. A mean accepted length near 1.2 cannot clear break-even against a 2.70-step verify. The static gate that declines B=1 MTP on this generation exists for the same reason, so these rows confirm a known property of the host rather than reporting a regression.
+
+### 3.2 Gates
+
+`cargo test --workspace --profile test-fast --features metal,accelerate`: 10507 passed, 0 failed. `cargo clippy --bin speculative_bench --features metal,accelerate -- -D warnings` and `cargo fmt --all -- --check` clean. All 13 CI jobs pass.
+
+One full-workspace run before the final one failed on `vision::inkling_vl::tests::mixed_prefill_scatter_order_is_normalized_text_then_image_then_audio`, a file this PR does not touch. It passes 3 of 3 in isolation and the whole `--lib` binary passes twice at the same test count, so it is intermittent and unrelated. Filed separately rather than absorbed here.
+
+---
+
+## 4. Change Summary
+
+### Statistics
+
+| Metric | Value |
+|---|---|
+| Files changed (code PR) | 4 |
+| Lines added | 268 |
+| Lines removed | 65 |
+
+### Changes by category
+
+- `src/bin/speculative_bench.rs`: per-variant adapter dispatch, the generic `run_mtp_timed`, the Qwen 3.8 pairings, the hoisted unsupported-variant check, the `models/mlx/<name>` probes in `resolve_model_dir`.
+- `src/server/batch/speculative_burst.rs`: visibility of `model_variant_label` only.
+- `src/lib.rs`: the crate-root re-export.
+- `docs/benchmarks.md`: the supported-target set.
+
+### Landed separately
+
+`benchmarks/metal_m1ultra_spec_2026-09-04.csv` (16 rows) and the `docs/benchmark_results/model_tests.md` update are on `bench/0.7.0-refresh` (PR #1617) as commit `f4ff37522`, because benchmark artifacts belong to that branch rather than to a code PR. That split means this PR can merge and close the issue while the documentation half is still unmerged; the PR body says so explicitly.
+
+### Related issues
+
+Closes #1613. Related: #154 (Gemma 4 Unified MTP drafter), #1165 (`qwen3_5_mtp` drafter and its Metal exactness gate), #638 (the K sweep behind `--k-values`).
+
+---
+
+## 5. Follow-up Actions
+
+- The M5 Max re-run of the two newly-reachable pairings is pending on that host. The M5 Max table in `model_tests.md` was left as it stands rather than being overwritten with M1 Ultra numbers, with its "unsupported target" note replaced by a statement that the harness restriction is lifted.
+- The three `--kind dflash` rows keep their existing deferral (DFlash loader plus a public `Qwen3NextCache` API).
+- Batched (`B > 1`) MTP adapters and Inkling pairings remain out of scope, the latter for want of a local checkpoint.
+
+### Transferable lesson
+
+The filed issue described a harness that refused to measure. The more expensive defect found while fixing it was a harness that measured nothing and said so nowhere: `resolve_model_dir` silently resolved every pairing to a skip on this host's layout. A benchmark that reports zero rows is obvious; one that completes with every row skipped looks like a clean run. When a sweep depends on path discovery, the discovery failure needs to be as loud as a measurement failure.

--- a/TECHNICAL_REPORTS/1621-speculative-bench-mtp-dispatch-20260904.ko.md
+++ b/TECHNICAL_REPORTS/1621-speculative-bench-mtp-dispatch-20260904.ko.md
@@ -1,0 +1,142 @@
+# 기술 보고서: PR #1621 - feat(bench): dispatch speculative_bench MTP past Gemma 4 Unified
+
+**작성일**: 2026-09-04
+**작성자**: mlxcel maintainers
+**리뷰어**: implementation review cycle
+**상태**: 완료 (기존에 실패하던 두 페어링을 M1 Ultra에서 측정. M5 Max 재측정은 해당 호스트에서 대기)
+**언어**: Rust
+**위험도**: Low (벤치마크 하네스 전용. 추론 경로 변경 없음, 진단용 헬퍼 하나만 `pub`으로 확대)
+
+---
+
+## 요약
+
+`run_mtp`은 `LoadedModel::Gemma4Unified`만 매칭하고 나머지 변형은 전부 `std::mem::discriminant`로 bail했다. 그래서 `speculative_bench`가 MTP 수치를 낼 수 있는 체크포인트가 딱 하나였다. 필요한 어댑터는 이미 다 있었고 서버 burst 경로는 이미 그것들을 디스패치하고 있었으니, 지원이 없는 척한 곳은 하네스뿐이었다.
+
+이제 변형 매칭이 `src/server/batch/speculative_burst.rs`를 그대로 따라가고, `REACHABLE_PAIRINGS`에 Qwen 3.8 페어링이 들어갔다. 전에 실패하던 두 페어링이 모두 수치를 낸다.
+
+작업 중에 발견한 별도 결함이 정작 발행된 것보다 더 문제였다. `resolve_model_dir`은 체크포인트 저장소가 `models/mlx/<name>`인 호스트에서 아무 모델도 찾지 못했고, 그런 호스트의 전체 스윕은 아무것도 측정하지 않으면서 오류도 내지 않았다.
+
+---
+
+## 1. 문제 정의
+
+### 1.1 배경
+
+`speculative_bench --sweep`은 `REACHABLE_PAIRINGS`를 훑고 MTP 행이면 `run_mtp`을 부른다. 그 함수는 변형 하나만 받는 매칭으로 시작했다.
+
+```rust
+let unified = match &model {
+    LoadedModel::Gemma4Unified(u) => u,
+    other => anyhow::bail!(
+        "MTP bench currently supports a Gemma 4 Unified target; \
+         load_model returned a different variant ({:?})",
+        std::mem::discriminant(other)
+    ),
+};
+```
+
+### 1.2 그 대가
+
+페어링 둘이다. Gemma 4 31B MTP 행은 K 세 값에서 모두 실패했는데 체크포인트가 없어서가 아니다. `models/gemma-4-31b-it-4bit`는 `Gemma4ForConditionalGeneration`이라 `LoadedModel::Gemma4VLM`로 로드되고, 12B가 `Gemma4UnifiedForConditionalGeneration`이다. Qwen 3.8 MTP는 아예 측정할 수 없었고, 카탈로그 항목만 추가해서는 소용이 없었다. 같은 매칭이 타깃을 거절하기 때문이다.
+
+필요한 조각은 전부 이미 있었다. `speculative_burst.rs`의 변형별 `&dyn LanguageModel` 선택과 변형별 `MtpTarget` 어댑터 선택, 31B 타깃이 필요로 하는 `Gemma4VLMtpTargetAdapter`, Qwen 3.8 타깃이 필요로 하는 `Qwen35MtpTargetAdapter`, `qwen3_5_mtp` 드래프터 해석, 그리고 `release_sequence_state_by_id`를 포함한 enum 자체의 `LanguageModel` 구현까지.
+
+### 1.3 이슈가 말하지 않은 결함
+
+`resolve_model_dir`은 `<CARGO_MANIFEST_DIR>/models/<name>`을 보고 그다음 `../mlxcel-internal/models/<name>`을 봤다. 체크포인트 저장소가 `models/mlx/<name>`이고 형제 체크아웃도 같은 배치인 호스트에서는 두 탐색 모두 빗나간다. 그러면 스윕의 모든 행이 "디스크에 체크포인트 없음" 스킵으로 흘러가고, 스윕은 완주하면서 아무것도 측정하지 않고 오류도 전혀 내지 않는다. 발행된 결함보다 나쁜 실패 양상이다. 조용하기 때문이다.
+
+---
+
+## 2. 기술적 결정
+
+### 2.1 변형마다가 아니라 제네릭 타이밍 함수 하나
+
+`MtpGenerator`가 `MtpTarget`에 대해 제네릭이므로, 워밍업 burst와 시간 측정 generate, 수용률 수집, 시퀀스 해제를 `T: MtpTarget`에 제네릭한 `run_mtp_timed` 하나로 옮기고 각 arm이 자기 어댑터 생성자로 호출하게 했다. 변형마다 다른 건 `MtpTarget` 생성뿐이다. 드래프터는 enum 자신의 `LanguageModel` 구현에 바인드하고 같은 참조로 해제하므로, 생명주기 코드를 arm마다 복사하지 않는다.
+
+### 2.2 공유 라벨은 `pub(crate)`이 아니라 `pub`
+
+원래 계획은 `model_variant_label`을 `pub(crate)`으로 넓히는 것이었다. 그건 통하지 않는다. `speculative_bench`는 `mlxcel` 라이브러리와 별개 크레이트이고 `pub(crate)`은 라이브러리 경계에서 멈춘다. 그래서 함수를 `pub`으로 두고 크레이트 루트에 재수출했으며, 두 자리 모두에 이유를 적었다. 대안은 벤치 쪽에 라벨 표를 하나 더 두는 것이었는데, 그러면 서버 쪽과 어긋나기 시작한다.
+
+노출된 표면은 진단용 이름을 돌려주는 `fn(&LoadedModel) -> &'static str` 하나라서 추가분이 작고 호환을 깨지 않는다. 공유 표는 speculative 가능 집합 밖의 변형을 `other`로 보고하므로, 벤치의 미지원 메시지는 라벨과 함께 타깃 디렉터리도 같이 적는다. 그 표 자체를 넓히는 일은 범위 밖으로 뒀다.
+
+### 2.3 미지원 변형 검사는 드래프터 IO보다 먼저
+
+처음 작성했을 때는 매칭이 `validate_target_compat` 뒤에 있었다. 그러면 hidden size가 안 맞는 미지원 타깃이 *드래프터* 메시지로 실패하고, "로드된 변형과 지원 계열을 알려 준다"는 합격 기준의 메시지는 정작 그 메시지가 설명하려던 입력에서 도달 불가능해진다. 이제 검사가 드래프터 로드보다 먼저 돈다. burst 경로와 같은 순서다.
+
+### 2.4 모든 실패는 행 상태로 남는다
+
+드래프터가 로드는 되지만 `validate_target_compat`에 걸리는 경우, 체크포인트 부재, `block_size < 2`, Qwen 3.5 MTP 정확성의 Metal 전용 가드까지 전부 스윕을 중단시키지 않고 행별 상태 문자열로 기록된다. CUDA 스윕은 런타임이 보증할 수 없는 숫자를 내놓는 대신 그 이유를 적는다.
+
+---
+
+## 3. 검증
+
+Apple M1 Ultra 128 GB, Metal, mlxcel 0.7.0-beta.1, MLX 핀 `9a795735`, `--kind mtp --block-size 4 --max-tokens 128`. 둘 다 변경 전 바이너리에서는 실패한다.
+
+```
+gemma-4-31b-it-4bit + gemma-4-31b-it-assistant-bf16
+  tok/s=14.8  rounds=34  acceptance_rate=0.529  mean_accepted_len=1.59
+
+qwen3.8-27b-4bit + qwen3.8-27b-mtp-4bit
+  tok/s=16.9  rounds=47  acceptance_rate=0.504  mean_accepted_len=1.51
+```
+
+전체 `--sweep --batch 1 --max-tokens 128`은 16행을 완주한다. 베이스라인 4개, K=2/4/8에서 측정된 MTP 행 9개, 자체 블로커로 여전히 보류인 DFlash 행 3개이고, `MTP bench currently supports`로 시작하는 상태를 단 한 행도 달고 있지 않다. `gemma-3-4b-it-4bit`를 `--kind mtp`로 넣으면 로드된 변형과 타깃 디렉터리와 지원 계열을 행 상태로 보고하고 중단하지 않는다.
+
+### 3.1 결과는 음성이고, 원인은 호스트다
+
+| 페어링 | 베이스라인 | K=2 | K=4 | K=8 |
+|---|---|---|---|---|
+| Gemma 4 31B + MTP assistant | 19.9 | 18.4 | 14.9 | 14.9 |
+| Gemma 4 Unified 12B + MTP assistant | 38.4 | 36.0 | 28.5 | 29.3 |
+| Qwen 3.8 27B + MTP head | 24.9 | 22.5 | 17.2 | 9.3 |
+
+모든 비율이 1.00x 아래다. 같은 Unified 12B 페어링이 M5 Max에서는 K=4에 1.57x를 낸다. 수용률이 설명은 아니다. 같은 페어링이 같은 K에서 M1 Ultra 쪽이 오히려 더 많이 수용하는데도(39.6%에 평균 수용 길이 1.19, M5 Max는 35.0%에 1.05) 0.74x에 머문다.
+
+차이는 verify 라운드다. `docs/benchmark_results/speculative-decoding-m1ultra-2026-08-19.md`는 block-4 verify 라운드 비용을 M1 Ultra 2.70 classic decode step, M3 Ultra 1.50, M5 Max 1.27로 측정했고, M1 Ultra를 Apple GPU 13세대의 첫 호스트로 지목한다. 평균 수용 길이가 1.2 언저리면 2.70 step짜리 verify를 상대로 손익분기를 넘을 수 없다. 이 세대에서 B=1 MTP를 거절하는 정적 게이트도 같은 이유로 존재한다. 즉 이 행들은 회귀 보고가 아니라 호스트의 알려진 성질을 재확인한 것이다.
+
+### 3.2 게이트
+
+`cargo test --workspace --profile test-fast --features metal,accelerate`: 10,507 통과, 0 실패. `cargo clippy --bin speculative_bench --features metal,accelerate -- -D warnings`와 `cargo fmt --all -- --check` 깨끗. CI 13개 항목 전부 통과.
+
+최종 실행 직전의 전체 워크스페이스 실행 하나가 `vision::inkling_vl::tests::mixed_prefill_scatter_order_is_normalized_text_then_image_then_audio`에서 실패했다. 이 PR이 건드리지 않는 파일이다. 단독 실행 3회 모두 통과하고 `--lib` 바이너리 전체도 같은 테스트 수로 두 번 통과하므로 간헐적이고 무관한 실패다. 여기에 흡수하지 않고 따로 발행했다.
+
+---
+
+## 4. 변경 요약
+
+### 통계
+
+| 항목 | 값 |
+|---|---|
+| 변경 파일 (코드 PR) | 4 |
+| 추가 줄 | 268 |
+| 삭제 줄 | 65 |
+
+### 분류별 변경
+
+- `src/bin/speculative_bench.rs`: 변형별 어댑터 디스패치, 제네릭 `run_mtp_timed`, Qwen 3.8 페어링, 앞으로 끌어올린 미지원 변형 검사, `resolve_model_dir`의 `models/mlx/<name>` 탐색.
+- `src/server/batch/speculative_burst.rs`: `model_variant_label` 가시성만.
+- `src/lib.rs`: 크레이트 루트 재수출.
+- `docs/benchmarks.md`: 지원 타깃 집합.
+
+### 따로 반영한 부분
+
+`benchmarks/metal_m1ultra_spec_2026-09-04.csv`(16행)와 `docs/benchmark_results/model_tests.md` 갱신은 `bench/0.7.0-refresh`(PR #1617)에 커밋 `f4ff37522`로 올렸다. 벤치마크 산출물은 코드 PR이 아니라 그 브랜치에 속하기 때문이다. 이 분리 때문에 이 PR이 머지되어 이슈가 닫혀도 문서 절반은 아직 미머지 상태로 남는다. PR 본문에 그 사실을 명시했다.
+
+### 관련 이슈
+
+Closes #1613. 관련: #154(Gemma 4 Unified MTP 드래프터), #1165(`qwen3_5_mtp` 드래프터와 Metal 정확성 게이트), #638(`--k-values` 뒤의 K 스윕).
+
+---
+
+## 5. 후속 작업
+
+- 새로 측정 가능해진 두 페어링의 M5 Max 재측정은 해당 호스트에서 대기 중이다. `model_tests.md`의 M5 Max 표는 M1 Ultra 수치로 덮어쓰지 않고 그대로 두되, "unsupported target" 주석만 하네스 제한이 풀렸다는 문장으로 교체했다.
+- `--kind dflash` 세 행은 기존 보류(DFlash 로더와 공개 `Qwen3NextCache` API)를 유지한다.
+- 배치(`B > 1`) MTP 어댑터와 Inkling 페어링은 범위 밖이다. 후자는 로컬 체크포인트가 없다.
+
+### 옮겨갈 만한 교훈
+
+발행된 이슈는 측정을 거부하는 하네스를 설명했다. 정작 고치는 길에 나온 더 비싼 결함은 아무것도 측정하지 않으면서 그 사실을 어디에도 말하지 않는 하네스였다. 이 호스트의 배치에서 `resolve_model_dir`이 모든 페어링을 조용히 스킵으로 해석했다. 행이 0개인 벤치마크는 눈에 띈다. 모든 행이 스킵된 채 완주한 벤치마크는 깨끗한 실행처럼 보인다. 스윕이 경로 탐색에 의존한다면, 탐색 실패도 측정 실패만큼 시끄러워야 한다.

--- a/docs/benchmarks.md
+++ b/docs/benchmarks.md
@@ -948,7 +948,14 @@ rather than stale and it keeps declining. Full record and method:
 
 The pairing is also wired into `speculative_bench` (`REACHABLE_PAIRINGS`), which
 runs once the `gemma-4-31b-it-4bit` and `gemma-4-31B-it-assistant-bf16`
-checkpoints are present in the model store.
+checkpoints are present in the model store. Checkpoint presence alone was not
+enough until #1613: `run_mtp` matched `LoadedModel::Gemma4Unified` only, so the
+31B target (which loads as `Gemma4VLM`) was rejected after load with both
+checkpoints on disk. The harness now selects the adapter per variant the way
+`src/server/batch/speculative_burst.rs` does, so the Gemma 4 text, VLM and
+Unified wrappers and the Qwen 3.5 text, MoE and VLM wrappers are all
+benchable, and the catalog carries a Qwen 3.8 27B pairing against the
+`qwen3_5_mtp` head as well.
 
 ### Adaptive B=1 MTP policy
 

--- a/src/bin/speculative_bench.rs
+++ b/src/bin/speculative_bench.rs
@@ -23,15 +23,21 @@
 //! in `docs/model_tests.md::Speculative drafters` and can be
 //! captured today against real on-disk checkpoints.
 //!
-//! ## MTP speculative path (active for the Gemma 4 Unified pair)
+//! ## MTP speculative path (Gemma 4 and Qwen 3.5 families)
 //!
-//! The `--kind mtp` path is wired for the Gemma 4 Unified target
-//! (`gemma4_unified`) + `gemma4_unified_assistant` drafter (issue #154). It
-//! loads the target, binds the MTP assistant drafter, drives
-//! `MtpGenerator` through `Gemma4UnifiedMtpTargetAdapter`, and records the
-//! real decode tok/s + speedup vs the no-drafter baseline. Mean acceptance
-//! length per verification round is emitted by the round loop's tracing
-//! diagnostics (`MtpRoundDiagnostics`) during the run.
+//! The `--kind mtp` path loads the target, binds the MTP drafter, drives
+//! `MtpGenerator` through the target family's `MtpTarget` adapter, and
+//! records the real decode tok/s + speedup vs the no-drafter baseline. Mean
+//! acceptance length per verification round is emitted by the round loop's
+//! tracing diagnostics (`MtpRoundDiagnostics`) during the run.
+//!
+//! Target selection mirrors the server burst path
+//! (`src/server/batch/speculative_burst.rs`): the Gemma 4 text, VLM and
+//! Unified wrappers pair with a `gemma4*_assistant` drafter (issue #154), and
+//! the Qwen 3.5 text, MoE and VLM wrappers pair with a `qwen3_5_mtp` head
+//! (issue #1165, Metal-only). Any other variant is reported as a row status
+//! naming the loaded variant and the supported families, not as a sweep
+//! abort.
 //!
 //! ## Scope still deferred
 //!
@@ -67,7 +73,7 @@ use anyhow::{Context, Result};
 use clap::{Parser, ValueEnum};
 
 use mlxcel::tokenizer::MlxcelTokenizer;
-use mlxcel::{LanguageModel, SamplingConfig, initialize_runtime, load_model};
+use mlxcel::{LanguageModel, LoadedModel, SamplingConfig, initialize_runtime, load_model};
 use mlxcel_core::generate::{CxxGenerator, GenerationStats};
 use mlxcel_core::speculative::mtp::MtpAcceptanceSummary;
 
@@ -87,9 +93,10 @@ enum BenchKind {
     /// No-drafter baseline. The denominator of the speedup column. Always
     /// reachable today via `LanguageModel::forward`.
     None,
-    /// MTP speculative path (Gemma 4 assistant). Active for the Gemma 4
-    /// Unified target + `gemma4_unified_assistant` drafter (issue #154):
-    /// records real decode tok/s + speedup vs the no-drafter baseline.
+    /// MTP speculative path. Active for the Gemma 4 family +
+    /// `gemma4*_assistant` drafter (issue #154) and the Qwen 3.5 family +
+    /// `qwen3_5_mtp` head (issue #1165): records real decode tok/s + speedup
+    /// vs the no-drafter baseline.
     Mtp,
     /// DFlash speculative path (Qwen 3.5 DFlash). DEFERRED: requires
     /// (a) public cache-construction API on `Qwen35Model` and (b) lazy-bind
@@ -281,6 +288,24 @@ const REACHABLE_PAIRINGS: &[Pairing] = &[
         kind: BenchKind::Mtp,
         block_size: Some(4),
     },
+    // Qwen 3.8 27B family — baseline + `qwen3_5_mtp` head (#1165). Reachable
+    // since #1613 lifted the bench's Gemma-4-Unified-only target gate; the
+    // target loads as a Qwen 3.5 variant and pairs with the MTP head split
+    // from the same checkpoint family.
+    Pairing {
+        name: "Qwen 3.8 27B (no drafter)",
+        target_subdir: "qwen3.8-27b-4bit",
+        draft_subdir: None,
+        kind: BenchKind::None,
+        block_size: None,
+    },
+    Pairing {
+        name: "Qwen 3.8 27B + MTP head",
+        target_subdir: "qwen3.8-27b-4bit",
+        draft_subdir: Some("qwen3.8-27b-mtp-4bit"),
+        kind: BenchKind::Mtp,
+        block_size: Some(4),
+    },
 ];
 
 /// Resolve a model directory against the canonical `models/` layout,
@@ -288,18 +313,29 @@ const REACHABLE_PAIRINGS: &[Pairing] = &[
 /// `mlxcel-internal` checkout (`../mlxcel-internal/models/<name>`) so the
 /// binary can be run from a `git worktree`-created secondary working tree
 /// even though `target/` and `models/` live in the primary tree.
+///
+/// A third and fourth probe cover the `models/mlx/<name>` store layout
+/// (#1613). Hosts that keep every checkpoint directly under `models/` are
+/// unaffected because the flat probes still run first; hosts that group MLX
+/// checkpoints under `models/mlx/` would otherwise resolve nothing and every
+/// sweep row would fall through to the "checkpoint missing on disk" skip,
+/// producing a sweep that measures nothing while reporting no error.
 fn resolve_model_dir(name: &str) -> PathBuf {
     let manifest_dir = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
     let primary = manifest_dir.join("models").join(name);
-    if primary.exists() {
-        return primary;
-    }
-    let shared = manifest_dir
-        .parent()
-        .map(|p| p.join("mlxcel-internal").join("models").join(name))
-        .unwrap_or_else(|| primary.clone());
-    if shared.exists() {
-        return shared;
+    let sibling_root = manifest_dir.parent().map(|p| p.join("mlxcel-internal"));
+    let candidates = [
+        Some(primary.clone()),
+        sibling_root.as_ref().map(|p| p.join("models").join(name)),
+        Some(manifest_dir.join("models").join("mlx").join(name)),
+        sibling_root
+            .as_ref()
+            .map(|p| p.join("models").join("mlx").join(name)),
+    ];
+    for candidate in candidates.into_iter().flatten() {
+        if candidate.exists() {
+            return candidate;
+        }
     }
     primary
 }
@@ -384,17 +420,56 @@ fn run_baseline(target_dir: &Path, prompt: &str, max_tokens: usize) -> Result<(f
     Ok((stats.decode_time_ms, generated))
 }
 
-/// Run the MTP speculative path against a real on-disk Gemma 4 Unified
-/// target + `gemma4_unified_assistant` drafter (issue #154). Returns the
-/// decode wall-clock (ms) and the number of generated tokens so the caller
-/// can fill in a `Row`.
+/// MTP target families this bench can drive, named in the unsupported-variant
+/// error so an operator sees which checkpoints the harness accepts instead of
+/// an opaque discriminant. Kept in step with the server burst path's variant
+/// gate in `src/server/batch/speculative_burst.rs`.
+///
+/// The variant name in that error comes from `mlxcel::model_variant_label`,
+/// the same table the burst path uses. It covers the speculative-capable
+/// variants and reports every other one as `other`, so the message also names
+/// the target directory to identify the checkpoint.
+const MTP_SUPPORTED_FAMILIES: &str = "Gemma 4 (Gemma4, Gemma4VLM, Gemma4Unified) \
+     and Qwen 3.5 (Qwen35, Qwen35Moe, Qwen35VLM, Qwen35MoeVLM)";
+
+/// Whether [`run_mtp`] can build an `MtpTarget` adapter for this variant.
+///
+/// Checked before the drafter is loaded, the same ordering the server burst
+/// path uses, and for the same reason: an unsupported target must report the
+/// target problem rather than surface it later as a drafter message. Without
+/// the hoist a `validate_target_compat` hidden-size mismatch fires first and
+/// describes the drafter, which is not the actual fault. The match in
+/// [`run_mtp`] repeats this list because it also binds the inner model; the
+/// two must stay in step.
+fn mtp_target_supported(model: &LoadedModel) -> bool {
+    matches!(
+        model,
+        LoadedModel::Gemma4(_)
+            | LoadedModel::Gemma4VLM(_)
+            | LoadedModel::Gemma4Unified(_)
+            | LoadedModel::Qwen35(_)
+            | LoadedModel::Qwen35Moe(_)
+            | LoadedModel::Qwen35VLM(_)
+            | LoadedModel::Qwen35MoeVLM(_)
+    )
+}
+
+/// Run the MTP speculative path against a real on-disk target + MTP drafter.
+/// Returns the decode wall-clock (ms), the number of generated tokens and the
+/// run's acceptance summary so the caller can fill in a `Row`.
 ///
 /// Mirrors [`run_baseline`]: same runtime init, warm-up, and streaming
-/// progress, but drives the MTP round loop through
-/// [`Gemma4UnifiedMtpTargetAdapter`] + `MtpGenerator` instead of the plain
-/// `CxxGenerator`. The drafter is bound after a compatibility check that
-/// rejects a mismatched target↔drafter pair (the same guard the server burst
-/// path runs).
+/// progress, but drives the MTP round loop through the target family's
+/// `MtpTarget` adapter + `MtpGenerator` instead of the plain `CxxGenerator`.
+///
+/// Variant dispatch mirrors the server burst path
+/// (`src/server/batch/speculative_burst.rs`): the Gemma 4 text, VLM and
+/// Unified wrappers and the Qwen 3.5 text, MoE and VLM wrappers each select
+/// their own adapter, and any other variant fails with a message naming the
+/// loaded variant and the supported families (#1613). The drafter is bound
+/// against the `LoadedModel` enum's own `LanguageModel` impl, which delegates
+/// to the inner model, so only the adapter construction needs a match; the
+/// timed run itself lives once in [`run_mtp_timed`].
 ///
 /// `block_size` is the effective MTP block size (defaults to the drafter's
 /// configured 4 when the caller passes `None`).
@@ -405,14 +480,11 @@ fn run_mtp(
     max_tokens: usize,
     block_size: Option<u32>,
 ) -> Result<(f64, usize, Option<MtpAcceptanceSummary>)> {
-    use std::sync::atomic::AtomicBool;
-
-    use mlxcel::LoadedModel;
-    use mlxcel::models::gemma4_mtp_target::Gemma4UnifiedMtpTargetAdapter;
+    use mlxcel::models::gemma4_mtp_target::{
+        Gemma4MtpTargetAdapter, Gemma4UnifiedMtpTargetAdapter, Gemma4VLMtpTargetAdapter,
+    };
+    use mlxcel::models::qwen3_5_mtp_target::{Qwen35MtpTargetAdapter, Qwen35VLMtpTargetAdapter};
     use mlxcel_core::drafter::{DrafterKind, load_drafter};
-    use mlxcel_core::generate::LanguageModel as _;
-    use mlxcel_core::sampling::LogprobsConfig;
-    use mlxcel_core::speculative::mtp::MtpGenerator;
 
     let block_size = block_size.unwrap_or(4) as usize;
     if block_size < 2 {
@@ -430,17 +502,36 @@ fn run_mtp(
 
     let (model, tokenizer) = load_model(target_dir).context("load_model failed")?;
 
-    // The MTP bench targets the Gemma 4 Unified decode path. Accept the
-    // Gemma 4 family broadly so a future text-only/VLM pairing reuses this
-    // harness, but the issue's measured pair is the Unified 12B target.
-    let unified = match &model {
-        LoadedModel::Gemma4Unified(u) => u,
-        other => anyhow::bail!(
-            "MTP bench currently supports a Gemma 4 Unified target; \
-             load_model returned a different variant ({:?})",
-            std::mem::discriminant(other)
-        ),
-    };
+    // Qwen 3.5 MTP exactness rests on the Metal chain-parity gated-delta
+    // kernel, so the server burst path declines the pairing when Metal is
+    // unavailable. Mirror that here: a CUDA sweep records the reason as this
+    // row's status instead of emitting a number the runtime cannot vouch for.
+    if matches!(
+        &model,
+        LoadedModel::Qwen35(_)
+            | LoadedModel::Qwen35Moe(_)
+            | LoadedModel::Qwen35VLM(_)
+            | LoadedModel::Qwen35MoeVLM(_)
+    ) && !mlxcel_core::metal_is_available()
+    {
+        anyhow::bail!(
+            "MTP bench: Qwen 3.5 MTP requires the Metal backend (its temperature-0 \
+             exactness rests on the Metal chain-parity gated-delta kernel); target \
+             loaded as {}",
+            mlxcel::model_variant_label(&model)
+        );
+    }
+
+    // Reject an unsupported target before any drafter IO, so the operator sees
+    // which variant loaded and which families the harness drives instead of a
+    // drafter compat message about a hidden size.
+    anyhow::ensure!(
+        mtp_target_supported(&model),
+        "MTP bench: target {} loaded as {}, which has no MTP target adapter; \
+         supported families are {MTP_SUPPORTED_FAMILIES}",
+        target_dir.display(),
+        mlxcel::model_variant_label(&model)
+    );
 
     let prompt_tokens = encode_prompt(&tokenizer, prompt);
     eprintln!(
@@ -449,8 +540,13 @@ fn run_mtp(
         max_tokens
     );
 
-    // Load + compat-check + bind the MTP assistant drafter. The compat guard
-    // rejects a mismatched backbone_hidden_size / vocab pairing before bind.
+    // Bind against the enum's own `LanguageModel` impl, which delegates every
+    // method to the inner model, so the compat guard, the bind and the
+    // per-sequence release are all variant-agnostic.
+    let target_lm: &dyn LanguageModel = &model;
+
+    // Load + compat-check + bind the MTP drafter. The compat guard rejects a
+    // mismatched backbone_hidden_size / vocab pairing before bind.
     eprintln!("[bench/mtp] Loading drafter from {:?}", draft_dir);
     let (mut drafter, kind) =
         load_drafter(draft_dir, Some(DrafterKind::Mtp)).context("MTP drafter load failed")?;
@@ -458,11 +554,103 @@ fn run_mtp(
         kind == DrafterKind::Mtp,
         "drafter did not resolve to MTP (got {kind:?})"
     );
-    let target_lm: &dyn mlxcel_core::generate::LanguageModel = unified;
     drafter
         .validate_target_compat(target_lm)
         .context("MTP drafter incompatible with target")?;
     drafter.bind(target_lm).context("MTP drafter bind failed")?;
+
+    // Only the `MtpTarget` construction is variant-specific. Gemma 4 adapters
+    // take the block size because their rotating-cache buffer is armed from
+    // it; the Qwen 3.5 attention caches are plain growing KVCaches, so their
+    // adapters take none (same split as the burst path).
+    match &model {
+        LoadedModel::Gemma4(wrapper) => run_mtp_timed(
+            |seq| Gemma4MtpTargetAdapter::new_with_block_size(wrapper, Some(seq), block_size),
+            drafter,
+            target_lm,
+            draft_dir,
+            &prompt_tokens,
+            max_tokens,
+            block_size,
+        ),
+        LoadedModel::Gemma4VLM(vlm) => run_mtp_timed(
+            |seq| Gemma4VLMtpTargetAdapter::new_with_block_size(vlm, Some(seq), block_size),
+            drafter,
+            target_lm,
+            draft_dir,
+            &prompt_tokens,
+            max_tokens,
+            block_size,
+        ),
+        LoadedModel::Gemma4Unified(unified) => run_mtp_timed(
+            |seq| {
+                Gemma4UnifiedMtpTargetAdapter::new_with_block_size(unified, Some(seq), block_size)
+            },
+            drafter,
+            target_lm,
+            draft_dir,
+            &prompt_tokens,
+            max_tokens,
+            block_size,
+        ),
+        LoadedModel::Qwen35(qwen) | LoadedModel::Qwen35Moe(qwen) => run_mtp_timed(
+            |seq| Qwen35MtpTargetAdapter::new(qwen, Some(seq)),
+            drafter,
+            target_lm,
+            draft_dir,
+            &prompt_tokens,
+            max_tokens,
+            block_size,
+        ),
+        LoadedModel::Qwen35VLM(vlm) | LoadedModel::Qwen35MoeVLM(vlm) => run_mtp_timed(
+            |seq| Qwen35VLMtpTargetAdapter::new(vlm, Some(seq)),
+            drafter,
+            target_lm,
+            draft_dir,
+            &prompt_tokens,
+            max_tokens,
+            block_size,
+        ),
+        // Unreachable while `mtp_target_supported` above covers the same
+        // list; kept so a variant added to one place and not the other fails
+        // with the same operator-facing message rather than a panic.
+        other => anyhow::bail!(
+            "MTP bench: target {} loaded as {}, which has no MTP target adapter; \
+             supported families are {MTP_SUPPORTED_FAMILIES}",
+            target_dir.display(),
+            mlxcel::model_variant_label(other)
+        ),
+    }
+}
+
+/// Warm-up burst + timed MTP run for one already-bound target adapter.
+///
+/// `MtpGenerator` is generic over `MtpTarget`, so the warm-up, the timed
+/// generate, the acceptance capture and the per-sequence release live here
+/// once and every `LoadedModel` arm in [`run_mtp`] calls it with its own
+/// adapter constructor instead of carrying a copy of the body (#1613).
+///
+/// `make_adapter` is invoked twice with two distinct sequence ids, once for
+/// the warm-up and once for the timed run, so the timed run never inherits
+/// the warm-up's per-sequence cache state.
+fn run_mtp_timed<T, F>(
+    make_adapter: F,
+    drafter: Box<dyn mlxcel_core::drafter::Drafter>,
+    target_lm: &dyn LanguageModel,
+    draft_dir: &Path,
+    prompt_tokens: &[i32],
+    max_tokens: usize,
+    block_size: usize,
+) -> Result<(f64, usize, Option<MtpAcceptanceSummary>)>
+where
+    T: mlxcel_core::speculative::mtp::MtpTarget,
+    F: Fn(mlxcel_core::cache::SequenceId) -> T,
+{
+    use std::sync::atomic::AtomicBool;
+
+    use mlxcel_core::drafter::{DrafterKind, load_drafter};
+    use mlxcel_core::sampling::LogprobsConfig;
+    use mlxcel_core::speculative::mtp::MtpGenerator;
 
     let sampling = SamplingConfig::greedy();
     let logprobs = LogprobsConfig::default();
@@ -479,22 +667,18 @@ fn run_mtp(
             .bind(target_lm)
             .context("warm-up drafter bind")?;
         let warm_seq = mlxcel_core::cache::SequenceId::from_raw(99_000);
-        let warm_adapter =
-            Gemma4UnifiedMtpTargetAdapter::new_with_block_size(unified, Some(warm_seq), block_size);
-        let mut warm_gen = MtpGenerator::new(warm_adapter, warm_drafter, block_size);
-        let _ = warm_gen.generate(&prompt_tokens, 4, &sampling, &[], &cancel, &logprobs);
-        unified.release_sequence_state_by_id(warm_seq);
+        let mut warm_gen = MtpGenerator::new(make_adapter(warm_seq), warm_drafter, block_size);
+        let _ = warm_gen.generate(prompt_tokens, 4, &sampling, &[], &cancel, &logprobs);
+        target_lm.release_sequence_state_by_id(warm_seq);
         mlxcel_core::synchronize_default();
     }
 
     eprintln!("[bench/mtp] Timed run starts");
     let seq_id = mlxcel_core::cache::SequenceId::from_raw(99_001);
-    let adapter =
-        Gemma4UnifiedMtpTargetAdapter::new_with_block_size(unified, Some(seq_id), block_size);
-    let mut generator = MtpGenerator::new(adapter, drafter, block_size);
+    let mut generator = MtpGenerator::new(make_adapter(seq_id), drafter, block_size);
     let started = Instant::now();
     let (tokens, _logprobs, stats) = generator.generate(
-        &prompt_tokens,
+        prompt_tokens,
         max_tokens,
         &sampling,
         &[],
@@ -509,7 +693,7 @@ fn run_mtp(
     // signal. The mean accepted length per round is
     // `accepted_draft_tokens / rounds`.
     let acceptance = generator.last_acceptance();
-    unified.release_sequence_state_by_id(seq_id);
+    target_lm.release_sequence_state_by_id(seq_id);
 
     let generated = tokens.len();
     let (acc_rate, acc_len, rounds) = acceptance
@@ -591,8 +775,8 @@ fn print_markdown_table(rows: &[Row]) {
         );
     }
     println!();
-    println!("Note: MTP rows (Gemma 4 Unified + gemma4_unified_assistant) are real");
-    println!("decode numbers captured on the host this binary ran on; the speedup");
+    println!("Note: MTP rows (Gemma 4 + gemma4*_assistant, Qwen 3.5 + qwen3_5_mtp) are");
+    println!("real decode numbers captured on the host this binary ran on; the speedup");
     println!("column is MTP tok/s ÷ the matching no-drafter baseline; acceptance rate");
     println!("and mean accepted length come from the run's MtpAcceptanceSummary. The");
     println!("DFlash row remains deferred, see `docs/benchmark_results/model_tests.md`.");

--- a/src/bin/speculative_bench.rs
+++ b/src/bin/speculative_bench.rs
@@ -288,7 +288,7 @@ const REACHABLE_PAIRINGS: &[Pairing] = &[
         kind: BenchKind::Mtp,
         block_size: Some(4),
     },
-    // Qwen 3.8 27B family — baseline + `qwen3_5_mtp` head (#1165). Reachable
+    // Qwen 3.8 27B family: baseline + `qwen3_5_mtp` head (#1165). Reachable
     // since #1613 lifted the bench's Gemma-4-Unified-only target gate; the
     // target loads as a Qwen 3.5 variant and pairs with the MTP head split
     // from the same checkpoint family.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -108,6 +108,12 @@ pub use mlxcel_core::session::{
     PreparedTensorDType, SessionCapabilities,
 };
 pub use server::ImageInputLimits;
+// Diagnostic variant name for a `LoadedModel`, shared with the
+// `speculative_bench` binary so an unsupported speculative target reports the
+// same label the server burst path reports (#1613). The defining module is
+// `pub(crate)`, so the re-export here is what makes the function reachable
+// from a separate binary crate.
+pub use server::batch::speculative_burst::model_variant_label;
 
 /// Return the image admission limits shared by CLI and server requests.
 #[must_use]

--- a/src/server/batch/speculative_burst.rs
+++ b/src/server/batch/speculative_burst.rs
@@ -3031,7 +3031,13 @@ pub(crate) fn sampling_config_eq(a: &SamplingConfig, b: &SamplingConfig) -> bool
 /// Best-effort diagnostic name for a [`LoadedModel`] variant, used in
 /// burst error messages so the operator can see which model variant the
 /// scheduler refused to speculatively-drive.
-fn model_variant_label(model: &LoadedModel) -> &'static str {
+///
+/// `pub` (and re-exported at the crate root as
+/// `mlxcel::model_variant_label`) so the `speculative_bench` binary, which
+/// is a separate crate from this library, can name the same labels in its
+/// unsupported-target message instead of carrying a second copy of the
+/// table (#1613).
+pub fn model_variant_label(model: &LoadedModel) -> &'static str {
     // Avoid pulling in `std::mem::discriminant` String formatting which
     // doesn't yield variant names by default. Returning a hand-picked
     // label per common variant keeps error messages stable and Greppable.


### PR DESCRIPTION
## Summary

`run_mtp` in `src/bin/speculative_bench.rs` matched `LoadedModel::Gemma4Unified` and bailed on every other variant with `std::mem::discriminant`, so the bench could produce MTP numbers for exactly one checkpoint. Every adapter the other families need already exists and the server burst path already dispatches them, so the harness was the only place pretending the support was absent. This replaces the unwrap with per-variant adapter selection and adds the Qwen 3.8 pairings the restriction was blocking.

## What changed

`src/bin/speculative_bench.rs`: `run_mtp` now selects the `MtpTarget` adapter per `LoadedModel` variant, mirroring `src/server/batch/speculative_burst.rs`. Gemma 4 text, VLM and Unified wrappers take their `gemma4_mtp_target` adapter (block-size-armed, because their rotating cache is sized from it); Qwen 3.5 text, MoE and VLM wrappers take their `qwen3_5_mtp_target` adapter. The drafter is loaded, compat-checked and bound against the `LoadedModel` enum's own `LanguageModel` impl, and the per-sequence release goes through the same reference, so only the adapter construction needs a match.

`src/bin/speculative_bench.rs`: the warm-up burst, the timed generate, the acceptance capture and the sequence release moved into one `run_mtp_timed` function generic over `T: MtpTarget`. Each variant arm calls it with its own adapter constructor; the timed body is not copied per variant.

`src/bin/speculative_bench.rs`: an unsupported variant now fails with a message naming the loaded variant, the target directory and the supported families, rather than printing `Discriminant(26)`. That check runs before the drafter is loaded, the same ordering the burst path uses and for the same reason: without the hoist a `validate_target_compat` hidden-size mismatch fires first and describes a drafter problem for what is a target problem. The variant name comes from the burst path's own label table, which reports anything outside the speculative-capable set as `other`, so the message names the target directory too; widening that table is out of scope here.

`src/bin/speculative_bench.rs`: Qwen 3.5 MTP exactness is Metal-only in the server path, so the bench declines the same way when `mlxcel_core::metal_is_available()` is false and records the reason as that row's status instead of emitting a number the runtime cannot vouch for. Drafter load failures, `validate_target_compat` mismatches, missing checkpoints and `block_size < 2` all stay per-row statuses and the sweep still completes its remaining rows.

`src/bin/speculative_bench.rs`: `REACHABLE_PAIRINGS` gains a `qwen3.8-27b-4bit` baseline (`BenchKind::None`) and the same target paired with the `qwen3.8-27b-mtp-4bit` drafter (`BenchKind::Mtp`, `block_size: Some(4)`).

`src/server/batch/speculative_burst.rs` and `src/lib.rs`: `model_variant_label` is `pub` and re-exported at the crate root. The bench is a separate crate from the library, so `pub(crate)` would not reach it, and the re-export is what lets the bench reuse the existing table instead of carrying a second copy of it. No other change to `speculative_burst.rs`.

`docs/benchmarks.md`: the paragraph claiming the 31B pairing "runs once the checkpoints are present in the model store" was not true before this change, since the target-variant gate rejected the 31B target with both checkpoints on disk. It now records that and the widened family list.

## Scope beyond the issue text

`resolve_model_dir` probed `<CARGO_MANIFEST_DIR>/models/<name>` and then `../mlxcel-internal/models/<name>`. On a host whose checkpoint store is `models/mlx/<name>` neither probe resolves, so every pairing in a `--sweep` silently falls through to the "checkpoint missing on disk" skip: the sweep completes, reports no error, and measures nothing. Two `models/mlx/<name>` probes now run after the existing two (repo-local, then sibling checkout), so no host that resolves today changes behavior. Without this the acceptance criteria below could not be verified at all on this host.

## Host substitution

The issue's figures come from an M5 Max sweep. This work was implemented and verified on **Apple M1 Ultra 128 GB (Metal)**, mlxcel 0.7.0-beta.1, MLX pin `9a795735`. The dispatch fix and the `REACHABLE_PAIRINGS` additions are host-independent; the numbers are not. The issue's K=4 figure of 70.9 tok/s for Gemma 4 Unified 12B is an M5 Max reading and is not the M1 Ultra expectation, so nothing here is asserted against it, and the M5 Max table in `docs/benchmark_results/model_tests.md` is not overwritten with M1 Ultra numbers. The M5 Max re-run against this binary is still pending.

## Test plan

- [x] `cargo build --release --features metal,accelerate --bin speculative_bench`
- [x] `cargo clippy --bin speculative_bench --features metal,accelerate -- -D warnings` (clean)
- [x] `cargo fmt --all -- --check` (clean)
- [x] `./target/release/speculative_bench --target models/mlx/gemma-4-31b-it-4bit --draft models/mlx/gemma-4-31b-it-assistant-bf16 --kind mtp --block-size 4 --max-tokens 128` on M1 Ultra: `[bench/mtp] Done: prompt=14 prefill_ms=306.0 decode_ms=5936.1 generated=88 tok/s=14.8 (wall 6.2s) rounds=34 acceptance_rate=0.529 mean_accepted_len=1.59`. This pairing fails on the pre-change binary.
- [x] `./target/release/speculative_bench --target models/mlx/qwen3.8-27b-4bit --draft models/mlx/qwen3.8-27b-mtp-4bit --kind mtp --block-size 4 --max-tokens 128` on M1 Ultra: `[bench/mtp] Done: prompt=13 prefill_ms=290.2 decode_ms=7051.4 generated=119 tok/s=16.9 (wall 7.3s) rounds=47 acceptance_rate=0.504 mean_accepted_len=1.51`. This pairing did not exist before.
- [x] `./target/release/speculative_bench --sweep --batch 1 --max-tokens 128` on M1 Ultra: 16 rows, 4 baselines and 9 measured MTP rows across Gemma 4 31B, Gemma 4 Unified 12B and Qwen 3.8 27B at K=2/4/8, 3 DFlash rows still deferred, and no row carrying a status that starts with `MTP bench currently supports`. Full table recorded on `bench/0.7.0-refresh` (see below).
- [x] `./target/release/speculative_bench --target models/mlx/gemma-3-4b-it-4bit --draft models/mlx/gemma-4-12b-it-assistant-4bit --kind mtp` reports `MTP bench: target <path> loaded as other, which has no MTP target adapter; supported families are Gemma 4 (Gemma4, Gemma4VLM, Gemma4Unified) and Qwen 3.5 (Qwen35, Qwen35Moe, Qwen35VLM, Qwen35MoeVLM)` as the row status, without aborting.

Every MTP pairing reads below 1.00x on this host, which is expected rather than a defect: `docs/benchmark_results/speculative-decoding-m1ultra-2026-08-19.md` measures a block-4 verify round at 2.70 classic decode steps on M1 Ultra against 1.27 on M5 Max, so a mean accepted length near 1.2 cannot clear break-even here. The `MLXCEL_ENABLE_MTP_B1` static gate already declines B=1 MTP on this Apple GPU generation for that reason. The numbers are the harness reporting the host it ran on, not a regression.

No unit tests are added: the binary has none today, its behavior is real-checkpoint dispatch, and a synthetic target cannot exercise the adapter selection this change is about.

## Where the acceptance criteria are satisfied

This issue splits across two destinations, so this PR closes it while part of its acceptance evidence sits unmerged elsewhere. Satisfied on `main` by this PR: `run_mtp` accepts `Gemma4`, `Gemma4VLM`, `Gemma4Unified`, `Qwen35`, `Qwen35Moe`, `Qwen35VLM` and `Qwen35MoeVLM` and names the loaded variant and the supported families otherwise; the Gemma 4 31B MTP pairing produces numeric tok/s, speedup, acceptance rate and mean accepted length at K=2/4/8 on M1 Ultra (18.4 / 14.9 / 14.9 tok/s, 0.93x / 0.75x / 0.75x against a 19.9 tok/s baseline, acceptance 74.0% / 52.9% / 52.9%, mean accepted length 0.74 / 1.59 / 1.59); the Qwen 3.8 27B baseline row and MTP pairing are in `REACHABLE_PAIRINGS` and both produce numbers (24.9 tok/s baseline, 22.5 / 17.2 / 9.3 tok/s at K=2/4/8); the Gemma 4 Unified 12B rows still produce numbers (38.4 tok/s baseline, 36.0 / 28.5 / 29.3 tok/s at K=2/4/8, acceptance 54.5% / 39.6% / 39.6%); clippy and fmt are clean.

Satisfied on `bench/0.7.0-refresh` (PR #1617), not on `main`: the `docs/benchmark_results/model_tests.md` edits that drop the unsupported-target limitation and record the new rows with their host named, and the M1 Ultra sweep CSV under `benchmarks/`. Those files are benchmark artifacts and that branch is the repository's benchmark-refresh PR, which is deliberately staying open until the M1 Ultra, M3 Ultra and GB10 sweeps land in it. Do not read this PR merging as those doc edits reaching `main`.

Closes #1613
