### PR TITLE
fix(mlx): bump MLX pin to 81ba1c6a so mxfp8 block scales round up

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -104,6 +104,11 @@ jobs:
               - 'scripts/iree/**'
               - 'rust-toolchain.toml'
               - '.github/workflows/ci.yml'
+              # The CUDA half of the same link line: mlxcel-core's build
+              # script names the CUDA libraries, and the MLX pin decides which
+              # of them libmlx.a needs. See the `xla-link` job comment.
+              - 'src/lib/mlxcel-core/build.rs'
+              - 'src/lib/mlx-cpp/CMakeLists.txt'
             # Everything that can compile differently per CUDA architecture: the
             # MLX overlays and turbo kernels, the pinned MLX commit, and the
             # build scripts that hand CMake the architecture list. Rust sources
@@ -519,6 +524,15 @@ jobs:
   # #1274 (found by hand later, not by CI). Running on every Rust PR was
   # rejected because the release link is minutes of shared-runner time and the
   # overwhelming majority of Rust PRs cannot affect the link line.
+  #
+  # `src/lib/mlxcel-core/build.rs` and `src/lib/mlx-cpp/CMakeLists.txt` are on
+  # the causal path as well. The former lists the CUDA libraries every
+  # `--features cuda` link resolves `libmlx.a` against; the latter holds the MLX
+  # pin, and a pin bump can add one without touching any build script. That is
+  # how ml-explore/mlx#4208's cuSOLVER dependency arrived with the 81ba1c6a bump
+  # (#1769): MLX links it PRIVATE, `cargo check` never links, and no job on the
+  # PR linked CUDA. A pin bump invalidates `mlxcel-core`'s MLX build, so those
+  # runs pay the cold figure below rather than the warm one.
   #
   # Measured cost of this job's link command on the GB10 runner: 15m40s from a
   # purged `CARGO_TARGET_DIR`, most of which is MLX's CUDA sources compiling

