### PR TITLE
feat(bench): hold the comparison preconditions in one tool

### DIFF
--- a/docs/benchmarks.md
+++ b/docs/benchmarks.md
@@ -95,6 +95,26 @@ actually hold: 88 carry `mlxcel_version`, 15 pre-2026-06-12 files carry a real
 `mlx_version` (the column was hardcoded to the MLX release then), and 26 Python
 baseline files carry `baseline_version`.
 
+## Comparing two CSVs
+
+Do not write the join by hand. `scripts/compare_bench_csv.py` holds the preconditions that a comparison has to satisfy, and it refuses rather than returning a number when one fails.
+
+```bash
+# the runtime against its own earlier sweep
+scripts/compare_bench_csv.py --before benchmarks/metal_m5max_vlm_2026-09-06.csv \
+    --after benchmarks/metal_m5max_vlm_2026-09-09.csv --allow-commit-change
+
+# the runtime against a reference, which has to be the same host and day
+scripts/compare_bench_csv.py --before benchmarks/pylm_m5max_vlm_2026-09-09.csv \
+    --after benchmarks/metal_m5max_vlm_2026-09-09.csv --reference
+```
+
+It refuses a VLM row paired with a text one, refuses two different `mlxcel_commit` values unless the version change is what you are measuring, refuses a reference measured more than a day apart, drops pairs whose `prompt_tokens` disagree by more than 10%, and excludes embedders and rerankers from a generation roster. Names resolve through `docs/model-catalog.tsv`, whose `aliases` column is `;`-separated. It also warns when a baseline row has been superseded by a newer reading in another CSV for the same host and harness, which is the case that reads as a change and is not one.
+
+Every drop is reported with its reason. A pair count alone hides what it left out.
+
+The tool exists because six published figures from the 2026-09 campaign were wrong in exactly these ways, and each comparison had been written separately with a different subset of the checks. Replaying them against the tool: the 0.35x cross-host deficit and the 298% margin both refuse outright, the 61% parity figure exits non-zero on the harness mismatch, and the pair count disagreement between two hosts resolves because the roster policy is in one place. The corrected margins reproduce, 105% on M5 Max and 108% on M1 Ultra.
+
 ## Suggested benchmark commands
 
 The repository contains benchmark helper scripts under `scripts/`. The exact

--- a/scripts/bench_all_models.sh
+++ b/scripts/bench_all_models.sh
@@ -6,7 +6,9 @@ set -euo pipefail
 
 MLXCEL="./target/release/mlxcel"
 BENCH="./target/release/examples/batch_benchmark"
-MODELS_DIR="./models"
+MODELS_DIR="${MODELS_DIR:-./models}"
+source "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/lib/store_guard.sh"
+
 PORT=18080
 OUTPUT="${1:-benchmark_batching_results.log}"
 MAX_TOKENS=50
@@ -30,6 +32,8 @@ SUCCESS=0
 FAILED=0
 SKIPPED=0
 FAILED_LIST=""
