### PR TITLE
fix(server): report an audio-only server healthy once its worker is ready

### DIFF
--- a/src/server/routes/availability_tests.rs
+++ b/src/server/routes/availability_tests.rs
@@ -159,6 +159,25 @@ async fn post(app: axum::Router, path: &str, body: Value) -> (StatusCode, Value)
     (status, body)
 }
 
+async fn get(app: axum::Router, path: &str) -> (StatusCode, Value) {
+    let response = app
+        .oneshot(
+            Request::builder()
+                .method(Method::GET)
+                .uri(path)
+                .body(Body::empty())
+                .expect("request builds"),
+        )
+        .await
+        .expect("route responds");
+    let status = response.status();
+    let bytes = axum::body::to_bytes(response.into_body(), usize::MAX)
+        .await
+        .expect("body reads");
+    let body = serde_json::from_slice(&bytes).expect("health body is JSON");
+    (status, body)
+}
+
 #[tokio::test]
 async fn embedding_only_server_returns_501_on_all_generation_routes() {
     let cases = [
@@ -229,6 +248,16 @@ async fn audio_only_server_names_the_served_routes() {
     let message = body["error"]["message"].as_str().expect("message");
     assert!(message.contains("/v1/audio/transcriptions"), "{body}");
     assert!(message.contains("/v1/audio/translations"), "{body}");
+}
+
+#[tokio::test]
+async fn audio_only_server_reports_healthy_after_its_worker_is_ready() {
+    let state = state_with(ModelProvider::chat_unavailable_for_route_tests())
+        .with_audio_model(Some(Arc::new(SideAudioProvider)));
+    let (status, body) = get(create_app(state), "/health").await;
+
+    assert_eq!(status, StatusCode::OK, "{body}");
+    assert_eq!(body, json!({ "status": "ok" }));
 }
 
 #[tokio::test]

--- a/src/server/routes/health.rs
+++ b/src/server/routes/health.rs
@@ -60,6 +60,8 @@ fn side_model_ready(state: &AppState) -> bool {
 ///
 /// `200 {"status": "ok"}` once the serving worker is up; the b10621 loading
 /// envelope before that. Never reports saturation (see module docs).
+///
+/// Used by: `mlxcel-server` and `mlxcel serve`.
 pub async fn health_check(State(state): State<AppState>) -> Response {
     // A server started with b10621's `--embeddings` or `--reranking` has no
     // chat worker to be "loaded", and reporting it unhealthy forever would
@@ -67,6 +69,13 @@ pub async fn health_check(State(state): State<AppState>) -> Response {
     // there is whether the worker the mode selected came up.
     let ready = if state.config.embedding_serving_mode.blocks_generation() {
         side_model_ready(&state)
+    } else if state.model_provider.is_chat_unavailable() && state.audio_model.is_some() {
+        // Whisper and Kokoro checkpoints are primary audio-only models: their
+        // dedicated worker has already loaded before the provider is installed,
+        // while the deliberately unused chat worker records a terminal state.
+        // Treat that combination as ready so the documented `-m <checkpoint>`
+        // audio server can pass container health checks.
+        true
     } else {
         state.model_provider.is_loaded()
     };


### PR DESCRIPTION
Closes #1747.

An audio-only server answers every audio route correctly and never reports itself ready, so `/health` fails any container probe pointed at it.

## The defect

`health_check` decides readiness with two arms: `side_model_ready(&state)` when `embedding_serving_mode.blocks_generation()`, and `model_provider.is_loaded()` otherwise. A server started with a primary audio checkpoint takes the second arm, because an audio-only mode does not set a generation-blocking embedding mode. In that configuration there is no chat worker to load: `startup.rs` detects `ModelType::Whisper` or `ModelType::Kokoro` and populates the audio slot instead, while the deliberately unused chat worker records a terminal state. `is_loaded()` therefore stays false for the life of the process and `/health` returns the b10621 loading envelope forever.

That contradicts two documented promises at once. `docs/server-features.md` says `GET /health` and `/v1/health` provide readiness, and `docs/audio-api.md` documents `-m <whisper checkpoint>` and `-m <kokoro checkpoint>` as the way to serve audio. A documented configuration cannot pass its documented readiness probe, so an orchestrator or load balancer in front of it restarts or drains a server whose transcription, translation and speech routes are all serving.

## The fix

A third arm: when the chat provider is unavailable and an audio provider is installed, report ready.

This cannot produce a false ready. `startup.rs` sets `audio_model` to `Some(..)` only after `WhisperSttProvider::load(..)` or `KokoroTtsProvider::load(..)` returns `Ok`, and `.with_audio_model(..)` runs before the HTTP listener binds. When the audio load fails the slot stays `None`, the new arm does not fire, and the server correctly reports not ready.

It also cannot mask a chat worker crash. `audio_model` is populated only when the primary checkpoint is itself an audio model, which is the deliberate case rather than the failure case. `exited_chat_worker_returns_503_without_channel_details` covers the crash case and is unchanged by this PR.

## Verification

- `audio_only_server_reports_healthy_after_its_worker_is_ready` asserts 200 with exactly `{"status": "ok"}` for an audio-only state, alongside the existing `audio_only_server_names_the_served_routes`. The `get` helper it needs mirrors the `post` helper already in the file.
- Negative control: with the new arm reverted and the test kept, the test fails. It guards the fix rather than restating it.
- `cargo test -p mlxcel --lib --features metal,accelerate availability` passes 7 of 7 on an M1 Ultra, including the two pre-existing failure-path tests.
- `cargo clippy -p mlxcel --lib --tests -- -D warnings`, the exact command the CI clippy job runs, is clean. `cargo fmt --check` is clean.