--- a/TECHNICAL_REPORTS/1772-mlx-pin-mxfp8-round-up-20260911.en.md
+++ b/TECHNICAL_REPORTS/1772-mlx-pin-mxfp8-round-up-20260911.en.md
@@ -1,0 +1,199 @@
+# Technical Report: PR #1772 - fix(mlx): bump MLX pin to 81ba1c6a so mxfp8 block scales round up
+
+**Date**: 2026-09-11
+**Author**: mlxcel maintainers
+**Reviewer**: implementation review cycle (implementation review, security and performance review, finalization)
+**Status**: Completed on Metal (M1 Ultra). CUDA compiled and linked in CI (GB10, sm_121); no CUDA test or inference ran. M5 Max not measured.
+**Languages**: C++, Rust, CMake, YAML
+**Risk Level**: Medium-High (every MLX-owned kernel and host path moves by 99 upstream commits; measured on one GPU generation)
+
+---
+
+## Executive Summary
+
+Issue #1769 reported that `fp8_block_requantize_matches_direct_path` failed deterministically on an M5 Max after its macOS 27 upgrade, and suspected the toolchain or the GPU generation. Running the issue's own decision criterion on an M1 Ultra, also on macOS 27, produced the byte-identical failure message. The test had simply never run on Metal: #1742 was validated on Linux/CUDA only.
+
+The cause is in MLX, not in mlxcel's requantize path and not in the test. At the pinned commit `9a795735`, the Metal and CPU backends choose the mxfp8 E8M0 block exponent as `round(log2(amax / 448))`. Rounded to nearest in log2 space, the scale lands below `amax / 448` for about half the blocks, those blocks' largest values scale past E4M3's 448 ceiling, and they saturate, losing up to `1 - 2^-1/2` (29.3%) of the block maximum. CUDA rounds the exponent up, which is why the test passed where it was written. Upstream fixed Metal and CPU in ml-explore/mlx#4353, six days after the pin.
+
+So the test's bound was correct and the quantizer was wrong. The same quantizer runs in production: `requantize_block_fp8_weights` is the only E8M0 quantize caller in the tree, and every vendor FP8 checkpoint loaded on Metal went through it.
+
+The maintainer chose to move the pin to upstream main `81ba1c6a` rather than patch around it. That brought 98 further commits, and three of them change behaviour underneath the bridge in ways that compile or pass tests while being wrong: a parameter inserted mid-signature, a new link dependency, and an accessor that started throwing. All three are handled here. The first surfaced at compile time; review found the other two.
+
+---
+
+## 1. The failure, and why the issue's hypothesis did not hold
+
+The issue asked for one experiment before any change: run the same seeded test on generation-13 hardware. The result on M1 Ultra:
+
+```
+element 4: mxfp8 error 0.50390625 exceeded 0.3002931 (group max 4.8046875)
+```
+
+That is the M5 Max message character for character. Both hosts ran macOS 27 and Xcode 27, so the experiment ruled out a generation difference but could not by itself rule out a toolchain one. What ruled that out was the history: #1742's validation section lists only CUDA runs, so there was never a macOS 26 pass to regress from.
+
+The mechanism reads directly off the pinned kernel (`mlx/backend/metal/kernels/fp8.h`, `struct fp8_e8m0`):
+
+```cpp
+float le = metal::log2(x);
+int n = int(metal::round(le));
+```
+
+For block 0 of the fixture, `log2(4.8046875 / 448) = -6.54` rounds to `-7`. The block maximum then scales to `4.8046875 * 128 = 615`, and E4M3's conversion saturates anything at or above 448. Element 4, `4.00390625`, scales to 512.5, saturates, and decodes as `448 / 128 = 3.5`, an error of 0.50390625. A host emulation of the pinned kernel over the whole seeded fixture reproduces that first failure exactly and gives the full picture: 301 of 650 blocks saturate, with a worst loss of 0.2928 of the group maximum. The theoretical ceiling for round-to-nearest in log2 space is `1 - 2^-1/2 = 0.2929`.
+
+The issue proposed, if both hosts failed, widening the bound from half an E4M3 step (`group_max / 16`) to a full step (`group_max / 8`), on the theory that the quantizer rounded toward zero. It does not round toward zero; it saturates. A full-step bound would still fail on the saturated maxima, and any bound loose enough to pass would have certified the defect. That option was rejected.
+
+---
+
+## 2. Why a pin bump
+
+Three options were on the table once the cause was known.
+
+| Option | What it costs | Why it was or was not taken |
+|---|---|---|
+| Widen the test bound | nothing | Certifies a production accuracy defect. Rejected. |
+| Overlay a backport of ml-explore/mlx#4353 | Whole-file overlays of `fp8.h`, the 2,000-line `fp_quantized.h`, CPU `quantized.cpp`, and `ops.cpp` (already a CUDA-only overlay) | Small in lines, but four new overlays to carry and later retire, one of them colliding with an existing overlay's target. |
+| Move the pin to upstream main | 99 commits of upstream change to absorb and validate | Chosen by the maintainer. The tree tracks upstream main already, and the range carries other fixes this tree would want. |
+
+The cost of the chosen option is that it moves the numbers everywhere MLX owns a kernel, which is why the validation in section 6 is broad rather than confined to the fp8 path.
+
+---
+
+## 3. Overlay reconciliation
+
+This tree carries 28 whole-file overlays under `src/lib/mlx-cpp/patches/` (applied to every build) and `src/lib/mlx-cpp/patches-cuda/` (CUDA builds only). Upstream touched seven of their targets between the pins. Each of those seven was three-way merged with `git merge-file overlay old-upstream new-upstream`. The check that the merge preserved both sides is that each overlay's delta against the new base has the same `+/-` count it had against the old base: upstream's changes came in, and ours stayed. The other 21 targets are byte-identical across the range and were left alone. Two of those are mlxcel-only files with no upstream counterpart.
+
+| Overlay target | Upstream commits | Delta, old base / new base |
+|---|---:|---|
+| `metal/quantized.cpp` (`MLXCEL_QMV_WIDE`) | 5 | +59/-1, +59/-1 |
+| `metal/kernels/utils.h` | 2 | +5/-4, +5/-4 |
+| `metal/compiled.cpp` | 1 | reduced to the mixed-dtype cast (see below) |
+| `cuda/device/binary_ops.cuh` | 1 | +53/-0, +53/-0 |
+| `cuda/quantized/quantized.cpp` | 1 | +358/-82, +361/-82 (sync comment only) |
+| `patches-cuda/fast.cpp` | 2 | +33/-6, +33/-6 |
+| `patches-cuda/ops.cpp` | 8 | +46/-11, +46/-11 |
+
+The only conflict was cosmetic: upstream's ml-explore/mlx#4353 bumped the copyright year on the same header line where the `ops.cpp` overlay starts its own comment block.
+
+Two of the merges matter beyond their line counts. `metal/compiled.cpp` now emits `cast_to<>` for fused `AsType` (ml-explore/mlx#4351). That function is defined in the new `kernels/utils.h`. Had the `utils.h` overlay been left at its old base while `compiled.cpp` took the new one, every JIT-fused kernel containing a cast would have failed to compile at runtime rather than at build time. `metal/quantized.cpp` carries the #1187 `qmv_wide` off-switch. The predicate it gates, `mode != "affine" || gen >= 15`, is unchanged upstream, and so is its single caller, so the switch still gates exactly what it did.
+
+Review found one thing the reconciliation method cannot see: an overlay that was already wrong at the old base. `metal/compiled.cpp` had been emitting `elem_to_loc_1<uint>` for 1-D inputs since an earlier sync applied part of ml-explore/mlx#3720 by hand and missed this line. In the large-index kernel that negative strides select, `uint(stride)` wraps a stride of -1 to about 2^32, which is an out-of-bounds read. Nothing in the tree reaches it today. The line now matches upstream, the overlay's delta is down to the mixed-dtype cast it exists for, and its header says so and warns to compare against upstream on every bump. The CUDA mixed-type `FloorDivide` overload in `binary_ops.cuh` was aligned the same way: it floors, like upstream's float branch after ml-explore/mlx#4108.
+
+---
+
+## 4. What the new pin changes underneath the bridge
+
+### 4.1 A parameter inserted mid-signature
+
+ml-explore/mlx#4458 added `const std::optional<array>& global_scale` to `mlx::core::gather_qmm` between `mode` and `sorted_indices`. All 13 bridge call sites pass `sorted_indices` positionally. The risk in this class is a silent rebinding, where the bool binds to the new parameter and compiles. It does not happen here because `array`'s scalar constructor is `explicit`, so `bool` has no implicit route to `std::optional<array>` and the old calls fail to compile. A small parser inserted `/* global_scale = */ std::nullopt` into each call, and refused to touch any call that did not have exactly the expected 11 arguments. `fast::scaled_dot_product_attention` also gained a parameter (`force_fused`, ml-explore/mlx#4185), ahead of the stream, but no call in the tree passes a stream, so nothing rebinds.
+
+### 4.2 A new link dependency
+
+ml-explore/mlx#4208 moved Cholesky onto cuSOLVER, and the new pin's `gpu::init()` creates a cuSOLVER handle cache on every CUDA start. MLX's CMake links `CUDA::cusolver` PRIVATE, which cargo never sees, and `link_cuda()` in `mlxcel-core/build.rs` did not name it, so every `--features cuda` link would have failed on `cusolverDnCreate`. `link_cuda()` now names it. `docs/installation.md` now lists the shared libraries a prebuilt CUDA binary links, because a runtime-only CUDA install without cuSOLVER will now fail at launch.
+
+That this reached review rather than CI is a gap in CI's path filters. The only PR job that links a CUDA binary, `xla-link`, triggered on the IREE half of the link recipe but not on `mlxcel-core/build.rs` or the MLX pin. The one CUDA job that did run for this PR was `cargo check`, which never links. `ci.yml` now triggers `xla-link` on both paths, and that is also what verified this change (section 7).
+
+### 4.3 An accessor that started throwing
+
+ml-explore/mlx#3742 made `array::detach_event()` call `Event::check_error()`, so `array::is_available()` now throws when a launch's command buffer failed, and the throw clears the error. Every event a failed command buffer signals points at the same encoder `Error`. At the old pin, `is_available()` on a signalled event returned true and dropped the error silently.
+
+The rejection sampler relied on the old behaviour. `drain_pending_verification()` inspects converged flags from earlier launches, including launches other requests stashed, and it used `is_available()` as a non-blocking status query. It runs inside `fused_sample`, which is not a `Result` bridge function. After a GPU fault, the next sampling call on any request would have thrown through cxx and terminated the server. It would also have consumed the error that the owning request's own evaluation exists to report.
+
+The drain now asks `stashed_launch_state()`, which reads the array's status, whether its event is signalled, and whether the event's error pointer holds a live message, all without calling anything that checks and clears. A failed launch is dropped unread. Metal's completion handler and the CPU scheduler both store an event's error before they signal it, and CUDA attaches none, so an error is visible by the time the signal is.
+
+A regression test (`a_failed_stashed_launch_is_dropped_without_throwing_or_consuming_its_error`) builds that state through MLX's public `Event`/`Error` API. It signals a real event, attaches a synthetic error afterwards, stashes a launch carrying it, drains, and asserts that nothing threw, the error is still live, and the slot is empty. With the drain reverted to `is_available()`, the test binary aborts with `terminating due to uncaught exception of type std::runtime_error`, which is the failure mode itself.
+
+### 4.4 Checked and not reaching the tree
+
+`StreamContext` now throws when destroyed on another thread (ml-explore/mlx#4462); nothing in the tree uses it. The GGUF bounds checks and the lazy-source `save` fix (ml-explore/mlx#4212, ml-explore/mlx#4378, ml-explore/mlx#4434) cover loaders mlxcel does not call. `get_array_buffer_size` and `fast::cross_entropy` are additions.
+
+---
+
+## 5. The test
+
+The byte-identity test, `fp8_block_requantize_matches_direct_path`, now asserts only the byte identity its name and doc comment claim. The accuracy check moved to `fp8_block_requantize_round_trip_stays_within_half_an_e4m3_step`, on the same seed (`0x51D3_9E11`) and the same 130x160 shape, because the padded trailing blocks are part of what is bounded. Its doc comment carries the derivation. With the scale rounded up, the block maximum scales into `(224, 448]`, and every element rounds to nearest. An element in the top binade moves by at most 16 of 256 or more units, `2^-4` of the maximum; lower binades move less.
+
+The test also gained a direct check of the property the bound depends on: for each block, decode the E8M0 byte and assert `group_max <= 448 * scale`. On the old pin this is what fails first, and it names the cause:
+
+```
+block 0: E8M0 scale 2^-7 is below amax / 448 = 0.0107247485, so its maximum 4.8046875 scales to 615 and saturates at 448 (the scale was rounded down, see ml-explore/mlx#4353)
+```
+
+The comparison is exact for this fixture, not approximately so. Every fixture value is an E4M3 decode times a bf16 scale, at most 12 significant bits. `amax / 448` therefore cannot fall within f32 rounding distance of a power of two without equalling it.
+
+---
+
+## 6. Validation
+
+All runs on M1 Ultra (generation 13), macOS 27.0, Xcode 27.0. The old-pin arm was built from `ca00c467` and isolated with its own `mlx.metallib`. The binaries resolve the metallib through an absolute path into the build directory, so without that copy the old binary would have loaded the new kernels once the rebuild overwrote them.
+
+### 6.1 The fp8 round trip
+
+| | Old pin | New pin |
+|---|---|---|
+| New test | fails at block 0 (above) | passes |
+| Blocks saturated (of 650) | 301 (host emulation) | 0 (device) |
+| Worst error / group max | 0.2928 (host emulation) | 0.0489, i.e. 0.96875 at 19.796875 (device) |
+
+The device's new-pin figure equals the host emulation's round-up figure to every printed digit.
+
+### 6.2 Turbo launchers
+
+`sparse_v_kernel_threshold_zero_matches_graph` passes; `delegated_fused_kernel_matches_reference_over_200_steps` at 1.7263e-4 and `delegated_steel_envelope_matches_cold_only_fused_over_200_steps` at 1.5259e-4 max RMS, against the 5e-3 contract.
+
+### 6.3 Teacher-forced logit traces
+
+`examples/logit_trace` over wikitext-2, old pin against new, compared with `scripts/compare_logit_traces.py`, at width 1 (128 positions), width 8 behind 512 tokens of context (640), and width 256 (512):
+
+| Checkpoint | Top-1 disagreement (w1 / w8 / w256) | Disagreement on decided positions |
+|---|---|---|
+| qwen2.5-7b-instruct-4bit | 0 / 3 / 1 | 0 at every width |
+| gemma-3-4b-it-4bit | 0 / 0 / 0, byte-identical in effect | 0 |
+| qwen3-30b-a3b-4bit | 4 / 14 / 15 | 0 at every width |
+| nvidia-nemotron-3-nano-30b-a3b-4bit | 4 / 21 / 8 | 0 at every width |
+| gemma-4-26b-a4b-it-4bit | 0 / 0 / 0, byte-identical in effect | 0 |
+
+The Gemmas use GELU and do not touch upstream's switch to `precise::exp` in `Sigmoid` (ml-explore/mlx#4461). The SiLU families do, and move within the rounding class. qwen3-30b-a3b moved most because MoE routing turns a last-ulp change in a router logit into a different expert. Over 4,096 positions at width 256, 1 of 1,720 decided positions disagrees, at the reference's rank 2, and perplexity moves by -0.20%.
+
+### 6.4 Branches the short runs could not reach
+
+A 575-token prompt never reaches three dispatch changes, so each was driven directly. Runs are greedy with arms alternated, and figures are the median of 3 on a quiet machine.
+
+| Branch | Checkpoint, context | Result |
+|---|---|---|
+| head-dim-512 vector decode past 1,024 keys | gemma-4-26b-a4b, 2,396 tokens | identical text on old pin, new pin, and new pin with `MLX_SDPA_D512_MIN_KL` disabling the kernel; 71.7 / 71.6 / 71.4 tok/s |
+| GQA-8 two-pass decode past 8,192 keys (ml-explore/mlx#4077) | qwen3-30b-a3b, 8,819 tokens | identical text; decode 55.6 to 60.8 tok/s (+9.4%), prefill unchanged |
+| head-dim-72 fused attention in vision towers (ml-explore/mlx#4330) | gemma-3-4b and gemma-4-26b with an image | image prefill 239 to 279 tok/s on gemma-3-4b; descriptions diverge after 20 to 50 tokens into equally faithful text; decided answers (the fixture square's colour, gemma-4-26b's count of six bars) unchanged |
+
+### 6.5 Throughput at short context
+
+`mlxcel generate --profile`, 575-token prompt, 128 tokens, median of 3: qwen2.5-7b prefill 681 to 677 and decode 100.3 to 100.4 tok/s; qwen3-30b-a3b 582 to 586 and 76.1 to 75.8; gemma-4-26b-a4b 713 to 709 and 70.9 to 70.8. All within 0.6%.
+
+### 6.6 Gates
+
+At the final head, the workspace gate (`cargo test --workspace --profile test-fast --features metal,accelerate --no-fail-fast -- --test-threads=1`) reports 122 binaries, 10,986 passed, 0 failed, 359 ignored. That is the issue's 10,981 passed plus #1770's two repairs, this issue's one, and the two new tests. Workspace clippy with `-D warnings`, `cargo fmt --check`, both pin parsers, and the cross-repo reference check are clean.
+
+---
+
+## 7. What is not verified
+
+- **CUDA execution.** CI's `OpenXLA feature link` job, which this PR's filter change now triggers, built `mlxcel-core` at the new pin and linked a `--features cuda,xla-iree` release test binary on GB10 (sm_121) in 12m19s, so the merged CUDA overlays compile and the cuSOLVER link resolves. No CUDA test or inference ran. The green `CUDA sm_70 compile` check is a skip: its runner's CUDA 13.0 cannot target sm_70, so it compiles nothing.
+- **M5 Max.** The quantize kernel has no generation-specific branch, and the issue's M5 failure message matches M1 Ultra's, but the NAX paths that changed in this range run only on generation 17 and were not measured: ml-explore/mlx#4171, ml-explore/mlx#4352 and ml-explore/mlx#4392.
+- **A real FP8 checkpoint on Metal.** None is on this host. The fixture is the measurement vehicle, and on it the quantizer's behaviour is now exactly the round-up rule.
+- **VLM coverage.** Two checkpoints, one synthetic image and one solid-colour fixture.
+
+---
+
+## 8. Follow-ups
+
+- **`array_evaluated_bytes` is another non-`Result` bridge function that waits.** It goes through `array::eval()`, and at the new pin it throws for a failed launch even after the event has landed; the old pin threw only before. The server's lookahead token read uses it, so a GPU fault there still terminates the process. The fix is to declare it `Result` and route the error through the scheduler's step-failure handling, which is a change of its own.
+- **The mixed-dtype cast in `metal/compiled.cpp` also casts comparison inputs.** For a comparison, the output dtype is `bool`, so the overlay would cast float inputs to `bool` before comparing. No compiled function in the tree contains a comparison today, so this is latent. It should be guarded before one does.
+- **The NemotronH loader prints progress to stdout.** That contaminates `examples/logit_trace`'s TSV, which is written to stdout, and `compare_logit_traces.py` rejects the file until the `[NemotronH]` lines are filtered.
+
+---
+
+## 9. Learning points
+
+- **Run an issue's decision criterion before accepting its framing.** The issue expected M1 Ultra either to pass (a backend divergence) or to fail with a bound that never held. It failed identically, and the reason was neither: a quantizer fixed upstream after the pin, behind a test that had only ever run on the one backend that rounds up.
+- **A green check proves only what it ran.** Three checks on this PR looked like CUDA coverage and were not. `cargo check` never links, the sm_70 job skipped, and the link job was not triggered. The missing library was found by reading the upstream diff.
+- **Pin bumps break semantics, not only signatures.** The signature change failed to compile. The link change and the accessor change would have compiled, passed the Metal gate, and failed in production. Read upstream's accessor and error-path changes, not only its headers.
+- **Isolate every arm of a pin A/B, runtime artifacts included.** A binary that resolves its metallib by absolute path is only half of an arm.

--- a/TECHNICAL_REPORTS/1772-mlx-pin-mxfp8-round-up-20260911.ko.md
+++ b/TECHNICAL_REPORTS/1772-mlx-pin-mxfp8-round-up-20260911.ko.md
@@ -1,0 +1,199 @@
+# 기술 리포트: PR #1772 - fix(mlx): bump MLX pin to 81ba1c6a so mxfp8 block scales round up
+
+**날짜**: 2026-09-11
+**작성자**: mlxcel maintainers
+**리뷰어**: 구현 리뷰 사이클(구현 리뷰, 보안·성능 리뷰, 마무리)
+**상태**: Metal(M1 Ultra)에서 완료. CUDA는 CI에서 컴파일·링크 확인(GB10, sm_121); CUDA 테스트나 추론은 돌리지 않음. M5 Max 미측정.
+**언어**: C++, Rust, CMake, YAML
+**위험도**: 중상(MLX가 소유한 모든 커널과 호스트 경로가 업스트림 99커밋만큼 움직임; 한 GPU 세대에서만 측정)
+
+---
+
+## 요약
+
+이슈 #1769는 `fp8_block_requantize_matches_direct_path`가 macOS 27로 올린 M5 Max에서 결정적으로 실패한다고 보고하며, 툴체인이나 GPU 세대를 의심했다. 이슈가 스스로 정한 판정 기준을 역시 macOS 27인 M1 Ultra에서 돌리자 실패 메시지가 바이트 단위로 같았다. 이 테스트는 애초에 Metal에서 한 번도 돌아간 적이 없었다. #1742는 Linux/CUDA에서만 검증됐다.
+
+원인은 mlxcel의 재양자화 경로도, 테스트도 아닌 MLX에 있다. 고정 커밋 `9a795735`에서 Metal과 CPU 백엔드는 mxfp8 E8M0 블록 지수를 `round(log2(amax / 448))`로 고른다. log2 공간에서 최근접으로 반올림하면 블록 절반가량에서 스케일이 `amax / 448`보다 작게 잡히고, 그 블록의 큰 값들은 E4M3 상한 448을 넘어 포화된다. 블록 최대값의 최대 `1 - 2^-1/2`(29.3%)를 잃는다. CUDA는 지수를 올림하므로 테스트를 작성한 곳에서는 통과했다. 업스트림은 핀 엿새 뒤 ml-explore/mlx#4353에서 Metal과 CPU를 고쳤다.
+
+즉 테스트의 경계는 옳았고 양자화기가 틀렸다. 같은 양자화기가 프로덕션에서도 돈다. `requantize_block_fp8_weights`는 트리 안의 유일한 E8M0 양자화 호출자이고, Metal에서 로드한 모든 벤더 FP8 체크포인트가 이 경로를 거쳤다.
+
+메인테이너는 이를 우회 패치하지 않고 핀을 업스트림 main `81ba1c6a`로 옮기기로 했다. 그러면서 98개 커밋이 더 들어왔고, 그중 셋은 브리지 아래에서 동작을 바꾼다. 컴파일되거나 테스트를 통과하면서도 틀리는 방식이다. 시그니처 중간에 끼어든 인자, 새 링크 의존성, throw하기 시작한 접근자다. 셋 다 이 PR에서 처리했다. 첫째는 컴파일 단계에서 드러났고, 나머지 둘은 리뷰가 찾았다.
+
+---
+
+## 1. 실패, 그리고 이슈의 가설이 맞지 않은 이유
+
+이슈는 어떤 변경보다 먼저 실험 하나를 요구했다. 같은 시드 테스트를 13세대 하드웨어에서 돌려 보라는 것이다. M1 Ultra의 결과는 다음과 같다.
+
+```
+element 4: mxfp8 error 0.50390625 exceeded 0.3002931 (group max 4.8046875)
+```
+
+M5 Max의 메시지와 한 글자도 다르지 않다. 두 호스트 모두 macOS 27과 Xcode 27이었으므로, 이 실험으로 세대 차이는 배제됐지만 툴체인 차이까지 배제되지는 않는다. 툴체인을 배제한 것은 이력이다. #1742의 검증 절은 CUDA 실행만 나열하므로, 되돌아갈 macOS 26 통과 기록이 애초에 없었다.
+
+메커니즘은 고정된 커널(`mlx/backend/metal/kernels/fp8.h`, `struct fp8_e8m0`)에 그대로 적혀 있다.
+
+```cpp
+float le = metal::log2(x);
+int n = int(metal::round(le));
+```
+
+픽스처의 블록 0에서 `log2(4.8046875 / 448) = -6.54`는 `-7`로 반올림된다. 그러면 블록 최대값은 `4.8046875 * 128 = 615`로 스케일되고, E4M3 변환은 448 이상을 모두 포화시킨다. 원소 4인 `4.00390625`는 512.5로 스케일되어 포화되고 `448 / 128 = 3.5`로 복원된다. 오차는 0.50390625다. 시드 픽스처 전체에 고정 커널을 호스트에서 에뮬레이션하면 이 첫 실패를 정확히 재현하고 전체 그림도 보여 준다. 650블록 중 301블록이 포화되고, 최악 손실은 그룹 최대값의 0.2928이다. log2 공간 최근접 반올림의 이론 상한은 `1 - 2^-1/2 = 0.2929`다.
+
+이슈는 두 호스트가 모두 실패하면 경계를 E4M3 반 스텝(`group_max / 16`)에서 한 스텝(`group_max / 8`)으로 넓히자고 제안했다. 양자화기가 0 방향으로 반올림한다는 가정이었다. 실제로는 0 방향 반올림이 아니라 포화다. 한 스텝 경계도 포화된 최대값에서 여전히 실패하고, 통과할 만큼 느슨한 경계라면 결함을 인증하는 셈이 된다. 그 선택지는 기각했다.
+
+---
+
+## 2. 왜 핀 범프인가
+
+원인이 드러난 뒤 선택지는 셋이었다.
+
+| 선택지 | 비용 | 채택 여부와 이유 |
+|---|---|---|
+| 테스트 경계 확대 | 없음 | 프로덕션 정확도 결함을 인증한다. 기각. |
+| ml-explore/mlx#4353 백포트 오버레이 | `fp8.h`, 2,000줄짜리 `fp_quantized.h`, CPU `quantized.cpp`, `ops.cpp`(이미 CUDA 전용 오버레이)의 파일 전체 오버레이 | 줄 수로는 작지만, 들고 다니다 나중에 걷어낼 새 오버레이가 넷이고 그중 하나는 기존 오버레이 대상과 겹친다. |
+| 핀을 업스트림 main으로 이동 | 업스트림 99커밋을 흡수하고 검증 | 메인테이너가 선택. 트리는 이미 업스트림 main을 추적하고, 범위 안에 이 트리가 원할 다른 수정도 있다. |
+
+선택한 방식의 비용은 MLX가 커널을 소유한 모든 곳에서 수치가 움직인다는 것이다. 그래서 6절의 검증은 fp8 경로에 한정하지 않고 넓게 잡았다.
+
+---
+
+## 3. 오버레이 재조정
+
+이 트리는 파일 전체 오버레이 28개를 `src/lib/mlx-cpp/patches/`(모든 빌드에 적용)와 `src/lib/mlx-cpp/patches-cuda/`(CUDA 빌드 전용)에 둔다. 두 핀 사이에 업스트림이 그 대상 중 일곱을 건드렸고, 일곱 개 모두 `git merge-file overlay old-upstream new-upstream`으로 3-way 병합했다. 병합이 양쪽을 보존했는지는, 각 오버레이의 새 베이스 대비 델타가 옛 베이스 대비와 같은 `+/-` 수를 갖는지로 확인한다. 업스트림의 변경은 들어왔고 우리 변경은 남았다는 뜻이다. 나머지 21개 대상은 범위 전체에서 바이트 동일이라 그대로 뒀다. 그중 둘은 업스트림에 대응 파일이 없는 mlxcel 전용이다.
+
+| 오버레이 대상 | 업스트림 커밋 | 델타, 옛 베이스 / 새 베이스 |
+|---|---:|---|
+| `metal/quantized.cpp` (`MLXCEL_QMV_WIDE`) | 5 | +59/-1, +59/-1 |
+| `metal/kernels/utils.h` | 2 | +5/-4, +5/-4 |
+| `metal/compiled.cpp` | 1 | 혼합 dtype 캐스트만 남도록 축소(아래) |
+| `cuda/device/binary_ops.cuh` | 1 | +53/-0, +53/-0 |
+| `cuda/quantized/quantized.cpp` | 1 | +358/-82, +361/-82 (동기화 주석만) |
+| `patches-cuda/fast.cpp` | 2 | +33/-6, +33/-6 |
+| `patches-cuda/ops.cpp` | 8 | +46/-11, +46/-11 |
+
+유일한 충돌은 외형상의 것이었다. 업스트림 ml-explore/mlx#4353이 저작권 연도를 올린 헤더 줄에서 `ops.cpp` 오버레이가 자기 주석 블록을 시작한다.
+
+병합 중 둘은 줄 수 이상의 의미가 있다. `metal/compiled.cpp`는 이제 퓨즈드 `AsType`에 `cast_to<>`를 내보낸다(ml-explore/mlx#4351). 이 함수는 새 `kernels/utils.h`에 정의돼 있다. `utils.h` 오버레이를 옛 베이스에 두고 `compiled.cpp`만 새 것을 받았다면, 캐스트를 포함한 모든 JIT 퓨즈드 커널이 빌드 때가 아니라 런타임에 컴파일에 실패했을 것이다. `metal/quantized.cpp`는 #1187의 `qmv_wide` 끄기 스위치를 담는다. 스위치가 거는 조건 `mode != "affine" || gen >= 15`는 업스트림에서 바뀌지 않았고, 유일한 호출자도 그대로라 스위치는 정확히 이전과 같은 것을 건다.
+
+리뷰는 이 재조정 방법으로는 볼 수 없는 것을 하나 찾았다. 옛 베이스에서 이미 틀려 있던 오버레이다. `metal/compiled.cpp`는 1-D 입력에 `elem_to_loc_1<uint>`를 내보내고 있었다. 예전 동기화가 ml-explore/mlx#3720 일부를 손으로 적용하면서 이 줄을 빠뜨린 탓이다. 음수 stride가 선택하는 large-index 커널에서 `uint(stride)`는 stride -1을 약 2^32로 감싸, 버퍼 밖을 읽는다. 오늘은 트리 어디서도 닿지 않는다. 이제 이 줄은 업스트림과 같고, 오버레이의 델타는 존재 이유인 혼합 dtype 캐스트만 남았다. 헤더에 그 사실을 적고, 범프 때마다 업스트림과 비교하라고 경고해 뒀다. `binary_ops.cuh`의 CUDA 혼합 타입 `FloorDivide` 오버로드도 같은 방식으로 맞췄다. ml-explore/mlx#4108 이후 업스트림 float 분기처럼 floor를 쓴다.
+
+---
+
+## 4. 새 핀이 브리지 아래에서 바꾸는 것
+
+### 4.1 시그니처 중간에 끼어든 인자
+
+ml-explore/mlx#4458은 `mlx::core::gather_qmm`의 `mode`와 `sorted_indices` 사이에 `const std::optional<array>& global_scale`을 넣었다. 브리지 호출 13곳 모두 `sorted_indices`를 위치 인자로 넘긴다. 이 계열의 위험은 조용한 재바인딩이다. bool이 새 인자에 바인딩되고 그대로 컴파일되는 경우다. 여기서는 그런 일이 없다. `array`의 스칼라 생성자가 `explicit`이라 `bool`이 `std::optional<array>`로 암묵 변환될 길이 없고, 옛 호출은 컴파일에 실패한다. 작은 파서로 각 호출에 `/* global_scale = */ std::nullopt`를 넣었고, 인자가 정확히 11개가 아닌 호출은 건드리지 않게 했다. `fast::scaled_dot_product_attention`도 스트림 앞에 `force_fused` 인자를 얻었지만(ml-explore/mlx#4185), 트리의 어떤 호출도 스트림을 넘기지 않으므로 재바인딩이 없다.
+
+### 4.2 새 링크 의존성
+
+ml-explore/mlx#4208은 Cholesky를 cuSOLVER로 옮겼고, 새 핀의 `gpu::init()`은 CUDA를 시작할 때마다 cuSOLVER 핸들 캐시를 만든다. MLX의 CMake는 `CUDA::cusolver`를 PRIVATE로 링크해 cargo가 볼 수 없는데, `mlxcel-core/build.rs`의 `link_cuda()`에는 이것이 없었다. 따라서 모든 `--features cuda` 링크가 `cusolverDnCreate`에서 실패했을 것이다. 이제 `link_cuda()`가 이것을 명시한다. cuSOLVER가 빠진 최소 CUDA 런타임 설치에서는 이제 실행 시점에 실패하므로, `docs/installation.md`에 사전 빌드 CUDA 바이너리가 링크하는 공유 라이브러리 목록을 적었다.
+
+이것이 CI가 아니라 리뷰에서 발견된 것은 CI 경로 필터의 구멍 때문이다. CUDA 바이너리를 실제로 링크하는 유일한 PR 잡 `xla-link`는 링크 레시피의 IREE 쪽 변경에만 반응했고, `mlxcel-core/build.rs`나 MLX 핀에는 반응하지 않았다. 이 PR에서 돈 CUDA 잡은 `cargo check` 하나였고, 이 명령은 링크를 하지 않는다. 이제 `ci.yml`이 두 경로 모두에서 `xla-link`를 트리거하며, 이 변경을 검증한 것도 그 잡이다(7절).
+
+### 4.3 throw하기 시작한 접근자
+
+ml-explore/mlx#3742는 `array::detach_event()`가 `Event::check_error()`를 부르게 바꿨다. 그래서 명령 버퍼가 실패한 실행에서 `array::is_available()`이 이제 throw하고, throw하면서 오류를 지운다. 실패한 명령 버퍼가 신호하는 모든 이벤트는 같은 인코더 `Error`를 가리킨다. 옛 핀에서는 신호된 이벤트에 대한 `is_available()`이 true를 반환하고 오류를 조용히 버렸다.
+
+rejection 샘플러는 옛 동작에 기대고 있었다. `drain_pending_verification()`은 이전 실행들의 수렴 플래그를 들여다보는데, 거기엔 다른 요청이 남긴 실행도 포함된다. 이때 `is_available()`을 비차단 상태 조회로 썼다. 이 함수는 `Result` 브리지가 아닌 `fused_sample` 안에서 돈다. GPU 장애 뒤라면 어느 요청이든 다음 샘플링 호출에서 cxx를 통해 throw해 서버를 종료시켰을 것이다. 게다가 그 실행을 소유한 요청이 스스로 보고해야 할 오류까지 먼저 소비했을 것이다.
+
+이제 드레인은 `stashed_launch_state()`에 묻는다. 이 함수는 배열 상태, 이벤트 신호 여부, 이벤트 오류 포인터에 살아 있는 메시지가 있는지를 읽기만 하고, 확인하면서 지우는 어떤 것도 부르지 않는다. 실패한 실행은 읽지 않고 버린다. Metal 완료 핸들러와 CPU 스케줄러는 모두 신호 전에 이벤트 오류를 저장하고 CUDA는 오류를 달지 않으므로, 신호가 보일 때쯤이면 오류도 보인다.
+
+회귀 테스트 `a_failed_stashed_launch_is_dropped_without_throwing_or_consuming_its_error`는 MLX 공개 `Event`/`Error` API로 그 상태를 만든다. 실제 이벤트를 신호한 뒤 합성 오류를 붙이고, 그것을 단 실행을 넣고, 드레인한 다음, 아무것도 throw하지 않았는지, 오류가 살아 있는지, 슬롯이 비었는지를 단언한다. 드레인을 `is_available()`로 되돌리면 테스트 바이너리가 `terminating due to uncaught exception of type std::runtime_error`로 중단된다. 막으려던 실패 그 자체다.
+
+### 4.4 확인했지만 트리에 닿지 않는 것
+
+`StreamContext`는 이제 다른 스레드에서 파괴되면 throw한다(ml-explore/mlx#4462). 트리에서 이를 쓰는 곳은 없다. GGUF 경계 검사와 지연 소스 `save` 수정(ml-explore/mlx#4212, ml-explore/mlx#4378, ml-explore/mlx#4434)은 mlxcel이 부르지 않는 로더에 해당한다. `get_array_buffer_size`와 `fast::cross_entropy`는 추가 기능이다.
+
+---
+
+## 5. 테스트
+
+바이트 동일성 테스트 `fp8_block_requantize_matches_direct_path`는 이제 이름과 문서 주석이 주장하는 바이트 동일성만 단언한다. 정확도 검사는 `fp8_block_requantize_round_trip_stays_within_half_an_e4m3_step`으로 옮겼다. 시드(`0x51D3_9E11`)와 130x160 형상은 그대로다. 패딩된 꼬리 블록도 경계로 묶이는 대상이기 때문이다. 문서 주석에 유도를 적었다. 스케일을 올림하면 블록 최대값은 `(224, 448]`로 스케일되고, 모든 원소가 최근접으로 반올림된다. 최상위 binade의 원소는 256 이상 단위 중 최대 16, 즉 최대값의 `2^-4`만큼 움직이고, 아래 binade는 그보다 덜 움직인다.
+
+경계가 기대는 성질도 직접 검사하게 했다. 블록마다 E8M0 바이트를 복원해 `group_max <= 448 * scale`을 단언한다. 옛 핀에서는 이것이 먼저 실패하며 원인을 이름으로 말한다.
+
+```
+block 0: E8M0 scale 2^-7 is below amax / 448 = 0.0107247485, so its maximum 4.8046875 scales to 615 and saturates at 448 (the scale was rounded down, see ml-explore/mlx#4353)
+```
+
+이 비교는 이 픽스처에서 근사가 아니라 정확하다. 모든 픽스처 값은 E4M3 복원값에 bf16 스케일을 곱한 것이라 유효 비트가 12개 이하다. 따라서 `amax / 448`은 2의 거듭제곱과 같지 않은 한 f32 반올림 거리 안으로 들어올 수 없다.
+
+---
+
+## 6. 검증
+
+모든 실행은 M1 Ultra(13세대), macOS 27.0, Xcode 27.0에서 했다. 옛 핀 arm은 `ca00c467`에서 빌드해 자기 `mlx.metallib`와 함께 격리했다. 바이너리는 metallib를 빌드 디렉터리 절대경로로 찾기 때문에, 그 사본이 없었다면 재빌드가 덮어쓴 뒤 옛 바이너리가 새 커널을 읽었을 것이다.
+
+### 6.1 fp8 왕복
+
+| | 옛 핀 | 새 핀 |
+|---|---|---|
+| 새 테스트 | 블록 0에서 실패(위) | 통과 |
+| 포화 블록(650 중) | 301(호스트 에뮬레이션) | 0(장치) |
+| 최악 오차 / 그룹 최대값 | 0.2928(호스트 에뮬레이션) | 0.0489, 곧 19.796875에서 0.96875(장치) |
+
+새 핀의 장치 수치는 호스트 에뮬레이션의 올림 규칙 수치와 출력된 모든 자릿수에서 같다.
+
+### 6.2 Turbo 런처
+
+`sparse_v_kernel_threshold_zero_matches_graph` 통과. `delegated_fused_kernel_matches_reference_over_200_steps`는 최대 RMS 1.7263e-4, `delegated_steel_envelope_matches_cold_only_fused_over_200_steps`는 1.5259e-4로, 계약 5e-3 안이다.
+
+### 6.3 teacher-forced logit trace
+
+wikitext-2에서 `examples/logit_trace`를 옛 핀과 새 핀으로 떠 `scripts/compare_logit_traces.py`로 비교했다. 폭 1(128위치), 512토큰 문맥 뒤의 폭 8(640위치), 폭 256(512위치)에서 잰 결과다.
+
+| 체크포인트 | top-1 불일치 (w1 / w8 / w256) | decided 위치 불일치 |
+|---|---|---|
+| qwen2.5-7b-instruct-4bit | 0 / 3 / 1 | 모든 폭에서 0 |
+| gemma-3-4b-it-4bit | 0 / 0 / 0, 효과상 바이트 동일 | 0 |
+| qwen3-30b-a3b-4bit | 4 / 14 / 15 | 모든 폭에서 0 |
+| nvidia-nemotron-3-nano-30b-a3b-4bit | 4 / 21 / 8 | 모든 폭에서 0 |
+| gemma-4-26b-a4b-it-4bit | 0 / 0 / 0, 효과상 바이트 동일 | 0 |
+
+Gemma 계열은 GELU를 써서 업스트림이 `Sigmoid`를 `precise::exp`로 바꾼 변경(ml-explore/mlx#4461)을 타지 않는다. SiLU 계열은 이를 타고 반올림 계층 안에서 움직인다. qwen3-30b-a3b가 가장 많이 움직인 것은 MoE 라우팅이 라우터 로짓의 마지막 ulp 변화를 다른 전문가 선택으로 바꾸기 때문이다. 폭 256의 4,096위치에서 decided 위치 1,720개 중 1개가 불일치했고, 그것도 참조의 2순위였으며, perplexity는 -0.20% 움직였다.
+
+### 6.4 짧은 실행이 닿지 못한 분기
+
+575토큰 프롬프트는 디스패치 변경 셋에 닿지 않아, 각각을 직접 몰았다. greedy로 arm을 교대했고, 조용한 머신에서 3회 중앙값이다.
+
+| 분기 | 체크포인트, 문맥 | 결과 |
+|---|---|---|
+| 키 1,024개 이상의 head-dim-512 벡터 디코드 | gemma-4-26b-a4b, 2,396토큰 | 옛 핀, 새 핀, `MLX_SDPA_D512_MIN_KL`로 커널을 끈 새 핀의 출력 텍스트 동일; 71.7 / 71.6 / 71.4 tok/s |
+| 키 8,192개 이상의 GQA-8 2-pass 디코드(ml-explore/mlx#4077) | qwen3-30b-a3b, 8,819토큰 | 텍스트 동일; 디코드 55.6에서 60.8 tok/s(+9.4%), prefill 불변 |
+| 비전 타워의 head-dim-72 fused 어텐션(ml-explore/mlx#4330) | 이미지 입력 gemma-3-4b, gemma-4-26b | gemma-3-4b 이미지 prefill 239에서 279 tok/s; 설명은 20~50토큰 뒤 똑같이 충실한 다른 문장으로 갈라짐; 답이 정해진 질문(픽스처 사각형의 색, gemma-4-26b의 막대 6개)의 답은 불변 |
+
+### 6.5 짧은 문맥 처리량
+
+`mlxcel generate --profile`, 575토큰 프롬프트, 128토큰, 3회 중앙값. qwen2.5-7b prefill 681에서 677, decode 100.3에서 100.4 tok/s; qwen3-30b-a3b 582에서 586, 76.1에서 75.8; gemma-4-26b-a4b 713에서 709, 70.9에서 70.8. 모두 0.6% 이내다.
+
+### 6.6 게이트
+
+최종 헤드에서 워크스페이스 게이트(`cargo test --workspace --profile test-fast --features metal,accelerate --no-fail-fast -- --test-threads=1`)는 122개 바이너리, 10,986 통과, 0 실패, 359 무시다. 이슈의 10,981 통과에 #1770이 고친 둘, 이 이슈의 하나, 새 테스트 둘을 더한 값이다. `-D warnings` 워크스페이스 clippy, `cargo fmt --check`, 두 핀 파서, 교차 저장소 참조 검사 모두 깨끗하다.
+
+---
+
+## 7. 검증하지 못한 것
+
+- **CUDA 실행.** 이 PR의 필터 수정으로 트리거된 CI `OpenXLA feature link` 잡이 GB10(sm_121)에서 새 핀으로 `mlxcel-core`를 빌드하고 `--features cuda,xla-iree` 릴리즈 테스트 바이너리를 12분 19초에 링크했다. 병합된 CUDA 오버레이가 컴파일되고 cuSOLVER 링크가 풀린다는 뜻이다. CUDA 테스트나 추론은 돌리지 않았다. 초록인 `CUDA sm_70 compile` 체크는 스킵이다. 그 러너의 CUDA 13.0이 sm_70을 대상으로 삼을 수 없어 아무것도 컴파일하지 않는다.
+- **M5 Max.** quantize 커널에는 세대별 분기가 없고, 이슈의 M5 실패 메시지가 M1 Ultra와 같다. 그러나 이 범위에서 바뀐 NAX 경로는 17세대에서만 돌고 측정하지 않았다(ml-explore/mlx#4171, ml-explore/mlx#4352, ml-explore/mlx#4392).
+- **Metal에서의 실제 FP8 체크포인트.** 이 호스트에는 없다. 측정 수단은 픽스처이며, 그 위에서 양자화기의 동작은 이제 정확히 올림 규칙이다.
+- **VLM 범위.** 체크포인트 둘, 합성 이미지 하나, 단색 픽스처 하나.
+
+---
+
+## 8. 후속 과제
+
+- **`array_evaluated_bytes`도 대기하는 비 `Result` 브리지 함수다.** `array::eval()`을 거치므로 새 핀에서는 실패한 실행에 대해 이벤트가 도착한 뒤에도 throw한다. 옛 핀은 도착 전에만 throw했다. 서버의 lookahead 토큰 읽기가 이를 쓰므로, 거기서 GPU 장애가 나면 여전히 프로세스가 종료된다. `Result`로 선언하고 오류를 스케줄러의 스텝 실패 처리로 넘겨야 하는데, 그 자체로 별도의 변경이다.
+- **`metal/compiled.cpp`의 혼합 dtype 캐스트는 비교 연산의 입력도 캐스트한다.** 비교의 출력 dtype은 `bool`이므로, float 입력을 비교 전에 `bool`로 캐스트하게 된다. 오늘 트리의 컴파일 함수 중 비교를 담은 것은 없어 잠재 결함이다. 그런 함수가 생기기 전에 막아야 한다.
+- **NemotronH 로더가 진행 메시지를 stdout에 찍는다.** stdout으로 쓰는 `examples/logit_trace`의 TSV를 오염시키고, `[NemotronH]` 줄을 걸러내기 전까지 `compare_logit_traces.py`가 파일을 거부한다.
+
+---
+
+## 9. 학습 포인트
+
+- **이슈의 판정 기준을 먼저 돌리고, 그 틀을 받아들이는 건 그다음이다.** 이슈는 M1 Ultra가 통과하거나(백엔드 발산), 애초에 성립하지 않던 경계로 실패하리라 봤다. 결과는 똑같은 실패였고, 이유는 둘 다 아니었다. 올림을 쓰는 단 하나의 백엔드에서만 돌던 테스트 뒤에, 핀 이후 업스트림에서 고쳐진 양자화기가 있었다.
+- **초록 체크는 그것이 실제로 돌린 것만 증명한다.** 이 PR에는 CUDA를 다룬 것처럼 보이지만 실제로는 아니었던 체크가 셋 있었다. `cargo check`는 링크하지 않고, sm_70 잡은 스킵했고, 링크 잡은 트리거되지 않았다. 빠진 라이브러리는 업스트림 diff를 읽어서 찾았다.
+- **핀 범프는 시그니처만이 아니라 의미를 깬다.** 시그니처 변경은 컴파일에 실패했다. 링크 변경과 접근자 변경은 컴파일도 되고 Metal 게이트도 통과한 뒤 프로덕션에서 실패했을 것이다. 헤더만이 아니라 업스트림의 접근자와 오류 경로 변경까지 읽어야 한다.
+- **핀 A/B의 각 arm은 런타임 산출물까지 격리한다.** metallib를 절대경로로 찾는 바이너리는 arm의 절반일 뿐이다.

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -236,6 +236,13 @@ available on the deployment host, not only the runtime libraries:
   Install the CUDA toolkit and set `CUDA_HOME` (or `CUDA_PATH`) if it is not at
   `/usr/local/cuda`. Without them the first NVRTC compile fails with
   `cannot open source file` errors.
+- **CUDA shared libraries** come from the host toolkit too. The binary links
+  `cudart`, `cublas`, `cublasLt`, `cufft`, `cusolver`, `nvrtc` and cuDNN
+  dynamically. cuSOLVER joined that list when the MLX pin moved to `81ba1c6a`
+  (MLX's CUDA backend now uses it for Cholesky and initializes it at startup),
+  so a runtime-only install that omits it fails at launch with
+  `libcusolver.so...: cannot open shared object file`. The full CUDA toolkit
+  package ships all of them.
 - An NVIDIA driver matching the CUDA toolkit must be present to run on the GPU.
 
 Compiled kernels are cached on disk (`MLX_PTX_CACHE_DIR`, default under the

--- a/src/lib/mlx-cpp/CMakeLists.txt
+++ b/src/lib/mlx-cpp/CMakeLists.txt
@@ -31,7 +31,7 @@ function(mlx_apply_source_overlays mlx_source_dir)
   # 2026-06-11 upstream main, which carries the fix natively (issue #222).
   # quantized.cpp carries one delta, the MLXCEL_QMV_WIDE off-switch on
   # `use_qmv_wide` (issue #1187). Upstream has no equivalent knob and the
-  # predicate is unchanged as of pin 9a795735, so it has to be overlaid here.
+  # predicate is unchanged as of pin 81ba1c6a, so it has to be overlaid here.
   # Refresh the file wholesale on a bump and re-apply that one hunk.
   set(_metal_patch_files
       "mlx/backend/metal/compiled.cpp"
@@ -119,7 +119,7 @@ else()
     #     `)` as ending the declaration, so one there would hide the tag
     #     instead of being read past.
     # Both parsers fail loudly rather than guess when the shape does not hold.
-    GIT_TAG 9a795735ad9a42664e08f42361b405ed570bcf1a)
+    GIT_TAG 81ba1c6a0e50a9268b931579c2d4f1158b9aab5a)
 
   # Use FetchContent_Populate + add_subdirectory so we can apply source
   # overlays before the MLX build system processes the files.

--- a/src/lib/mlx-cpp/patches-cuda/fast.cpp
+++ b/src/lib/mlx-cpp/patches-cuda/fast.cpp
@@ -208,6 +208,107 @@ bool RMSNormVJP::is_equivalent(const Primitive& other) const {
   return eps_ == a_other.eps_;
 }
 
+array cross_entropy(
+    const array& logits,
+    const array& targets,
+    StreamOrDevice s_ /* = {} */) {
+  if (logits.ndim() < 1) {
+    throw std::invalid_argument(
+        "[cross_entropy] logits must have at least 1 dimension but got input "
+        "with 0 dimensions.");
+  }
+  auto expected = logits.shape();
+  expected.pop_back();
+  if (targets.shape() != expected) {
+    std::ostringstream msg;
+    msg << "[cross_entropy] targets shape " << targets.shape()
+        << " does not match logits shape " << logits.shape()
+        << " with the last axis removed.";
+    throw std::invalid_argument(msg.str());
+  }
+  if (!issubdtype(logits.dtype(), floating)) {
+    std::ostringstream msg;
+    msg << "[cross_entropy] Received unsupported logits type " << logits.dtype()
+        << ".";
+    throw std::invalid_argument(msg.str());
+  }
+  if (!issubdtype(targets.dtype(), integer)) {
+    std::ostringstream msg;
+    msg << "[cross_entropy] targets must be integer class indices but got "
+        << targets.dtype() << ".";
+    throw std::invalid_argument(msg.str());
+  }
+
+  auto s = to_stream(s_);
+  auto fallback = [s](const std::vector<array>& inputs) {
+    auto& x = inputs[0];
+    auto& y = inputs[1];
+    auto score =
+        squeeze(take_along_axis(x, expand_dims(y, -1, s), -1, s), -1, s);
+    auto loss = subtract(logsumexp(x, -1, /* keepdims= */ false, s), score, s);
+    return std::vector<array>{astype(loss, float32, s)};
+  };
+
+  auto passed_targets = astype(targets, int32, s);
+
+  if (!CrossEntropy::use_fallback(s)) {
+    return array(
+        expected,
+        float32,
+        std::make_shared<CrossEntropy>(s, fallback),
+        {logits, passed_targets});
+  }
+  return fallback({logits, passed_targets})[0];
+}
+
+std::vector<array> CrossEntropy::vjp(
+    const std::vector<array>& primals,
+    const std::vector<array>& cotangents,
+    const std::vector<int>& argnums,
+    const std::vector<array>& outputs) {
+  assert(primals.size() == 2);
+  assert(outputs.size() == 1);
+  assert(cotangents.size() == 1);
+
+  for (auto arg : argnums) {
+    if (arg != 0) {
+      throw std::invalid_argument(
+          "[cross_entropy] Cannot differentiate with respect to the targets.");
+    }
+  }
+
+  auto s = stream();
+  auto fallback = [s](const std::vector<array>& inputs) {
+    auto& x = inputs[0];
+    auto& y = inputs[1];
+    auto& loss = inputs[2];
+    auto& g = inputs[3];
+
+    auto score =
+        squeeze(take_along_axis(x, expand_dims(y, -1, s), -1, s), -1, s);
+    auto lse = add(loss, astype(score, float32, s), s);
+    auto p =
+        exp(subtract(astype(x, float32, s), expand_dims(lse, -1, s), s), s);
+    Shape class_shape(x.ndim(), 1);
+    class_shape.back() = x.shape(-1);
+    auto onehot = astype(
+        equal(
+            expand_dims(y, -1, s),
+            reshape(arange(x.shape(-1), y.dtype(), s), class_shape, s),
+            s),
+        float32,
+        s);
+    auto gx = multiply(expand_dims(g, -1, s), subtract(p, onehot, s), s);
+    return std::vector<array>{astype(gx, x.dtype(), s)};
+  };
+
+  return {array(
+      primals[0].shape(),
+      primals[0].dtype(),
+      std::make_shared<CrossEntropyVJP>(s, fallback),
+      {primals[0], primals[1], outputs[0], cotangents[0]})};
+}
+
 array layer_norm(
     const array& x,
     const std::optional<array>& weight,
@@ -645,7 +746,8 @@ array scaled_dot_product_attention(
     const std::string& mask_mode /* = "" */,
     std::optional<array> mask_arr /* = {} */,
     const std::optional<array>& sinks /* = {} */,
-    StreamOrDevice s /* = {}*/) {
+    bool force_fused /* = false */,
+    StreamOrDevice s /* = {} */) {
   for (const auto& tensor : {queries, keys, values}) {
     if (tensor.ndim() != 4) {
       std::ostringstream msg;
@@ -861,6 +963,7 @@ array scaled_dot_product_attention(
           do_causal,
           is_training,
           output_logsumexp,
+          force_fused,
           stream)) {
     if (has_bool_mask && !ScaledDotProductAttention::supports_bool_mask()) {
       // Convert bool mask to additive mask.
@@ -873,7 +976,13 @@ array scaled_dot_product_attention(
     }
     Shape out_shape{q.shape(0), q.shape(1), q.shape(2), v.shape(-1)};
     auto primitive = std::make_shared<ScaledDotProductAttention>(
-        stream, fallback, scale, do_causal, has_sinks, output_logsumexp);
+        stream,
+        fallback,
+        scale,
+        do_causal,
+        has_sinks,
+        output_logsumexp,
+        force_fused);
     if (output_logsumexp) {
       return array::make_arrays(
           {std::move(out_shape), Shape{q.shape(0), q.shape(1), q.shape(2), 1}},
@@ -939,7 +1048,8 @@ bool ScaledDotProductAttention::is_equivalent(const Primitive& other) const {
       static_cast<const ScaledDotProductAttention&>(other);
   return scale_ == a_other.scale_ && do_causal_ == a_other.do_causal_ &&
       has_sinks_ == a_other.has_sinks_ &&
-      output_logsumexp_ == a_other.output_logsumexp_;
+      output_logsumexp_ == a_other.output_logsumexp_ &&
+      force_fused_ == a_other.force_fused_;
 }
 
 bool ScaledDotProductAttentionVJP::is_equivalent(const Primitive& other) const {

--- a/src/lib/mlx-cpp/patches-cuda/fast.cpp
+++ b/src/lib/mlx-cpp/patches-cuda/fast.cpp
@@ -2,7 +2,8 @@
 //
 // CUDA patch: bf16 scalar/constant generation in normalization ops
 //
-// Modified from upstream MLX v0.31.1 mlx/fast.cpp
+// Modified from upstream MLX 81ba1c6a mlx/fast.cpp (three-way merged at each
+// pin bump; the two fallbacks below are the whole delta)
 //
 // Changes:
 //   - rms_norm() fallback: When out_type is bf16, compute in bf16 instead of

--- a/src/lib/mlx-cpp/patches-cuda/ops.cpp
+++ b/src/lib/mlx-cpp/patches-cuda/ops.cpp
@@ -1,8 +1,8 @@
-// Copyright © 2023-2024 Apple Inc.
+// Copyright © 2023-2026 Apple Inc.
 //
 // CUDA patch: Mixed-precision binary operation dispatch for bf16
 //
-// Modified from upstream MLX e9463bb mlx/ops.cpp
+// Modified from upstream MLX 81ba1c6a mlx/ops.cpp
 //
 // Changes:
 //   - Added bf16_mixed_astype() helper that skips astype conversion when the
@@ -10,7 +10,7 @@
 //   - Modified add, subtract, multiply, divide, maximum, minimum to use the
 //     helper, avoiding copy_v kernel insertion for bf16/fp32 mixed operations.
 //
-// Everything else is byte-identical to upstream e9463bb.
+// Everything else is byte-identical to upstream 81ba1c6a.
 //
 // This patch is CUDA-only -- applied via the overlay system in CMakeLists.txt
 // only when MLX_BUILD_CUDA is set. Metal builds use the unmodified upstream file.
@@ -1341,7 +1341,9 @@ array concatenate(
   };
 
   auto shape = arrays[0].shape();
-  shape[ax] = 0;
+  // Accumulate the concatenation axis in 64 bits so a total that does not fit
+  // in a shape dimension is reported rather than silently wrapping.
+  int64_t concat_size = 0;
   // Make the output shape and validate that all arrays have the same shape
   // except for the concatenation axis.
   for (auto& a : arrays) {
@@ -1360,8 +1362,9 @@ array concatenate(
         throw_invalid_shapes();
       }
     }
-    shape[ax] += a.shape(ax);
+    concat_size += a.shape(ax);
   }
+  shape[ax] = safe_cast(concat_size, "concatenate");
 
   // Promote all the arrays to the same type
   auto dtype = result_type(arrays);
@@ -1437,7 +1440,8 @@ array repeat(const array& arr, int repeats, int axis, StreamOrDevice s) {
 
   // Reshape back into a contiguous array where S_axis is now S_axis * repeats
   shape.erase(shape.begin() + axis + 1);
-  shape[axis] *= repeats;
+  shape[axis] =
+      safe_cast(static_cast<int64_t>(shape[axis]) * repeats, "repeat");
   out = reshape(out, shape, s);
 
   return out;
@@ -1490,7 +1494,7 @@ array reflect_pad(
   Shape starts(a.ndim(), 0);
   auto stops = a.shape();
   for (size_t i = 0; i < axes.size(); i++) {
-    int ax = axes[i];
+    int ax = normalize_axis_index(axes[i], a.ndim(), "[pad] ");
     starts[ax] = low_pad_size[i];
     stops[ax] += low_pad_size[i];
   }
@@ -1498,7 +1502,7 @@ array reflect_pad(
   array padded = slice_update(out, a, starts, stops, s);
 
   for (size_t i = 0; i < axes.size(); i++) {
-    int ax = axes[i];
+    int ax = normalize_axis_index(axes[i], a.ndim(), "[pad] ");
     int n = a.shape(ax);
     int L = low_pad_size[i];
     int H = high_pad_size[i];
@@ -1571,37 +1575,41 @@ array edge_pad(
     const Shape& out_shape,
     StreamOrDevice s /* = {}*/) {
   array out = zeros(out_shape, a.dtype(), s);
-  auto stops = a.shape();
-  for (int i = 0; i < stops.size(); i++) {
-    stops[i] += low_pad_size[i];
+  Shape in_starts(a.ndim(), 0);
+  auto in_stops = a.shape();
+  for (size_t i = 0; i < axes.size(); i++) {
+    int ax = normalize_axis_index(axes[i], a.ndim(), "[pad] ");
+    in_starts[ax] = low_pad_size[i];
+    in_stops[ax] += low_pad_size[i];
   }
   // Copy over values from the unpadded array
-  array padded = slice_update(out, a, low_pad_size, stops, s);
+  array padded = slice_update(out, a, in_starts, in_stops, s);
 
-  for (int axis = 0; axis < a.ndim(); axis++) {
-    if (low_pad_size[axis] > 0) {
+  for (size_t i = 0; i < axes.size(); i++) {
+    int ax = normalize_axis_index(axes[i], a.ndim(), "[pad] ");
+    if (low_pad_size[i] > 0) {
       Shape starts(a.ndim(), 0);
-      starts[axis] = low_pad_size[axis];
+      starts[ax] = low_pad_size[i];
       auto stops = out.shape();
-      stops[axis] = low_pad_size[axis] + 1;
+      stops[ax] = low_pad_size[i] + 1;
       // Fetch edge values
       array edge_value = slice(padded, starts, stops, s);
 
-      starts[axis] = 0;
-      stops[axis] = low_pad_size[axis];
+      starts[ax] = 0;
+      stops[ax] = low_pad_size[i];
       // Update edge values in the padded array
       padded = slice_update(padded, edge_value, starts, stops, s);
     }
 
-    if (high_pad_size[axis] > 0) {
+    if (high_pad_size[i] > 0) {
       Shape starts(a.ndim(), 0);
-      starts[axis] = -high_pad_size[axis] - 1;
+      starts[ax] = -high_pad_size[i] - 1;
       auto stops = out.shape();
-      stops[axis] = -high_pad_size[axis];
+      stops[ax] = -high_pad_size[i];
       array edge_value = slice(padded, starts, stops, s);
 
-      starts[axis] = -high_pad_size[axis];
-      stops[axis] = out.shape(axis);
+      starts[ax] = -high_pad_size[i];
+      stops[ax] = out.shape(ax);
       padded = slice_update(padded, edge_value, starts, stops, s);
     }
   }
@@ -1643,7 +1651,7 @@ array pad(
       throw std::invalid_argument(msg.str());
     }
 
-    auto ax = axes[i] < 0 ? a.ndim() + axes[i] : axes[i];
+    auto ax = normalize_axis_index(axes[i], a.ndim(), "[pad] ");
     out_shape[ax] = safe_cast(
         static_cast<int64_t>(out_shape[ax]) + low_pad_size[i] +
             high_pad_size[i],
@@ -1779,7 +1787,7 @@ array transpose(
   }
   if (axes.size() != a.ndim()) {
     std::ostringstream msg;
-    msg << "[transpose] Recived " << axes.size() << " axes for array with "
+    msg << "[transpose] Received " << axes.size() << " axes for array with "
         << a.ndim() << " dimensions.";
     throw std::invalid_argument(msg.str());
   }
@@ -2436,6 +2444,16 @@ array median(
         array(0.5, dtype),
         s);
   }
+  // Sorting moves NaN to the end, so the midpoint slice never selects it.
+  // Propagate it explicitly to stay consistent with max, min and mean.
+  if (issubdtype(a.dtype(), inexact)) {
+    median_a = where(
+        any(isnan(flat_a, s), -1, /* keepdims = */ true, s),
+        array(std::numeric_limits<float>::quiet_NaN(), dtype),
+        median_a,
+        s);
+  }
+
   median_a = squeeze(median_a, -1, s);
   if (keepdims) {
     median_a = expand_dims(median_a, sorted_axes, s);
@@ -2809,17 +2827,9 @@ array sort(const array& a, StreamOrDevice s /* = {} */) {
 
 /** Returns a sorted copy of the array along a given axis. */
 array sort(const array& a, int axis, StreamOrDevice s /* = {} */) {
-  // Check for valid axis
-  if (axis + static_cast<int>(a.ndim()) < 0 ||
-      axis >= static_cast<int>(a.ndim())) {
-    std::ostringstream msg;
-    msg << "[sort] Received invalid axis " << axis << " for array with "
-        << a.ndim() << " dimensions.";
-    throw std::invalid_argument(msg.str());
-  }
-
+  auto ax = normalize_axis_index(axis, a.ndim(), "[sort] ");
   return array(
-      a.shape(), a.dtype(), std::make_shared<Sort>(to_stream(s), axis), {a});
+      a.shape(), a.dtype(), std::make_shared<Sort>(to_stream(s), ax), {a});
 }
 
 /** Returns indices that sort the flattened array. */
@@ -2830,17 +2840,9 @@ array argsort(const array& a, StreamOrDevice s /* = {} */) {
 
 /** Returns indices that sort the array along a given axis. */
 array argsort(const array& a, int axis, StreamOrDevice s /* = {} */) {
-  // Check for valid axis
-  if (axis + static_cast<int>(a.ndim()) < 0 ||
-      axis >= static_cast<int>(a.ndim())) {
-    std::ostringstream msg;
-    msg << "[argsort] Received invalid axis " << axis << " for array with "
-        << a.ndim() << " dimensions.";
-    throw std::invalid_argument(msg.str());
-  }
-
+  auto ax = normalize_axis_index(axis, a.ndim(), "[argsort] ");
   return array(
-      a.shape(), uint32, std::make_shared<ArgSort>(to_stream(s), axis), {a});
+      a.shape(), uint32, std::make_shared<ArgSort>(to_stream(s), ax), {a});
 }
 
 /**
@@ -3681,11 +3683,13 @@ array kron(const array& a, const array& b, StreamOrDevice s /* = {} */) {
 
   for (int i = ndim - 1, j = a.ndim() - 1; j >= 0; j--, i--) {
     a_shape[2 * i] = a.shape(j);
-    out_shape[i] *= a.shape(j);
+    out_shape[i] =
+        safe_cast(static_cast<int64_t>(out_shape[i]) * a.shape(j), "kron");
   }
   for (int i = ndim - 1, j = b.ndim() - 1; j >= 0; j--, i--) {
     b_shape[2 * i + 1] = b.shape(j);
-    out_shape[i] *= b.shape(j);
+    out_shape[i] =
+        safe_cast(static_cast<int64_t>(out_shape[i]) * b.shape(j), "kron");
   }
 
   return reshape(
@@ -4179,14 +4183,7 @@ array cumsum(
     bool inclusive /* = true*/,
     std::optional<Dtype> dtype /* = std::nullopt*/,
     StreamOrDevice s /* = {}*/) {
-  int ndim = a.ndim();
-  if (axis >= ndim || axis < -ndim) {
-    std::ostringstream msg;
-    msg << "[cumsum] Axis " << axis << " is out of bounds for array with "
-        << a.ndim() << " dimensions.";
-    throw std::invalid_argument(msg.str());
-  }
-  axis = (axis + a.ndim()) % a.ndim();
+  axis = normalize_axis_index(axis, a.ndim(), "[cumsum] ");
   auto x = dtype ? astype(a, *dtype, s) : a;
   auto out_type = x.dtype() == bool_ ? int32 : x.dtype();
   return array(
@@ -4214,14 +4211,7 @@ array cumprod(
     bool inclusive /* = true*/,
     std::optional<Dtype> dtype /* = std::nullopt*/,
     StreamOrDevice s /* = {}*/) {
-  int ndim = a.ndim();
-  if (axis >= ndim || axis < -ndim) {
-    std::ostringstream msg;
-    msg << "[cumprod] Axis " << axis << " is out of bounds for array with "
-        << a.ndim() << " dimensions.";
-    throw std::invalid_argument(msg.str());
-  }
-  axis = (axis + a.ndim()) % a.ndim();
+  axis = normalize_axis_index(axis, a.ndim(), "[cumprod] ");
   auto x = dtype ? astype(a, *dtype, s) : a;
   return array(
       x.shape(),
@@ -4246,14 +4236,7 @@ array cummax(
     bool reverse /* = false*/,
     bool inclusive /* = true*/,
     StreamOrDevice s /* = {}*/) {
-  int ndim = a.ndim();
-  if (axis >= ndim || axis < -ndim) {
-    std::ostringstream msg;
-    msg << "[cummax] Axis " << axis << " is out of bounds for array with "
-        << a.ndim() << " dimensions.";
-    throw std::invalid_argument(msg.str());
-  }
-  axis = (axis + a.ndim()) % a.ndim();
+  axis = normalize_axis_index(axis, a.ndim(), "[cummax] ");
   return array(
       a.shape(),
       a.dtype(),
@@ -4276,14 +4259,7 @@ array cummin(
     bool reverse /* = false*/,
     bool inclusive /* = true*/,
     StreamOrDevice s /* = {}*/) {
-  int ndim = a.ndim();
-  if (axis >= ndim || axis < -ndim) {
-    std::ostringstream msg;
-    msg << "[cummin] Axis " << axis << " is out of bounds for array with "
-        << a.ndim() << " dimensions.";
-    throw std::invalid_argument(msg.str());
-  }
-  axis = (axis + a.ndim()) % a.ndim();
+  axis = normalize_axis_index(axis, a.ndim(), "[cummin] ");
   return array(
       a.shape(),
       a.dtype(),
@@ -4333,14 +4309,7 @@ array logcumsumexp(
     bool reverse /* = false*/,
     bool inclusive /* = true*/,
     StreamOrDevice s /* = {}*/) {
-  int ndim = a.ndim();
-  if (axis >= ndim || axis < -ndim) {
-    std::ostringstream msg;
-    msg << "[logcumsumexp] Axis " << axis << " is out of bounds for array with "
-        << a.ndim() << " dimensions.";
-    throw std::invalid_argument(msg.str());
-  }
-  axis = (axis + a.ndim()) % a.ndim();
+  axis = normalize_axis_index(axis, a.ndim(), "[logcumsumexp] ");
   return array(
       a.shape(),
       a.dtype(),
@@ -5183,11 +5152,17 @@ std::vector<array> fp_quantize(
     } else {
       // convert to e8m0
       auto z = array(0, scales.dtype());
-      scales = where(
-          equal(scales, z, s),
-          z,
-          astype(round(log2(scales, s), s), int32, s),
+      // Round the scale up so the block maximum stays representable,
+      // matching the CUDA backend.
+      auto exponent = astype(round(log2(scales, s), s), int32, s);
+      auto decoded =
+          power(array(2.0f, float32), astype(exponent, float32, s), s);
+      exponent = where(
+          less(decoded, astype(scales, float32, s), s),
+          add(exponent, array(1, int32), s),
+          exponent,
           s);
+      scales = where(equal(scales, z, s), z, exponent, s);
 
       wq = divide(wq, power(array(2.0f, w.dtype()), scales, s), s);
       scales = astype(add(scales, array(127, int32), s), uint8, s);
@@ -5596,9 +5571,14 @@ array gather_qmm(
     std::optional<int> group_size_ /* = std::nullopt */,
     std::optional<int> bits_ /* = std::nullopt */,
     const std::string& mode /* = "affine" */,
+    const std::optional<array>& global_scale /* = std::nullopt */,
     bool sorted_indices /* = false */,
     StreamOrDevice s /* = {} */) {
   if (!lhs_indices_ && !rhs_indices_) {
+    if (global_scale) {
+      throw std::invalid_argument(
+          "[gather_qmm] Global scale is not supported without indices.");
+    }
     return quantized_matmul(
         x, w, scales, biases, transpose, group_size_, bits_, mode, s);
   }
@@ -5609,6 +5589,32 @@ array gather_qmm(
       quantization_params_from_mode(qmode, group_size_, bits_);
   auto [w_inner_dims, w_outer_dims] = extract_quantized_matmul_dims(
       "gather_qmm", x, w, scales, biases, transpose, group_size, bits);
+  if (global_scale) {
+    if (qmode != QuantizationMode::Nvfp4) {
+      throw std::invalid_argument(
+          "[gather_qmm] Global scale is only supported for 'nvfp4' "
+          "quantization mode.");
+    }
+    if (global_scale->dtype() != float32) {
+      std::ostringstream msg;
+      msg << "[gather_qmm] Global scale must have dtype float32 but got "
+          << global_scale->dtype() << ".";
+      throw std::invalid_argument(msg.str());
+    }
+    // One scale per expert, so it matches the batch dimensions of w.
+    Shape expected(w.shape().begin(), w.shape().end() - 2);
+    if (global_scale->shape() != expected) {
+      std::ostringstream msg;
+      msg << "[gather_qmm] Global scale must have one entry per expert with "
+          << "shape " << expected << " but got " << global_scale->shape()
+          << ".";
+      throw std::invalid_argument(msg.str());
+    }
+    if (to_stream(s).device != Device::gpu || !metal::is_available()) {
+      throw std::invalid_argument(
+          "[gather_qmm] Global scale is only supported on the Metal backend.");
+    }
+  }
   if (qmode == QuantizationMode::Affine) {
     out_type = promote_types(x.dtype(), out_type);
   } else {
@@ -5642,12 +5648,12 @@ array gather_qmm(
         std::move(lhs_indices),
         std::move(rhs_indices)};
   } else {
-    inputs = {
-        astype(x, out_type, s),
-        std::move(w),
-        std::move(scales),
-        std::move(lhs_indices),
-        std::move(rhs_indices)};
+    inputs = {astype(x, out_type, s), std::move(w), std::move(scales)};
+    if (global_scale) {
+      inputs.push_back(*global_scale);
+    }
+    inputs.push_back(std::move(lhs_indices));
+    inputs.push_back(std::move(rhs_indices));
   }
   return array(
       std::move(out_shape),

--- a/src/lib/mlx-cpp/patches/mlx/backend/cuda/device/binary_ops.cuh
+++ b/src/lib/mlx-cpp/patches/mlx/backend/cuda/device/binary_ops.cuh
@@ -52,7 +52,7 @@ struct FloorDivide {
       return cuda::std::floor(x / y);
     }
   }
-  MLX_MIXED_BINARY_OP(cuda::std::trunc(float(x) / float(y)))
+  MLX_MIXED_BINARY_OP(cuda::std::floor(float(x) / float(y)))
 };
 
 struct Divide {

--- a/src/lib/mlx-cpp/patches/mlx/backend/cuda/device/binary_ops.cuh
+++ b/src/lib/mlx-cpp/patches/mlx/backend/cuda/device/binary_ops.cuh
@@ -38,9 +38,18 @@ struct FloorDivide {
   template <typename T>
   __device__ T operator()(T x, T y) {
     if constexpr (cuda::std::is_integral_v<T>) {
+      auto q = x / y;
+      if constexpr (cuda::std::is_signed_v<T>) {
+        if (x % y != 0 && (x < 0) != (y < 0)) {
+          q -= 1;
+        }
+      }
+      return q;
+    } else if constexpr (is_complex_v<T>) {
+      // Complex is not supported, simply make compiler happy.
       return x / y;
     } else {
-      return cuda::std::trunc(x / y);
+      return cuda::std::floor(x / y);
     }
   }
   MLX_MIXED_BINARY_OP(cuda::std::trunc(float(x) / float(y)))

--- a/src/lib/mlx-cpp/patches/mlx/backend/cuda/quantized/qmm/qmm_naive.cu
+++ b/src/lib/mlx-cpp/patches/mlx/backend/cuda/quantized/qmm/qmm_naive.cu
@@ -53,7 +53,7 @@
 //     tensor-core MMA to re-measure the wide tile against. Unset, neither has
 //     any effect.
 //
-// Everything else is byte-identical upstream at the current pin (9a795735).
+// Everything else is byte-identical upstream at the current pin (81ba1c6a).
 
 #include "mlx/backend/cuda/device/qmm_naive.cuh"
 

--- a/src/lib/mlx-cpp/patches/mlx/backend/cuda/quantized/quantized.cpp
+++ b/src/lib/mlx-cpp/patches/mlx/backend/cuda/quantized/quantized.cpp
@@ -10,14 +10,17 @@
 // qmm_sm80, the naive kernel and qmv is the most architecture-dependent
 // dispatch in decode and MLX exposes no hook for it, so the one-shot trace has
 // to be emitted from the dispatch site itself.
-// Synced to upstream 9a795735. Upstream did not touch
-// mlx/backend/cuda/quantized/ at all between 2c46b953 and 9a795735, so this
-// overlay carries the same delta it did at the previous sync and the call sites
-// below need no adjustment. qmm.h is byte-identical across that range, which
-// means every dispatch entry point consumed here (qmm_naive, qmm_sm90,
-// qmm_sm80, qmv, gather_qmv, fp_qmv) kept its signature, including the
-// `const std::optional<array>& global_scale` parameter #3757 added to qmm_naive
-// at position 5 that both call sites below pass std::nullopt for.
+// Synced to upstream 81ba1c6a. Between 9a795735 and 81ba1c6a upstream touched
+// this file once, ml-explore/mlx#4458, which gives GatherQMM::eval_gpu a
+// guard that refuses a global scale outside Metal and keys `biases` on
+// `mode_ == Affine` instead of `inputs.size() == 6`. Both land ahead of delta
+// (3) and merged without conflict, and the grouped-GEMM gate below already
+// reads `biases` only on the affine path. qmm/qmm.h is byte-identical across
+// that range, which means every dispatch entry point consumed here
+// (qmm_naive, qmm_sm90, qmm_sm80, qmv, gather_qmv, fp_qmv) kept its
+// signature, including the `const std::optional<array>& global_scale`
+// parameter ml-explore/mlx#3757 added to qmm_naive at position 5 that both
+// call sites below pass std::nullopt for.
 //
 // Re-verify these call sites against qmm.h on the next pin bump; an overlay
 // that silently reverts an upstream change is how #830 / #831 happened.
@@ -325,11 +328,16 @@ void GatherQMM::eval_gpu(const std::vector<array>& inputs, array& out) {
   auto& s = stream();
   auto& encoder = cu::get_command_encoder(s);
 
+  if (mode_ != QuantizationMode::Affine && inputs.size() == 6) {
+    throw std::runtime_error(
+        "[GatherQMM] Global scale is only supported on the Metal backend.");
+  }
+
   array x = ensure_row_contiguous(inputs[0], encoder, s);
   const array& w = inputs[1];
   const array& scales = inputs[2];
   std::optional<array> biases;
-  if (inputs.size() == 6) {
+  if (mode_ == QuantizationMode::Affine) {
     biases = inputs[3];
   }
   array lhs_indices =

--- a/src/lib/mlx-cpp/patches/mlx/backend/metal/compiled.cpp
+++ b/src/lib/mlx-cpp/patches/mlx/backend/metal/compiled.cpp
@@ -210,7 +210,7 @@ inline void build_kernel(
         "  {0} tmp_{1} = ", get_type_string(x.dtype()), namer.get_name(x));
     if (is_static_cast(x.primitive())) {
       os += fmt::format(
-          "static_cast<{0}>(tmp_{1});\n",
+          "cast_to<{0}>(tmp_{1});\n",
           get_type_string(x.dtype()),
           namer.get_name(x.inputs()[0]));
     } else {

--- a/src/lib/mlx-cpp/patches/mlx/backend/metal/compiled.cpp
+++ b/src/lib/mlx-cpp/patches/mlx/backend/metal/compiled.cpp
@@ -1,6 +1,10 @@
 // Copyright © 2023-2024 Apple Inc.
 // mlxcel patch: adds static_cast for mixed-dtype compiled ops.
-// upstream API drift fixed for 6a9a121 (metal::get_command_encoder).
+// Synced to upstream 81ba1c6a. The only delta is that cast, in build_kernel's
+// emission of an op's inputs; everything else is upstream verbatim. Until this
+// sync the file also emitted `elem_to_loc_1<uint>` for 1-D inputs, a leftover
+// from before ml-explore/mlx#3720 that wraps a negative stride in the large
+// kernel negative strides select, so compare against upstream on every bump.
 #include <fmt/format.h>
 #include <sstream>
 
@@ -141,8 +145,8 @@ inline void build_kernel(
     os += fmt::format("  {0} index_{1} = ", idx_type, xname);
     if (ndim == 1) {
       int offset = i * ndim;
-      os +=
-          fmt::format("elem_to_loc_1<uint>(pos.x, in_strides[{0}]);\n", offset);
+      os += fmt::format(
+          "elem_to_loc_1<{0}>(pos.x, in_strides[{1}]);\n", idx_type, offset);
     } else if (ndim == 2) {
       int offset = i * ndim;
       os += fmt::format(
@@ -336,6 +340,7 @@ void Compiled::eval_gpu(
           /* dynamic_dims = */ false,
           /* use_big_index = */ false,
           /* work_per_thread = */ i > 3 ? 2 : 1);
+      // Generate int64_t index variant for all ndim, including ndim=1.
       // Negative strides force large mode even for small arrays.
       build_kernel(
           kernel,

--- a/src/lib/mlx-cpp/patches/mlx/backend/metal/kernels/utils.h
+++ b/src/lib/mlx-cpp/patches/mlx/backend/metal/kernels/utils.h
@@ -354,6 +354,29 @@ inline complex64_t log1p(complex64_t in) {
   }
 }
 
+// https://github.com/pytorch/pytorch/blob/a82aae9d4a7827849ce50f31c4c7ee8f278d05f5/c10/metal/utils.h#L554
+inline float hypot(float x, float y) {
+  if (metal::isinf(x) || metal::isinf(y)) {
+    return metal::numeric_limits<float>::infinity();
+  }
+  if (metal::isnan(x) || metal::isnan(y)) {
+    return metal::numeric_limits<float>::quiet_NaN();
+  }
+  float a = metal::fmax(metal::fabs(x), metal::fabs(y));
+  float b = metal::fmin(metal::fabs(x), metal::fabs(y));
+  if (a == 0.0f) {
+    return 0.0f;
+  }
+  float r = (b / a) * (b / a);
+  float sqrt_1_plus_r = metal::precise::sqrt(1.0f + r);
+  float h1 = metal::sqrt(2.0f) * a;
+  float h2 = a + a * r / 2.0f;
+  float h3 = a * sqrt_1_plus_r;
+  bool is_h1 = (a == b);
+  bool is_h2 = ((sqrt_1_plus_r == 1.0f) && (r > 0.0f));
+  return metal::select(metal::select(h3, h2, is_h2), h1, is_h1);
+}
+
 ///////////////////////////////////////////////////////////////////////////////
 // SIMD shuffle ops
 ///////////////////////////////////////////////////////////////////////////////
@@ -447,3 +470,27 @@ template <typename T, typename U>
 struct ConditionalType<true, T, U> {
   using type = T;
 };
+
+///////////////////////////////////////////////////////////////////////////////
+// Type casting utils
+///////////////////////////////////////////////////////////////////////////////
+
+template <typename U, typename T>
+inline U cast_to(T val) {
+  return static_cast<U>(val);
+}
+
+template <>
+inline bool cast_to<bool, float>(float val) {
+  return (as_type<uint32_t>(val) & 0x7FFFFFFF) != 0;
+}
+
+template <>
+inline bool cast_to<bool, bfloat16_t>(bfloat16_t val) {
+  return (as_type<uint16_t>(val) & 0x7FFF) != 0;
+}
+
+template <>
+inline bool cast_to<bool, complex64_t>(complex64_t val) {
+  return cast_to<bool, float>(val.real) || cast_to<bool, float>(val.imag);
+}

--- a/src/lib/mlx-cpp/patches/mlx/backend/metal/quantized.cpp
+++ b/src/lib/mlx-cpp/patches/mlx/backend/metal/quantized.cpp
@@ -1,8 +1,10 @@
 // Copyright © 2023-2026 Apple Inc.
 // Patched by mlxcel: `use_qmv_wide` gains an off-switch, `MLXCEL_QMV_WIDE=0`.
-// Synced to upstream 81ba1c6a; the only delta is `qmv_wide_enabled()` and the
-// one call it adds to `use_qmv_wide`. Everything else is upstream verbatim, so
-// a bump refreshes this file and re-applies those two hunks.
+// Synced to upstream 81ba1c6a. The delta is three hunks: the includes below,
+// `mlxcel_qmv_wide_flag()` with the one call it adds to `use_qmv_wide`, and the
+// two bridge entry points `mlxcel_set_qmv_wide()` / `mlxcel_qmv_wide()` at the
+// end of the file. Everything else is upstream verbatim, so a bump refreshes
+// this file and re-applies those three hunks.
 //
 // Why it exists (lablup/mlxcel#1186, #1187). `use_qmv_wide` sends `M >= 2`
 // affine quantized matmuls down `qmv_wide` on GPU generation 15 and later

--- a/src/lib/mlx-cpp/patches/mlx/backend/metal/quantized.cpp
+++ b/src/lib/mlx-cpp/patches/mlx/backend/metal/quantized.cpp
@@ -1,6 +1,6 @@
 // Copyright © 2023-2026 Apple Inc.
 // Patched by mlxcel: `use_qmv_wide` gains an off-switch, `MLXCEL_QMV_WIDE=0`.
-// Synced to upstream 9a795735; the only delta is `qmv_wide_enabled()` and the
+// Synced to upstream 81ba1c6a; the only delta is `qmv_wide_enabled()` and the
 // one call it adds to `use_qmv_wide`. Everything else is upstream verbatim, so
 // a bump refreshes this file and re-applies those two hunks.
 //
@@ -13,7 +13,7 @@
 // there entirely. Generations 13 and 14 take `qmv` on both sides and stay
 // equal up to `get_qmv_batch_limit`, so forcing that path is a way to buy the
 // contract back. Upstream exposes no knob for this and `use_qmv_wide` is
-// unchanged as of 9a795735, so the switch has to live here.
+// unchanged as of 81ba1c6a, so the switch has to live here.
 //
 // Off-switch only, matching MLXCEL_METAL4_ATTENTION: unset behaves exactly as
 // upstream, and the value is read once per process because this sits on the
@@ -272,21 +272,18 @@ void quantize_impl(
   auto w = ensure_row_contiguous(w_pre, d, s);
   if (dequantize) {
     auto scales = ensure_row_contiguous(inputs[1], d, s);
-    compute_encoder.set_input_array(w, 0);
-    compute_encoder.set_input_array(scales, 1);
     if (has_biases) {
       auto biases = ensure_row_contiguous(inputs[2], d, s);
       compute_encoder.set_input_array(biases, 2);
     } else if (has_global_scale) {
       compute_encoder.set_input_array(inputs[2], 2);
     }
+    compute_encoder.set_input_array(w, 0);
+    compute_encoder.set_input_array(scales, 1);
     compute_encoder.set_output_array(out, 3);
   } else {
     auto& scales = outputs[1];
     scales.set_data(allocator::malloc(scales.nbytes()));
-    compute_encoder.set_input_array(w, 0);
-    compute_encoder.set_output_array(out, 1);
-    compute_encoder.set_output_array(scales, 2);
     if (has_biases) {
       auto& biases = outputs[2];
       biases.set_data(allocator::malloc(biases.nbytes()));
@@ -294,6 +291,9 @@ void quantize_impl(
     } else if (has_global_scale) {
       compute_encoder.set_input_array(inputs[1], 3);
     }
+    compute_encoder.set_input_array(w, 0);
+    compute_encoder.set_output_array(out, 1);
+    compute_encoder.set_output_array(scales, 2);
   }
 
   auto type_string = dequantize ? get_type_string(out.dtype())
@@ -876,7 +876,9 @@ void qmm_nax(
 
   int wm = 2;
   int wn = 2;
-  int bm = 64;
+  // Use smaller bm when one block covers all of M. Only qmm_t_nax has a 32-row
+  // instantiation.
+  int bm = (transpose && M <= 32) ? 32 : 64;
   int bn = 64;
   int bk = 64;
   MTL::Size group_dims(32, wn, wm);
@@ -965,6 +967,7 @@ void gather_qmm_nax(
     const array& w,
     const array& scales,
     const std::optional<array>& biases,
+    const std::optional<array>& global_scale,
     const array& lhs_indices,
     const array& rhs_indices,
     array& out,
@@ -1011,13 +1014,14 @@ void gather_qmm_nax(
       wm,
       "_wn",
       wn,
-      transpose ? (aligned ? "_alN_true" : "_alN_false") : "");
+      transpose ? (aligned ? "_alN_true" : "_alN_false") : "",
+      global_scale ? "_hgs" : "");
   MTL::ComputePipelineState* kernel;
   if (transpose) {
     kernel = get_qmm_nax_kernel_wrapped(
         d,
         kname,
-        "gather_qmm_t_nax_",
+        "gather_qmm_t_nax",
         mode,
         type_string,
         group_size,
@@ -1027,12 +1031,13 @@ void gather_qmm_nax(
         bk,
         bn,
         wm,
-        wn);
+        wn,
+        global_scale.has_value());
   } else {
     kernel = get_qmm_nax_kernel_wrapped(
         d,
         kname,
-        "gather_qmm_n_nax_",
+        "gather_qmm_n_nax",
         mode,
         type_string,
         group_size,
@@ -1047,12 +1052,14 @@ void gather_qmm_nax(
   auto& compute_encoder = metal::get_command_encoder(s);
   compute_encoder.set_compute_pipeline_state(kernel);
 
-  int c = 0;
-  compute_encoder.set_input_array(w, c++);
-  compute_encoder.set_input_array(scales, c++);
+  compute_encoder.set_input_array(w, 0);
+  compute_encoder.set_input_array(scales, 1);
   if (biases) {
-    compute_encoder.set_input_array(*biases, c++);
+    compute_encoder.set_input_array(*biases, 2);
+  } else if (global_scale) {
+    compute_encoder.set_input_array(*global_scale, 2);
   }
+  int c = 3;
   compute_encoder.set_input_array(x, c++);
   compute_encoder.set_input_array(lhs_indices, c++);
   compute_encoder.set_input_array(rhs_indices, c++);
@@ -1083,7 +1090,8 @@ void qmm(
     const std::string& mode) {
   bool has_nax_kernel =
       metal::is_nax_available() && (transpose || mode == "affine");
-  if (has_nax_kernel && transpose && (K % 64 == 0) &&
+  bool nax_aligned = (K % 64 == 0) && (transpose || N % 64 == 0);
+  if (has_nax_kernel && nax_aligned &&
       (env::enable_tf32() || x.dtype() != float32)) {
     return qmm_nax(
         /* const array& x = */ x,
@@ -1266,6 +1274,7 @@ void gather_qmm(
     const array& w,
     const array& scales,
     const std::optional<array>& biases,
+    const std::optional<array>& global_scale,
     const array& lhs_indices,
     const array& rhs_indices,
     array& out,
@@ -1285,6 +1294,7 @@ void gather_qmm(
         /* const array& w = */ w,
         /* const array& scales = */ scales,
         /* const std::optional<array>& biases = */ biases,
+        /* const std::optional<array>& global_scale = */ global_scale,
         /* const array& lhs_indices = */ lhs_indices,
         /* const array& rhs_indices = */ rhs_indices,
         /* array& out = */ out,
@@ -1320,25 +1330,43 @@ void gather_qmm(
       group_size,
       "_b_",
       bits,
-      transpose ? (aligned ? "_alN_true" : "_alN_false") : "");
+      transpose ? (aligned ? "_alN_true" : "_alN_false") : "",
+      global_scale ? "_hgs" : "");
   MTL::ComputePipelineState* kernel;
   if (transpose) {
     kernel = get_quantized_kernel_wrapped(
-        d, kname, "gather_qmm_t", mode, type_string, group_size, bits, aligned);
+        d,
+        kname,
+        "gather_qmm_t",
+        mode,
+        type_string,
+        group_size,
+        bits,
+        aligned,
+        global_scale.has_value());
   } else {
     kernel = get_quantized_kernel_wrapped(
-        d, kname, "gather_qmm_n", mode, type_string, group_size, bits);
+        d,
+        kname,
+        "gather_qmm_n",
+        mode,
+        type_string,
+        group_size,
+        bits,
+        global_scale.has_value());
   }
 
   auto& compute_encoder = metal::get_command_encoder(s);
   compute_encoder.set_compute_pipeline_state(kernel);
 
-  int c = 0;
-  compute_encoder.set_input_array(w, c++);
-  compute_encoder.set_input_array(scales, c++);
+  compute_encoder.set_input_array(w, 0);
+  compute_encoder.set_input_array(scales, 1);
   if (biases) {
-    compute_encoder.set_input_array(*biases, c++);
+    compute_encoder.set_input_array(*biases, 2);
+  } else if (global_scale) {
+    compute_encoder.set_input_array(*global_scale, 2);
   }
+  int c = 3;
   compute_encoder.set_input_array(x, c++);
   compute_encoder.set_input_array(lhs_indices, c++);
   compute_encoder.set_input_array(rhs_indices, c++);
@@ -1497,6 +1525,7 @@ void gather_qmm_rhs_nax(
     const array& w_,
     const array& scales_,
     const std::optional<array>& biases_,
+    const std::optional<array>& global_scale,
     const array& indices_,
     array& out,
     bool transpose,
@@ -1536,6 +1565,10 @@ void gather_qmm_rhs_nax(
   if (biases_) {
     biases = ensure_row_contiguous(*biases_, d, s);
   }
+  std::optional<array> gs;
+  if (global_scale) {
+    gs = ensure_row_contiguous(*global_scale, d, s);
+  }
 
   // Use smaller bm for many experts and few tokens.
   int E = w.size() / w.shape(-1) / w.shape(-2);
@@ -1569,7 +1602,8 @@ void gather_qmm_rhs_nax(
       "_wm_",
       wm,
       "_wn_",
-      wn);
+      wn,
+      global_scale ? "_hgs" : "");
 
   metal::MTLFCList func_consts = {
       {&align_M, MTL::DataType::DataTypeBool, 200},
@@ -1606,19 +1640,22 @@ void gather_qmm_rhs_nax(
       bk,
       wm,
       wn,
-      transpose);
+      transpose,
+      global_scale.has_value());
   compute_encoder.set_compute_pipeline_state(kernel);
 
   MTL::Size group_dims(32, wn, wm);
   MTL::Size grid_dims((N + bn - 1) / bn, (M + bm - 1) / bm, 1);
 
-  int c = 0;
-  compute_encoder.set_input_array(x, c++);
-  compute_encoder.set_input_array(w, c++);
-  compute_encoder.set_input_array(scales, c++);
+  compute_encoder.set_input_array(x, 0);
+  compute_encoder.set_input_array(w, 1);
+  compute_encoder.set_input_array(scales, 2);
   if (biases) {
-    compute_encoder.set_input_array(*biases, c++);
+    compute_encoder.set_input_array(*biases, 3);
+  } else if (gs) {
+    compute_encoder.set_input_array(*gs, 3);
   }
+  int c = 4;
   compute_encoder.set_input_array(indices, c++);
   compute_encoder.set_output_array(out, c++);
   compute_encoder.set_bytes(M, c++);
@@ -1633,6 +1670,7 @@ void gather_qmm_rhs(
     const array& w_,
     const array& scales_,
     const std::optional<array>& biases_,
+    const std::optional<array>& global_scale,
     const array& indices_,
     array& out,
     bool transpose,
@@ -1651,6 +1689,7 @@ void gather_qmm_rhs(
         /* const array& w_ = */ w_,
         /* const array& scales_ = */ scales_,
         /* const std::optional<array>& biases_ = */ biases_,
+        /* const std::optional<array>& global_scale = */ global_scale,
         /* const array& indices_ = */ indices_,
         /* array& out = */ out,
         /* bool transpose = */ transpose,
@@ -1692,6 +1731,10 @@ void gather_qmm_rhs(
   if (biases_) {
     biases = ensure_row_contiguous(*biases_, d, s);
   }
+  std::optional<array> gs;
+  if (global_scale) {
+    gs = ensure_row_contiguous(*global_scale, d, s);
+  }
 
   // TODO: Tune the block sizes
   int bm = 16, bn = 32, bk = 32;
@@ -1722,7 +1765,8 @@ void gather_qmm_rhs(
       "_wm_",
       wm,
       "_wn_",
-      wn);
+      wn,
+      global_scale ? "_hgs" : "");
 
   metal::MTLFCList func_consts = {
       {&align_M, MTL::DataType::DataTypeBool, 200},
@@ -1759,19 +1803,22 @@ void gather_qmm_rhs(
       bk,
       wm,
       wn,
-      transpose);
+      transpose,
+      global_scale.has_value());
   compute_encoder.set_compute_pipeline_state(kernel);
 
   MTL::Size group_dims(32, wn, wm);
   MTL::Size grid_dims((N + bn - 1) / bn, (M + bm - 1) / bm, 1);
 
-  int c = 0;
-  compute_encoder.set_input_array(x, c++);
-  compute_encoder.set_input_array(w, c++);
-  compute_encoder.set_input_array(scales, c++);
+  compute_encoder.set_input_array(x, 0);
+  compute_encoder.set_input_array(w, 1);
+  compute_encoder.set_input_array(scales, 2);
   if (biases) {
-    compute_encoder.set_input_array(*biases, c++);
+    compute_encoder.set_input_array(*biases, 3);
+  } else if (gs) {
+    compute_encoder.set_input_array(*gs, 3);
   }
+  int c = 4;
   compute_encoder.set_input_array(indices, c++);
   compute_encoder.set_output_array(out, c++);
   compute_encoder.set_bytes(M, c++);
@@ -1928,9 +1975,13 @@ void GatherQMM::eval_gpu(const std::vector<array>& inputs, array& out) {
   array x = ensure_row_contiguous_matrix(inputs[0], d, s);
   array w = ensure_row_contiguous_matrix(inputs[1], d, s);
   array scales = ensure_row_contiguous_matrix(inputs[2], d, s);
+  // Affine gets biases at index 3, nvfp4 an optional global scale.
   std::optional<array> biases = std::nullopt;
-  if (inputs.size() == 6) {
+  std::optional<array> global_scale = std::nullopt;
+  if (mode_ == QuantizationMode::Affine) {
     biases = ensure_row_contiguous_matrix(inputs[3], d, s);
+  } else if (inputs.size() == 6) {
+    global_scale = ensure_row_contiguous(inputs[3], d, s);
   }
   const array& lhs_indices = inputs[inputs.size() - 2];
   const array& rhs_indices = inputs[inputs.size() - 1];
@@ -1953,6 +2004,7 @@ void GatherQMM::eval_gpu(const std::vector<array>& inputs, array& out) {
         w,
         scales,
         biases,
+        global_scale,
         rhs_indices,
         out,
         transpose_,
@@ -1974,6 +2026,7 @@ void GatherQMM::eval_gpu(const std::vector<array>& inputs, array& out) {
         w,
         scales,
         biases,
+        global_scale,
         lhs_indices,
         rhs_indices,
         out,
@@ -1995,7 +2048,7 @@ void GatherQMM::eval_gpu(const std::vector<array>& inputs, array& out) {
         w,
         scales,
         biases,
-        std::nullopt,
+        global_scale,
         lhs_indices,
         rhs_indices,
         out,
@@ -2015,7 +2068,7 @@ void GatherQMM::eval_gpu(const std::vector<array>& inputs, array& out) {
       w,
       scales,
       biases,
-      std::nullopt,
+      global_scale,
       lhs_indices,
       rhs_indices,
       out,
@@ -2132,6 +2185,15 @@ void GatherQQMM::eval_gpu(const std::vector<array>& inputs, array& out) {
   int K = x.shape(-1);
   int M = non_batched ? x.size() / K : x.shape(-2);
   int N = out.shape(-1);
+
+  // temporary, until we add proper scaling for gather qqmm
+  if (global_scale_w) {
+    int E = w_q.size() / w_q.shape(-1) / w_q.shape(-2);
+    array gs_e(Shape{E}, float32, nullptr, {});
+    broadcast(*global_scale_w, gs_e);
+    global_scale_w = ensure_row_contiguous(gs_e, d, s);
+  }
+
   gather_qmv(
       x,
       w_q,

--- a/src/lib/mlxcel-core/build.rs
+++ b/src/lib/mlxcel-core/build.rs
@@ -506,6 +506,11 @@ fn link_cuda() {
     println!("cargo:rustc-link-lib=dylib=cublas");
     println!("cargo:rustc-link-lib=dylib=cublasLt");
     println!("cargo:rustc-link-lib=dylib=cufft");
+    // cuSOLVER, since MLX 81ba1c6a: ml-explore/mlx#4208 moved Cholesky onto it
+    // and `gpu::init()` now creates its handle cache on every CUDA start, so a
+    // link without it fails on `cusolverDnCreate`. MLX's own CMake links it
+    // PRIVATE, which cargo never sees, so it has to be named here like the rest.
+    println!("cargo:rustc-link-lib=dylib=cusolver");
 
     // CUDA driver API (cuLaunchKernel, cuModuleLoad, etc.)
     println!("cargo:rustc-link-lib=dylib=cuda");

--- a/src/lib/mlxcel-core/cpp/mlx_cxx_bridge.cpp
+++ b/src/lib/mlxcel-core/cpp/mlx_cxx_bridge.cpp
@@ -5565,17 +5565,55 @@ static bool rejection_path_selected(
         rejection_sample_applies(x, temperature, top_k, top_p, min_p);
 }
 
+// Where a stashed launch stands, read without waiting, throwing, or touching
+// the launch's error.
+//
+// `array::is_available()` is not that query any more. Since MLX 81ba1c6a
+// (ml-explore/mlx#3742) it detaches the array's event through
+// `Event::check_error()`, which throws when the launch failed and clears the
+// error while doing so, and every event a failed command buffer signals points
+// at the same encoder error. Called on a slot that another request stashed, it
+// would throw inside `fused_sample`, which is not a `Result` bridge function,
+// so the process would terminate; and it would consume the error that the
+// owning request's own eval exists to report. Status, the event's signal and
+// its error pointer answer the question without either effect. Metal's
+// completion handler and the CPU scheduler both store an event's error before
+// they signal it (CUDA attaches none), so an error is visible by the time
+// `is_signaled()` is.
+enum class StashedLaunch { InFlight, Landed, Failed };
+
+static StashedLaunch stashed_launch_state(const mlx::core::array& a) {
+    using Status = mlx::core::array::Status;
+    if (a.status() == Status::available) {
+        return StashedLaunch::Landed;
+    }
+    if (a.status() != Status::evaluated) {
+        return StashedLaunch::InFlight;
+    }
+    const auto& event = a.event();
+    if (!event.valid()) {
+        return StashedLaunch::Landed;
+    }
+    if (!event.is_signaled()) {
+        return StashedLaunch::InFlight;
+    }
+    const auto* error = event.load_error();
+    return (error != nullptr && error->valid()) ? StashedLaunch::Failed
+                                                : StashedLaunch::Landed;
+}
+
 // Inspect the previous production launch's converged flags, but ONLY if they
 // have already landed. Never waits, so it is safe to call from inside a decode
 // loop's graph-building phase.
 //
-// `array::is_available()` is MLX's non-blocking status query: it is false while
-// the launch is still unscheduled or in flight, and true once the event is
-// signalled. A decode loop reads each step's token before building the next, so
-// in practice the check lands one step late and costs nothing. If it never
-// lands (a caller that discards its tokens) the stash is simply replaced by the
-// next launch and nothing is reported, which is the correct outcome for a
-// sample that was never used.
+// A launch is in flight while it is unscheduled or its event is unsignalled,
+// and landed once the event is signalled (see `stashed_launch_state`). A decode
+// loop reads each step's token before building the next, so in practice the
+// check lands one step late and costs nothing. If it never lands (a caller that
+// discards its tokens) the stash is simply replaced by the next launch and
+// nothing is reported, which is the correct outcome for a sample that was never
+// used. A launch whose command buffer failed is dropped unread: its flags were
+// never written, and its error belongs to the request that owns it.
 static void drain_pending_verification() {
     auto& pending = pending_verification();
     std::vector<std::tuple<mlx::core::array, mlx::core::array, int>> landed;
@@ -5583,9 +5621,20 @@ static void drain_pending_verification() {
         std::lock_guard<std::mutex> lock(pending.mu);
         for (size_t slot = 0; slot < PendingVerification::SLOTS; ++slot) {
             if (!pending.ok[slot].has_value() ||
-                !pending.rounds[slot].has_value() ||
-                !pending.ok[slot]->is_available() ||
-                !pending.rounds[slot]->is_available()) {
+                !pending.rounds[slot].has_value()) {
+                continue;
+            }
+            const auto ok_state = stashed_launch_state(*pending.ok[slot]);
+            const auto rounds_state = stashed_launch_state(*pending.rounds[slot]);
+            if (ok_state == StashedLaunch::Failed ||
+                rounds_state == StashedLaunch::Failed) {
+                pending.ok[slot].reset();
+                pending.rounds[slot].reset();
+                pending.cap[slot] = 0;
+                continue;
+            }
+            if (ok_state != StashedLaunch::Landed ||
+                rounds_state != StashedLaunch::Landed) {
                 continue;
             }
             landed.emplace_back(

--- a/src/lib/mlxcel-core/cpp/mlx_cxx_bridge.cpp
+++ b/src/lib/mlxcel-core/cpp/mlx_cxx_bridge.cpp
@@ -5653,6 +5653,75 @@ static void drain_pending_verification() {
     (void)unconverged;
 }
 
+// -- Test-only fixture for the Failed branch of `drain_pending_verification` --
+//
+// A real Failed launch takes an actual command-buffer error, which nothing in
+// a unit test process triggers on purpose. This hand-builds the same state
+// using only the public `Event`/`Error` API (`mlx/event.h`, `mlx/error.h`): a
+// real event, signalled through a real, successful command, with a synthetic
+// error attached AFTERWARDS so nothing has called `Error::check()` on it
+// (which would consume it) before the test does.
+namespace {
+    // Leaked like `pending_verification()` above: `Event::set_error` stores a
+    // raw pointer, so the error has to outlive every event that points at it,
+    // including one a prior stash left behind.
+    mlx::core::Error& stashed_test_error() {
+        static mlx::core::Error* error = new mlx::core::Error();
+        return *error;
+    }
+}
+
+// Test-only. Stash a launch into slot 0 of the pending-verification ring
+// whose shared event is valid, signalled, and carries an error, mirroring a
+// genuinely failed command buffer at MLX 81ba1c6a (ml-explore/mlx#3742).
+// `array::is_available()` would call `Event::check_error()` on this and
+// throw, consuming the error; `stashed_launch_state` must not.
+void sampling_dispatch_stash_failed_launch_for_test() {
+    auto stream = mlx::core::default_stream(mlx::core::default_device());
+    mlx::core::Event event(stream);
+    event.set_value(1);
+    event.signal(stream);
+    // Land the signal for real before an error is attached: `synchronize`
+    // commits and waits on it, which is safe here because nothing has stored
+    // an error on the event yet for it to `check()` and consume.
+    mlx::core::synchronize(stream);
+
+    auto& error = stashed_test_error();
+    error.set_message(std::make_shared<std::string>(
+        "mlxcel test: synthetic launch failure"));
+    event.set_error(error);
+
+    const uint32_t zero = 0;
+    mlx::core::array ok(&zero, mlx::core::Shape{1}, mlx::core::uint32);
+    mlx::core::array rounds(&zero, mlx::core::Shape{1}, mlx::core::uint32);
+    ok.set_status(mlx::core::array::Status::evaluated);
+    rounds.set_status(mlx::core::array::Status::evaluated);
+    ok.attach_event(event);
+    rounds.attach_event(event);
+
+    auto& pending = pending_verification();
+    std::lock_guard<std::mutex> lock(pending.mu);
+    pending.ok[0] = std::move(ok);
+    pending.rounds[0] = std::move(rounds);
+    pending.cap[0] = 1;
+}
+
+// Test-only. True while the error the stash above attached has not been
+// consumed, i.e. nothing called `Error::check()` on it (which
+// `Event::check_error()`, and so `array::is_available()`, would have done).
+bool sampling_dispatch_stashed_test_error_is_valid() {
+    return stashed_test_error().valid();
+}
+
+// Test-only. True once slot 0 no longer holds a stashed launch, which is what
+// dropping a Failed launch looks like from outside
+// `drain_pending_verification`.
+bool sampling_dispatch_stashed_test_slot_is_empty() {
+    auto& pending = pending_verification();
+    std::lock_guard<std::mutex> lock(pending.mu);
+    return !pending.ok[0].has_value() && !pending.rounds[0].has_value();
+}
+
 // The overflow counting rule and its report, shared by the deferred drain and
 // by the test hook so there is exactly one implementation of both.
 //

--- a/src/lib/mlxcel-core/cpp/mlx_cxx_bridge.cpp
+++ b/src/lib/mlxcel-core/cpp/mlx_cxx_bridge.cpp
@@ -2485,12 +2485,14 @@ namespace {
             auto gate = mlx::core::gather_qmm(
                 x, gate_w, gate_s, std::optional<array>(gate_b),
                 std::nullopt, std::optional<array>(rhs_indices),
-                transpose, group_size, bits, "affine", sorted_indices);
+                transpose, group_size, bits, "affine",
+                /* global_scale = */ std::nullopt, sorted_indices);
 
             auto up = mlx::core::gather_qmm(
                 x, up_w, up_s, std::optional<array>(up_b),
                 std::nullopt, std::optional<array>(rhs_indices),
-                transpose, group_size, bits, "affine", sorted_indices);
+                transpose, group_size, bits, "affine",
+                /* global_scale = */ std::nullopt, sorted_indices);
 
             // GeGLU: Python mlx-lm uses nn.gelu_approx(gate) * up.
             auto activated = mlx::core::multiply(gelu_tanh_approx(gate), up);
@@ -2498,7 +2500,8 @@ namespace {
             auto down = mlx::core::gather_qmm(
                 activated, down_w, down_s, std::optional<array>(down_b),
                 std::nullopt, std::optional<array>(rhs_indices),
-                transpose, group_size, bits, "affine", sorted_indices);
+                transpose, group_size, bits, "affine",
+                /* global_scale = */ std::nullopt, sorted_indices);
 
             return {down};
         };
@@ -2559,12 +2562,12 @@ std::unique_ptr<MlxArray> compiled_switch_qgeglu_forward(
         x.inner, gate_w.inner, gate_s.inner, gb_opt,
         std::nullopt, rhs_opt, true,
         std::optional<int>(group_size), std::optional<int>(bits),
-        mode_str, false);
+        mode_str, /* global_scale = */ std::nullopt, false);
     auto up = mlx::core::gather_qmm(
         x.inner, up_w.inner, up_s.inner, ub_opt,
         std::nullopt, rhs_opt, true,
         std::optional<int>(group_size), std::optional<int>(bits),
-        mode_str, false);
+        mode_str, /* global_scale = */ std::nullopt, false);
 
     auto activated = mlx::core::multiply(gelu_tanh_approx(gate), up);
 
@@ -2572,7 +2575,7 @@ std::unique_ptr<MlxArray> compiled_switch_qgeglu_forward(
         activated, down_w.inner, down_s.inner, db_opt,
         std::nullopt, rhs_opt, true,
         std::optional<int>(group_size), std::optional<int>(bits),
-        mode_str, false);
+        mode_str, /* global_scale = */ std::nullopt, false);
 
     return std::make_unique<MlxArray>(std::move(down));
 }
@@ -3219,13 +3222,13 @@ std::unique_ptr<MlxArray> gather_qmm(
             x.inner, w.inner, scales.inner, biases_opt,
             lhs_opt, rhs_opt, transpose,
             std::optional<int>(group_size), std::optional<int>(bits),
-            "affine", sorted_indices));
+            "affine", /* global_scale = */ std::nullopt, sorted_indices));
     }
     return std::make_unique<MlxArray>(mlx::core::gather_qmm(
         x.inner, w.inner, scales.inner, biases_opt,
         lhs_opt, rhs_opt, transpose,
         std::optional<int>(group_size), std::optional<int>(bits),
-        std::string(mode.data(), mode.size()), sorted_indices));
+        std::string(mode.data(), mode.size()), /* global_scale = */ std::nullopt, sorted_indices));
 }
 
 std::unique_ptr<MlxArray> quantized_matmul(

--- a/src/lib/mlxcel-core/cpp/mlx_cxx_bridge.h
+++ b/src/lib/mlxcel-core/cpp/mlx_cxx_bridge.h
@@ -1483,6 +1483,18 @@ void sampling_dispatch_drain_pending();
 // Clear every recorded dispatch outcome and both cap-overflow counters.
 void sampling_dispatch_reset();
 
+// Test-only. Stash a launch into slot 0 of the pending-verification ring
+// whose event is valid, signalled, and carries an error, the shape a failed
+// command buffer produces at MLX 81ba1c6a (ml-explore/mlx#3742).
+void sampling_dispatch_stash_failed_launch_for_test();
+
+// Test-only. True while the error the stash above attached has not been
+// consumed.
+bool sampling_dispatch_stashed_test_error_is_valid();
+
+// Test-only. True once slot 0 no longer holds a stashed launch.
+bool sampling_dispatch_stashed_test_slot_is_empty();
+
 // SSM (State Space Model) primitives for Mamba/Jamba/Nemotron-H.
 // Cumulative sum along axis
 std::unique_ptr<MlxArray> cumsum(const MlxArray& a, int32_t axis, bool reverse, bool inclusive);

--- a/src/lib/mlxcel-core/cpp/mlx_cxx_kernels.cpp
+++ b/src/lib/mlxcel-core/cpp/mlx_cxx_kernels.cpp
@@ -1362,13 +1362,13 @@ std::unique_ptr<MlxArray> fused_moe_forward(
         auto h = gather_qmm(
             x_exp, fc1_weight.inner, fc1_scales.inner, fc1_biases.inner,
             std::nullopt, topk_indices,
-            true, group_size, bits, "affine", false);
+            true, group_size, bits, "affine", /* global_scale = */ std::nullopt, false);
         // relu² = relu(x)²
         { MlxArray h_w{h}; h = compiled_relu_squared(h_w)->inner; }
         h = gather_qmm(
             h, fc2_weight.inner, fc2_scales.inner, fc2_biases.inner,
             std::nullopt, topk_indices,
-            true, group_size, bits, "affine", false);
+            true, group_size, bits, "affine", /* global_scale = */ std::nullopt, false);
         h = squeeze(h, -2);  // [tokens, top_k, hidden]
         if (profile_nemotron_moe) {
             h.eval();
@@ -2082,12 +2082,12 @@ std::unique_ptr<MlxArray> run_fused_moe_two_kernel(
             x4, gate_w.inner, gate_s.inner, std::optional<array>(gate_b.inner),
             std::nullopt, std::optional<array>(idx2), true,
             std::optional<int>(group_size), std::optional<int>(gu_bits),
-            "affine", false);
+            "affine", /* global_scale = */ std::nullopt, false);
         auto up = mlx::core::gather_qmm(
             x4, up_w.inner, up_s.inner, std::optional<array>(up_b.inner),
             std::nullopt, std::optional<array>(idx2), true,
             std::optional<int>(group_size), std::optional<int>(gu_bits),
-            "affine", false);
+            "affine", /* global_scale = */ std::nullopt, false);
         array act_ref = (act == 1)
             ? multiply(gelu_tanh_approx(gate), up)
             : multiply(multiply(gate, sigmoid(gate)), up);
@@ -2095,7 +2095,7 @@ std::unique_ptr<MlxArray> run_fused_moe_two_kernel(
             act_ref, down_w.inner, down_s.inner, std::optional<array>(down_b.inner),
             std::nullopt, std::optional<array>(idx2), true,
             std::optional<int>(group_size), std::optional<int>(d_bits),
-            "affine", false);
+            "affine", /* global_scale = */ std::nullopt, false);
         auto per_expert = reshape(astype(down, float32), {k, din});
         auto w_col = reshape(astype(scores.inner, float32), {k, 1});
         auto ref = sum(multiply(per_expert, w_col), /*axis=*/0, false);

--- a/src/lib/mlxcel-core/src/lib.rs
+++ b/src/lib/mlxcel-core/src/lib.rs
@@ -2287,6 +2287,21 @@ mod ffi {
         /// counters. The state is process-wide; tests need a clean slate.
         fn sampling_dispatch_reset();
 
+        /// Test-only. Stash a launch into slot 0 of the pending-verification
+        /// ring whose event is valid, signalled, and carries an error, the
+        /// shape a genuinely failed command buffer produces at MLX 81ba1c6a
+        /// (ml-explore/mlx#3742). Exercises the Failed branch of the deferred
+        /// drain without needing a real command-buffer failure.
+        fn sampling_dispatch_stash_failed_launch_for_test();
+
+        /// Test-only. True while the error the stash above attached has not
+        /// been consumed by `Error::check()` (which `array::is_available()`
+        /// would have done through `Event::check_error()`).
+        fn sampling_dispatch_stashed_test_error_is_valid() -> bool;
+
+        /// Test-only. True once slot 0 no longer holds a stashed launch.
+        fn sampling_dispatch_stashed_test_slot_is_empty() -> bool;
+
         // SSM (State Space Model) primitives for Mamba/Jamba/Nemotron-H.
         /// Cumulative sum along axis
         fn cumsum(a: &MlxArray, axis: i32, reverse: bool, inclusive: bool) -> UniquePtr<MlxArray>;

--- a/src/lib/mlxcel-core/src/sampling_rejection_tests.rs
+++ b/src/lib/mlxcel-core/src/sampling_rejection_tests.rs
@@ -1375,6 +1375,45 @@ fn cap_overflow_is_detected_without_waiting_on_the_production_path() {
     );
 }
 
+/// A launch whose command buffer failed must be dropped by the deferred
+/// drain without the drain throwing or consuming the launch's own error.
+///
+/// This does not go through the rejection kernel at all, unlike every other
+/// test in this file: it stashes a launch whose shared event is valid,
+/// signalled, and carries an error, using only core MLX `Event`/`Error`
+/// primitives (see `sampling_dispatch_stash_failed_launch_for_test` in
+/// `mlx_cxx_bridge.cpp`), which needs no GPU JIT support. Since MLX 81ba1c6a
+/// (ml-explore/mlx#3742), `array::is_available()` detaches an evaluated
+/// array's event through `Event::check_error()`, which throws and CLEARS the
+/// error while doing so. Called on a slot the drain does not own, that would
+/// both terminate the process (a throw across a non-`Result` cxx bridge
+/// function) and consume the error the owning request's own eval exists to
+/// report. `drain_pending_verification` reads status, the event's signal and
+/// its error pointer instead, so it must do neither.
+#[test]
+fn a_failed_stashed_launch_is_dropped_without_throwing_or_consuming_its_error() {
+    let _dispatch = crate::sampling_dispatch::dispatch_test_guard();
+
+    sampling_dispatch_stash_failed_launch_for_test();
+    assert!(
+        sampling_dispatch_stashed_test_error_is_valid(),
+        "the fixture's own error was not valid before the drain ran"
+    );
+
+    // Must not throw (which would abort the whole test process rather than
+    // fail this test by name) and must not consume the error.
+    sampling_dispatch_drain_pending();
+
+    assert!(
+        sampling_dispatch_stashed_test_error_is_valid(),
+        "drain_pending_verification consumed the error of a launch it does not own"
+    );
+    assert!(
+        sampling_dispatch_stashed_test_slot_is_empty(),
+        "drain_pending_verification did not drop the Failed slot"
+    );
+}
+
 // -- agreement with the distribution #902 reports --
 
 /// Row 0 of `fused_sample_probs` as host floats.

--- a/src/models/fp8_block.rs
+++ b/src/models/fp8_block.rs
@@ -34,6 +34,14 @@
 //! reconstruction is transient and per tensor, so peak memory stays close to
 //! the checkpoint's own footprint rather than its dequantized size.
 //!
+//! How close the requantized weights stay depends on the MLX pin. MLX rounds
+//! each E8M0 exponent up from `amax / 448`, so no block maximum saturates and
+//! every element lands within half an E4M3 step, but Metal and CPU have done
+//! that only since ml-explore/mlx#4353. Before it they rounded to nearest in
+//! log2 space and clipped the maximum of about half the blocks by up to 29%.
+//! `fp8_block_requantize_round_trip_stays_within_half_an_e4m3_step` holds the
+//! pin to the first behavior.
+//!
 //! This module deliberately lives outside `sanitize.rs`: that file is already
 //! 3k lines, and the FP8 path is a self-contained pre-pass with its own tests.
 //!

--- a/src/models/fp8_block_tests.rs
+++ b/src/models/fp8_block_tests.rs
@@ -231,10 +231,44 @@ fn fp8_block_requantize_matches_direct_path() {
         raw_bytes(&reference_scales),
         "mxfp8 scale plane diverged from quantize(decode(bytes) * expanded_scales)"
     );
+}
 
-    // Dequantizing must reproduce the reconstruction within the mxfp8 step.
-    // E4M3 carries four significant bits, so a value sharing its group's
-    // binade with the group maximum rounds by at most 2^-4 of that maximum.
+/// Dequantizing the requantized planes must land within half an E4M3 step of
+/// the reconstruction, which holds only while every mxfp8 block scale is
+/// rounded up.
+///
+/// The block scale is `amax / 448` encoded as E8M0, a bare power of two.
+/// Rounded up, the block maximum scales into `(224, 448]` and every element
+/// stays inside the E4M3 range, where it rounds to nearest. E4M3 carries four
+/// significant bits, so an element in the top binade (`[256, 448]` after
+/// scaling) moves by at most 16 of those units, which is at most 2^-4 of a
+/// block maximum that is itself at least 256; an element in a lower binade, or
+/// in a block whose maximum scaled below 256, moves by less.
+///
+/// Rounded to nearest in log2 space instead, the scale lands below
+/// `amax / 448` for about half the blocks, their maxima scale past 448 and
+/// saturate, and the loss on a block maximum reaches `1 - 2^-1/2`, about 29%.
+/// No per-element bound between those two holds, one full E4M3 step
+/// (`group_max / 8`) included. Metal and CPU rounded that way until
+/// ml-explore/mlx#4353 while CUDA always rounded up. On an MLX pin that
+/// predates it, 301 of this fixture's 650 blocks saturate, block 0 among them:
+/// its maximum 4.8046875 takes the scale 2^-7 and would scale to 615, so
+/// element 4 (4.00390625, scaled to 512.5) comes back as 3.5.
+///
+/// Same seed and shape as [`fp8_block_requantize_matches_direct_path`]: the
+/// padded trailing blocks are part of what is being bounded.
+#[test]
+fn fp8_block_requantize_round_trip_stays_within_half_an_e4m3_step() {
+    let fixture = block_fp8_fixture("model.layers.0.mlp.down_proj", 130, 160, 0x51D3_9E11);
+    let converted = requantize_block_fp8_weights(fixture.weights, SUPPORTED_FP8_BLOCK)
+        .expect("block FP8 requantization");
+    let packed = converted
+        .get("model.layers.0.mlp.down_proj.weight")
+        .expect("packed weight");
+    let scales = converted
+        .get("model.layers.0.mlp.down_proj.scales")
+        .expect("mxfp8 scales");
+
     let dequantized = unsafe {
         mlxcel_core::dequantize(
             packed.as_ref().expect("packed"),
@@ -249,17 +283,39 @@ fn fp8_block_requantize_matches_direct_path() {
     assert_eq!(recovered.len(), fixture.expanded.len());
 
     let group = MXFP8_GROUP_SIZE as usize;
-    for (index, (expected, actual)) in fixture.expanded.iter().zip(&recovered).enumerate() {
-        let group_start = (index / group) * group;
-        let group_max = fixture.expanded[group_start..group_start + group]
-            .iter()
-            .fold(0f32, |m, v| m.max(v.abs()));
-        let bound = group_max / 16.0 + f32::EPSILON;
-        let error = (expected - actual).abs();
+    let exponents = raw_bytes(scales);
+    assert_eq!(exponents.len(), fixture.expanded.len() / group);
+    let e4m3_max = f8_e4m3_to_f32(0x7E);
+
+    for (g, (block, restored)) in fixture
+        .expanded
+        .chunks_exact(group)
+        .zip(recovered.chunks_exact(group))
+        .enumerate()
+    {
+        let group_max = block.iter().fold(0f32, |m, v| m.max(v.abs()));
+        // E8M0 stores a biased exponent and nothing else.
+        let exponent = i32::from(exponents[g]) - 127;
+        let scale = 2f32.powi(exponent);
         assert!(
-            error <= bound,
-            "element {index}: mxfp8 error {error} exceeded {bound} (group max {group_max})"
+            group_max <= e4m3_max * scale,
+            "block {g}: E8M0 scale 2^{exponent} is below amax / 448 = {}, so its maximum \
+             {group_max} scales to {} and saturates at 448 (the scale was rounded down, \
+             see ml-explore/mlx#4353)",
+            group_max / e4m3_max,
+            group_max / scale
         );
+
+        let bound = group_max / 16.0 + f32::EPSILON;
+        for (k, (expected, actual)) in block.iter().zip(restored).enumerate() {
+            let error = (expected - actual).abs();
+            assert!(
+                error <= bound,
+                "element {}: mxfp8 error {error} exceeded {bound} (group max {group_max}, \
+                 scale 2^{exponent})",
+                g * group + k
+            );
+        }
     }
 }
 


### PR DESCRIPTION
## Why

The fp8 round-trip bound failed on every Metal host, M1 Ultra byte-identically to M5 Max, because the pinned MLX `9a795735` predates ml-explore/mlx#4353: Metal and CPU encoded the mxfp8 E8M0 block scale as `round(log2(amax / 448))`, so about half the blocks saturated their maxima, losing up to `1 - 2^-1/2`. CUDA rounds up, which is why #1742 passed on GB10. The test was right, and `requantize_block_fp8_weights`, the only E8M0 quantize caller, was clipping vendor FP8 checkpoints on Metal. Widening the bound, as the issue proposed, was rejected.

## What changed

- MLX pin `9a795735` to upstream main `81ba1c6a` (99 commits). The seven overlays whose targets upstream touched are three-way merged and keep their deltas; the other 21 are unchanged upstream. `metal/compiled.cpp` also drops a leftover `elem_to_loc_1<uint>` that undid part of ml-explore/mlx#3720, so its only delta is the mixed-dtype cast.
- Adaptations to what the new pin changes under the bridge:
  - `gather_qmm` gained `global_scale` ahead of `sorted_indices` (ml-explore/mlx#4458), so all 13 calls pass `std::nullopt`.
  - CUDA now needs cuSOLVER (ml-explore/mlx#4208). `link_cuda()` names it, `docs/installation.md` lists it, and CI's link job now runs on pin and CUDA link-list changes, which is how this slipped past CI.
  - `array::is_available()` now throws and clears a failed launch's error (ml-explore/mlx#3742). The rejection sampler's drain now reads status, signal and error pointer instead, so a GPU fault no longer terminates the process from inside `fused_sample` or hides the error from its owner. A regression test aborts the process with the old drain and passes with the new one.
- The round-trip check moves into its own test, `fp8_block_requantize_round_trip_stays_within_half_an_e4m3_step`, with the same seed and shape. It states the derivation and asserts `group_max <= 448 * scale` per block.

## Validation (M1 Ultra, macOS 27.0)

- fp8: the old pin fails the new test at block 0 (the maximum 4.8046875 scales to 615 and saturates). The new pin saturates 0 of 650 blocks, with a worst error of 0.0489 of the group max against 0.2928 before.
- Turbo launchers pass (max RMS 1.7263e-4 and 1.5259e-4).
- Teacher-forced logit traces, old pin vs new, on five checkpoints at widths 1, 8 and 256: 0 disagreements on decided positions. Over 4,096 positions on qwen3-30b-a3b, 1 of 1,720 decided positions differs, at the reference's rank 2, with perplexity -0.20%.
- Branches the short runs missed:
  - head-dim-512 decode past 1,024 keys: identical text.
  - GQA-8 decode past 8,192 keys: identical text, decode 55.6 to 60.8 tok/s.
  - head-dim-72 vision towers: image prefill 239 to 279 tok/s. Descriptions diverge into equally faithful text; decided answers are unchanged.
- Short-context throughput is within 0.6% on three checkpoints.
- Workspace gate: 10986 passed, 0 failed, 359 ignored. Clippy, fmt, both pin parsers and the cross-repo reference check are clean.
- CUDA was compiled and linked in CI but not run: `OpenXLA feature link` linked a `--features cuda,xla-iree` release binary on GB10 at the new pin, which covers the overlays and the cuSOLVER link. The green `CUDA sm_70 compile` check is a skip, because CUDA 13.0 cannot target sm_70.

The per-checkpoint numbers, method and derivations are in `TECHNICAL_REPORTS/1772-mlx-pin-mxfp8-round-up-20260911.en.md`.

## Not validated, or reported and not fixed

- No CUDA execution. No M5 Max run: the generation-17 NAX paths changed upstream in this range are unmeasured.
- `array_evaluated_bytes`, the server's lookahead read, is another non-`Result` bridge function that now throws on a failed launch. It needs routing through the scheduler's step-failure path.
- The mixed-dtype cast in `metal/compiled.cpp` would cast a comparison's inputs to `bool`. This is latent, since no compiled function contains a comparison.

Closes #1769
