### PR TITLE
docs(models): record the two RMS-norm A/B verdicts that changed no code

### DIFF
--- a/src/models/falcon_h1.rs
+++ b/src/models/falcon_h1.rs
@@ -219,6 +219,14 @@ impl ModelArgs {
 // Promotes to float32 for the whole gated-norm computation, matching the
 // Nemotron-H mixer: float16/bf16 RMS-norm (x^2 sum) and mixed-dtype multiply
 // can overflow to NaN on M5 Max (Metal GPU Family 4) NAx kernels.
+//
+// Whether that promotion is still needed after #1718 was measured for the other
+// two families carrying it and cannot be measured here: there is nothing to
+// measure rather than nothing measured. `mamba_rms_norm` defaults to false and
+// the only Falcon-H1 checkpoint in the store, `falcon-h1-tiny-90m-instruct-4bit`,
+// spells it `false`, so `forward` below is never reached on any checkpoint
+// available to test with. Removing the promotion here would be an unmeasurable
+// change; a checkpoint with the flag on has to arrive first.
 struct MambaRMSNormGated {
     weight: UniquePtr<MlxArray>,
     eps: f32,

--- a/src/models/nemotron_h.rs
+++ b/src/models/nemotron_h.rs
@@ -442,6 +442,20 @@ impl NemotronLayerCache {
 }
 
 // MambaRMSNormGated - RMS norm with gating and group structure.
+//
+// Promotes the whole computation to float32, the same local defense against the
+// M5 Max half-precision `x^2` NaN that `granitemoehybrid.rs` and `falcon_h1.rs`
+// carry. Whether it is still needed after #1718 was measured, and the answer
+// here is that the promotion stays.
+//
+// Measured on M1 Ultra with `nvidia-nemotron-3-nano-30b-a3b-4bit`, five runs per
+// arm: 96.51 tok/s promoted against 97.31 native, ranges 96.34-96.63 and
+// 97.14-97.46, disjoint but 1.008x. Outputs are token-identical between the arms
+// once `--show-reasoning` is passed. `granitemoehybrid.rs` gets 1.079x from the
+// same removal, which is worth the argument; 0.8% is not worth giving up a NaN
+// defense whose coverage after #1718 is not established, because that fix
+// changed the bridge's reduction helpers and not MLX's fused `fast_rms_norm`.
+// Do not re-run this A/B without a reason the numbers above do not already give.
 struct MambaRMSNormGated {
     weight: UniquePtr<MlxArray>,
     eps: f32,


### PR DESCRIPTION
Three families carry the same local float32 promotion in their gated RMSNorm, put there against a half-precision `x^2` NaN on M5 Max. All three were A/B'd after #1718 to see whether the promotion is still earning its cost. Only one answer changes code, and that is #1723 (`granitemoehybrid`, 1.079x on M1 Ultra). The other two answers are "leave it", so they moved nothing and had nowhere to be recorded. This puts them in the struct comments, where the next person to consider the same removal will actually read them.

`nemotron_h.rs`: measured on M1 Ultra with `nvidia-nemotron-3-nano-30b-a3b-4bit`, five runs per arm, `-n 200 --ignore-eos`. 96.51 tok/s promoted against 97.31 native, ranges 96.34-96.63 and 97.14-97.46. Disjoint, so the effect is real, but it is 1.008x. Outputs are token-identical between the arms once `--show-reasoning` is passed (the content channel is empty on this checkpoint at short budgets, which is #1721's subject). 0.8% does not buy giving up a NaN defense whose coverage after #1718 is not established: that fix changed the bridge's reduction helpers (`max_all`, `sum_all`, `mean_all` and the axis forms) and did not touch MLX's fused `fast_rms_norm`, which is what computes the sum here.

`falcon_h1.rs`: there is nothing to measure, which is a different statement from nothing measured. `mamba_rms_norm` defaults to false, and `falcon-h1-tiny-90m-instruct-4bit`, the only Falcon-H1 checkpoint in the store, spells it `false`. The gated-norm `forward` is gated on that flag at `falcon_h1.rs:938`, so it is unreachable on every checkpoint available to test with. Removing the promotion there would be an unmeasurable change until a checkpoint with the flag on exists.

Comments only, no behavior change. `cargo check --lib` and `cargo fmt --all -- --check` are clean.
