### PR TITLE
fix(solar_open): pair the GPTQ biases dtype with the scales dtype

### DIFF
--- a/docs/f32-promotion-audit.md
+++ b/docs/f32-promotion-audit.md
@@ -1,0 +1,38 @@
+# The f32 promotion audit
+
+`lablup/mlxcel#1711` found that `mistral4.rs` built its Llama-4 attention scale from a host `&[f32]`, so the multiply promoted `q` to f32, and that dtype rode the residual stream through every later layer, forcing each matmul to promote its own weight. The checkpoint measured 37% of mlx-vlm before the cast and 100% after, which is 5.19x on M5 Max.
+
+That issue's description asked for a static audit of every other site where an f32 constant is constructed and combined with an activation. This file records the result, because the useful part is the negative one: of 50 candidate sites, one was a defect. `scripts/audit_f32_promotion.py` runs the same two searches, and reports 49 in broad mode now that the one defect is fixed.
+
+## What the search looks for
+
+An f32 array is built by `from_slice_f32`, `full_f32`, `zeros_f32`, `ones_f32` or `arange_f32` without being told a dtype, and then reaches `multiply`, `add`, `subtract`, `divide`, `maximum` or `minimum` with another operand. MLX promotes on the wider operand, so if that other operand is an activation, the result leaves the line as f32.
+
+Three refinements matter, and each was learned by getting it wrong first. A constructor that takes a dtype captured earlier (`full_f32(&[1], alpha, input_dtype)`) is not a source, and missing that put 80 sites on the first list instead of 50. A block that computes in f32 on purpose and casts at the end is not a defect either, and the cast is usually applied to a derived variable several lines later, so a search that only looks for a cast of the constructed name reports the whole block. And a constructor immediately re-bound through a cast is fixed, not broken: without that check the narrow search reported the very site it had just caused to be repaired.
+
+## Why 49 of the 50 are not defects
+
+**The promotion is cast away before it reaches the residual stream.** The five MoE routers that multiply `topk_scores` by an f32 `routed_scaling_factor` (`glm4_moe`, `solar_open`, `deepseek`, `glm4_moe_lite`, `dots1`) all pass their scores to `switch_layers::moe_weighted_sum`, which casts to `array_dtype(expert_out)` before the multiply and to the requested output dtype after the sum. The f32 arithmetic is real but confined to a `[n_tokens, k]` tensor. `ernie4_5_moe_vl` reaches the same function.
+
+**The block computes in f32 deliberately and casts at the end.** `llama4.rs` captures `q_dtype` before building the attention scale and casts before multiplying into `q`, which is what `#1711` meant when it said llama4 was the original of the pattern and needed no change. `gemma3n.rs`'s sparse activation ends in `astype(..., array_dtype(&gate))`. `deepseek_v4_hyper`'s Sinkhorn gate ends in `astype(&collapsed, x_dtype)`. `bailing_moe_linear`'s chunk decay casts inside the same expression.
+
+**The quantity is f32 by design.** `deepseek_v4_indexer` documents its inputs as f32 and returns int32 indices. Rope angle tables in `glm4v` and `hunyuan_vl` cast the positions to f32 first, on purpose. `kimi_linear` passes `FLOAT16` explicitly, and the search flagged it only because the literal is not `array_dtype`.
+
+**The site runs once per image or per request rather than per token.** Fourteen of the 50 are in `src/vision/encoders/`, eight elsewhere under `src/vision/`, six in `src/audio/`, and one in `lora/loader.rs` at load time. A promotion there costs prefill, not decode, and none of them was found to escape either.
+
+## The one that was real
+
+`solar_open.rs`, in `gptq_to_mlx_tensors`. Step 4 casts the scales to f16 with a comment saying it does so because `quantized_matmul` and `gather_qmm` expect that dtype. Step 5 then computes the biases, and the two branches disagreed: the `qzeros` branch passed `scales_dtype` down to `compute_mlx_biases_from_qzeros`, while the symmetric branch built its zero point from a host `f32` and let MLX promote, returning f32 biases beside f16 scales. A GPTQ checkpoint without `qzeros` loaded a mismatched pair into every quantized matmul.
+
+The function stated its own intent two lines above the line that broke it, which is the shape worth remembering. The search that finds this one is narrower than the general audit: a site inside a function that names an intended dtype and does not use it at that call.
+
+`gptq_biases_match_the_scales_dtype_in_both_branches` pins it, and asserts the two dtypes are equal rather than naming f16 twice, because the pairing is the invariant. Reverting the cast fails the test with `left: 10` against `right: 9`.
+
+## Re-running it
+
+```bash
+python3 scripts/audit_f32_promotion.py --mode narrow   # 19 sites
+python3 scripts/audit_f32_promotion.py --mode broad    # 49 sites
+```
+
+The audit is a search, not a test, and it is not wired into CI. Nothing here forbids a new f32 constructor; the point is that the broad form has a high false-positive rate and the narrow form is where the one defect came from. The script was checked the same way the fix was: it reports nothing for the repaired code and names `solar_open.rs:196` again the moment the cast is removed.

