### PR TITLE
chore(build): include benches/ in insert_apache_header.py target roots

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -257,6 +257,44 @@ jobs:
       - name: Check every CUDA JIT launch keys its cache on the input dtypes
         run: python3 scripts/ci/check_kernel_dtype_keys.py
 
+  license-headers:
+    name: license headers
+    # Deliberately not behind the `changes` filter, like `crate-versions` and
+    # `kernel-dtype-keys`: it needs no toolchain and runs in seconds.
+    #
+    # This gate exists because coverage without enforcement did nothing. Issue
+    # #1707 found `benches/audio_fft.rs` shipping unlicensed and traced it to
+    # `benches` missing from the script's `TARGET_ROOTS`. That was only the
+    # visible instance: the roots list already named `src`, `examples` and
+    # `tests`, and 95 files under those three roots were unlicensed anyway,
+    # because nothing ever ran the script. Fixing the list would not have
+    # caught a single one of them. Running it in CI does.
+    #
+    # `--check` writes nothing and reports the files the default insert mode
+    # would touch, reusing the same `has_existing_header` predicate the writer
+    # branches on, so the gate can never demand an edit that running
+    # `python3 scripts/insert_apache_header.py` does not produce. Files that
+    # already carry someone else's provenance (the vendored MLX patches under
+    # src/lib/mlx-cpp/patches/ keep Apple's copyright) are skipped by that same
+    # predicate and must stay that way: this gate must never stamp a Lablup
+    # header onto upstream-derived code.
+    #
+    # The second step is the script's own unit suite, which nothing else runs:
+    # tests/test_insert_apache_header.py sits outside python/, and
+    # python.yml's pytest step is scoped to `python/tests` behind a
+    # `python/**` path filter.
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          persist-credentials: false
+      - name: Every owned source file carries the license header
+        run: python3 scripts/insert_apache_header.py --check
+      - name: Header script unit tests
+        run: python3 -m unittest discover -s tests -p 'test_insert_apache_header.py' -v
+
   llama-compat-manifest:
     name: llama-compat manifest
     # Deliberately not behind the `changes` filter, like `crate-versions`: it

--- a/benches/audio_fft.rs
+++ b/benches/audio_fft.rs
@@ -1,3 +1,17 @@
+// Copyright 2025-2026 Lablup Inc. and Jeongkyu Shin
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 use std::f64::consts::PI;
 use std::time::Duration;
 

--- a/build.rs
+++ b/build.rs
@@ -1,3 +1,17 @@
+// Copyright 2025-2026 Lablup Inc. and Jeongkyu Shin
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 // Root build script for the `mlxcel` binary.
 //
 // It does NOTHING for default / `xla-backend` builds, so Apple-Silicon, CUDA, and

--- a/examples/bridge_overhead_microbench.rs
+++ b/examples/bridge_overhead_microbench.rs
@@ -1,3 +1,17 @@
+// Copyright 2025-2026 Lablup Inc. and Jeongkyu Shin
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 // Bridge-overhead microbench.
 //
 // Isolates the per-op cost of the Rust → cxx → C++ → MLX dispatch path for

--- a/examples/layer_shaped_microbench.rs
+++ b/examples/layer_shaped_microbench.rs
@@ -1,3 +1,17 @@
+// Copyright 2025-2026 Lablup Inc. and Jeongkyu Shin
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 // Layer-shaped workload microbench.
 //
 // Motivated by `bridge_overhead_microbench.rs` showing per-op cost at or

--- a/examples/mtp_projection_width_bench.rs
+++ b/examples/mtp_projection_width_bench.rs
@@ -1,3 +1,17 @@
+// Copyright 2025-2026 Lablup Inc. and Jeongkyu Shin
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 // MTP verify LM-head projection cost as a function of projected width.
 //
 // Issue #1179 asks whether a device-side early-exit verify walk is worth

--- a/examples/perplexity.rs
+++ b/examples/perplexity.rs
@@ -1,3 +1,17 @@
+// Copyright 2025-2026 Lablup Inc. and Jeongkyu Shin
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 // Teacher-forced perplexity harness for quantization quality gates.
 //
 // Motivated by issue #683: requantizing gemma-4-12b's 8-bit MLP modules to

--- a/examples/qmm_gemv_microbench.rs
+++ b/examples/qmm_gemv_microbench.rs
@@ -1,3 +1,17 @@
+// Copyright 2025-2026 Lablup Inc. and Jeongkyu Shin
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 // Quantized-matmul GEMV effective-bandwidth microbench.
 //
 // Motivated by the #680 investigation: gemma-4-12b decode streams ~10.1 GB

--- a/examples/xla_traj_dump.rs
+++ b/examples/xla_traj_dump.rs
@@ -1,3 +1,17 @@
+// Copyright 2025-2026 Lablup Inc. and Jeongkyu Shin
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 //! Dump the OpenXLA/IREE engine's greedy argmax trajectory (no EOS stop) as an
 //! oracle JSON `{"prompt_ids":[...], "ref_token_ids":[...]}`, at the ambient
 //! `MLXCEL_XLA_PRECISION`.

--- a/scripts/insert_apache_header.py
+++ b/scripts/insert_apache_header.py
@@ -17,7 +17,7 @@ PROJECT_HEADER = """\
 
 """
 PROJECT_COPYRIGHT_LINE = "// Copyright 2025-2026 Lablup Inc. and Jeongkyu Shin"
-TARGET_ROOTS = ("src", "examples", "tests")
+TARGET_ROOTS = ("src", "examples", "tests", "benches")
 ALLOWED_SUFFIXES = {".rs", ".cpp", ".h"}
 SKIP_DIR_NAMES = {".git", "target", "__pycache__"}
 HEADER_SCAN_LINE_COUNT = 40