+
+require_checkpoints "$MODELS_DIR" "continuous-batching sweep"
 
 for MODEL_DIR in "$MODELS_DIR"/*/; do
     MODEL_NAME=$(basename "$MODEL_DIR")

--- a/scripts/bench_longprompt.sh
+++ b/scripts/bench_longprompt.sh
@@ -101,7 +101,9 @@ trap 'echo "Interrupted (signal received)" >&2; exit 130' INT TERM
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 BENCH_DECODE="${SCRIPT_DIR}/bench_decode.sh"
-MODELS_DIR="./models"
+MODELS_DIR="${MODELS_DIR:-./models}"
+source "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/lib/store_guard.sh"
+
 BENCHMARKS_DIR="./benchmarks"
 DATE=$(date '+%Y-%m-%d')
 
@@ -113,7 +115,11 @@ CSV_HEADER="model,model_path,prompt_tokens,generated_tokens,prefill_ms,prefill_t
 
 # Representative subset: mix of dense (llama, qwen2.5), MoE (qwen3-a3b,
 # mixtral), and a large multimodal-capable text model (gemma-4).
-MODELS_DEFAULT="llama-3.1-8b-4bit qwen2.5-7b-4bit qwen3-30b-a3b-4bit mixtral-8x7b-4bit gemma-4-31b-it-4bit"
+# Directory names as of the 2026-09-09 store consolidation. Three of the
+# previous five (llama-3.1-8b-4bit, qwen2.5-7b-4bit, mixtral-8x7b-4bit) were
+# renamed then, so this list had been naming directories that no longer
+# existed and the sweep skipped them.
+MODELS_DEFAULT="meta-llama-3.1-8b-instruct-4bit qwen2.5-7b-instruct-4bit qwen3-30b-a3b-4bit mixtral-8x7b-instruct-v0.1-4bit gemma-4-31b-it-4bit"
 LADDER_DEFAULT="512 2048 8192 32768"
 
 MODELS="$MODELS_DEFAULT"
@@ -402,6 +408,8 @@ fi
 >&2 echo ""
 
 header_written=0
+require_named_checkpoints "$MODELS_DIR" "long-prompt sweep" $MODELS
+
 for model_name in $MODELS; do
   model_path="${MODELS_DIR}/${model_name}"
   if [[ ! -d "$model_path" ]]; then

--- a/scripts/bench_na_attention.sh
+++ b/scripts/bench_na_attention.sh
@@ -14,7 +14,9 @@
 set -euo pipefail
 
 MLXCEL="./target/release/mlxcel"
-MODELS_DIR="./models"
+MODELS_DIR="${MODELS_DIR:-./models}"
+source "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/lib/store_guard.sh"
+
 BENCHMARKS_DIR="./benchmarks"
 PROMPT="Hello, how are you today?"
 MAX_TOKENS=50
@@ -234,6 +236,7 @@ emit() {
 }
 
 if [[ "$MODEL_ARG" == "all" ]]; then
+  require_checkpoints "$MODELS_DIR" "NA-attention sweep"
   while IFS= read -r dir; do
     [[ -d "$dir" ]] || continue
     emit "$(bench_one "$dir")"

--- a/scripts/compare_bench_csv.py
+++ b/scripts/compare_bench_csv.py
@@ -1,0 +1,279 @@
+#!/usr/bin/env python3
+"""Compare two benchmark CSVs and refuse the joins that are not comparable.
+
+Every wrong number the 2026-09 VLM campaign put in front of a reader came from
+pairing two rows that were not measuring the same thing, and each time the
+comparison itself was ad-hoc, so a precondition checked in one place was missing
+in the next. This tool holds all of them in one place:
+
+  harness   a VLM row is never paired with a text row
+  prompt    prompt_tokens must agree within a tolerance
+  commit    both sides must carry the same mlxcel_commit, unless the comparison
+            is against a reference runtime, where the runtime commit is the
+            thing being compared and only the dates have to be close
+  roster    non-generative checkpoints are excluded by an explicit list rather
+            than by whoever wrote the join that day
+
+Names are resolved through docs/model-catalog.tsv, whose `aliases` column is
+`;`-separated. Splitting it on `,` silently loses thirteen keys, two of which
+were the control checkpoints of that campaign.
+
+Dropped rows are always reported with the reason. A pair count on its own says
+nothing about what it left out, and "n=48" was itself one of the wrong numbers.
+
+Examples:
+
+    # runtime against its own earlier sweep: commits must differ, everything
+    # else must match, and the tool says which rows moved
+    scripts/compare_bench_csv.py --before benchmarks/metal_m5max_vlm_2026-09-06.csv \\
+        --after benchmarks/metal_m5max_vlm_2026-09-09.csv --allow-commit-change
+
+    # runtime against a reference: same host, same day
+    scripts/compare_bench_csv.py --before benchmarks/pylm_m5max_vlm_2026-09-09.csv \\
+        --after benchmarks/metal_m5max_vlm_2026-09-09.csv --reference
+"""
+
+import argparse
+import csv
+import glob
+import os
+import statistics
+import sys
+
+CATALOG = "docs/model-catalog.tsv"
+
+# Checkpoints that a generation harness loads but does not meaningfully measure.
+# An embedder or reranker driven through a decode loop produces a number, and
+# that number is not a decode rate. Excluding them is a policy, so it lives here
+# rather than in whichever comparison is being written.
+NON_GENERATIVE = ("embedding", "rerank", "-embed-", "colqwen", "colsmol")
+
+
+def load_aliases(path=CATALOG):
+    """Map every historical name to the directory name in use now."""
+    alias = {}
+    if not os.path.exists(path):
+        return alias
+    with open(path, encoding="utf-8") as fh:
+        for row in csv.DictReader(fh, delimiter="\t"):
+            local = row["local_name"]
+            alias[local] = local
+            for name in (row.get("aliases") or "").split(";"):
+                if name.strip():
+                    alias[name.strip()] = local
+    return alias
+
+
+def harness_of(path):
+    """VLM sweeps carry `_vlm_` in the filename; nothing else distinguishes them."""
+    return "vlm" if "_vlm_" in os.path.basename(path) else "text"
+
+
+def load_rows(path, alias):
+    rows = {}
+    with open(path, encoding="utf-8") as fh:
+        for row in csv.DictReader(fh):
+            name = row.get("model")
+            if not name:
+                continue
+            try:
+                decode = float(row["decode_tok_s"])
+                prompt = float(row["prompt_tokens"])
+            except (KeyError, TypeError, ValueError):
+                continue
+            key = alias.get(name, name)
+            rows[key] = {
+                "decode": decode,
+                "prompt": prompt,
+                "prefill": row.get("prefill_tok_s") or "",
+                "commit": (row.get("mlxcel_commit") or "").replace("-dirty", ""),
+                "date": row.get("date") or "",
+                "raw_name": name,
+            }
+    return rows
+
+
+def newer_readings_elsewhere(before_path, after_path, names, alias, before_rows):
+    """Rows in `before` that some other CSV has measured more recently.
+
+    This is the check that matters most. `mistral-small-4-119b-2603-4bit` read
+    0.35x cross-host and was taken for the largest hardware deficit in the set,
+    because one host's sweep file still held a pre-fix number while a newer
+    per-model CSV sitting beside it held the current one. Comparing two sweep
+    files is correct and still misses that, so the scan is over every CSV for
+    the same host and harness, not just the two being compared.
+    """
+    base = os.path.basename(before_path)
+    host = "m5max" if "m5max" in base else "m1ultra" if "m1ultra" in base else None
+    runtime = "pylm" if base.startswith("pylm") else "metal"
+    if host is None:
+        return {}
+    harness = harness_of(before_path)
+    after_date = ""
+    with open(after_path, encoding="utf-8") as fh:
+        for row in csv.DictReader(fh):
+            after_date = max(after_date, row.get("date") or "")
+
+    stale = {}
+    for path in sorted(glob.glob(f"benchmarks/{runtime}_{host}_*.csv")):
+        if os.path.abspath(path) in (os.path.abspath(before_path), os.path.abspath(after_path)):
+            continue
+        if harness_of(path) != harness:
+            continue
+        try:
+            rows = load_rows(path, alias)
+        except (OSError, csv.Error):
+            continue
+        for name, row in rows.items():
+            if name not in names:
+                continue
+            # Only a reading taken after the baseline row and before the run
+            # being judged supersedes anything. Without the first half of that
+            # the scan reports every older file as if it were newer.
+            if row["date"] <= before_rows[name]["date"]:
+                continue
+            if after_date and row["date"] >= after_date:
+                continue
+            prev = stale.get(name)
+            if prev is None or row["date"] > prev[1]:
+                stale[name] = (row["decode"], row["date"], os.path.basename(path))
+    return stale
+
+
+def quantiles(values):
+    ordered = sorted(values)
+    n = len(ordered)
+    return (
+        statistics.median(ordered),
+        ordered[n // 4],
+        ordered[(3 * n) // 4],
+        ordered[0],
+        ordered[-1],
+    )
+
+
+def main():
+    ap = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument("--before", required=True, help="baseline CSV")
+    ap.add_argument("--after", required=True, help="CSV being judged")
+    ap.add_argument(
+        "--reference",
+        action="store_true",
+        help="the two sides are different runtimes, so compare dates rather than commits",
+    )
+    ap.add_argument(
+        "--allow-commit-change",
+        action="store_true",
+        help="the two sides are the same runtime at different commits, which is the point",
+    )
+    ap.add_argument("--prompt-tolerance", type=float, default=0.10)
+    ap.add_argument("--max-date-gap-days", type=int, default=1)
+    ap.add_argument("--include-non-generative", action="store_true")
+    ap.add_argument("--moved-threshold", type=float, default=0.10)
+    args = ap.parse_args()
+
+    h_before, h_after = harness_of(args.before), harness_of(args.after)
+    if h_before != h_after:
+        print(
+            f"error: refusing to pair a {h_before} harness with a {h_after} one.\n"
+            f"  before: {args.before}\n  after:  {args.after}\n"
+            "  These measure different workloads. A VLM row compared against a text\n"
+            "  baseline produced a 61% figure that was really 157%.",
+            file=sys.stderr,
+        )
+        return 2
+
+    alias = load_aliases()
+    before = load_rows(args.before, alias)
+    after = load_rows(args.after, alias)
+
+    shared = sorted(set(before) & set(after))
+    paired, dropped = [], {"prompt": [], "commit": [], "non_generative": [], "date": []}
+
+    for name in shared:
+        b, a = before[name], after[name]
+        if not args.include_non_generative and any(t in name.lower() for t in NON_GENERATIVE):
+            dropped["non_generative"].append(name)
+            continue
+        if b["prompt"] > 0 and abs(a["prompt"] - b["prompt"]) / b["prompt"] > args.prompt_tolerance:
+            dropped["prompt"].append((name, b["prompt"], a["prompt"]))
+            continue
+        if args.reference:
+            if b["date"] and a["date"] and b["date"] != a["date"]:
+                gap = abs(int(a["date"].replace("-", "")) - int(b["date"].replace("-", "")))
+                if gap > args.max_date_gap_days:
+                    dropped["date"].append((name, b["date"], a["date"]))
+                    continue
+        elif not args.allow_commit_change:
+            if b["commit"] and a["commit"] and b["commit"] != a["commit"]:
+                dropped["commit"].append((name, b["commit"], a["commit"]))
+                continue
+        if b["decode"] > 0:
+            paired.append((a["decode"] / b["decode"], name, b["decode"], a["decode"]))
+
+    print(f"before: {args.before}  ({len(before)} measured)")
+    print(f"after:  {args.after}  ({len(after)} measured)")
+    print(f"harness: {h_after}    names in common: {len(shared)}")
+    print()
+
+    if not paired:
+        print("no comparable pairs. Every reason is listed below.")
+    else:
+        ratios = [p[0] for p in paired]
+        med, q1, q3, lo, hi = quantiles(ratios)
+        print(f"pairs {len(paired)}   median {med:.3f}x   quartiles {q1:.3f}/{q3:.3f}   range {lo:.3f}-{hi:.3f}x")
+        moved = [p for p in paired if p[0] > 1 + args.moved_threshold or p[0] < 1 - args.moved_threshold]
+        print(f"moved more than {args.moved_threshold:.0%}: {len(moved)}")
+        for ratio, name, b, a in sorted(moved, key=lambda t: -t[0]):
+            print(f"  {ratio:6.2f}x  {name:<44} {b:>9.2f} -> {a:>9.2f}")
+
+    print()
+    total_dropped = sum(len(v) for v in dropped.values())
+    print(f"dropped {total_dropped} of {len(shared)} shared names:")
+    if dropped["non_generative"]:
+        print(f"  non-generative ({len(dropped['non_generative'])}): {', '.join(dropped['non_generative'])}")
+    if dropped["prompt"]:
+        print(f"  prompt length beyond {args.prompt_tolerance:.0%} ({len(dropped['prompt'])}):")
+        for name, b, a in sorted(dropped["prompt"], key=lambda t: -abs(t[2] - t[1]) / max(t[1], 1)):
+            print(f"    {name:<44} {b:>7.0f} -> {a:>7.0f}   delta {a - b:+.0f}")
+    if dropped["commit"]:
+        print(f"  different mlxcel_commit ({len(dropped['commit'])}), pass --allow-commit-change if that is the comparison:")
+        for name, b, a in dropped["commit"][:10]:
+            print(f"    {name:<44} {b} -> {a}")
+        if len(dropped["commit"]) > 10:
+            print(f"    ... and {len(dropped['commit']) - 10} more")
+    if dropped["date"]:
+        print(f"  measured more than {args.max_date_gap_days} day(s) apart ({len(dropped['date'])}):")
+        for name, b, a in dropped["date"][:10]:
+            print(f"    {name:<44} {b} vs {a}")
+        if len(dropped["date"]) > 10:
+            print(f"    ... and {len(dropped['date']) - 10} more")
+
+    if paired:
+        paired_names = {p[1] for p in paired}
+        newer = newer_readings_elsewhere(args.before, args.after, paired_names, alias, before)
+        superseded = []
+        for name, (decode, date, src) in newer.items():
+            was = before[name]["decode"]
+            if was > 0 and abs(decode - was) / was > args.moved_threshold:
+                superseded.append((name, was, decode, date, src))
+        if superseded:
+            print()
+            print(f"WARNING: {len(superseded)} of the {len(paired)} baselines are superseded elsewhere.")
+            print("  A newer reading for the same checkpoint, host and harness exists in another")
+            print("  CSV, so these ratios are measuring a stale row rather than a change.")
+            for name, was, now, date, src in sorted(superseded, key=lambda t: -abs(t[2] - t[1]) / t[1]):
+                print(f"    {name:<44} {was:>9.2f} -> {now:>9.2f}  ({date}, {src})")
+
+    only_before = sorted(set(before) - set(after))
+    only_after = sorted(set(after) - set(before))
+    if only_before or only_after:
+        print()
+        print(f"measured on one side only: {len(only_before)} before, {len(only_after)} after")
+        print("  These are not failures and not comparisons; they are unmeasured on the other side.")
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/lib/store_guard.sh
+++ b/scripts/lib/store_guard.sh
@@ -1,0 +1,62 @@
+# Shared model-store discovery guard for the benchmark shell harnesses.
+#
+# `MODELS_DIR` defaults to ./models, which holds checkpoints directly on one
+# benchmark host and only container directories on the other, where the real
+# roots are models/mlx and models/mlx-big. A sweep pointed at the wrong root
+# enumerated nothing, wrote a header-only CSV and exited 0; the only signal was
+# that a sweep budgeted in hours finished in two minutes. It happened twice in
+# one day, in two different harnesses.
+#
+# Source this, then call `require_checkpoints "$MODELS_DIR" <label>` before the
+# enumeration. A checkpoint is a directory holding config.json, the same
+# predicate the sweeps use to classify SKIP:not_a_checkpoint.
+#
+# Call it before any output file is created. A guard that runs after the header
+# is written cannot honestly say nothing was written.
+
+require_checkpoints() {
+  local root="$1" label="${2:-sweep}" entries=0 checkpoints=0 dir
+  for dir in "$root"/*/; do
+    [[ -d "$dir" ]] || continue
+    entries=$((entries + 1))
+    [[ -f "$dir/config.json" ]] && checkpoints=$((checkpoints + 1))
+  done
+  >&2 echo "Model store: $root ($entries entries, $checkpoints checkpoints)"
+  if [[ "$checkpoints" -eq 0 ]]; then
+    >&2 echo ""
+    >&2 echo "Error: no checkpoints under '$root' for the $label."
+    >&2 echo "  A sweep that measures nothing is a configuration error, not a"
+    >&2 echo "  result. Nothing was written and no existing file was touched."
+    >&2 echo "  If this host keeps checkpoints one level down, name that root:"
+    >&2 echo "    MODELS_DIR=models/mlx $0 ..."
+    exit 1
+  fi
+}
+
+# Named-roster variant. `bench_longprompt.sh` takes a model list rather than
+# enumerating, so its failure mode is different: the default roster named three
+# directories that the 2026-09-09 store consolidation had renamed, and the
+# sweep skipped them one at a time while still producing a CSV. Refuse when
+# none of the named models resolves, and say which ones did not.
+require_named_checkpoints() {
+  local root="$1" label="$2"; shift 2
+  local found=0 missing=() name
+  for name in "$@"; do
+    if [[ -f "$root/$name/config.json" ]]; then
+      found=$((found + 1))
+    else
+      missing+=("$name")
+    fi
+  done
+  >&2 echo "Model store: $root ($found of $# named checkpoints present)"
+  if [[ ${#missing[@]} -gt 0 ]]; then
+    >&2 echo "  not found: ${missing[*]}"
+    >&2 echo "  A renamed directory reads as a skip, so check these against"
+    >&2 echo "  docs/model-catalog.tsv rather than assuming they are absent."
+  fi
+  if [[ "$found" -eq 0 ]]; then
+    >&2 echo ""
+    >&2 echo "Error: none of the named checkpoints exists under '$root' for the $label."
+    exit 1
+  fi
+}


### PR DESCRIPTION
Six figures published during the 2026-09 VLM campaign were wrong, none of them because of a code defect. Each came from a comparison written inline for that one occasion, so a precondition enforced in one place was missing in the next. This adds the tool that holds all of them, and fixes the three sweeps that could still measure nothing and say it went fine.

## The comparison tool

`scripts/compare_bench_csv.py`. Fifty scripts under `scripts/` produce benchmark CSVs and nothing consumed them, which is why every join was hand-written.

It refuses a VLM row paired with a text one, refuses two different `mlxcel_commit` values unless the version change is what is being measured, refuses a reference runtime measured more than a day apart, drops pairs whose `prompt_tokens` disagree beyond a tolerance, and excludes embedders and rerankers from a generation roster. Names resolve through `docs/model-catalog.tsv`, whose `aliases` column is `;`-separated; splitting it on `,` loses thirteen keys, two of which were that campaign's control checkpoints. Every drop is reported with its reason, because a pair count alone hides what it left out and one of the six wrong figures was a pair count.

It also warns when a baseline row has been superseded by a newer reading in another CSV for the same host and harness. That is the shape that produced the worst of the six: a sweep file held a pre-fix number while a newer per-model CSV beside it held the current one, and comparing the two sweeps is correct and still misses it.

Validated by replaying all six. The two commit-mixing cases refuse outright, the harness mismatch exits 2, the roster disagreement resolves to 47 pairs on both hosts, and the corrected margins reproduce at 105% on M5 Max and 108% on M1 Ultra. The superseded warning was checked in both directions, silent where nothing supersedes and naming seventeen rows where something does.

## The three unguarded sweeps

`bench_decode.sh` and `bench_mlxlm.py` were guarded when each of them enumerated an empty store and exited 0. `bench_all_models.sh`, `bench_longprompt.sh` and `bench_na_attention.sh` had the same shape and hardcoded their store root, so they could not even be pointed at the other host's layout. All three now read `MODELS_DIR` and share `scripts/lib/store_guard.sh`, which prints the root and checkpoint count on every run and refuses before anything is written.

`bench_longprompt.sh` names a roster instead of enumerating, and three of its five defaults (`llama-3.1-8b-4bit`, `qwen2.5-7b-4bit`, `mixtral-8x7b-4bit`) were renamed by the 2026-09-09 store consolidation. The default sweep had been skipping them one at a time and still producing a CSV. Corrected, with a guard that names what is missing and refuses only when nothing resolves.

## What was checked and found sound

`bench_embeddings.py` was re-checked for the column shift fixed earlier; all three `writerow` calls are 21 fields against a 21-field header. A checker that reported otherwise was itself wrong, which is worth saying because it was the first result.

## Validation

Exit codes read without a pipe, since reading one through `sed` returns the status of `sed` rather than the script. Container-only root exits 1 in both `all`-mode scripts, the real store passes at 211 checkpoints, an all-missing roster exits 1, and a partial roster warns and proceeds. `bash -n` clean on all four shell files.
