### PR TITLE
fix(reductions): accumulate half-precision reductions in f32

### DIFF
--- a/src/distributed/disaggregated/prefill_scheduler.rs
+++ b/src/distributed/disaggregated/prefill_scheduler.rs
@@ -304,6 +304,16 @@ impl PrefillHandoff {
     pub fn is_timed_out(&self, timeout: Duration) -> bool {
         self.initiated_at.elapsed() > timeout
     }
+
+    /// Whether no measurable time has passed since this handoff was created.
+    ///
+    /// Exists so a test can wait for the clock to tick instead of assuming it
+    /// already has; `is_timed_out` is a strict comparison, so a zero timeout is
+    /// not satisfied until `elapsed` is non-zero.
+    #[cfg(test)]
+    pub(crate) fn elapsed_is_zero(&self) -> bool {
+        self.initiated_at.elapsed() == Duration::ZERO
+    }
 }
 
 /// Protocol interface for the prefill-to-decode handoff.

--- a/src/distributed/disaggregated/prefill_scheduler_tests.rs
+++ b/src/distributed/disaggregated/prefill_scheduler_tests.rs
@@ -366,8 +366,15 @@ fn handoff_timeout_check() {
     // Just created, should not be timed out.
     assert!(!handoff.is_timed_out(Duration::from_secs(30)));
 
-    // Zero timeout should be timed out immediately (or nearly so).
-    // Note: there may be a tiny race here, but Duration::ZERO should work.
+    // `is_timed_out` is a strict `elapsed() > timeout`, so a zero timeout needs
+    // the clock to have advanced at least one tick since construction. On a
+    // coarse `Instant` that is not guaranteed, and the assertion failed on
+    // roughly one gate run in three. Wait for the tick rather than assume it:
+    // this keeps the case the test is about, a zero timeout expiring at once,
+    // without depending on timer granularity.
+    while handoff.elapsed_is_zero() {
+        std::hint::spin_loop();
+    }
     assert!(handoff.is_timed_out(Duration::ZERO));
 }
 

--- a/src/lib/mlxcel-core/cpp/mlx_cxx_bridge.cpp
+++ b/src/lib/mlxcel-core/cpp/mlx_cxx_bridge.cpp
@@ -817,36 +817,102 @@ std::unique_ptr<MlxArray> isposinf(const MlxArray& a) {
 }
 
 // Reduction operations.
