### PR TITLE
fix(cuda): serialize JIT kernel configuration to stop a divide-by-zero

### DIFF
--- a/src/lib/mlx-cpp/patches/mlx/backend/cuda/jit_module.cpp
+++ b/src/lib/mlx-cpp/patches/mlx/backend/cuda/jit_module.cpp
@@ -15,6 +15,7 @@
 
 #include "cuda_jit_sources.h"
 
+#include <mutex>
 #include <cstdio>
 #include <cstdlib>
 #include <filesystem>
@@ -520,6 +521,23 @@ std::pair<CUfunction, uint32_t> JitModule::get_kernel_and_dims(
         fmt::format("There is no kernel named {}.", kernel_name));
   }
 
+  // [mlxcel #1566] Serialize the lazy fill below. Upstream published the
+  // configured flag before max_block_dim, so a second thread could observe the
+  // flag set, skip the block, and read max_block_dim while it was still zero.
+  // That zero reaches get_launch_args as max_block_dim, which computes
+  // block_dim = min(max_block_dim, nthreads) = 0 and then divides nthreads by
+  // it, raising SIGFPE. Reproduced on a Tesla V100 with
+  // `mlxcel_core ffi_tests::compiled --test-threads=4`, which dies in the grid
+  // computation for a compiled kernel; the same fault predates this repository's
+  // Volta work and is upstream's, not the overlay's.
+  //
+  // The lock is held across configure_kernel, which is safe: every call site
+  // passes a lambda that only calls cuFuncSetAttribute and never re-enters this
+  // function. kernels_.find above needs no lock because the map is filled once
+  // in the constructor, under the write lock in get_jit_module, and is never
+  // restructured afterwards; only the two mapped fields are mutated here.
+  std::lock_guard<std::mutex> lock(kernels_mtx_);
+
   // If it is the first time we run this kernel then configure it. Do it only
   // once!
   auto kernel = std::get<0>(it->second);
@@ -527,8 +545,10 @@ std::pair<CUfunction, uint32_t> JitModule::get_kernel_and_dims(
     if (configure_kernel) {
       configure_kernel(kernel);
     }
-    std::get<1>(it->second) = true;
+    // Publish max_block_dim before the flag, so that even without the lock a
+    // reader that sees the flag set cannot observe a zero dimension.
     std::get<2>(it->second) = max_occupancy_block_dim(kernel);
+    std::get<1>(it->second) = true;
   }
 
   return {kernel, std::get<2>(it->second)};

--- a/src/lib/mlx-cpp/patches/mlx/backend/cuda/jit_module.h
+++ b/src/lib/mlx-cpp/patches/mlx/backend/cuda/jit_module.h
@@ -1,0 +1,138 @@
+// Copyright © 2025 Apple Inc.
+//
+// Modified by mlxcel (lablup/mlxcel#1566): serialize the per-kernel lazy
+// configuration in JitModule::get_kernel_and_dims.
+//
+// Upstream stores each kernel as (CUfunction, configured_flag, max_block_dim)
+// and fills the last two on first use with no lock, while publishing the flag
+// *before* the dimension. A second thread that observes the flag already set
+// skips the block and reads max_block_dim while it is still zero, which reaches
+// get_launch_args as max_block_dim = 0 and divides by zero in the grid
+// computation. The kernels_ map itself is safe: it is filled once in the
+// constructor under the write lock in get_jit_module and never restructured.
+// Only the two mapped fields race, so a per-module mutex around the lazy
+// initialization is sufficient. Everything else is byte-identical upstream
+// (pin 9a795735).
+
+#pragma once
+
+#include "mlx/array.h"
+#include "mlx/backend/common/utils.h"
+#include "mlx/backend/cuda/device.h"
+#include "mlx/backend/cuda/device/config.h"
+
+#include <deque>
+#include <mutex>
+#include <unordered_map>
+#include <utility>
+#include <variant>
+
+#include <cuda.h>
+#include <fmt/format.h>
+
+namespace mlx::core::cu {
+
+class Device;
+
+using KernelBuilderResult = std::tuple<
+    /* precompiled */ bool,
+    /* source code */ std::string,
+    /* kernel names */ std::vector<std::string>>;
+using KernelBuilder = std::function<KernelBuilderResult()>;
+
+struct KernelArgs {
+  void** args() {
+    return args_.data();
+  }
+
+  void append(const array& a) {
+    append(reinterpret_cast<CUdeviceptr>(gpu_ptr<void>(a)));
+  }
+
+  template <typename T>
+  void append(T val) {
+    storage_.emplace_back(val);
+    append_ptr(&storage_.back());
+  }
+
+  template <typename T>
+  void append(SmallVector<T> vec) {
+    storage_.emplace_back(std::move(vec));
+    append_ptr(std::get<SmallVector<T>>(storage_.back()).data());
+  }
+
+  template <typename T>
+  void append(const std::vector<T>& vec) {
+    append(SmallVector<T>(vec.begin(), vec.end()));
+  }
+
+  // Make sure the arg is copied to an array with size of NDIM.
+  template <size_t NDIM = MAX_NDIM, typename T>
+  void append_ndim(SmallVector<T> vec) {
+    if (vec.size() > NDIM) {
+      throw std::runtime_error(
+          fmt::format("ndim can not be larger than {}.", NDIM));
+    }
+    vec.resize(NDIM);
+    append(std::move(vec));
+  }
+
+  void append_ptr(const void* v) {
+    args_.push_back(const_cast<void*>(v));
+  }
+
+ private:
+  std::vector<void*> args_;
+
+  // The cuGraphAddKernelNode API requires passing pointers to arguments so
+  // store temporary values until the node is created.
+  using Arg = std::variant<
+      std::monostate,
+      CUdeviceptr,
+      bool,
+      int32_t,
+      uint32_t,
+      int64_t,
+      float,
+      SmallVector<const void*>,
+      SmallVector<int32_t>,
+      SmallVector<int64_t>>;
+  std::deque<Arg> storage_;
+};
+
+class JitModule {
+ public:
+  JitModule(
+      Device& device,
+      const std::string& module_name,
+      const KernelBuilder& builder,
+      bool use_disk_cache);
+  ~JitModule();
+
+  JitModule(const JitModule&) = delete;
+  JitModule& operator=(const JitModule&) = delete;
+
+  CUfunction get_kernel(
+      const std::string& kernel_name,
+      std::function<void(CUfunction)> configure_kernel = nullptr);
+  std::pair<CUfunction, uint32_t> get_kernel_and_dims(
+      const std::string& kernel_name,
+      std::function<void(CUfunction)> configure_kernel = nullptr);
+
+ private:
+  CUmodule module_{nullptr};
+  std::unordered_map<std::string, std::tuple<CUfunction, bool, uint32_t>>
+      kernels_;
+  // [mlxcel #1566] Guards the lazy (configured_flag, max_block_dim) fill in
+  // get_kernel_and_dims. Held only around that initialization, which happens
+  // once per kernel; steady-state launches take an uncontended lock.
+  std::mutex kernels_mtx_;
+};
+
+JitModule& get_jit_module(
+    Device& device,
+    const std::string& name,
+    const KernelBuilder& builder,
+    bool use_disk_cache = true);
+
+} // namespace mlx::core::cu


