### PR TITLE
docs(examples): fix dead link, placeholder, and stale in-progress claim in surgery examples

### DIFF
--- a/examples/surgery/prune_head_example.yaml
+++ b/examples/surgery/prune_head_example.yaml
@@ -8,8 +8,9 @@
 # silently kill more Q heads than the user asked for). See
 # `src/lib/mlxcel-surgery/src/ops/prune.rs` for the full policy.
 #
-# Use this YAML with the (in-progress) `--surgery` CLI flag (A4, #) or programmatically by passing the parsed pipeline as
-# the `WeightTransform` argument to `load_text_weights`.
+# Use this YAML with the `--surgery` CLI flag or programmatically
+# by passing the parsed pipeline as the `WeightTransform` argument
+# to `load_text_weights`.
 #
 # Equivalent variants:
 #   granularity: layer        with `layer_ids:   [12]`

--- a/examples/surgery/scale_only.yaml
+++ b/examples/surgery/scale_only.yaml
@@ -1,6 +1,6 @@
 # Example surgery config: scale every attention output projection
-# weight by 1.2.  See `mlxcel-surgery` (+) for the
-# schema and operation semantics.
+# weight by 1.2.  Schema and operation semantics are documented in
+# `src/lib/mlxcel-surgery/src/config.rs`.
 #
 # Quantized-tensor handling:
 #   For affine-quantized layers (4bit / 8bit), the `weight` key holds
@@ -9,8 +9,7 @@
 #   `weight` key transparently rewrites the multiplication to operate
 #   on `scales` (and `biases`, if present) instead of the packed
 #   codes — the user-observable result is `factor * effective_weight`
-#   regardless of layout. See `docs/apple-silicon-precision.md` for
-#   the quantization layout rationale.
+#   regardless of layout.
 #
 # All paths in this file (none here, but see add / replace /
 # interpolate examples for usage) are resolved relative to this YAML


### PR DESCRIPTION
## Summary

Comment-only fixes in the surgery example YAMLs: fills the unfilled schema cross-reference in `scale_only.yaml` to point at `src/lib/mlxcel-surgery/src/config.rs` (matching `full_example.yaml`), drops the dead reference to the non-existent `docs/apple-silicon-precision.md`, and rewrites the `prune_head_example.yaml` comment to describe `--surgery` as shipped (removing the stale "(in-progress)" claim and the "(A4, #)" placeholder, restoring the file's ~65-column comment wrapping).

## Related issues

Closes #1632

## Type of change

- [ ] `feat` — new user-visible feature
- [ ] `fix` — bug fix
- [ ] `perf` — performance improvement (include before/after numbers in the PR body)
- [ ] `refactor` — internal restructuring without behavior change
- [ ] `chore` — build, CI, dependencies, release infrastructure
- [x] `docs` — documentation only
- [ ] `test` — tests only