+// Reduce a half-precision input in f32 and hand the input dtype back.
+//
+// A flat `max` over a bfloat16 array on M5 returns NaN for a finite input, on
+// roughly one call in six. It is the reduction and not the data: reading the
+// same row back to the host finds every element finite on 60 of 60 runs while
+// the device reduction reports non-finite on 28 of them, with no overlap.
+// Casting to f32 first is the only thing that fixes it; measured one variant
+// per process over 150 forwards of granite-4.0-3b-vision-4bit, whose logits are
+// bfloat16, the counts are 23 for the plain reduction, 31 reshaped to 1-D, 20
+// made contiguous, 24 reduced over an axis, and 0 cast to f32. Contiguity and
+// the flat-versus-axis choice are therefore not the trigger and the element
+// width is.
+//
+// Measuring several of those variants inside one loop hides this: each `eval`
+// synchronises the next one, and the 1-D reshape read 0 of 60 that way against
+// 123 of 150 when it was the only variant in the process.
+//
+// `llama4.rs` already cast to f32 before calling this, which reads as an
+// earlier encounter with the same fault. Promotion is lossless for a max or a
+// min, whose result is one of the inputs, so the restore is exact.
+static std::unique_ptr<MlxArray> reduce_in_f32(
+    const mlx::core::array& in,
+    mlx::core::array (*op)(const mlx::core::array&, mlx::core::StreamOrDevice)) {
+    const auto dt = in.dtype();
+    const bool half = dt == mlx::core::bfloat16 || dt == mlx::core::float16;
+    if (!half) {
+        return std::make_unique<MlxArray>(op(in, {}));
+    }
+    auto wide = mlx::core::astype(in, mlx::core::float32);
+    return std::make_unique<MlxArray>(mlx::core::astype(op(wide, {}), dt));
+}
+
+
+static std::unique_ptr<MlxArray> reduce_axis_in_f32(
+    const mlx::core::array& in, int32_t axis, bool keepdims,
+    mlx::core::array (*op)(const mlx::core::array&, int, bool, mlx::core::StreamOrDevice)) {
+    const auto dt = in.dtype();
+    const bool half = dt == mlx::core::bfloat16 || dt == mlx::core::float16;
+    if (!half) {
+        return std::make_unique<MlxArray>(op(in, axis, keepdims, {}));
+    }
+    auto wide = mlx::core::astype(in, mlx::core::float32);
+    return std::make_unique<MlxArray>(mlx::core::astype(op(wide, axis, keepdims, {}), dt));
+}
+
 std::unique_ptr<MlxArray> sum_all(const MlxArray& a) {
-    return std::make_unique<MlxArray>(mlx::core::sum(a.inner));
+    return reduce_in_f32(a.inner, [](const mlx::core::array& x, mlx::core::StreamOrDevice s) {
+        return mlx::core::sum(x, s);
+    });
 }
 
 std::unique_ptr<MlxArray> sum_axis(const MlxArray& a, int32_t axis, bool keepdims) {
-    return std::make_unique<MlxArray>(mlx::core::sum(a.inner, axis, keepdims));
+    return reduce_axis_in_f32(a.inner, axis, keepdims,
+        [](const mlx::core::array& x, int ax, bool kd, mlx::core::StreamOrDevice s) {
+            return mlx::core::sum(x, ax, kd, s);
+        });
 }
 
 std::unique_ptr<MlxArray> mean_all(const MlxArray& a) {
-    return std::make_unique<MlxArray>(mlx::core::mean(a.inner));
+    return reduce_in_f32(a.inner, [](const mlx::core::array& x, mlx::core::StreamOrDevice s) {
+        return mlx::core::mean(x, s);
+    });
 }
 
 std::unique_ptr<MlxArray> mean_axis(const MlxArray& a, int32_t axis, bool keepdims) {
-    return std::make_unique<MlxArray>(mlx::core::mean(a.inner, axis, keepdims));
+    return reduce_axis_in_f32(a.inner, axis, keepdims,
+        [](const mlx::core::array& x, int ax, bool kd, mlx::core::StreamOrDevice s) {
+            return mlx::core::mean(x, ax, kd, s);
+        });
 }
 
 std::unique_ptr<MlxArray> max_all(const MlxArray& a) {
-    return std::make_unique<MlxArray>(mlx::core::max(a.inner));
+    return reduce_in_f32(a.inner, [](const mlx::core::array& x, mlx::core::StreamOrDevice s) {
+        return mlx::core::max(x, s);
+    });
 }
 
 std::unique_ptr<MlxArray> max_axis(const MlxArray& a, int32_t axis, bool keepdims) {
-    return std::make_unique<MlxArray>(mlx::core::max(a.inner, axis, keepdims));
+    return reduce_axis_in_f32(a.inner, axis, keepdims,
+        [](const mlx::core::array& x, int ax, bool kd, mlx::core::StreamOrDevice s) {
+            return mlx::core::max(x, ax, kd, s);
+        });
 }
 
 std::unique_ptr<MlxArray> min_all(const MlxArray& a) {
-    return std::make_unique<MlxArray>(mlx::core::min(a.inner));
+    // Same reduction, same fault class; see `max_all`.
+    return reduce_in_f32(a.inner, [](const mlx::core::array& x, mlx::core::StreamOrDevice s) {
+        return mlx::core::min(x, s);
+    });
 }
 
 std::unique_ptr<MlxArray> min_axis(const MlxArray& a, int32_t axis, bool keepdims) {
-    return std::make_unique<MlxArray>(mlx::core::min(a.inner, axis, keepdims));
+    return reduce_axis_in_f32(a.inner, axis, keepdims,
+        [](const mlx::core::array& x, int ax, bool kd, mlx::core::StreamOrDevice s) {
+            return mlx::core::min(x, ax, kd, s);
+        });
 }
 
 // Product reduction

