### PR TITLE
fix(core): clear the two clippy errors failing nightly verify

### DIFF
--- a/src/lib/mlxcel-core/src/ffi_tests.rs
+++ b/src/lib/mlxcel-core/src/ffi_tests.rs
@@ -3546,10 +3546,12 @@ fn test_compiled_softcap_sdpa_gqa_decode_matches_repeated_reference() {
     // would pass even if the grouping mapped heads to the wrong KV group.
     let fill = |n: i32, seed: f32| -> Vec<f32> {
         (0..n)
-            .map(|i| ((i as f32 * 0.37 + seed).sin() * 0.5) as f32)
+            .map(|i| (i as f32 * 0.37 + seed).sin() * 0.5)
             .collect()
     };
-    let q = from_slice_f32(&fill(b * h_q * 1 * d, 0.1), &[b, h_q, 1, d]);
+    // Decode shape: one query position, so the element count drops the q_len of
+    // 1 that the shape literal still spells out.
+    let q = from_slice_f32(&fill(b * h_q * d, 0.1), &[b, h_q, 1, d]);
     let k = from_slice_f32(&fill(b * h_kv * s * d, 1.7), &[b, h_kv, s, d]);
     let v = from_slice_f32(&fill(b * h_kv * s * d, 2.9), &[b, h_kv, s, d]);
 


### PR DESCRIPTION
`cargo clippy --workspace --all-targets -- -D warnings` has failed on main since 897a50f7f. The PR gate stays green because it does not run that scope, so the only place this shows up is Nightly verify, which has been red every night since 2026-09-05 (runs 34262127778 and its four predecessors, all failing at the same two lines).

Both lints are in `test_compiled_softcap_sdpa_gqa_decode_matches_repeated_reference`: an `f32 -> f32` cast on the `fill` closure's return value, and `b * h_q * 1 * d`, where the `1` is the decode q_len that the `&[b, h_q, 1, d]` shape literal on the same line already states. The element count is identical either way, so the test's inputs and expectations do not move; a comment keeps the q_len readable.

Validated on M1 Ultra: `cargo clippy --workspace --all-targets --features metal,accelerate -- -D warnings` clean, `cargo fmt --all -- --check` clean, and the three `ffi_tests::test_compiled_softcap_sdpa_gqa*` tests pass.
