### PR TITLE
fix(bench): move the store guards ahead of the output file, again

### DIFF
--- a/scripts/bench_all_models.sh
+++ b/scripts/bench_all_models.sh
@@ -11,6 +11,11 @@ source "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/lib/store_guard.sh"
 
 PORT=18080
 OUTPUT="${1:-benchmark_batching_results.log}"
+
+# Before the first `tee -a "$OUTPUT"` below. A guard placed at the enumeration
+# runs after the log has already been created, and $1 here is the log name
+# rather than a mode, so a stray argument creates a file named after it.
+require_checkpoints "$MODELS_DIR" "continuous-batching sweep"
 MAX_TOKENS=50
 RUNS=2
 CONCURRENCY="1,2,4"
@@ -32,8 +37,6 @@ SUCCESS=0
 FAILED=0
 SKIPPED=0
 FAILED_LIST=""
-
-require_checkpoints "$MODELS_DIR" "continuous-batching sweep"
 
 for MODEL_DIR in "$MODELS_DIR"/*/; do
     MODEL_NAME=$(basename "$MODEL_DIR")

--- a/scripts/bench_longprompt.sh
+++ b/scripts/bench_longprompt.sh
@@ -369,6 +369,11 @@ for _len in $LADDER; do
   fi
 done
 
+# Before the output path is chosen. Line 379 truncates $OUTPUT, so a guard
+# placed at the model loop would refuse only after an --output naming an
+# existing CSV had already lost its contents.
+require_named_checkpoints "$MODELS_DIR" "long-prompt sweep" $MODELS
+
 if [[ -z "$OUTPUT" ]]; then
   BACKEND=$(detect_backend)
   HW=$(detect_hardware_short)
@@ -408,7 +413,6 @@ fi
 >&2 echo ""
 
 header_written=0
-require_named_checkpoints "$MODELS_DIR" "long-prompt sweep" $MODELS
 
 for model_name in $MODELS; do
   model_path="${MODELS_DIR}/${model_name}"

--- a/scripts/bench_na_attention.sh
+++ b/scripts/bench_na_attention.sh
@@ -221,6 +221,13 @@ if [[ ! -x "$MLXCEL" ]]; then
   exit 1
 fi
 
+# Before the output path is chosen, not after: the header write below
+# truncates $OUTPUT, so a guard placed at the enumeration cannot say nothing
+# was written, and an --output naming an existing CSV loses its contents.
+if [[ "$MODEL_ARG" == "all" ]]; then
+  require_checkpoints "$MODELS_DIR" "NA-attention sweep"
+fi
+
 if [[ -z "$OUTPUT" ]]; then
   OUTPUT="${BENCHMARKS_DIR}/na_attention_${HARDWARE_SHORT}_${DATE}.csv"
 fi
@@ -236,7 +243,6 @@ emit() {
 }
 
 if [[ "$MODEL_ARG" == "all" ]]; then
-  require_checkpoints "$MODELS_DIR" "NA-attention sweep"
   while IFS= read -r dir; do
     [[ -d "$dir" ]] || continue
     emit "$(bench_one "$dir")"


### PR DESCRIPTION
Follow-up to #1732. The three guards it added sit after the point where each script creates its output, so they refuse only once the damage is done.

`bench_na_attention.sh` truncates `$OUTPUT` and writes a header before reaching the guard. `bench_longprompt.sh` runs `: > "$OUTPUT"` thirty lines before its own. `bench_all_models.sh` takes `$1` as the log filename and writes to it immediately, so a stray argument creates a file named after it.

This is the same defect #1729 fixed in `bench_decode.sh`, reintroduced two PRs later. It surfaced because running the guards during review left a file called `all` and an empty `na_attention_m5max_2026-09-10.csv` in the tree, both from invocations that had been correctly refused.

All three now check before the output path is chosen. The test is the one that distinguishes the two versions: an existing file named with `--output` has to survive a refused run. All three exit 1 with the file byte-identical and leave nothing behind. Verifying that the guard fires is not enough, because a guard that fires after the truncation still fires, and that is what passed review the first time.
