### PR TITLE
fix(tests): point real-model tests at the names the store now uses

### DIFF
--- a/docs/model-catalog.md
+++ b/docs/model-catalog.md
@@ -20,7 +20,7 @@ With no heading and no `base_model`, leave the name alone. A name assembled from
 | Column | Meaning |
 |---|---|
 | `local_name` | Directory name under `models/`. |
-| `aliases` | Names this checkpoint was measured under before a rename, `;`-separated. A past-dated CSV row joins to the current one through this. |
+| `aliases` | Names this checkpoint was measured under before a rename, `;`-separated. A past-dated CSV row joins to the current one through this. An alias records that one set of weights had another name, not that a directory was once misnamed after a different model: `jamba-v0.1-4bit` held AI21-Jamba-Reasoning-3B and no Jamba v0.1 was ever in the store, so renaming that directory was right and listing the old name as an alias was not. |
 | `upstream_repo_id` | The HuggingFace repo, empty when neither source yielded one. |
 | `id_source` | `heading`, `base_model` or `none`. Reliability is readable from this column alone. |
 | `precision` | From `config.json`, or from the shard headers when `torch_dtype` is absent. |

--- a/docs/model-catalog.tsv
+++ b/docs/model-catalog.tsv
@@ -1,6 +1,6 @@
 local_name	aliases	upstream_repo_id	id_source	precision	size_gb	present_on_m1ultra	present_on_m5max	verified_by	store	shards_ok_m5max	csv_rows	doc_mentions	shards_ok_m1ultra	m5_absence
 afm-4.5b			none	bfloat16	9.3	yes	yes	none	repo	ok(2)	3	5	ok	
-ai21-jamba-reasoning-3b-4bit	jamba-v0.1-4bit	mlx-community/AI21-Jamba-Reasoning-3B-4bit	heading	4bit	1.7	yes	yes	config	repo	ok(1)	45	5	ok	
+ai21-jamba-reasoning-3b-4bit		mlx-community/AI21-Jamba-Reasoning-3B-4bit	heading	4bit	1.7	yes	yes	config	repo	ok(1)	45	5	ok	
 all-minilm-l6-v2			none	unquantized	0.1	yes	yes	none	repo	ok(1)	3	1	ok	
 apertus-8b-instruct-2509-4bit		mlx-community/Apertus-8B-Instruct-2509-4bit	heading	4bit	4.5	yes	yes	config	repo	ok(1)	26	3	ok	
 aya-expanse-8b-4bit		mlx-community/aya-expanse-8b-4bit	heading	4bit	4.5	yes	yes	config	repo	ok(1)	44	4	ok	

--- a/tests/apply_template_tools_parity.rs
+++ b/tests/apply_template_tools_parity.rs
@@ -51,7 +51,7 @@ use common::{repo_binary_path, repo_model_dir};
 const YOUTU_MODEL: &str = "mlx/youtu-llm-2b-4bit";
 
 /// Llama 3.2 template, carried in `tokenizer_config.json`.
-const LLAMA_MODEL: &str = "mlx/llama-3.2-1b-4bit";
+const LLAMA_MODEL: &str = "llama-3.2-1b-instruct-4bit";
 
 /// The one-line user turn every request below sends.
 const PROMPT: &str = "The Fibonacci sequence begins with";