--- a/src/models/falcon_h1.rs
+++ b/src/models/falcon_h1.rs
@@ -417,7 +417,8 @@ impl FalconH1Mixer {
         // `eval` here is gone: measured on M5 Max with MLX pin 9a795735 it cost
         // 3.31x decode on Falcon-H1 and 2.24x on GraniteMoeHybrid while greedy
         // output stayed byte-identical with it removed, across short and long
-        // prompts. `mamba2_hybrid_decode_is_finite` guards the regression it
+        // prompts. `mamba2_hybrid_decode_is_finite` in
+        // `tests/mamba2_hybrid_finite.rs` guards the regression it
         // was protecting against. CLAUDE.md "Apple Silicon precision".
         result
     }

--- a/src/models/granitemoehybrid.rs
+++ b/src/models/granitemoehybrid.rs
@@ -452,7 +452,8 @@ impl GraniteMoeHybridMamba2Mixer {
         // `eval` here is gone: measured on M5 Max with MLX pin 9a795735 it cost
         // 3.31x decode on Falcon-H1 and 2.24x on GraniteMoeHybrid while greedy
         // output stayed byte-identical with it removed, across short and long
-        // prompts. `mamba2_hybrid_decode_is_finite` guards the regression it
+        // prompts. `mamba2_hybrid_decode_is_finite` in
+        // `tests/mamba2_hybrid_finite.rs` guards the regression it
         // was protecting against. CLAUDE.md "Apple Silicon precision".
         result
     }