### PR DESCRIPTION
## Summary

`JitModule::get_kernel_and_dims` published its "configured" flag before the block dimension that flag guards. A second thread could therefore observe `configured == true` while `max_block_dim` was still zero, then reach `get_launch_args` and divide by it, raising SIGFPE. The window is narrow, but the mlxcel-core CUDA test binary hit it because many tests reach the same freshly loaded module at once.

The fix takes a per-module mutex around the configure-and-publish sequence and writes `max_block_dim` before setting the flag, so no ordering of the two stores can expose a zero to a reader. The `kernels_` map itself was never the problem: it is filled once in the constructor under the write lock in `get_jit_module` and never restructured afterward, so only the two mapped fields race and a mutex around the lazy initialization is sufficient.

The minimal reproducer (`ffi_tests::compiled --test-threads=4`) went from crashing roughly one run in three to twelve clean runs.

## The second crash is not a second bug

An earlier revision of this PR reported a separate, undiagnosed SIGABRT still reproducing later in the suite, and treated it as a second race. It is not one, and the repository already knew that.

Running the full suite at the default thread count fails `cuda_test_serialization_tests::the_cuda_test_suite_must_run_single_threaded`, a guard whose message states the finding directly: driving MLX from many host threads is unsafe on the CUDA backend, the default multi-thread run dies with SIGABRT from `cudaStreamEndCapture ... previous error during capture` at a different test each time, and the same binary under `--test-threads=1` completes. Measured here on a Tesla V100: `--test-threads=1` passes 1691 tests in 209 s with zero failures, while the default thread count reproduces the abort. `MLX_USE_CUDA_GRAPHS=0` does not avoid it either, so it is not specific to graph capture.

So this PR fixes the one real defect, and the remaining crash is an unsupported way of running the suite rather than something to fix in the code.

## Overlay note for the next MLX pin bump

`jit_module.h` is new to the overlay set. The CUDA overlay directory is applied by wholesale file copy (`configure_file ... COPYONLY`), not as a diff, so this header now has to be refreshed against upstream on every pin bump the way `patches/mlx/backend/metal/quantized.cpp` already is. Against pin 9a795735 it carries exactly three deltas: a header comment explaining the change, `#include <mutex>`, and the `kernels_mtx_` member. Everything else is byte-identical upstream, and the file says so at the top.

Apple Silicon is unaffected. The file lives under `patches/mlx/backend/cuda/`, which CMakeLists applies unconditionally but which only compiles for CUDA targets, `JitModule` is a CUDA-only type with no Metal counterpart, and the Metal overlay list is untouched.

Refs #1566
