### PR TITLE
docs: add CMake to the CONTRIBUTING.md minimum development environment

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -154,6 +154,7 @@ Detailed setup instructions are in [`docs/installation.md`](docs/installation.md
 Minimum:
 
 - Rust **1.97+** (project uses edition 2024)
+- CMake available on `PATH` on both platforms (required by the `mlxcel-core` and `sentencepiece-sys` build scripts)
 - macOS: Apple Silicon Mac on macOS Sonoma+; Xcode Command Line Tools
 - Linux: CUDA 13+ toolchain, OpenBLAS, LAPACK (see [`docs/installation.md`](docs/installation.md) for the package list)
 


### PR DESCRIPTION
## Summary

Adds CMake to the minimum development environment list in CONTRIBUTING.md. The build already requires it on both platforms — `docs/installation.md` lists "CMake available on `PATH`" for macOS and Linux, and `nightly-verify.yml` installs it because the `mlxcel-core` and `sentencepiece-sys` build scripts need it — but CONTRIBUTING omitted it, so a first-time contributor following CONTRIBUTING alone failed at `cargo build`.

## Related issues

Closes #1627

## Type of change

- [ ] `feat` — new user-visible feature
- [ ] `fix` — bug fix
- [ ] `perf` — performance improvement (include before/after numbers in the PR body)
- [ ] `refactor` — internal restructuring without behavior change
- [ ] `chore` — build, CI, dependencies, release infrastructure
- [x] `docs` — documentation only
- [ ] `test` — tests only