--- a/src/models/llama4.rs
+++ b/src/models/llama4.rs
@@ -1301,7 +1301,11 @@ impl Llama4CxxModel {
         let h_dtype = mlxcel_core::array_dtype(&h);
         println!("Embedding output shape: {:?}, dtype: {}", h_shape, h_dtype);
 
-        // Convert to float32 before computing statistics (float16 sum has precision issues)
+        // The f32 cast is no longer what keeps these statistics finite: the
+        // bridge promotes a half-precision reduction to f32 internally and
+        // restores the dtype, so `sum_all`, `max_all` and `min_all` accumulate
+        // in f32 wherever they are called. Kept because reading the widened
+        // array once is cheaper than three separate promotions.
         let h_f32 = mlxcel_core::astype(&h, mlxcel_core::dtype::FLOAT32);
         let h_sum = mlxcel_core::sum_all(&h_f32);
         mlxcel_core::eval(&h_sum);

--- a/tests/mamba2_hybrid_finite.rs
+++ b/tests/mamba2_hybrid_finite.rs
@@ -1,0 +1,65 @@
+//! The guard `granitemoehybrid.rs` and `falcon_h1.rs` name in the comment that
+//! records why the M5 per-mixer `eval` was removed. It did not exist: both
+//! comments cited `mamba2_hybrid_decode_is_finite` and nothing defined it, so
+//! the claim that the regression was covered rested on a test that was never
+//! written.
+//!
+//! Run enough forwards to see a sporadic fault. The reduction defect that
+//! prompted this reproduced on roughly one call in six, so a single pass proves
+//! nothing; sixty is chosen to make a fault of that rate practically certain
+//! while still finishing in seconds. Raised to 250 after 60 caught it in only one
+//! run of three: two test functions sharing the GPU lowers the observed rate.
+
+mod common;
+use common::repo_model_dir;
+
+fn finite_over_repeated_forwards(model_name: &str) {
+    let dir = repo_model_dir(model_name);
+    if !dir.exists() {
+        eprintln!("Skipping {model_name}: not in the store at {dir:?}");
+        return;
+    }
+    let (model, tokenizer) = mlxcel::load_model(&dir).expect("load model");
+    let tokens: Vec<i32> = tokenizer
+        .encode("Hello, world.", true)
+        .expect("tokenize")
+        .iter()
+        .map(|&t| t as i32)
+        .collect();
+
+    for iteration in 0..250 {
+        let input_ids = mlxcel_core::from_slice_i32(&tokens, &[1, tokens.len() as i32]);
+        let mut caches = mlxcel_core::generate::LanguageModel::make_caches(&model);
+        let logits =
+            mlxcel_core::generate::LanguageModel::forward(&model, &input_ids, &mut caches, None);
+        mlxcel_core::eval(&logits);
+
+        let shape = mlxcel_core::array_shape(&logits);
+        let vocab = *shape.last().unwrap();
+        let last = shape[1] - 1;
+        let row = mlxcel_core::slice(&logits, &[0, last, 0], &[1, last + 1, vocab]);
+        let max = mlxcel_core::max_all(&row);
+        mlxcel_core::eval(&max);
+        let v = mlxcel_core::item_f32(&max);
+        assert!(
+            v.is_finite(),
+            "{model_name}: iteration {iteration} produced {v} (nan={}, inf={})",
+            v.is_nan(),
+            v.is_infinite()
+        );
+    }
+}
+
+// One model per test function. Running another model first changed the outcome:
+// with the tiny checkpoint exercised ahead of it the vision checkpoint stopped
+// faulting entirely, so a combined test would have passed without the fix and
+// guarded nothing.
+#[test]
+fn mamba2_hybrid_decode_is_finite() {
+    finite_over_repeated_forwards("granite-4.0-3b-vision-4bit");
+}
+
+#[test]
+fn mamba2_hybrid_decode_is_finite_tiny() {
+    finite_over_repeated_forwards("granite-4.0-h-tiny-4bit");
+}


### PR DESCRIPTION
Closes #997.

`text_only_forward_produces_finite_logits` has failed intermittently since 2026-08-02. The fault is not in the model: reading the logits row back to the host found every element finite on 60 of 60 runs while the device reduction over the same row reported non-finite on 28, with no overlap. `max` over a bfloat16 array returns NaN for a finite input on M5 Max, about one call in six.

Measured one variant per process over 150 forwards of `granite-4.0-3b-vision-4bit`: 23 non-finite for the plain reduction, 31 reshaped to 1-D, 20 made contiguous, 24 reduced over an axis, 0 cast to f32. Element width is the trigger; contiguity and the flat-versus-axis choice are not. `sum_all` fails the same way at 28 of 150, so the whole reduction family promotes to f32 and restores the input dtype.

## What this cost to find, and what stops the next one

Four hypotheses were eliminated by measurement before the right one: the Metal 4 attention route (`MLXCEL_METAL4_ATTENTION=0` changed nothing), the grouped GQA decode path, the `granitemoehybrid` backbone (two text checkpoints on it are 0 of 40), and repeated `make_caches`. The M1 Ultra sees none of it.

Two traps produced wrong intermediate answers and are recorded in the code:

Timing several variants inside one loop hides the fault, because each `eval` synchronises the next one. The 1-D reshape read 0 of 60 measured that way and 123 of 150 as the only variant in its process, which would have been reported as a fix.

`cargo build` reported a 0.12s no-op after the bridge `.cpp` changed, so the first verification ran against a binary without the fix. Touching `build.rs` forced the 2m50s rebuild that actually contained it.

## The guard

`c07826df` removed the M5 per-mixer `eval` from the Mamba2 hybrids and said `mamba2_hybrid_decode_is_finite` guarded the regression. It did not exist: the name appeared only in two comments pointing at each other. It exists now, and it took two corrections to make it discriminate. Sixty iterations passed without the fix, so it guarded nothing; and running the tiny checkpoint first in the same function stopped the fault appearing at all, so each checkpoint gets its own test. With the fix reverted it fails 4 of 4; with it applied it passes 4 of 4.

Also fixes `handoff_timeout_check`, which failed about one gate run in three on a clock-granularity race its own comment had flagged.

Gate: fmt, `clippy --workspace --all-targets`, and four consecutive workspace runs at 10534 passing with no failures.
