### PR TITLE
docs: update the SECURITY.md supported-versions table to the 0.7.x line

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -11,11 +11,11 @@ We provide security updates for the following versions:
 | Version              | Supported          | End of Support              |
 | -------------------- | ------------------ | --------------------------- |
 | 0.7.x                | :white_check_mark: | Current release line        |
-| < 0.7.0              | :x:                | Unsupported                  |
+| < 0.7.0              | :x:                | Unsupported                 |
 
 > **Note**: mlxcel's current release line is 0.7.x (tags v0.1.4 through v0.7.0-beta.1 have shipped). The latest published `0.7.x` release is the only supported version and security fixes ship as a new patch release. End-of-support dates for older lines will be defined as the project approaches 1.0.
 
-We strongly recommend always running the latest stable release to ensure you have the most recent security fixes.
+We strongly recommend always running the latest published release to ensure you have the most recent security fixes. The current line's latest tag is a beta (`v0.7.0-beta.1`); the last tag without a pre-release suffix is `v0.6.0`.
 
 ## Reporting a Vulnerability
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -10,10 +10,10 @@ We provide security updates for the following versions:
 
 | Version              | Supported          | End of Support              |
 | -------------------- | ------------------ | --------------------------- |
-| 0.5.x                | :white_check_mark: | Current stable line         |
-| < 0.5.0              | :x:                | Unsupported                  |
+| 0.7.x                | :white_check_mark: | Current release line        |
+| < 0.7.0              | :x:                | Unsupported                  |
 
-> **Note**: mlxcel's current release line is 0.5.x (tags v0.1.4 through v0.5.2 have shipped). The latest published `0.5.x` stable is the only supported version and security fixes ship as a new patch release. End-of-support dates for older lines will be defined as the project approaches 1.0.
+> **Note**: mlxcel's current release line is 0.7.x (tags v0.1.4 through v0.7.0-beta.1 have shipped). The latest published `0.7.x` release is the only supported version and security fixes ship as a new patch release. End-of-support dates for older lines will be defined as the project approaches 1.0.
 
 We strongly recommend always running the latest stable release to ensure you have the most recent security fixes.
 


### PR DESCRIPTION
## Summary

Updates the SECURITY.md supported-versions table and note to the actual current release line: 0.7.x (`Cargo.toml` is at `0.7.0-beta.1`, and `v0.6.0` and `v0.7.0-beta.1` have shipped per git tags and the CHANGELOG). Keeps the existing minimal two-row style: the current line is supported, everything older is unsupported.

## Related issues

Closes #1630

## Type of change

- [ ] `feat` — new user-visible feature
- [ ] `fix` — bug fix
- [ ] `perf` — performance improvement (include before/after numbers in the PR body)
- [ ] `refactor` — internal restructuring without behavior change
- [ ] `chore` — build, CI, dependencies, release infrastructure
- [x] `docs` — documentation only
- [ ] `test` — tests only
