### PR TITLE
docs(python): link the python/examples scripts from the README and client docs

### DIFF
--- a/docs/python-client.md
+++ b/docs/python-client.md
@@ -95,6 +95,8 @@ with mlxcel.LLM("mlx-community/Qwen3-4B-4bit") as llm:
         print(delta, end="", flush=True)
 ```
 
+A runnable version of this example lives at [`python/examples/streaming.py`](../python/examples/streaming.py).
+
 ## Chat
 
 `chat` returns the assistant message content as a string.
@@ -146,6 +148,8 @@ reply = llm.chat(
 )
 person = json.loads(reply)
 ```
+
+A runnable version of this example lives at [`python/examples/structured_output.py`](../python/examples/structured_output.py); it also issues the same request through the raw `openai_client`.
 
 ## The `openai_client` escape hatch
 

--- a/python/README.md
+++ b/python/README.md
@@ -43,6 +43,14 @@ llm = mlxcel.LLM(socket="/tmp/mlxcel.sock")  # Unix socket
 
 Async usage mirrors the sync API via `mlxcel.AsyncLLM` (`await llm.generate(...)`, `async for delta in llm.stream(...)`).
 
+## Examples
+
+Runnable scripts live in [`examples/`](examples/). Each expects the `mlxcel` binary on `PATH` (or `MLXCEL_BIN`) and a model available locally or downloadable from Hugging Face; run them from the repo root:
+
+- [`quickstart.py`](examples/quickstart.py) — managed-mode tour: spawn a local server, then `generate`, `chat`, `models`, and `tokenize`/`detokenize`. `python python/examples/quickstart.py`
+- [`streaming.py`](examples/streaming.py) — print `stream` and `chat_stream` deltas as they arrive. `python python/examples/streaming.py`
+- [`structured_output.py`](examples/structured_output.py) — schema-constrained JSON via `response_format`, plus the same request through the raw `openai_client`. `python python/examples/structured_output.py`
+
 ## Modes
 
 - **Managed mode** (default when `model=` is given): the client spawns `mlxcel serve`, waits until `/health` returns ready, forwards server logs to the `mlxcel.server` Python logger, and stops the process on exit.


### PR DESCRIPTION
## Summary

Adds an "Examples" section to `python/README.md` listing the three runnable scripts in `python/examples/` (`quickstart.py`, `streaming.py`, `structured_output.py`) with one-line descriptions and run commands, and adds pointer lines to the matching Streaming and Structured output sections of `docs/python-client.md`.

Spot-checked the scripts against `python/src/mlxcel/_client.py`: every method they call (`generate`, `stream`, `chat`, `chat_stream`, `models`, `tokenize`, `detokenize`, the `model` and `openai_client` properties) exists on the current client, so none of the scripts is stale.

## Related issues

Closes #1636

## Type of change

- [ ] `feat` — new user-visible feature
- [ ] `fix` — bug fix
- [ ] `perf` — performance improvement (include before/after numbers in the PR body)
- [ ] `refactor` — internal restructuring without behavior change
- [ ] `chore` — build, CI, dependencies, release infrastructure
- [x] `docs` — documentation only
- [ ] `test` — tests only