--- a/scripts/insert_apache_header.py
+++ b/scripts/insert_apache_header.py
@@ -1,3 +1,7 @@
+from __future__ import annotations
+
+import argparse
+import sys
 from pathlib import Path
 
 PROJECT_HEADER = """\
@@ -18,6 +22,15 @@ PROJECT_HEADER = """\
 """
 PROJECT_COPYRIGHT_LINE = "// Copyright 2025-2026 Lablup Inc. and Jeongkyu Shin"
 TARGET_ROOTS = ("src", "examples", "tests", "benches")
+# Repo-relative files that ship with the crate but sit outside every
+# TARGET_ROOTS directory, so the walk above cannot reach them. `build.rs` is
+# the crate's own build script (`build = "build.rs"` in Cargo.toml), so it is
+# part of the published package and needs the header like any other source.
+#
+# `spike/` is deliberately absent: those are scratch crates outside the
+# workspace `members` list that are never published. Add them here, not by
+# guessing, if that ever changes.
+TARGET_FILES = ("build.rs",)
 ALLOWED_SUFFIXES = {".rs", ".cpp", ".h"}
 SKIP_DIR_NAMES = {".git", "target", "__pycache__"}
 HEADER_SCAN_LINE_COUNT = 40
@@ -30,6 +43,8 @@ def should_process_path(path: Path) -> bool:
         return False
     if any(part in SKIP_DIR_NAMES for part in path.parts):
         return False
+    if path.as_posix() in TARGET_FILES:
+        return True
     return path.parts[0] in TARGET_ROOTS
 
 
@@ -71,6 +86,10 @@ def insert_header_in_file(path: Path) -> bool:
 
 def iter_target_files(repo_root: Path):
     """Yield target Rust/C++ files under the repository roots we own."""
+    for file_name in TARGET_FILES:
+        path = repo_root / file_name
+        if path.is_file() and should_process_path(path.relative_to(repo_root)):
+            yield path
     for root_name in TARGET_ROOTS:
         root = repo_root / root_name
         if not root.exists():
@@ -80,10 +99,56 @@ def iter_target_files(repo_root: Path):
                 yield path
 
 
-def main() -> None:
+def files_missing_header(repo_root: Path) -> list[Path]:
+    """Return the target files that `main()` would insert a header into.
+
+    Deliberately expressed as "what would the writer touch" rather than as its
+    own notion of a valid header: it reuses `has_existing_header`, the same
+    predicate `insert_header_in_file` branches on, so `--check` and the default
+    insert mode can never disagree about which files are covered. A check that
+    re-derived the rule would eventually demand an edit the script itself does
+    not make.
+    """
+    return [
+        path
+        for path in iter_target_files(repo_root)
+        if not has_existing_header(path.read_text(encoding="utf-8"))
+    ]
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Insert the project Apache 2.0 header into owned Rust/C++ sources. "
+            "With --check, report files that are missing it and exit non-zero "
+            "instead of writing."
+        )
+    )
+    parser.add_argument(
+        "--check",
+        action="store_true",
+        help="report files missing the header and exit 1; write nothing",
+    )
+    args = parser.parse_args(argv)
+
+    if args.check:
+        missing = sorted(files_missing_header(REPO_ROOT))
+        if missing:
+            print("❌ Missing the project license header:")
+            for path in missing:
+                print(f"   {path.relative_to(REPO_ROOT).as_posix()}")
+            print(
+                f"\n{len(missing)} file(s) need a header. "
+                "Run `python3 scripts/insert_apache_header.py` to insert it."
+            )
+            return 1
+        print("✅ Every target file carries a license header.")
+        return 0
+
     for path in iter_target_files(REPO_ROOT):
         insert_header_in_file(path)
+    return 0
 
 
 if __name__ == "__main__":
-    main()
+    sys.exit(main())

--- a/src/audio/preprocessing_policy.rs
+++ b/src/audio/preprocessing_policy.rs
@@ -1,3 +1,17 @@
+// Copyright 2025-2026 Lablup Inc. and Jeongkyu Shin
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 use super::AudioPreprocessError;
 
 const DEFAULT_MAX_ENCODED_BYTES: usize = 64 * 1024 * 1024;

--- a/src/audio/preprocessing_resample.rs
+++ b/src/audio/preprocessing_resample.rs
@@ -1,3 +1,17 @@
+// Copyright 2025-2026 Lablup Inc. and Jeongkyu Shin
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 use std::f64::consts::PI;
 
 use super::{AudioCancellation, AudioPreprocessCheckpoint, AudioPreprocessError, check_cancel};

--- a/src/audio/preprocessing_tests.rs
+++ b/src/audio/preprocessing_tests.rs
@@ -1,3 +1,17 @@
+// Copyright 2025-2026 Lablup Inc. and Jeongkyu Shin
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 use super::*;
 
 struct NeverCancel;

--- a/src/audio/preprocessing_wav.rs
+++ b/src/audio/preprocessing_wav.rs
@@ -1,3 +1,17 @@
+// Copyright 2025-2026 Lablup Inc. and Jeongkyu Shin
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 use super::{
     AudioCancellation, AudioFamilyPolicy, AudioPreprocessCheckpoint, AudioPreprocessError,
     AudioResamplingPolicy, check_cancel,

--- a/src/distributed/backpressure_tests.rs
+++ b/src/distributed/backpressure_tests.rs
@@ -1,3 +1,17 @@
+// Copyright 2025-2026 Lablup Inc. and Jeongkyu Shin
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 use super::*;
 
 fn default_monitor() -> BackpressureMonitor {

--- a/src/distributed/bench_tests.rs
+++ b/src/distributed/bench_tests.rs
@@ -1,3 +1,17 @@
+// Copyright 2025-2026 Lablup Inc. and Jeongkyu Shin
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 use super::*;
 
 #[test]

--- a/src/distributed/config_tests.rs
+++ b/src/distributed/config_tests.rs
@@ -1,3 +1,17 @@
+// Copyright 2025-2026 Lablup Inc. and Jeongkyu Shin
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 use super::*;
 use crate::distributed::TransportBackend;
 

--- a/src/distributed/connection_pool_tests.rs
+++ b/src/distributed/connection_pool_tests.rs
@@ -1,3 +1,17 @@
+// Copyright 2025-2026 Lablup Inc. and Jeongkyu Shin
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 use super::*;
 
 #[test]

--- a/src/distributed/correlation_tests.rs
+++ b/src/distributed/correlation_tests.rs
@@ -1,3 +1,17 @@
+// Copyright 2025-2026 Lablup Inc. and Jeongkyu Shin
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 use super::*;
 
 #[test]

--- a/src/distributed/disaggregated/decode_scheduler_tests.rs
+++ b/src/distributed/disaggregated/decode_scheduler_tests.rs
@@ -1,3 +1,17 @@
+// Copyright 2025-2026 Lablup Inc. and Jeongkyu Shin
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 use super::*;
 use crate::distributed::kv_cache_serde::types::{
     CacheMetadata, CacheType, SerializableCacheState, SerializableSamplingState,

--- a/src/distributed/disaggregated/prefill_scheduler_tests.rs
+++ b/src/distributed/disaggregated/prefill_scheduler_tests.rs
@@ -1,3 +1,17 @@
+// Copyright 2025-2026 Lablup Inc. and Jeongkyu Shin
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 use std::time::Duration;
 
 use super::*;

--- a/src/distributed/discovery_tests.rs
+++ b/src/distributed/discovery_tests.rs
@@ -1,3 +1,17 @@
+// Copyright 2025-2026 Lablup Inc. and Jeongkyu Shin
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 use super::*;
 use crate::distributed::config::{ClusterConfig, NodeRole};
 

--- a/src/distributed/failure_detector_tests.rs
+++ b/src/distributed/failure_detector_tests.rs
@@ -1,3 +1,17 @@
+// Copyright 2025-2026 Lablup Inc. and Jeongkyu Shin
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 use std::time::Duration;
 
 use super::*;

--- a/src/distributed/handoff_queue_tests.rs
+++ b/src/distributed/handoff_queue_tests.rs
@@ -1,3 +1,17 @@
+// Copyright 2025-2026 Lablup Inc. and Jeongkyu Shin
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 use super::*;
 
 fn make_item(request_id: &str, from: &str, to: &str) -> HandoffItem {

--- a/src/distributed/heartbeat_tests.rs
+++ b/src/distributed/heartbeat_tests.rs
@@ -1,3 +1,17 @@
+// Copyright 2025-2026 Lablup Inc. and Jeongkyu Shin
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 use std::time::Duration;
 
 use super::*;

--- a/src/distributed/metrics_tests.rs
+++ b/src/distributed/metrics_tests.rs
@@ -1,3 +1,17 @@
+// Copyright 2025-2026 Lablup Inc. and Jeongkyu Shin
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 use std::collections::VecDeque;
 use std::time::Duration;
 

--- a/src/distributed/mock_transport_tests.rs
+++ b/src/distributed/mock_transport_tests.rs
@@ -1,3 +1,17 @@
+// Copyright 2025-2026 Lablup Inc. and Jeongkyu Shin
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 use std::time::Duration;
 
 use bytes::Bytes;

--- a/src/distributed/pipeline/partition_balance_tests.rs
+++ b/src/distributed/pipeline/partition_balance_tests.rs
@@ -1,3 +1,17 @@
+// Copyright 2025-2026 Lablup Inc. and Jeongkyu Shin
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 use super::*;
 
 #[test]

--- a/src/distributed/pipeline/partition_profile_tests.rs
+++ b/src/distributed/pipeline/partition_profile_tests.rs
@@ -1,3 +1,17 @@
+// Copyright 2025-2026 Lablup Inc. and Jeongkyu Shin
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 use super::*;
 use serde_json::json;
 

--- a/src/distributed/pipeline/partition_quality_tests.rs
+++ b/src/distributed/pipeline/partition_quality_tests.rs
@@ -1,3 +1,17 @@
+// Copyright 2025-2026 Lablup Inc. and Jeongkyu Shin
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 use super::*;
 use crate::distributed::pipeline::partition::{ModelProfile, StageAssignment};
 

--- a/src/distributed/pipeline/partition_tests.rs
+++ b/src/distributed/pipeline/partition_tests.rs
@@ -1,3 +1,17 @@
+// Copyright 2025-2026 Lablup Inc. and Jeongkyu Shin
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 use super::*;
 
 // ---------------------------------------------------------------------------

--- a/src/distributed/pipeline/stage_worker_tests.rs
+++ b/src/distributed/pipeline/stage_worker_tests.rs
@@ -1,3 +1,17 @@
+// Copyright 2025-2026 Lablup Inc. and Jeongkyu Shin
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 use anyhow::{Result, bail};
 use mlxcel_core::layers::KVCache;
 use mlxcel_core::{MlxArray, UniquePtr};

--- a/src/distributed/registry_tests.rs
+++ b/src/distributed/registry_tests.rs
@@ -1,3 +1,17 @@
+// Copyright 2025-2026 Lablup Inc. and Jeongkyu Shin
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 use super::*;
 use crate::distributed::config::{ClusterConfig, NodeRole};
 

--- a/src/distributed/request_tracker_tests.rs
+++ b/src/distributed/request_tracker_tests.rs
@@ -1,3 +1,17 @@
+// Copyright 2025-2026 Lablup Inc. and Jeongkyu Shin
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 use super::*;
 
 #[test]

--- a/src/distributed/routing_tests.rs
+++ b/src/distributed/routing_tests.rs
@@ -1,3 +1,17 @@
+// Copyright 2025-2026 Lablup Inc. and Jeongkyu Shin
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 use super::*;
 
 fn make_candidate(id: &str, role: NodeRole, status: NodeStatus) -> NodeCandidate {

--- a/src/distributed/scheduler_tests.rs
+++ b/src/distributed/scheduler_tests.rs
@@ -1,3 +1,17 @@
+// Copyright 2025-2026 Lablup Inc. and Jeongkyu Shin
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 use std::net::SocketAddr;
 use std::sync::Arc;
 

--- a/src/distributed/tcp_transport_tests.rs
+++ b/src/distributed/tcp_transport_tests.rs
@@ -1,3 +1,17 @@
+// Copyright 2025-2026 Lablup Inc. and Jeongkyu Shin
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 use bytes::Bytes;
 
 use super::*;

--- a/src/distributed/test_harness_tests.rs
+++ b/src/distributed/test_harness_tests.rs
@@ -1,3 +1,17 @@
+// Copyright 2025-2026 Lablup Inc. and Jeongkyu Shin
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 use std::time::Duration;
 
 use bytes::Bytes;

--- a/src/distributed/thunderbolt_transport_tests.rs
+++ b/src/distributed/thunderbolt_transport_tests.rs
@@ -1,3 +1,17 @@
+// Copyright 2025-2026 Lablup Inc. and Jeongkyu Shin
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 use std::net::{IpAddr, Ipv4Addr, SocketAddr};
 
 use super::*;

--- a/src/distributed/transport_tests.rs
+++ b/src/distributed/transport_tests.rs
@@ -1,3 +1,17 @@
+// Copyright 2025-2026 Lablup Inc. and Jeongkyu Shin
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 use super::*;
 
 #[test]

--- a/src/lib/mlx-cpp/patches/mlx/backend/cuda/gemms/grouped_gemm_arch.h
+++ b/src/lib/mlx-cpp/patches/mlx/backend/cuda/gemms/grouped_gemm_arch.h
@@ -1,3 +1,17 @@
+// Copyright 2025-2026 Lablup Inc. and Jeongkyu Shin
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 // Added by mlxcel (lablup/mlxcel#1544). Not an upstream MLX file.
 //
 // The CUTLASS architecture tag selection for the grouped GEMM in

--- a/src/lib/mlx-cpp/patches/mlx/backend/cuda/quantized/qmm/qmm_naive_tile.h
+++ b/src/lib/mlx-cpp/patches/mlx/backend/cuda/quantized/qmm/qmm_naive_tile.h
@@ -1,3 +1,17 @@
+// Copyright 2025-2026 Lablup Inc. and Jeongkyu Shin
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 // Added by mlxcel (lablup/mlxcel#1541). Not an upstream MLX file.
 //
 // The CTA tile selection for `qmm_naive`, factored out of `qmm_naive.cu` as a

--- a/src/lib/mlxcel-core/src/cache/paged.rs
+++ b/src/lib/mlxcel-core/src/cache/paged.rs
@@ -1,3 +1,17 @@
+// Copyright 2025-2026 Lablup Inc. and Jeongkyu Shin
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 use std::collections::HashMap;
 
 use cxx::UniquePtr;

--- a/src/lib/mlxcel-core/src/drafter/inkling_mtp/config.rs
+++ b/src/lib/mlxcel-core/src/drafter/inkling_mtp/config.rs
@@ -1,3 +1,17 @@
+// Copyright 2025-2026 Lablup Inc. and Jeongkyu Shin
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 use std::path::Path;
 
 use serde_json::Value;

--- a/src/lib/mlxcel-core/src/drafter/inkling_mtp/mod.rs
+++ b/src/lib/mlxcel-core/src/drafter/inkling_mtp/mod.rs
@@ -1,3 +1,17 @@
+// Copyright 2025-2026 Lablup Inc. and Jeongkyu Shin
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 //! Native Inkling chained multi-token-prediction drafter.
 
 pub mod config;

--- a/src/lib/mlxcel-core/src/drafter/inkling_mtp/model.rs
+++ b/src/lib/mlxcel-core/src/drafter/inkling_mtp/model.rs
@@ -1,3 +1,17 @@
+// Copyright 2025-2026 Lablup Inc. and Jeongkyu Shin
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 use std::path::Path;
 
 use crate::UniquePtr;

--- a/src/lib/mlxcel-core/src/drafter/inkling_mtp/sanitize.rs
+++ b/src/lib/mlxcel-core/src/drafter/inkling_mtp/sanitize.rs
@@ -1,3 +1,17 @@
+// Copyright 2025-2026 Lablup Inc. and Jeongkyu Shin
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 use crate::UniquePtr;
 use crate::ffi::{self, MlxArray};
 use crate::weights::WeightMap;

--- a/src/lib/mlxcel-core/src/drafter/inkling_mtp/tests.rs
+++ b/src/lib/mlxcel-core/src/drafter/inkling_mtp/tests.rs
@@ -1,3 +1,17 @@
+// Copyright 2025-2026 Lablup Inc. and Jeongkyu Shin
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 use std::io::Write;
 
 use serde_json::json;

--- a/src/lib/mlxcel-core/src/grouped_gemm_arch_tests.rs
+++ b/src/lib/mlxcel-core/src/grouped_gemm_arch_tests.rs
@@ -1,3 +1,17 @@
+// Copyright 2025-2026 Lablup Inc. and Jeongkyu Shin
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 //! [#1544] The CUTLASS architecture tag the grouped GEMM selects, and the
 //! numbers that path produces on the device it selects it for.
 //!

--- a/src/lib/mlxcel-core/src/grouped_gemm_numeric_tests.rs
+++ b/src/lib/mlxcel-core/src/grouped_gemm_numeric_tests.rs
@@ -1,3 +1,17 @@
+// Copyright 2025-2026 Lablup Inc. and Jeongkyu Shin
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 //! [#1544] The numbers the CUDA grouped GEMM produces on the device it is
 //! dispatched for.
 //!

--- a/src/lib/mlxcel-core/src/inkling_layer/attention.rs
+++ b/src/lib/mlxcel-core/src/inkling_layer/attention.rs
@@ -1,3 +1,17 @@
+// Copyright 2025-2026 Lablup Inc. and Jeongkyu Shin
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 use crate::layers::{RMSNorm, UnifiedLinear};
 use crate::weights::WeightMap;
 use crate::{MlxArray, UniquePtr, dtype};

--- a/src/lib/mlxcel-core/src/inkling_layer/cache.rs
+++ b/src/lib/mlxcel-core/src/inkling_layer/cache.rs
@@ -1,3 +1,17 @@
+// Copyright 2025-2026 Lablup Inc. and Jeongkyu Shin
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 use crate::generate::ModelStateSnapshot;
 use crate::layers::KVCache;
 use crate::{MlxArray, UniquePtr};

--- a/src/lib/mlxcel-core/src/inkling_layer/dense_mlp.rs
+++ b/src/lib/mlxcel-core/src/inkling_layer/dense_mlp.rs
@@ -1,3 +1,17 @@
+// Copyright 2025-2026 Lablup Inc. and Jeongkyu Shin
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 use crate::layers::UnifiedLinear;
 use crate::weights::WeightMap;
 use crate::{MlxArray, UniquePtr};

--- a/src/lib/mlxcel-core/src/inkling_layer/mod.rs
+++ b/src/lib/mlxcel-core/src/inkling_layer/mod.rs
@@ -1,3 +1,17 @@
+// Copyright 2025-2026 Lablup Inc. and Jeongkyu Shin
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 //! Shared Inkling decoder-layer primitives.
 //!
 //! The text target and the native MTP drafter execute the same attention,

--- a/src/lib/mlxcel-core/src/qmm_naive_tile_tests.rs
+++ b/src/lib/mlxcel-core/src/qmm_naive_tile_tests.rs
@@ -1,3 +1,17 @@
+// Copyright 2025-2026 Lablup Inc. and Jeongkyu Shin
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 //! [#1541] Host-side unit tests for the `qmm_naive` CTA tile selector.
 //!
 //! `qmm_naive` sized its N tile with `enough_smem = sm80 && itemsize <= 2 &&

--- a/src/lib/mlxcel-core/src/ttft_profile_tests.rs
+++ b/src/lib/mlxcel-core/src/ttft_profile_tests.rs
@@ -1,3 +1,17 @@
+// Copyright 2025-2026 Lablup Inc. and Jeongkyu Shin
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 //! [#1545] Host-side unit tests for the pre-first-token phase breakdown.
 //!
 //! `MLXCEL_PROFILE_TTFT` reports the phases of the path that produces the

--- a/src/lib/mlxcel-xla/build.rs
+++ b/src/lib/mlxcel-xla/build.rs
@@ -1,3 +1,17 @@
+// Copyright 2025-2026 Lablup Inc. and Jeongkyu Shin
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 // Build script for mlxcel-xla.
 //
 // Default / `xla-backend`-only builds do NOTHING here: the crate is pure Rust

--- a/src/lib/mlxcel-xla/src/emitter/builder.rs
+++ b/src/lib/mlxcel-xla/src/emitter/builder.rs
@@ -1,3 +1,17 @@
+// Copyright 2025-2026 Lablup Inc. and Jeongkyu Shin
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 //! Minimal StableHLO text builder.
 //!
 //! Tracks SSA value names and their tensor types, and exposes one method per

--- a/src/lib/mlxcel-xla/src/emitter/config.rs
+++ b/src/lib/mlxcel-xla/src/emitter/config.rs
@@ -1,3 +1,17 @@
+// Copyright 2025-2026 Lablup Inc. and Jeongkyu Shin
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 //! Emitter config for the dense architectures the OpenXLA backend serves.
 //! The hard-coded [`Config::llama_3_2_1b`] matches spike/openxla/model_jax.py;
 //! [`Config::from_json`] reads the same shape from a checkpoint's `config.json`.

--- a/src/lib/mlxcel-xla/src/emitter/gemma3n.rs
+++ b/src/lib/mlxcel-xla/src/emitter/gemma3n.rs
@@ -1,3 +1,17 @@
+// Copyright 2025-2026 Lablup Inc. and Jeongkyu Shin
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 //! Validated Gemma3n text-backbone configuration and dense-PLE ABI metadata.
 //!
 //! Gemma3n is not a flag combination of the ordinary Llama emitter: AltUp keeps

--- a/src/lib/mlxcel-xla/src/emitter/gemma3n_decode.rs
+++ b/src/lib/mlxcel-xla/src/emitter/gemma3n_decode.rs
@@ -1,3 +1,17 @@
+// Copyright 2025-2026 Lablup Inc. and Jeongkyu Shin
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 //! Single-token and fixed-slot ragged Gemma3n decode StableHLO graphs.
 
 use super::builder::{Builder, Precision, Ty, Val, precision_from_env};

--- a/src/lib/mlxcel-xla/src/emitter/gemma3n_emit.rs
+++ b/src/lib/mlxcel-xla/src/emitter/gemma3n_emit.rs
@@ -1,3 +1,17 @@
+// Copyright 2025-2026 Lablup Inc. and Jeongkyu Shin
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 //! Gemma3n StableHLO prefill graphs.
 //!
 //! Both entries share the complete AltUp/LAUREL/shared-KV backbone. Token

--- a/src/lib/mlxcel-xla/src/emitter/gemma3n_emit_ops.rs
+++ b/src/lib/mlxcel-xla/src/emitter/gemma3n_emit_ops.rs
@@ -1,3 +1,17 @@
+// Copyright 2025-2026 Lablup Inc. and Jeongkyu Shin
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 //! StableHLO building blocks shared by Gemma3n token and embeddings+PLE prefill.
 
 use super::builder::{Builder, Val};

--- a/src/lib/mlxcel-xla/src/emitter/gemma3n_math.rs
+++ b/src/lib/mlxcel-xla/src/emitter/gemma3n_math.rs
@@ -1,3 +1,17 @@
+// Copyright 2025-2026 Lablup Inc. and Jeongkyu Shin
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 //! Small f32 Gemma3n oracle kernels used to isolate graph math in unit tests.
 //!
 //! These are deliberately dependency-free and operate on flattened row-major

--- a/src/lib/mlxcel-xla/src/emitter/gemma3n_qmv.rs
+++ b/src/lib/mlxcel-xla/src/emitter/gemma3n_qmv.rs
@@ -1,3 +1,17 @@
+// Copyright 2025-2026 Lablup Inc. and Jeongkyu Shin
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 //! CUDA custom-dispatch definition for Gemma3n Q4 prefill projections.
 //!
 //! The PTX is generated only by the CUDA-IREE build and embedded into every

--- a/src/lib/mlxcel-xla/src/emitter/gemma3n_schema.rs
+++ b/src/lib/mlxcel-xla/src/emitter/gemma3n_schema.rs
@@ -1,3 +1,17 @@
+// Copyright 2025-2026 Lablup Inc. and Jeongkyu Shin
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 //! Stable Gemma3n graph argument schema shared by prefill and decode.
 
 use super::builder::{Builder, Ty, Val};

--- a/src/lib/mlxcel-xla/src/emitter/gemma3n_weights.rs
+++ b/src/lib/mlxcel-xla/src/emitter/gemma3n_weights.rs
@@ -1,3 +1,17 @@
+// Copyright 2025-2026 Lablup Inc. and Jeongkyu Shin
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 //! Gemma3n checkpoint tensors in a deterministic graph-argument order.
 
 use super::gemma3n::Gemma3nConfig;

--- a/src/lib/mlxcel-xla/src/emitter/model.rs
+++ b/src/lib/mlxcel-xla/src/emitter/model.rs
@@ -1,3 +1,17 @@
+// Copyright 2025-2026 Lablup Inc. and Jeongkyu Shin
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 //! Emits the `decode_step` / `prefill` StableHLO modules for the supported dense
 //! architectures from Rust. One per-layer core ([`emit_transformer_layer`], built
 //! on the shared [`emit_attention`] of issue #494) serves every family: the norm

--- a/src/lib/mlxcel-xla/src/emitter/rope.rs
+++ b/src/lib/mlxcel-xla/src/emitter/rope.rs
@@ -1,3 +1,17 @@
+// Copyright 2025-2026 Lablup Inc. and Jeongkyu Shin
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 //! RoPE tables. The llama3 path is byte-for-byte with HF
 //! `_compute_llama3_parameters` and the JAX reference `llama3_inv_freq` /
 //! `rope_tables` in spike/openxla/model_jax.py; the plain path (Qwen2, #449 M3

--- a/src/lib/mlxcel-xla/src/prepared_gemma3n.rs
+++ b/src/lib/mlxcel-xla/src/prepared_gemma3n.rs
@@ -1,3 +1,17 @@
+// Copyright 2025-2026 Lablup Inc. and Jeongkyu Shin
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 //! Owned dense per-layer embeddings for Gemma3n prepared prefill.
 //!
 //! The scheduler keeps this value in the pending request.  Its `Vec<f32>`

--- a/src/loading/vlm_muse_glimmer_tests.rs
+++ b/src/loading/vlm_muse_glimmer_tests.rs
@@ -1,3 +1,17 @@
+// Copyright 2025-2026 Lablup Inc. and Jeongkyu Shin
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 use super::*;
 use image::{DynamicImage, Rgb, RgbImage};
 use mlxcel_core::cache::SequenceId;

--- a/src/models/inkling/speculative.rs
+++ b/src/models/inkling/speculative.rs
@@ -1,3 +1,17 @@
+// Copyright 2025-2026 Lablup Inc. and Jeongkyu Shin
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 use mlxcel_core::cache::SequenceId;
 use mlxcel_core::{MlxArray, UniquePtr};
 

--- a/src/models/muse_glimmer_batch_tests.rs
+++ b/src/models/muse_glimmer_batch_tests.rs
@@ -1,3 +1,17 @@
+// Copyright 2025-2026 Lablup Inc. and Jeongkyu Shin
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 use super::*;
 use mlxcel_core::cache::{SequenceId, SequenceStateBackend};
 use mlxcel_core::generate::LanguageModel;

--- a/src/models/muse_glimmer_tests.rs
+++ b/src/models/muse_glimmer_tests.rs
@@ -1,3 +1,17 @@
+// Copyright 2025-2026 Lablup Inc. and Jeongkyu Shin
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 use super::*;
 use mlxcel_core::weights::WeightMap;
 

--- a/src/models/registry.rs
+++ b/src/models/registry.rs
@@ -1,3 +1,17 @@
+// Copyright 2025-2026 Lablup Inc. and Jeongkyu Shin
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 use serde::Serialize;
 
 use super::{ALL_MODEL_TYPES, ModelType};

--- a/src/multimodal/muse_glimmer_runtime_tests.rs
+++ b/src/multimodal/muse_glimmer_runtime_tests.rs
@@ -1,3 +1,17 @@
+// Copyright 2025-2026 Lablup Inc. and Jeongkyu Shin
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 use super::*;
 use crate::models::{
     DEFAULT_IMAGE_END_TOKEN_ID, DEFAULT_IMAGE_START_TOKEN_ID, DEFAULT_IMAGE_TOKEN_ID,

--- a/src/server/batch/generation_bounds.rs
+++ b/src/server/batch/generation_bounds.rs
@@ -1,3 +1,17 @@
+// Copyright 2025-2026 Lablup Inc. and Jeongkyu Shin
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 //! Per-request generation bounds that b10621 enforces during decode: the
 //! minimum-indentation stop (`n_indent`) and the prediction-phase deadline
 //! (`t_max_predict_ms`), both issue #1477.

--- a/src/server/batch/generation_bounds_tests.rs
+++ b/src/server/batch/generation_bounds_tests.rs
@@ -1,3 +1,17 @@
+// Copyright 2025-2026 Lablup Inc. and Jeongkyu Shin
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 //! Unit coverage for the two b10621 generation bounds (#1477).
 //!
 //! The fixtures are the pinned-binary measurements: a seeded `n_indent: 4`

--- a/src/server/batch/scheduler_muse_glimmer_parallel_tests.rs
+++ b/src/server/batch/scheduler_muse_glimmer_parallel_tests.rs
@@ -1,3 +1,17 @@
+// Copyright 2025-2026 Lablup Inc. and Jeongkyu Shin
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 use super::scheduler_muse_glimmer_support as muse;
 use super::*;
 use mlxcel_core::cache::{SequenceId, SequenceStateBackend};

--- a/src/server/batch/scheduler_muse_glimmer_support.rs
+++ b/src/server/batch/scheduler_muse_glimmer_support.rs
@@ -1,3 +1,17 @@
+// Copyright 2025-2026 Lablup Inc. and Jeongkyu Shin
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 use super::*;
 use image::{DynamicImage, ImageFormat, Rgb, RgbImage};
 use mlxcel_core::generate::SamplingConfig;

--- a/src/server/batch/scheduler_muse_glimmer_tests.rs
+++ b/src/server/batch/scheduler_muse_glimmer_tests.rs
@@ -1,3 +1,17 @@
+// Copyright 2025-2026 Lablup Inc. and Jeongkyu Shin
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 use super::*;
 use image::{DynamicImage, ImageFormat, Rgb, RgbImage};
 use mlxcel_core::cache::{SequenceId, SequenceStateBackend};

--- a/src/server/batch/xla_audio_preprocess_tests.rs
+++ b/src/server/batch/xla_audio_preprocess_tests.rs
@@ -1,3 +1,17 @@
+// Copyright 2025-2026 Lablup Inc. and Jeongkyu Shin
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 use std::sync::{Arc, Mutex, mpsc};
 use std::time::Duration;
 

--- a/src/server/max_tokens_route_tests.rs
+++ b/src/server/max_tokens_route_tests.rs
@@ -1,3 +1,17 @@
+// Copyright 2025-2026 Lablup Inc. and Jeongkyu Shin
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 use std::path::PathBuf;
 use std::sync::{Arc, mpsc};
 

--- a/src/server/model_provider_test_support.rs
+++ b/src/server/model_provider_test_support.rs
@@ -1,3 +1,17 @@
+// Copyright 2025-2026 Lablup Inc. and Jeongkyu Shin
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 impl ModelProvider {
     /// Build a model-free provider that records the options dispatched by HTTP
     /// route tests and immediately returns an empty successful generation.

--- a/src/server/muse_atem_roundtrip_tests.rs
+++ b/src/server/muse_atem_roundtrip_tests.rs
@@ -1,3 +1,17 @@
+// Copyright 2025-2026 Lablup Inc. and Jeongkyu Shin
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 use serde_json::{Value, json};
 
 use super::anthropic_translator::{

--- a/src/server/muse_atem_stream_anthropic_tests.rs
+++ b/src/server/muse_atem_stream_anthropic_tests.rs
@@ -1,3 +1,17 @@
+// Copyright 2025-2026 Lablup Inc. and Jeongkyu Shin
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 use std::collections::BTreeMap;
 
 use serde_json::{Value, json};

--- a/src/server/muse_atem_stream_chat_tests.rs
+++ b/src/server/muse_atem_stream_chat_tests.rs
@@ -1,3 +1,17 @@
+// Copyright 2025-2026 Lablup Inc. and Jeongkyu Shin
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 use std::collections::BTreeMap;
 
 use serde_json::json;

--- a/src/server/muse_atem_stream_responses_tests.rs
+++ b/src/server/muse_atem_stream_responses_tests.rs
@@ -1,3 +1,17 @@
+// Copyright 2025-2026 Lablup Inc. and Jeongkyu Shin
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 use std::collections::BTreeMap;
 
 use serde_json::json;

--- a/src/server/muse_atem_stream_support.rs
+++ b/src/server/muse_atem_stream_support.rs
@@ -1,3 +1,17 @@
+// Copyright 2025-2026 Lablup Inc. and Jeongkyu Shin
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 use serde::Serialize;
 use serde_json::{Value, json};
 

--- a/src/server/tool_calls/atem_stream_tests.rs
+++ b/src/server/tool_calls/atem_stream_tests.rs
@@ -1,3 +1,17 @@
+// Copyright 2025-2026 Lablup Inc. and Jeongkyu Shin
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 use super::{FilterOutput, StreamFilter};
 use crate::server::tool_calls::{ToolCallFormat, parse_tool_calls};
 

--- a/src/server/tool_calls/atem_tests.rs
+++ b/src/server/tool_calls/atem_tests.rs
@@ -1,3 +1,17 @@
+// Copyright 2025-2026 Lablup Inc. and Jeongkyu Shin
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 use std::str::FromStr as _;
 
 use serde_json::Value;

--- a/src/vision/processors/muse_glimmer_tests.rs
+++ b/src/vision/processors/muse_glimmer_tests.rs
@@ -1,3 +1,17 @@
+// Copyright 2025-2026 Lablup Inc. and Jeongkyu Shin
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 use image::{DynamicImage, Rgb, RgbImage};
 
 use super::*;

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -1,3 +1,17 @@
+// Copyright 2025-2026 Lablup Inc. and Jeongkyu Shin
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 use std::ffi::OsStr;
 use std::path::{Path, PathBuf};
 

--- a/tests/mamba2_hybrid_finite.rs
+++ b/tests/mamba2_hybrid_finite.rs
@@ -1,3 +1,17 @@
+// Copyright 2025-2026 Lablup Inc. and Jeongkyu Shin
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 //! The guard `granitemoehybrid.rs` and `falcon_h1.rs` name in the comment that
 //! records why the M5 per-mixer `eval` was removed. It did not exist: both
 //! comments cited `mamba2_hybrid_decode_is_finite` and nothing defined it, so

--- a/tests/pipeline_cli_real_models.rs
+++ b/tests/pipeline_cli_real_models.rs
@@ -1,3 +1,17 @@
+// Copyright 2025-2026 Lablup Inc. and Jeongkyu Shin
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 mod common;
 
 use std::process::Command;

--- a/tests/pipeline_remote_real_models.rs
+++ b/tests/pipeline_remote_real_models.rs
@@ -1,3 +1,17 @@
+// Copyright 2025-2026 Lablup Inc. and Jeongkyu Shin
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 mod common;
 
 use std::net::{IpAddr, TcpListener};

--- a/tests/pipeline_server_real_models.rs
+++ b/tests/pipeline_server_real_models.rs
@@ -1,3 +1,17 @@
+// Copyright 2025-2026 Lablup Inc. and Jeongkyu Shin
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 mod common;
 
 use std::net::TcpListener;

--- a/tests/pipeline_server_remote_real_models.rs
+++ b/tests/pipeline_server_remote_real_models.rs
@@ -1,3 +1,17 @@
+// Copyright 2025-2026 Lablup Inc. and Jeongkyu Shin
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 mod common;
 
 use std::net::TcpListener;

--- a/tests/pre_ampere_f16_quality.rs
+++ b/tests/pre_ampere_f16_quality.rs
@@ -1,3 +1,17 @@
+// Copyright 2025-2026 Lablup Inc. and Jeongkyu Shin
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 //! Quality gate for the pre-Ampere load-time bf16 -> f16 conversion (#1542).
 //!
 //! Volta (sm_70) and Turing (sm_75) have no bf16 ALU, no bf16 tensor-core MMA

--- a/tests/test_insert_apache_header.py
+++ b/tests/test_insert_apache_header.py
@@ -9,10 +9,13 @@ sys.path.insert(0, str(REPO_ROOT))
 from scripts.insert_apache_header import (  # noqa: E402
     PROJECT_COPYRIGHT_LINE,
     PROJECT_HEADER,
+    TARGET_FILES,
+    files_missing_header,
     has_existing_header,
     insert_header,
     insert_header_in_file,
     iter_target_files,
+    main,
     should_process_path,
 )
 
@@ -23,7 +26,12 @@ class InsertApacheHeaderTests(unittest.TestCase):
         self.assertTrue(should_process_path(Path("examples/demo.cpp")))
         self.assertTrue(should_process_path(Path("tests/sample.h")))
         self.assertTrue(should_process_path(Path("benches/audio_fft.rs")))
+        # Top-level shipped files reached via TARGET_FILES, not a root walk:
+        # `Path("build.rs").parts[0]` is the file itself and matches no root.
+        self.assertTrue(should_process_path(Path("build.rs")))
         self.assertFalse(should_process_path(Path("references/upstream.rs")))
+        # `spike/` is outside the workspace members and deliberately uncovered.
+        self.assertFalse(should_process_path(Path("spike/rust-emitter/src/main.rs")))
         self.assertFalse(should_process_path(Path("src/lib/mlxcel-core/target/tmp.rs")))
         self.assertFalse(should_process_path(Path("scripts/insert_apache_header.py")))
 
@@ -76,6 +84,86 @@ class InsertApacheHeaderTests(unittest.TestCase):
             paths = sorted(path.relative_to(root).as_posix() for path in iter_target_files(root))
 
             self.assertEqual(paths, ["src/owned.rs"])
+
+    def test_target_files_are_repo_relative_posix_paths(self):
+        # `should_process_path` compares against `path.as_posix()`, so a
+        # backslash or a leading "./" here would silently never match.
+        for name in TARGET_FILES:
+            self.assertEqual(name, Path(name).as_posix())
+
+    def test_iter_target_files_yields_top_level_target_files(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            (root / "build.rs").write_text("fn main() {}\n", encoding="utf-8")
+            (root / "src").mkdir()
+            (root / "src" / "owned.rs").write_text("fn main() {}\n", encoding="utf-8")
+            # A top-level Rust file that is NOT in TARGET_FILES stays out.
+            (root / "stray.rs").write_text("fn main() {}\n", encoding="utf-8")
+
+            paths = sorted(path.relative_to(root).as_posix() for path in iter_target_files(root))
+
+            self.assertEqual(paths, ["build.rs", "src/owned.rs"])
+
+    def test_files_missing_header_agrees_with_the_writer(self):
+        # The check mode must report exactly the files the default insert mode
+        # would write to. If these two ever diverge, CI would demand an edit
+        # that running the script does not produce.
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            (root / "src").mkdir()
+            bare = root / "src" / "bare.rs"
+            bare.write_text("fn main() {}\n", encoding="utf-8")
+            covered = root / "src" / "covered.rs"
+            covered.write_text(PROJECT_HEADER + "fn main() {}\n", encoding="utf-8")
+            external = root / "src" / "external.rs"
+            external.write_text(
+                "// Copyright 2025 upstream authors\nfn main() {}\n", encoding="utf-8"
+            )
+
+            missing = files_missing_header(root)
+            self.assertEqual([p.relative_to(root).as_posix() for p in missing], ["src/bare.rs"])
+
+            # The writer touches exactly that one file, and no other.
+            written = {
+                path.relative_to(root).as_posix()
+                for path in iter_target_files(root)
+                if insert_header_in_file(path)
+            }
+            self.assertEqual(written, {"src/bare.rs"})
+
+    def test_files_missing_header_does_not_write(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            (root / "src").mkdir()
+            bare = root / "src" / "bare.rs"
+            original = "fn main() {}\n"
+            bare.write_text(original, encoding="utf-8")
+
+            files_missing_header(root)
+
+            self.assertEqual(bare.read_text(encoding="utf-8"), original)
+
+    def test_check_mode_passes_on_the_real_repository(self):
+        # The gate `.github/workflows/ci.yml` runs. Kept as a unit test too so
+        # a missing header fails locally before it reaches CI.
+        self.assertEqual(main(["--check"]), 0)
+
+    def test_check_mode_reports_and_fails_on_a_missing_header(self):
+        # Negative coverage: without this, a --check that always returned 0
+        # would pass every other test here.
+        import scripts.insert_apache_header as mod
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            (root / "src").mkdir()
+            (root / "src" / "bare.rs").write_text("fn main() {}\n", encoding="utf-8")
+
+            original_root = mod.REPO_ROOT
+            mod.REPO_ROOT = root
+            try:
+                self.assertEqual(mod.main(["--check"]), 1)
+            finally:
+                mod.REPO_ROOT = original_root
 
 
 if __name__ == "__main__":

--- a/tests/test_insert_apache_header.py
+++ b/tests/test_insert_apache_header.py
@@ -22,6 +22,7 @@ class InsertApacheHeaderTests(unittest.TestCase):
         self.assertTrue(should_process_path(Path("src/lib.rs")))
         self.assertTrue(should_process_path(Path("examples/demo.cpp")))
         self.assertTrue(should_process_path(Path("tests/sample.h")))
+        self.assertTrue(should_process_path(Path("benches/audio_fft.rs")))
         self.assertFalse(should_process_path(Path("references/upstream.rs")))
         self.assertFalse(should_process_path(Path("src/lib/mlxcel-core/target/tmp.rs")))
         self.assertFalse(should_process_path(Path("scripts/insert_apache_header.py")))


### PR DESCRIPTION
## Summary

Add `"benches"` to `TARGET_ROOTS` in `scripts/insert_apache_header.py` so the Apache-header insertion script covers the `benches/` directory. Insert the standard header into `benches/audio_fft.rs`, the only Rust source file under a top-level source root that was missing it. Extend the Python test by one assertion to pin the new root.

Closes #1707

## Changes

| File | Change |
|------|--------|
| `scripts/insert_apache_header.py` | Add `"benches"` to `TARGET_ROOTS` |
| `benches/audio_fft.rs` | Insert the standard Apache 2.0 license header |
| `tests/test_insert_apache_header.py` | Add `should_process_path("benches/audio_fft.rs")` assertion |

## Verification

```bash
python3 -m pytest tests/test_insert_apache_header.py -v
# 5 passed
```

Running the script itself confirms `benches/audio_fft.rs` is now recognized and skipped (header already present):
```
⏭️  Skipped existing header: .../benches/audio_fft.rs
```

## Acceptance Criteria (from #1707)

- [x] `benches/audio_fft.rs` carries the standard header
- [x] The script and its test cover `benches/`