--- a/tests/gcp_predict_real_model.rs
+++ b/tests/gcp_predict_real_model.rs
@@ -53,7 +53,7 @@ fn stop_server(child: &mut Child) {
 #[tokio::test]
 #[ignore = "requires local model weights and a built mlxcel-server binary"]
 async fn predict_serves_a_chat_completions_batch_against_a_real_model() {
-    let model_dir = repo_model_dir("mlx/llama-3.2-1b-4bit");
+    let model_dir = repo_model_dir("llama-3.2-1b-instruct-4bit");
     if !model_dir.exists() {
         eprintln!(
             "skipping: model checkpoint not found at {}",
@@ -106,14 +106,14 @@ async fn predict_serves_a_chat_completions_batch_against_a_real_model() {
             "instances": [
                 {
                     "@requestFormat": "chatCompletions",
-                    "model": "llama-3.2-1b-4bit",
+                    "model": "llama-3.2-1b-instruct-4bit",
                     "messages": [{"role": "user", "content": "Reply with one word: hello"}],
                     "max_tokens": 8,
                     "temperature": 0
                 },
                 {
                     "@requestFormat": "chatCompletions",
-                    "model": "llama-3.2-1b-4bit",
+                    "model": "llama-3.2-1b-instruct-4bit",
                     "messages": [{"role": "user", "content": "Reply with one word: goodbye"}],
                     "max_tokens": 8,
                     "temperature": 0

--- a/tests/glm4v_moe_parity.rs
+++ b/tests/glm4v_moe_parity.rs
@@ -33,7 +33,7 @@ use common::repo_model_dir;
 use mlxcel::models::{ModelType, get_model_type};
 use mlxcel::vision::encoders::glm4v::Glm4vVisionConfig;
 
-const MODEL_NAME: &str = "GLM-4.5V";
+const MODEL_NAME: &str = "glm-4.5v-4bit";
 
 fn model_dir() -> Option<PathBuf> {
     let dir = repo_model_dir(MODEL_NAME);

--- a/tests/glm4v_parity.rs
+++ b/tests/glm4v_parity.rs
@@ -32,7 +32,7 @@ use common::repo_model_dir;
 use mlxcel::models::{ModelType, get_model_type};
 use mlxcel::vision::encoders::glm4v::Glm4vVisionConfig;
 
-const MODEL_NAME: &str = "GLM-4.1V-9B-Thinking";
+const MODEL_NAME: &str = "glm-4.1v-9b-thinking-4bit";
 
 fn model_dir() -> Option<PathBuf> {
     let dir = repo_model_dir(MODEL_NAME);

--- a/tests/internvl_parity.rs
+++ b/tests/internvl_parity.rs
@@ -37,7 +37,7 @@ use mlxcel::models::{ModelType, get_model_type};
 use mlxcel::vision::processors::ImageProcessor;
 use mlxcel::vision::processors::internvl::InternVLProcessor;
 
-const MODEL_NAME: &str = "internvl3-1b";
+const MODEL_NAME: &str = "internvl3-1b-4bit";
 const QWEN2_VOCAB: i32 = 151674;
 
 fn model_dir() -> Option<PathBuf> {

--- a/tests/mllama_parity.rs
+++ b/tests/mllama_parity.rs
@@ -674,7 +674,7 @@ fn prepare_stashes_real_tile_states() {
 
 // --- Model-gated smoke test (inert without the checkpoint). ---
 
-const MODEL_NAME: &str = "llama-3.2-11b-vision";
+const MODEL_NAME: &str = "llama-3.2-11b-vision-instruct-4bit";
 
 fn model_dir() -> Option<PathBuf> {
     let dir = repo_model_dir(MODEL_NAME);

--- a/tests/molmo_parity.rs
+++ b/tests/molmo_parity.rs
@@ -36,7 +36,7 @@ use common::repo_model_dir;
 use mlxcel::models::{ModelType, get_model_type};
 use mlxcel::vision::processors::molmo::{MolmoImageTokens, MolmoProcessor};
 
-const MODEL_NAME: &str = "molmo-7b";
+const MODEL_NAME: &str = "molmo-7b-d-0924-4bit";
 const MOLMO_VOCAB: i32 = 152064;
 const PATCH_DIM: i32 = 14 * 14 * 3; // 588
 const N_PATCHES: i32 = 24 * 24; // 576 patches per 336/14 crop

--- a/tests/paged_decode_v2_greedy_parity.rs
+++ b/tests/paged_decode_v2_greedy_parity.rs
@@ -326,7 +326,7 @@ fn paged_decode_v2_greedy_parity_qwen3() {
 fn paged_decode_v2_greedy_parity_llama3() {
     let _runtime = initialize_runtime();
     assert_parity_for(
-        "llama-3.2-1b-4bit",
+        "llama-3.2-1b-instruct-4bit",
         "mlx-community/Llama-3.2-1B-Instruct-4bit",
     );
 }

--- a/tests/paged_handoff_parity.rs
+++ b/tests/paged_handoff_parity.rs
@@ -74,7 +74,7 @@ use mlxcel_core::cache::{CachePool, PagedKvLayout, SequenceStateLayout};
 /// qwen3 checkpoint directory name (pool-backed family).
 const QWEN3_DIR: &str = "qwen3-0.6b-4bit";
 /// llama3 checkpoint directory name (pool-backed family).
-const LLAMA3_DIR: &str = "llama-3.2-1b-4bit";
+const LLAMA3_DIR: &str = "llama-3.2-1b-instruct-4bit";
 
 /// Paged block size (tokens per physical block), matching the scheduler's
 /// `DEFAULT_PAGED_BLOCK_SIZE`.

--- a/tests/paged_kv_serialize_parity.rs
+++ b/tests/paged_kv_serialize_parity.rs
@@ -71,7 +71,7 @@ use mlxcel_core::cache::{CachePool, PagedKvLayout, SequenceStateLayout};
 /// qwen3 checkpoint directory name (pool-backed family).
 const QWEN3_DIR: &str = "qwen3-0.6b-4bit";
 /// llama3 checkpoint directory name (pool-backed family).
-const LLAMA3_DIR: &str = "llama-3.2-1b-4bit";
+const LLAMA3_DIR: &str = "llama-3.2-1b-instruct-4bit";
 
 /// Paged block size (tokens per physical block) — matches the scheduler's
 /// `DEFAULT_PAGED_BLOCK_SIZE`.

--- a/tests/paged_prefix_share_parity.rs
+++ b/tests/paged_prefix_share_parity.rs
@@ -71,7 +71,7 @@ use mlxcel_core::cache::{CachePool, PagedKvLayout, SequenceStateLayout};
 /// qwen3 checkpoint directory name (pool-backed family).
 const QWEN3_DIR: &str = "qwen3-0.6b-4bit";
 /// llama3 checkpoint directory name (pool-backed family).
-const LLAMA3_DIR: &str = "llama-3.2-1b-4bit";
+const LLAMA3_DIR: &str = "llama-3.2-1b-instruct-4bit";
 
 /// Paged block size (tokens per physical block) — matches the scheduler's
 /// `DEFAULT_PAGED_BLOCK_SIZE`.

--- a/tests/paged_scheduler_parity.rs
+++ b/tests/paged_scheduler_parity.rs
@@ -82,7 +82,7 @@ use mlxcel_core::cache::{CachePool, PagedKvLayout, SequenceStateLayout};
 /// qwen3 checkpoint directory name (pool-backed family).
 const QWEN3_DIR: &str = "qwen3-0.6b-4bit";
 /// llama3 checkpoint directory name (pool-backed family).
-const LLAMA3_DIR: &str = "llama-3.2-1b-4bit";
+const LLAMA3_DIR: &str = "llama-3.2-1b-instruct-4bit";
 
 /// Paged block size (tokens per physical block) — matches the scheduler's
 /// `DEFAULT_PAGED_BLOCK_SIZE`.

--- a/tests/pipeline_ci_multi_stage_real_models.rs
+++ b/tests/pipeline_ci_multi_stage_real_models.rs
@@ -309,8 +309,8 @@ fn assert_multi_stage_coordinator_matches_dense_baseline(
 #[test]
 #[ignore = "requires local model weights; CI drives with --ignored"]
 fn pipeline_multi_stage_two_host_logical_smoke() {
-    let model =
-        std::env::var("MLXCEL_CI_PP_MODEL").unwrap_or_else(|_| "llama-3.2-1b-4bit".to_string());
+    let model = std::env::var("MLXCEL_CI_PP_MODEL")
+        .unwrap_or_else(|_| "llama-3.2-1b-instruct-4bit".to_string());
     assert_multi_stage_coordinator_matches_dense_baseline(&model, "Hello", 2);
 }
 
@@ -320,7 +320,7 @@ fn pipeline_multi_stage_two_host_logical_smoke() {
 #[test]
 #[ignore = "requires local model weights and is driven by the on-demand self-hosted 3-host CI job"]
 fn pipeline_multi_stage_three_host_real_model_parity() {
-    assert_multi_stage_coordinator_matches_dense_baseline("llama-3.2-1b-4bit", "Hello", 3);
+    assert_multi_stage_coordinator_matches_dense_baseline("llama-3.2-1b-instruct-4bit", "Hello", 3);
 }
 
 /// Heterogeneous-memory partition regression.

--- a/tests/pipeline_cli_real_models.rs
+++ b/tests/pipeline_cli_real_models.rs
@@ -21,7 +21,7 @@ fn run_generate(args: &[&str]) -> String {
 #[test]
 #[ignore = "requires local model weights and the mlxcel binary"]
 fn pipeline_cli_llama_real_model_parity() {
-    let model_dir = repo_model_dir("llama-3.2-1b-4bit");
+    let model_dir = repo_model_dir("llama-3.2-1b-instruct-4bit");
     if !model_dir.exists() {
         eprintln!(
             "Skipping test: model directory not found at {}",

--- a/tests/pipeline_elastic_repartition_real_models.rs
+++ b/tests/pipeline_elastic_repartition_real_models.rs
@@ -138,7 +138,7 @@ fn describe_ranges(ranges: &[Range<usize>]) -> String {
 #[test]
 #[ignore = "requires local llama-3.2-1b-4bit weights and the mlxcel binary"]
 fn elastic_repartition_completes_and_preserves_continued_serving() {
-    let model_dir = repo_model_dir("llama-3.2-1b-4bit");
+    let model_dir = repo_model_dir("llama-3.2-1b-instruct-4bit");
     if !model_dir.exists() {
         eprintln!(
             "Skipping test: model directory not found at {}",

--- a/tests/pipeline_lora_composition_real_models.rs
+++ b/tests/pipeline_lora_composition_real_models.rs
@@ -49,7 +49,7 @@ fn run_generate(args: &[&str]) -> String {
 #[test]
 #[ignore = "requires local model weights, a paired LoRA adapter, and the mlxcel binary"]
 fn pipeline_cli_llama_real_model_lora_parity() {
-    let model_dir = repo_model_dir("llama-3.2-1b-4bit");
+    let model_dir = repo_model_dir("llama-3.2-1b-instruct-4bit");
     let adapter_dir = repo_model_dir("llama-3.2-1b-4bit-lora");
     if !model_dir.exists() {
         eprintln!(

--- a/tests/pipeline_observability_real_models.rs
+++ b/tests/pipeline_observability_real_models.rs
@@ -78,7 +78,7 @@ fn cache_config(stage_index: u32, budget_bytes: u64) -> PipelineCacheConfig {
 #[test]
 #[ignore = "requires local llama-3.2-1b-4bit weights and the mlxcel binary"]
 fn pp_observability_populates_all_four_metric_families() {
-    let model_dir = repo_model_dir("llama-3.2-1b-4bit");
+    let model_dir = repo_model_dir("llama-3.2-1b-instruct-4bit");
     if !model_dir.exists() {
         eprintln!(
             "Skipping test: model directory not found at {}",

--- a/tests/pipeline_remote_real_models.rs
+++ b/tests/pipeline_remote_real_models.rs
@@ -151,7 +151,7 @@ fn assert_remote_runtime_matches_full_model(
 #[test]
 #[ignore = "requires local model weights and TCP-bound remote pipeline stages"]
 fn pipeline_remote_runtime_llama_real_model_parity_and_cleanup() {
-    let model_dir = repo_model_dir("llama-3.2-1b-4bit");
+    let model_dir = repo_model_dir("llama-3.2-1b-instruct-4bit");
     if !model_dir.exists() {
         eprintln!(
             "Skipping test: model directory not found at {}",
@@ -218,7 +218,7 @@ fn pipeline_remote_runtime_llama_real_model_parity_and_cleanup() {
 #[test]
 #[ignore = "requires local model weights and TCP-bound remote pipeline stages"]
 fn pipeline_remote_runtime_llama_drain_and_shutdown_transition() {
-    let model_dir = repo_model_dir("llama-3.2-1b-4bit");
+    let model_dir = repo_model_dir("llama-3.2-1b-instruct-4bit");
     if !model_dir.exists() {
         eprintln!(
             "Skipping test: model directory not found at {}",
@@ -259,7 +259,7 @@ fn pipeline_remote_runtime_llama_drain_and_shutdown_transition() {
 #[test]
 #[ignore = "requires local model weights and an active Thunderbolt Bridge interface"]
 fn pipeline_remote_runtime_llama_thunderbolt_bridge_parity() {
-    let model_dir = repo_model_dir("llama-3.2-1b-4bit");
+    let model_dir = repo_model_dir("llama-3.2-1b-instruct-4bit");
     if !model_dir.exists() {
         eprintln!(
             "Skipping test: model directory not found at {}",
@@ -317,13 +317,13 @@ fn pipeline_remote_runtime_llama_thunderbolt_bridge_parity() {
 #[test]
 #[ignore = "requires local model weights and TCP-bound remote pipeline stages"]
 fn pipeline_remote_runtime_gpt_oss_real_model_parity_and_cleanup() {
-    assert_remote_runtime_matches_full_model("gpt-oss-20b-mxfp4", &[42, 43], 44, 420, None);
+    assert_remote_runtime_matches_full_model("gpt-oss-20b-mxfp4-q4", &[42, 43], 44, 420, None);
 }
 
 #[test]
 #[ignore = "requires local model weights and TCP-bound remote pipeline stages"]
 fn pipeline_remote_runtime_gemma3_real_model_parity_and_cleanup() {
-    assert_remote_runtime_matches_full_model("gemma3-1b-4bit", &[2, 3], 4, 430, None);
+    assert_remote_runtime_matches_full_model("gemma-3-1b-it-4bit", &[2, 3], 4, 430, None);
 }
 
 #[test]
@@ -347,7 +347,7 @@ fn pipeline_remote_runtime_qwen35_real_model_parity_and_cleanup() {
 #[test]
 #[ignore = "requires local model weights and TCP-bound remote pipeline stages"]
 fn pipeline_remote_runtime_glm4_real_model_parity_and_cleanup() {
-    assert_remote_runtime_matches_full_model("glm4-flash-4bit", &[2, 3], 4, 470, None);
+    assert_remote_runtime_matches_full_model("glm-4.7-flash-4bit", &[2, 3], 4, 470, None);
 }
 
 #[test]
@@ -374,7 +374,7 @@ fn pipeline_remote_runtime_glm_moe_dsa_real_model_parity_and_cleanup() {
 #[test]
 #[ignore = "requires local model weights and RDMA-capable or fallback-enabled loopback"]
 fn pipeline_remote_runtime_llama_rdma_real_model_parity_and_cleanup() {
-    let model_dir = repo_model_dir("llama-3.2-1b-4bit");
+    let model_dir = repo_model_dir("llama-3.2-1b-instruct-4bit");
     if !model_dir.exists() {
         eprintln!(
             "Skipping test: model directory not found at {}",

--- a/tests/pipeline_server_real_models.rs
+++ b/tests/pipeline_server_real_models.rs
@@ -84,7 +84,7 @@ fn completion_text_is_non_empty(response: &serde_json::Value) -> bool {
 #[tokio::test]
 #[ignore = "requires local model weights and the mlxcel-server binary"]
 async fn pipeline_server_llama_multi_request_smoke() {
-    let model_dir = repo_model_dir("llama-3.2-1b-4bit");
+    let model_dir = repo_model_dir("llama-3.2-1b-instruct-4bit");
     if !model_dir.exists() {
         eprintln!(
             "Skipping test: model directory not found at {}",
@@ -182,7 +182,7 @@ async fn pipeline_server_llama_multi_request_smoke() {
 #[tokio::test]
 #[ignore = "requires local model weights and the mlxcel-server binary"]
 async fn pipeline_server_llama_dense_baseline_smoke() {
-    let model_dir = repo_model_dir("llama-3.2-1b-4bit");
+    let model_dir = repo_model_dir("llama-3.2-1b-instruct-4bit");
     if !model_dir.exists() {
         eprintln!(
             "Skipping test: model directory not found at {}",

--- a/tests/pipeline_server_remote_real_models.rs
+++ b/tests/pipeline_server_remote_real_models.rs
@@ -171,19 +171,19 @@ fn assert_remote_coordinator_matches_dense_baseline(
 #[test]
 #[ignore = "requires local model weights and TCP-bound remote stage services"]
 fn pipeline_server_remote_coordinator_llama_matches_dense_baseline() {
-    assert_remote_coordinator_matches_dense_baseline("llama-3.2-1b-4bit", "Hello", None);
+    assert_remote_coordinator_matches_dense_baseline("llama-3.2-1b-instruct-4bit", "Hello", None);
 }
 
 #[test]
 #[ignore = "requires local model weights and TCP-bound remote stage services"]
 fn pipeline_server_remote_coordinator_gpt_oss_matches_dense_baseline() {
-    assert_remote_coordinator_matches_dense_baseline("gpt-oss-20b-mxfp4", "Hello", None);
+    assert_remote_coordinator_matches_dense_baseline("gpt-oss-20b-mxfp4-q4", "Hello", None);
 }
 
 #[test]
 #[ignore = "requires local model weights and TCP-bound remote stage services"]
 fn pipeline_server_remote_coordinator_gemma3_matches_dense_baseline() {
-    assert_remote_coordinator_matches_dense_baseline("gemma3-1b-4bit", "Hello", None);
+    assert_remote_coordinator_matches_dense_baseline("gemma-3-1b-it-4bit", "Hello", None);
 }
 
 #[test]
@@ -207,7 +207,7 @@ fn pipeline_server_remote_coordinator_qwen35_matches_dense_baseline() {
 #[test]
 #[ignore = "requires local model weights and TCP-bound remote stage services"]
 fn pipeline_server_remote_coordinator_glm4_matches_dense_baseline() {
-    assert_remote_coordinator_matches_dense_baseline("glm4-flash-4bit", "Hello", None);
+    assert_remote_coordinator_matches_dense_baseline("glm-4.7-flash-4bit", "Hello", None);
 }
 
 #[test]

--- a/tests/pipeline_stage_executor_real_models.rs
+++ b/tests/pipeline_stage_executor_real_models.rs
@@ -199,7 +199,7 @@ fn assert_two_stage_model_worker_loop_matches_full_model(
 #[ignore = "requires local model weights and extended real-model generation"]
 fn pipeline_stage_executor_llama_real_model_parity() {
     assert_two_stage_model_matches_full_model(
-        &repo_model_dir("llama-3.2-1b-4bit"),
+        &repo_model_dir("llama-3.2-1b-instruct-4bit"),
         &[128000, 9906],
         13,
         None,
@@ -210,7 +210,7 @@ fn pipeline_stage_executor_llama_real_model_parity() {
 #[ignore = "requires local model weights and extended real-model generation"]
 fn pipeline_stage_worker_loop_llama_real_model_parity() {
     assert_two_stage_model_worker_loop_matches_full_model(
-        &repo_model_dir("llama-3.2-1b-4bit"),
+        &repo_model_dir("llama-3.2-1b-instruct-4bit"),
         &[128000, 9906],
         13,
         None,
@@ -221,7 +221,7 @@ fn pipeline_stage_worker_loop_llama_real_model_parity() {
 #[ignore = "requires local model weights and extended real-model generation"]
 fn pipeline_stage_executor_gpt_oss_real_model_parity() {
     assert_two_stage_model_matches_full_model(
-        &repo_model_dir("gpt-oss-20b-mxfp4"),
+        &repo_model_dir("gpt-oss-20b-mxfp4-q4"),
         &[42, 43],
         44,
         None,
@@ -232,7 +232,7 @@ fn pipeline_stage_executor_gpt_oss_real_model_parity() {
 #[ignore = "requires local model weights and extended real-model generation"]
 fn pipeline_stage_worker_loop_gpt_oss_real_model_parity() {
     assert_two_stage_model_worker_loop_matches_full_model(
-        &repo_model_dir("gpt-oss-20b-mxfp4"),
+        &repo_model_dir("gpt-oss-20b-mxfp4-q4"),
         &[42, 43],
         44,
         None,
@@ -242,14 +242,19 @@ fn pipeline_stage_worker_loop_gpt_oss_real_model_parity() {
 #[test]
 #[ignore = "requires local model weights and extended real-model generation"]
 fn pipeline_stage_executor_gemma3_real_model_parity() {
-    assert_two_stage_model_matches_full_model(&repo_model_dir("gemma3-1b-4bit"), &[2, 3], 4, None);
+    assert_two_stage_model_matches_full_model(
+        &repo_model_dir("gemma-3-1b-it-4bit"),
+        &[2, 3],
+        4,
+        None,
+    );
 }
 
 #[test]
 #[ignore = "requires local model weights and extended real-model generation"]
 fn pipeline_stage_worker_loop_gemma3_real_model_parity() {
     assert_two_stage_model_worker_loop_matches_full_model(
-        &repo_model_dir("gemma3-1b-4bit"),
+        &repo_model_dir("gemma-3-1b-it-4bit"),
         &[2, 3],
         4,
         None,
@@ -320,14 +325,19 @@ fn pipeline_stage_worker_loop_qwen35_real_model_parity() {
 #[test]
 #[ignore = "requires local model weights and extended real-model generation"]
 fn pipeline_stage_executor_glm4_real_model_parity() {
-    assert_two_stage_model_matches_full_model(&repo_model_dir("glm4-flash-4bit"), &[2, 3], 4, None);
+    assert_two_stage_model_matches_full_model(
+        &repo_model_dir("glm-4.7-flash-4bit"),
+        &[2, 3],
+        4,
+        None,
+    );
 }
 
 #[test]
 #[ignore = "requires local model weights and extended real-model generation"]
 fn pipeline_stage_worker_loop_glm4_real_model_parity() {
     assert_two_stage_model_worker_loop_matches_full_model(
-        &repo_model_dir("glm4-flash-4bit"),
+        &repo_model_dir("glm-4.7-flash-4bit"),
         &[2, 3],
         4,
         None,

--- a/tests/pp_tp_2d_real_models.rs
+++ b/tests/pp_tp_2d_real_models.rs
@@ -46,7 +46,7 @@ fn run_generate(args: &[&str]) -> (bool, String, String) {
 #[test]
 #[ignore = "requires local model weights and a 2×2 PP×TP capable environment"]
 fn pp_tp_2x2_llama_real_model_parity() {
-    let model_dir = repo_model_dir("llama-3.2-1b-4bit");
+    let model_dir = repo_model_dir("llama-3.2-1b-instruct-4bit");
     if !model_dir.exists() {
         eprintln!(
             "Skipping test: model directory not found at {}",

--- a/tests/smolvlm_parity.rs
+++ b/tests/smolvlm_parity.rs
@@ -44,7 +44,7 @@ use mlxcel::vision::processors::smolvlm::{
     DEFAULT_SIGLIP_MEAN, DEFAULT_SIGLIP_STD, SmolVLMProcessor, TileLayout,
 };
 
-const MODEL_NAME: &str = "SmolVLM-Instruct";
+const MODEL_NAME: &str = "smolvlm-instruct-bf16";
 
 fn model_dir() -> Option<PathBuf> {
     let dir = repo_model_dir(MODEL_NAME);

--- a/tests/tensor_parallel_real_models.rs
+++ b/tests/tensor_parallel_real_models.rs
@@ -289,7 +289,7 @@ fn assert_tp_generates_tokens(
 #[ignore = "requires local model weights and extended real-model generation"]
 fn llama_tp2_matches_single_rank_greedy_long_generation() {
     assert_tp_matches_single_rank(
-        &repo_model_dir("llama-3.2-1b-4bit"),
+        &repo_model_dir("llama-3.2-1b-instruct-4bit"),
         "Continue this sequence with more entries separated by commas: 1, 2, 3, 4, 5,",
         32,
         2,
@@ -300,7 +300,7 @@ fn llama_tp2_matches_single_rank_greedy_long_generation() {
 #[ignore = "requires local model weights and extended real-model generation"]
 fn llama31_8b_tp4_matches_single_rank_greedy_long_generation() {
     assert_tp_matches_single_rank(
-        &repo_model_dir("llama-3.1-8b-4bit"),
+        &repo_model_dir("meta-llama-3.1-8b-instruct-4bit"),
         "Continue this sequence with more entries separated by commas: 1, 2, 3, 4, 5,",
         32,
         4,
@@ -311,7 +311,7 @@ fn llama31_8b_tp4_matches_single_rank_greedy_long_generation() {
 #[ignore = "requires local model weights and extended real-model generation"]
 fn qwen2_5_tp2_matches_single_rank_greedy_long_generation() {
     assert_tp_matches_single_rank(
-        &repo_model_dir("qwen2.5-0.5b-4bit"),
+        &repo_model_dir("qwen2.5-0.5b-instruct-4bit"),
         "Continue this sequence with more entries separated by commas: alpha, beta, gamma,",
         24,
         2,
@@ -322,7 +322,7 @@ fn qwen2_5_tp2_matches_single_rank_greedy_long_generation() {
 #[ignore = "requires local model weights and extended real-model generation"]
 fn qwen2_5_7b_tp4_matches_single_rank_greedy_long_generation() {
     assert_tp_matches_single_rank(
-        &repo_model_dir("qwen2.5-7b-4bit"),
+        &repo_model_dir("qwen2.5-7b-instruct-4bit"),
         "Continue this sequence with more entries separated by commas: alpha, beta, gamma,",
         32,
         4,
@@ -435,7 +435,7 @@ fn qwen3_8_27b_tp4_matches_single_rank_stepwise() {
 #[ignore = "requires local model weights and extended real-model generation"]
 fn ernie45_tp2_matches_single_rank_greedy_long_generation() {
     assert_tp_matches_single_rank(
-        &repo_model_dir("ernie-4.5-0.3b-4bit"),
+        &repo_model_dir("ernie-4.5-0.3b-pt-4bit"),
         "Continue this sequence with more entries separated by commas: red, blue, green,",
         32,
         2,
@@ -446,7 +446,7 @@ fn ernie45_tp2_matches_single_rank_greedy_long_generation() {
 #[ignore = "requires local model weights and extended real-model generation"]
 fn ernie45_tp4_matches_single_rank_greedy_long_generation() {
     assert_tp_matches_single_rank(
-        &repo_model_dir("ernie-4.5-0.3b-4bit"),
+        &repo_model_dir("ernie-4.5-0.3b-pt-4bit"),
         "Continue this sequence with more entries separated by commas: red, blue, green,",
         32,
         4,
@@ -479,7 +479,7 @@ fn hunyuan_v1_dense_tp4_matches_single_rank_greedy_long_generation() {
 #[ignore = "requires local model weights and extended real-model generation"]
 fn gemma3_tp2_matches_single_rank_greedy_long_generation() {
     assert_tp_matches_single_rank(
-        &repo_model_dir("gemma3-1b-4bit"),
+        &repo_model_dir("gemma-3-1b-it-4bit"),
         "Continue this sequence with more entries separated by commas: north, south, east,",
         24,
         2,
@@ -490,7 +490,7 @@ fn gemma3_tp2_matches_single_rank_greedy_long_generation() {
 #[ignore = "requires local model weights and extended real-model generation"]
 fn llama_tp4_matches_single_rank_greedy_long_generation() {
     assert_tp_matches_single_rank(
-        &repo_model_dir("llama-3.2-1b-4bit"),
+        &repo_model_dir("llama-3.2-1b-instruct-4bit"),
         "Continue this sequence with more entries separated by commas: 1, 2, 3, 4, 5,",
         32,
         4,
@@ -501,7 +501,7 @@ fn llama_tp4_matches_single_rank_greedy_long_generation() {
 #[ignore = "requires local model weights and extended real-model generation"]
 fn gemma3_tp4_matches_single_rank_greedy_long_generation() {
     assert_tp_matches_single_rank(
-        &repo_model_dir("gemma3-1b-4bit"),
+        &repo_model_dir("gemma-3-1b-it-4bit"),
         "Continue this sequence with more entries separated by commas: north, south, east,",
         24,
         4,

--- a/tests/turbo_kv_e2e.rs
+++ b/tests/turbo_kv_e2e.rs
@@ -845,13 +845,13 @@ fn test_rotation_kurtosis_sanity() {
         "qwen2.5-0.5b-bf16",
         "gemma3n-e4b-bf16",
         "Qwen2.5-7B-Instruct-4bit",
-        "qwen2.5-7b-4bit",
+        "qwen2.5-7b-instruct-4bit",
         // base model used by B3 quality gate since
         "Qwen2.5-1.5B-4bit",
         "Qwen2.5-1.5B-Instruct-4bit",
         "Meta-Llama-3.1-8B-Instruct-4bit",
         "gemma-3-4b-it-4bit",
-        "llama-3.1-8b-4bit",
+        "meta-llama-3.1-8b-instruct-4bit",
         "gemma3-4b-4bit",
     ];
 

--- a/tests/zero_config_cluster_init.rs
+++ b/tests/zero_config_cluster_init.rs
@@ -150,7 +150,7 @@ fn two_stage_assignments(num_layers: usize, split: usize) -> [StageAssignment; 2
 #[test]
 #[ignore = "requires local model weights and TCP-bound remote stage services"]
 fn zero_config_two_stage_cluster_matches_dense_baseline() {
-    let model_dir = repo_model_dir("llama-3.2-1b-4bit");
+    let model_dir = repo_model_dir("llama-3.2-1b-instruct-4bit");
     if !model_dir.exists() {
         eprintln!(
             "Skipping test: model directory not found at {}",


### PR DESCRIPTION
Follow-up to #1722, which made a checkpoint name that resolves nowhere fail loudly under `MLXCEL_REQUIRE_MODELS=1` instead of turning its test into a silent no-op. Running that on M5 Max, 20 of the 46 distinct names under `tests/` resolved to nothing.

Fifteen are fixed, in 55 places. Ten are looked up through the catalog's `aliases` column, so each replacement is backed by a recorded former name rather than a guess. Five differed only in case or in a suffix the directory carries, and one kept an `mlx/` prefix from the old two-level layout.

## The one that is not remapped

`jamba-v0.1-4bit` stays unresolved and its alias is removed from the catalog. That directory held `AI21-Jamba-Reasoning-3B-4bit`, a 3B 28-layer model, not Jamba v0.1. Renaming it was right; recording the old name as an alias was not. An alias means one set of weights was measured under another name, and following this one would have pointed a parity test at a different architecture. `docs/model-catalog.md` now states the distinction, since the same mistake is available to anyone who renames a misnamed directory.

## What is left, and why editing a string will not fix it

Five names have no checkpoint behind them on this host: `glm5-4bit` was an aborted download removed on 2026-09-09, `llama-3.2-1b-4bit-lora` is an adapter directory rather than a base checkpoint, and `mistral-7b-instruct-v0.3-4bit`, `nvidia-nemotron-h-8b-base-8bit` and the jamba entry are simply not in the store. They will keep skipping, which is the correct behaviour now that skipping is visible.

Gate: 10539 tests pass with no failures, up from 10534. The five extra are tests that now run.