--- a/scripts/audit_f32_promotion.py
+++ b/scripts/audit_f32_promotion.py
@@ -1,0 +1,116 @@
+#!/usr/bin/env python3
+"""Find f32 constants that may promote an activation.
+
+Two searches, described in docs/f32-promotion-audit.md. Neither is a gate: the
+broad form has a high false-positive rate by construction, and the narrow form
+is the one that found the only real defect the 2026-09 audit turned up.
+
+  broad   an f32 array built without a dtype reaches an elementwise op
+  narrow  the same, inside a function that names an intended dtype and does
+          not pass it at this call
+
+Every hit needs reading. A block that computes in f32 on purpose and casts at
+the end is correct, and the cast is usually applied to a derived name several
+lines later, so no purely local rule can tell the two apart.
+"""
+
+import argparse
+import glob
+import re
+
+CTOR = re.compile(
+    r"let\s+(?:mut\s+)?(\w+)\s*=\s*mlxcel_core::"
+    r"(from_slice_f32|full_f32|zeros_f32|ones_f32|arange_f32)\s*\("
+)
+ELEM = re.compile(
+    r"mlxcel_core::(multiply|add|subtract|divide|maximum|minimum)\(\s*&?([\w.]+)\s*,\s*&?([\w.]+)"
+)
+FN = re.compile(r"^\s*(pub\s+)?(async\s+)?fn\s+(\w+)")
+DTVAR = re.compile(r"let\s+(\w+)\s*(?::\s*\w+)?\s*=\s*mlxcel_core::array_dtype\(")
+DTLOCAL = re.compile(r"let\s+(\w*dtype\w*)\s*(?::\s*\w+)?\s*=")
+
+
+def enclosing_fn(lines, i):
+    for j in range(i, -1, -1):
+        m = FN.match(lines[j])
+        if not m:
+            continue
+        depth, seen = 0, False
+        for k in range(j, len(lines)):
+            depth += lines[k].count("{") - lines[k].count("}")
+            seen = seen or lines[k].count("{") > 0
+            if seen and depth <= 0:
+                return m.group(3), j, k
+        return m.group(3), j, len(lines) - 1
+    return None
+
+
+def sources(path):
+    return [
+        f
+        for f in glob.glob(f"{path}/**/*.rs", recursive=True)
+        if "_tests.rs" not in f and "/tests/" not in f and "/examples/" not in f
+    ]
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--mode", choices=["broad", "narrow"], default="narrow")
+    ap.add_argument("--path", default="src")
+    args = ap.parse_args()
+
+    hits = []
+    for f in sources(args.path):
+        text = open(f, encoding="utf-8").read()
+        lines = text.split("\n")
+        dtvars = set(DTVAR.findall(text))
+        for i, line in enumerate(lines):
+            m = CTOR.search(line)
+            if not m:
+                continue
+            name = m.group(1)
+            call = "\n".join(lines[i : i + 6]).split(";")[0]
+            # a constructor told a dtype is not a promotion source
+            if "array_dtype(" in call:
+                continue
+            if any(re.search(rf"\b{re.escape(v)}\b", call) for v in dtvars):
+                continue
+            enc = enclosing_fn(lines, i)
+            if not enc:
+                continue
+            fn_name, start, end = enc
+            body = "\n".join(lines[start : end + 1])
+            # A constructor immediately re-bound through a cast is handled,
+            # whichever mode is running. Without this the search reports the
+            # sites it has already caused to be fixed.
+            window = lines[i + 1 : i + 12]
+            if any(
+                re.search(rf"let\s+{re.escape(name)}\s*=\s*mlxcel_core::astype\(", w)
+                for w in window
+            ):
+                continue
+
+            if args.mode == "narrow":
+                intended = set(DTLOCAL.findall(body))
+                if not intended:
+                    continue
+                if any(re.search(rf"\b{re.escape(v)}\b", call) for v in intended):
+                    continue
+                hits.append((f, i + 1, name, fn_name, ",".join(sorted(intended))))
+            else:
+                if any("array_dtype(" in w and name in w for w in window):
+                    continue
+                for w in window:
+                    em = ELEM.search(w)
+                    if em and name in (em.group(2), em.group(3)):
+                        hits.append((f, i + 1, name, fn_name, ""))
+                        break
+
+    for f, ln, name, fn_name, extra in hits:
+        note = f"  intended dtype in scope: {extra}" if extra else ""
+        print(f"{f}:{ln}  {name}  (fn {fn_name}){note}")
+    print(f"\n{len(hits)} candidate(s) in {args.mode} mode. Each needs reading.")
+
+
+if __name__ == "__main__":
+    main()

