### PR TITLE
perf(granitemoehybrid): run the gated RMSNorm in the input dtype

### DIFF
--- a/src/models/granitemoehybrid.rs
+++ b/src/models/granitemoehybrid.rs
@@ -248,14 +248,20 @@ impl ModelArgs {
 // RMSNorm (no `n_groups` grouping, unlike the Falcon-H1 gated norm).
 //
 // Runs in the input dtype. It used to promote the whole computation to float32
-// against a NaN seen on M5 Max, from a half-precision `x^2` sum. #1718 found
-// that fault in the bridge's reduction helpers, where a bfloat16 `max` or `sum`
-// returned NaN for a finite input on roughly one call in six, and fixed it by
-// accumulating those reductions in f32; `tests/mamba2_hybrid_finite.rs` is the
-// guard, and it fails 4 runs of 4 with that fix reverted. This promotion is a
-// second, local copy of the same defense, and it is the expensive one: every
-// mixer step widens the residual stream to f32 and each later matmul promotes
-// its own weight to match.
+// against a NaN seen on M5 Max, from a half-precision `x^2` sum.
+//
+// The promotion is removed on measurement, not on an argument that the fault is
+// gone. #1718 fixed a bfloat16 reduction defect in the bridge's own helpers
+// (`max_all`, `sum_all`, `mean_all` and their axis forms, all routed through
+// `reduce_in_f32`), but this norm calls `mlx::core::fast::rms_norm` directly and
+// does not pass through them, so that fix does not cover this site. What covers
+// it is `tests/mamba2_hybrid_finite.rs`, which runs 250 forwards per checkpoint
+// and passed 3 runs of 3 on both hosts with the promotion removed, plus a
+// 3000-token needle recall on M5 Max where an overflow would show. If MLX
+// changes that kernel, the measurement has to be repeated rather than inferred.
+//
+// What the promotion cost: every mixer step widened the residual stream to f32
+// and each later matmul promoted its own weight to match.
 struct GraniteMoeHybridRMSNormGated {
     weight: UniquePtr<MlxArray>,
     eps: f32,

--- a/src/models/granitemoehybrid.rs
+++ b/src/models/granitemoehybrid.rs
@@ -245,10 +245,17 @@ impl ModelArgs {
 // Gated RMSNorm (`GraniteMoeHybridRMSNormGated`).
 //
 // `rms_norm(swiglu(gate, y), weight, eps)` = gate BEFORE a PLAIN full-weight
-// RMSNorm (no `n_groups` grouping, unlike the Falcon-H1 gated norm). Promotes to
-// float32 for the whole computation: float16/bf16 RMS-norm (x^2 sum) and
-// mixed-dtype multiply can overflow to NaN on M5 Max (Metal GPU Family 4) NAx
-// kernels.
+// RMSNorm (no `n_groups` grouping, unlike the Falcon-H1 gated norm).
+//
+// Runs in the input dtype. It used to promote the whole computation to float32
+// against a NaN seen on M5 Max, from a half-precision `x^2` sum. #1718 found
+// that fault in the bridge's reduction helpers, where a bfloat16 `max` or `sum`
+// returned NaN for a finite input on roughly one call in six, and fixed it by
+// accumulating those reductions in f32; `tests/mamba2_hybrid_finite.rs` is the
+// guard, and it fails 4 runs of 4 with that fix reverted. This promotion is a
+// second, local copy of the same defense, and it is the expensive one: every
+// mixer step widens the residual stream to f32 and each later matmul promotes
+// its own weight to match.
 struct GraniteMoeHybridRMSNormGated {
     weight: UniquePtr<MlxArray>,
     eps: f32,
@@ -257,21 +264,18 @@ struct GraniteMoeHybridRMSNormGated {
 
 impl GraniteMoeHybridRMSNormGated {
     fn forward(&self, y: &MlxArray, gate: &MlxArray) -> UniquePtr<MlxArray> {
-        let orig_dtype = mlxcel_core::array_dtype(y);
+        let dtype = mlxcel_core::array_dtype(y);
 
-        let y_f32 = mlxcel_core::astype(y, mlxcel_core::dtype::FLOAT32);
-        let g_f32 = mlxcel_core::astype(gate, mlxcel_core::dtype::FLOAT32);
         // swiglu(gate, y) = silu(gate) * y (gate applied before the norm).
-        let gated = mlxcel_core::multiply(&y_f32, &silu(&g_f32));
+        let gated = mlxcel_core::multiply(y, &silu(gate));
 
         // Full-weight RMSNorm (no grouping): normalize with a ones vector, then
-        // multiply the learned weight, keeping everything in float32.
-        let ones = mlxcel_core::ones(&[self.dim], mlxcel_core::dtype::FLOAT32);
+        // multiply the learned weight. Every operand is already `dtype`, so the
+        // result leaves in the dtype it arrived in with no cast.
+        let ones = mlxcel_core::ones(&[self.dim], dtype);
         let normed = mlxcel_core::fast_rms_norm(&gated, &ones, self.eps);
-        let w_f32 = mlxcel_core::astype(&self.weight, mlxcel_core::dtype::FLOAT32);
-        let result = mlxcel_core::multiply(&w_f32, &normed);
 
-        mlxcel_core::astype(&result, orig_dtype)
+        mlxcel_core::multiply(&self.weight, &normed)
     }
 }
 


### PR DESCRIPTION
## What changed

`GraniteMoeHybridRMSNormGated::forward` promoted `y`, `gate` and `weight` to float32, ran the gate and the norm there, and cast back. Every operand is already the input dtype, so the promotion buys nothing arithmetically and costs everywhere: the mixer widens the residual stream to f32 on each decode step, and each later matmul promotes its own weight to match. The forward now runs in the dtype it was given and returns it with no cast.

## Throughput

Both hosts, before and after alternating, five runs per arm, `mlxcel-bench-decode`, binaries built from this branch and its merge-base. M1 Ultra at `-n 200 --ignore-eos` with Time Machine confirmed stopped; M5 Max at `-n 128`.

| checkpoint | host | before (median) | after (median) | ratio | before range | after range |
|---|---|---|---|---|---|---|
| granite-4.0-h-350m-4bit | M1 Ultra | 272.29 | 293.88 | 1.079x | 265.46-273.10 | 286.78-294.35 |
| granite-4.0-h-350m-4bit | M5 Max | 438.67 | 519.19 | 1.184x | 432.00-440.36 | 515.75-522.27 |
| granite-4.0-h-tiny-4bit | M1 Ultra | 107.43 | 112.17 | 1.044x | 105.51-107.78 | 109.95-112.74 |
| granite-4.0-h-tiny-4bit | M5 Max | 200.09 | 209.27 | 1.046x | 196.36-200.32 | 208.82-209.36 |

Every range is disjoint. The two hosts agree on direction, and on `tiny` they agree on size. The gap on `350m`, 1.184x against 1.079x, is not explained. The obvious explanation was that #1718 already promotes M5's reductions so the local promotion is redundant there, but that reasoning does not hold: #1718 changed the bridge's reduction helpers and this code path runs MLX's fused `fast_rms_norm`. Recorded as unexplained rather than attributed.

## Output

The arms are not byte-identical, which is expected once the arithmetic changes, so `scripts/ab_output_equality.sh` reports EQUAL on 350m and DIFFERS on tiny. Both tiny outputs are fluent and factually correct; greedy decoding diverges at one position and never reconverges, which is exactly the case byte-identity cannot judge.

The teacher-forced logit trace judges it. `granite-4.0-h-tiny-4bit`, `tests/fixtures/wikitext2_excerpt.txt`, gating on disagreement at decided positions (`gap >= 2.0`):

| shape | positions | top-1 disagreement | on decided positions | worst rank | perplexity |
|---|---|---|---|---|---|
| decode width 1, 512 context | 400 | 19 (4.75%) | **0 / 156 (0.00%)** | 3 | +0.145% |
| prefill width 256 | 1024 | 51 (4.98%) | **0 / 386 (0.00%)** | 3 | +0.410% |

Every disagreement falls in the undecided band: at decode width, 17 of 19 are at a top-two gap under 0.5, and the 2-to-inf bands are 0 of 156. The control, the baseline binary traced against itself at the same width, is 0 of 400, so the 4.75% is attributable to this change rather than to run-to-run jitter.

## Safety

The comment justified the f32 promotion with a NaN in a half-precision `x^2` sum on M5 Max. #1718 located that fault in the bridge's reduction helpers, where a bfloat16 `max` or `sum` returned NaN for a finite input on roughly one call in six, and fixed it by accumulating those reductions in f32.

**That fix does not subsume this promotion.** It routes `max_all`, `min_all`, `sum_all`, `mean_all` and their axis forms through `reduce_in_f32` (`mlx_cxx_bridge.cpp:840`); `fast_rms_norm` (line 3675) calls `mlx::core::fast::rms_norm` directly and never reaches those wrappers. Two code paths that do not meet. So the safety of this removal rests on the guard, on the hardware where the fault reproduces, and the struct comment says so: if MLX changes that kernel the measurement has to be repeated rather than inferred.

`tests/mamba2_hybrid_finite.rs` with this arm applied: M5 Max 3 runs of 3, 3.23s / 3.25s / 3.28s, no panic under `MLXCEL_REQUIRE_MODELS=1`. M1 Ultra 3 runs of 3 at 7.96-8.03s. The elapsed times matter here: the same guard reports `2 passed ... finished in 0.00s` on a tree where the checkpoints do not resolve, so a green run is not by itself evidence that it ran. #1722 is what makes it resolve on the M1 Ultra layout; the M5 Max tree resolves it already because its `models/` symlink points at the store root.

Also on M5 Max with the arm applied: `granite-4.0-h-350m-4bit`, `granite-4.0-h-tiny-4bit` and `granite-4.0-3b-vision-4bit` all answer "The capital of France is Paris.", and all three recall `COBALT-3317` correctly from a roughly 3000-token context. An overflow in the norm would surface at that length.

## Note on the commit history

The first commit's body ends "The M5 Max half is required before merge", written when this was a draft. That half is now in the tables above. Its comment also called the promotion "a second, local copy of the same defense" as #1718, which reads as the opposite of what the paragraph above establishes; the follow-up commit corrects it. Both were left unamended rather than force-pushed.