--- a/src/models/solar_open.rs
+++ b/src/models/solar_open.rs
@@ -183,9 +183,18 @@ fn gptq_to_mlx_tensors(
     let mlx_biases = if let Some(qz) = qzeros {
         compute_mlx_biases_from_qzeros(qz, &mlx_scales, pack_factor, scales_dtype)
     } else {
-        // Symmetric quantization: zero_point = 2^(bits-1)
+        // Symmetric quantization: zero_point = 2^(bits-1).
+        //
+        // The scalar is built from a host `f32`, so it has to be cast to
+        // `scales_dtype` before the multiply. Without the cast MLX promotes on
+        // the wider operand and this branch hands back f32 biases beside f16
+        // scales, while the `qzeros` branch above passes `scales_dtype` through
+        // and returns f16. Step 4 casts the scales specifically so the
+        // quantized_matmul and gather_qmm paths see the dtype they expect, and
+        // biases are the other half of that pair.
         let zero_point = (1 << (bits - 1)) as f32;
         let neg_zp = mlxcel_core::from_slice_f32(&[-zero_point], &[1]);
+        let neg_zp = mlxcel_core::astype(&neg_zp, scales_dtype);
         mlxcel_core::multiply(&mlx_scales, &neg_zp)
     };
 
@@ -932,6 +941,59 @@ fn get_weight_copy(weights: &WeightMap, name: &str) -> Result<UniquePtr<MlxArray
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// Both quantization branches have to hand back biases in the same dtype as
+    /// the scales they sit beside.
+    ///
+    /// Step 4 of `gptq_to_mlx_tensors` casts the scales to f16 on purpose, so
+    /// that `quantized_matmul` and `gather_qmm` see the dtype they expect. The
+    /// `qzeros` branch passes that dtype down; the symmetric branch built its
+    /// zero point from a host `f32` and let MLX promote on the wider operand,
+    /// so a checkpoint without `qzeros` loaded f16 scales beside f32 biases.
+    /// The pair is what matters here, not either dtype on its own, which is why
+    /// this asserts equality rather than naming f16 twice.
+    #[test]
+    fn gptq_biases_match_the_scales_dtype_in_both_branches() {
+        let bits = 4;
+        let pack_factor = 32 / bits;
+        let in_features = 16;
+        let out_features = 4;
+        let n_groups = 2;
+
+        let qweight = mlxcel_core::from_slice_i32(
+            &vec![0x1234_5678u32 as i32; ((in_features / pack_factor) * out_features) as usize],
+            &[in_features / pack_factor, out_features],
+        );
+        let scales = mlxcel_core::from_slice_f32(
+            &vec![0.05f32; (n_groups * out_features) as usize],
+            &[n_groups, out_features],
+        );
+        let qzeros = mlxcel_core::from_slice_i32(
+            &vec![0x8888_8888u32 as i32; (n_groups * (out_features / pack_factor).max(1)) as usize],
+            &[n_groups, (out_features / pack_factor).max(1)],
+        );
+
+        let (_, sym_scales, sym_biases) = gptq_to_mlx_tensors(&qweight, &scales, None, bits, 128);
+        assert_eq!(
+            mlxcel_core::array_dtype(&sym_biases),
+            mlxcel_core::array_dtype(&sym_scales),
+            "symmetric branch: biases dtype must equal scales dtype"
+        );
+
+        let (_, qz_scales, qz_biases) =
+            gptq_to_mlx_tensors(&qweight, &scales, Some(&qzeros), bits, 128);
+        assert_eq!(
+            mlxcel_core::array_dtype(&qz_biases),
+            mlxcel_core::array_dtype(&qz_scales),
+            "qzeros branch: biases dtype must equal scales dtype"
+        );
+
+        assert_eq!(
+            mlxcel_core::array_dtype(&sym_biases),
+            mlxcel_core::array_dtype(&qz_biases),
+            "the two branches must agree with each other"
+        );
+    }
 
     #[test]
     fn test_solar_open_config_parsing() {


### PR DESCRIPTION
The static audit lablup/mlxcel#1711 asked for, plus the one defect it found.

#1711 fixed `mistral4.rs`, where an attention scale built from a host `&[f32]` promoted `q` and that dtype rode the residual stream through every later layer. The checkpoint went from 37% of mlx-vlm to 100%. Its description asked for a sweep of every other site with the same shape.

## The result is mostly negative, and that is the deliverable

50 candidate sites, one defect. `docs/f32-promotion-audit.md` records why the other 49 are not, grouped by the reason, because re-running the search without that file produces the same list and the same three days of reading.

The largest group is five MoE routers that multiply `topk_scores` by an f32 `routed_scaling_factor`. They all reach `switch_layers::moe_weighted_sum`, which casts to `array_dtype(expert_out)` before the multiply, so the promotion never leaves a `[n_tokens, k]` tensor. `llama4`, `gemma3n` and `deepseek_v4_hyper` compute in f32 on purpose and cast at the end, which is what #1711 meant by calling llama4 the original of the pattern. Rope angle tables and the `deepseek_v4` indexer are f32 by design. Twenty-nine sites are in vision encoders, audio encoders or weight loading, so they cost prefill rather than decode.

## The defect

`solar_open.rs`, `gptq_to_mlx_tensors`. Step 4 casts the scales to f16 and says why: `quantized_matmul` and `gather_qmm` expect it. Step 5 computes the biases in two branches, and only one of them honours that. The `qzeros` branch passes `scales_dtype` down; the symmetric branch built its zero point from a host `f32` and let MLX promote, returning f32 biases beside f16 scales. A GPTQ checkpoint without `qzeros` loaded a mismatched pair into every quantized matmul.

The function stated its own intent two lines above the line that broke it, which is why the narrow search finds this class and the broad one drowns it.

## Tooling

`scripts/audit_f32_promotion.py` runs both searches so the next person starts from a method rather than a claim. Narrow mode reports 19 sites, broad mode 49. It skips a constructor that is immediately re-bound through a cast, because without that it reported the very site it had just caused to be repaired.

## Validation

`gptq_biases_match_the_scales_dtype_in_both_branches` asserts the two dtypes are equal rather than naming f16 twice, since the pairing is the invariant. Reverting the cast fails it with `left: 10` against `right: 9`, and the script names the site again in the same state. Workspace gate 10540 passed, 0 failed; fmt and clippy clean.

No checkpoint measurement is included. The change is a load-time dtype for GPTQ checkpoints without `qzeros`, and no such checkpoint is in either benchmark store, so a claim about its speed would not be one I had measured.
