### PR TITLE
chore(core): fix create_causal_mask roster count and add a drift guard

### DIFF
--- a/TECHNICAL_REPORTS/1775-causal-mask-roster-guard-20260911.en.md
+++ b/TECHNICAL_REPORTS/1775-causal-mask-roster-guard-20260911.en.md
@@ -1,0 +1,73 @@
+# Technical Report: PR #1775 - chore(core): fix create_causal_mask roster count and add a drift guard
+
+**Date**: 2026-09-11
+**Author**: mlxcel maintainers
+**Reviewer**: implementation review cycle (implementation review, security and performance review)
+**Status**: Completed
+**Languages**: Rust (doc comments and a unit test), Markdown
+**Risk Level**: Low (no production code path changes; the new test is `#[cfg(test)]` only)
+
+---
+
+## Executive Summary
+
+The `// Used by:` rosters in `src/lib/mlxcel-core/src/utils.rs` are how a contributor answers "what breaks if I change this helper", and `create_causal_mask` is the worked example `docs/code-guidelines.md` points at. Its count said 45 caller files under `src/models` when the grep it documents returned 49. The command it printed searched all of `src` and returned 64. Six sibling rosters had drifted as well, and two of them named callers that never reach the function.
+
+This PR corrects all seven rosters from fresh greps at the base commit `8ad62d4b` and from each call site. It narrows the printed command to the population the count describes, and adds a unit test that fails with an actionable message whenever the stated count and the tree disagree.
+
+---
+
+## Problem Statement
+
+The count was last right at `f0bf3a2c` (#1121, 44). Five caller files arrived afterwards, and only one of them was ever named in the prose. The issue traced the drift commit by commit. Nothing enforced the roster: `make verify` checks crate versions, CUDA kernel dtype keys and the llama-server manifest, but not rosters. So each new family that called the mask helper silently made the discovery mechanism wrong.
+
+Review of the first commit found a worse failure than a stale number, a roster that lists non-callers:
+
+- **`create_causal_mask_with_window`** named Gemma2, Gemma3 and Qwen3. Gemma2 and Qwen3 call `causal_attention` with window `0`, which takes the plain causal branch. Gemma3 never calls `causal_attention`; its window mask comes from `create_sliding_window_prefill_mask`. The families that actually reach the function through a nonzero window are Baichuan, Cohere2, Cohere2MoE, CohereCompass, Exaone4, ExaoneMoE, Gemma3n, Gemma4, IQuestLoopCoder, Laguna, Mellum, Ministral3, MuseGlimmer and Step3P5.
+- **`softplus`** counted the cxx declaration of `ffi::softplus` in `lib.rs` and Apertus's own scalar `fn softplus(x: f32)` as callers. It also missed that `pub use ffi::*` makes `mlxcel_core::softplus` the raw FFI function. Mamba, Mamba2, Jamba, RecurrentGemma, FalconH1, GraniteMoeHybrid, NemotronH, Plamo2 and the two audio attention files call that directly and never touch the wrapper. Only GatedDelta, Laguna and DeepSeekV4MoE call `utils::softplus`.
+
+A contributor reading those rosters before changing either helper would have checked the wrong models.
+
+---
+
+## Change Summary
+
+- **Rosters.** `create_causal_mask` states 49 and assigns every file to a named group: Laguna joins the hybrid group, CohereCompass the sliding-window group, and the GLM4-MoE-Lite MTP drafter and the LFM2 DSpark drafter fold into their families. The "outside `src/models`" sentence now covers every grep hit, including a test-only use in `cache.rs` and a comment mention in the Qwen3.5 MTP drafter. The six sibling rosters distinguish direct callers from callers that arrive through a wrapper or the shared `causal_attention` dispatch, and they name the grep's false matches as such. `repeat_kv` and `softcap` were already accurate and are untouched.
+- **Regeneration command.** It is now `grep -rln '\bcreate_causal_mask(' src/models --include='*.rs' | grep -v 'tests\.rs$'`, which returns the stated number. The copy of it in `docs/code-guidelines.md` matches, and the guidelines' worked example writes `N` instead of a count that would go stale on its own.
+- **Guard test** `utils::tests::create_causal_mask_roster_count_matches_repo`:
+  - It walks `src/models` with `std::fs`, recursing on `DirEntry::file_type()` so it never follows a symlink, the same as `grep -r`.
+  - It counts files containing `create_causal_mask(` at a word boundary and excludes files whose names end in `tests.rs`, which drops `diffusion_gemma/tests.rs`.
+  - It reads the stated count from a fixed sentence prefix in `include_str!("utils.rs")` and asserts equality.
+  - On failure it prints the stated and measured counts, the sorted file list, the file and line to edit, and the command to re-run. The line number is computed from the marker's position, so it does not go stale.
+  - It skips only when the workspace's own `utils.rs` is unreachable from the computed root, as in a vendored build, and otherwise asserts that `src/models` exists. I/O errors panic with the path, not with a misleading drift message. It adds no dependency.
+
+---
+
+## Technical Decisions
+
+**A unit test, not a `make verify-*` script.** The count is one integer behind a fixed prefix, and `verify-test` already runs on every PR. A script would need a new Makefile target and CI job for one integer. The script-shaped alternative is `scripts/ci/check_kernel_dtype_keys.py`, and it was rejected for this.
+
+**A preceding `:` still counts.** The issue asked to exclude a match preceded by `_`, an alphanumeric character, or `:`. Excluding `:` would measure 35, because 14 files call the helper as `utils::create_causal_mask(`. The test would then disagree with the grep definition the doc comment freezes. The implementation follows `grep`'s `\b` semantics, and a comment at the rule explains why, so nobody "fixes" it to match the issue text.
+
+**Count only, not family names.** The sibling rosters name families rather than counts, so there is no integer to compare. A general `// Used by:` checker (absence detection, a family-to-path map) is #1141's design question and stays out of scope.
+
+---
+
+## Validation
+
+- The regeneration command returns 49 at the base with this shell's `grep`, BSD `/usr/bin/grep` and `rg`.
+- Negative proof: with the count edited to 48 and then 50, the guard fails with the full actionable message; restored to 49, it passes.
+- On the first commit, the workspace gate (123 binaries, 11,015 passed, 0 failed, 359 ignored), workspace clippy with `-D warnings`, fmt, and `make verify-versions` / `verify-kernel-dtype-keys` / `verify-llama-compat` all pass. The review-fix commit touches only the doc comments and the test module of the same file, and was re-verified with the full `mlxcel-core` lib suite and workspace clippy.
+
+---
+
+## Learning Points
+
+- **A roster that names non-callers is worse than an incomplete one.** An incomplete roster makes a reader look further. A wrong one sends them to check Gemma2 and Qwen3 for a change that cannot affect them, and to skip the fourteen families it does affect. The count guard cannot catch this; only reading each call site's arguments does. The window roster's errors were found that way in review.
+- **The definition has to be the same in three places.** The sentence, the printed command and the test each encode what counts as a caller file. They drifted apart once (the command said `src`, the sentence meant `src/models`), and this PR makes the test fail whenever the other two disagree.
+
+---
+
+## Follow-ups
+
+- #1141 remains open for the general `// Used by:` checker over `utils.rs`, `layers.rs`, `switch_layers.rs` and `gated_delta.rs`. Its criterion "passes on `main` as it stands" is now true again for `utils.rs`.

--- a/TECHNICAL_REPORTS/1775-causal-mask-roster-guard-20260911.ko.md
+++ b/TECHNICAL_REPORTS/1775-causal-mask-roster-guard-20260911.ko.md
@@ -1,0 +1,73 @@
+# 기술 리포트: PR #1775 - chore(core): fix create_causal_mask roster count and add a drift guard
+
+**날짜**: 2026-09-11
+**작성자**: mlxcel maintainers
+**리뷰어**: 구현 리뷰 사이클(구현 리뷰, 보안·성능 리뷰)
+**상태**: 완료
+**언어**: Rust(문서 주석과 단위 테스트), Markdown
+**위험도**: 낮음(프로덕션 코드 경로 변경 없음; 새 테스트는 `#[cfg(test)]` 전용)
+
+---
+
+## 요약
+
+`src/lib/mlxcel-core/src/utils.rs`의 `// Used by:` 로스터는 기여자가 '이 헬퍼를 바꾸면 무엇이 깨지는가'를 확인하는 수단이고, `docs/code-guidelines.md`가 예시로 가리키는 것이 `create_causal_mask`다. 그 수치는 `src/models` 아래 호출 파일이 45개라고 적었는데, 주석이 안내하는 grep은 49를 돌려줬다. 주석에 찍힌 명령은 `src` 전체를 뒤져 64를 냈다. 형제 로스터 여섯 개도 어긋나 있었고, 그중 둘은 함수에 실제로 도달하지 않는 호출자를 적고 있었다.
+
+이 PR은 기준 커밋 `8ad62d4b`에서 grep을 새로 돌리고 각 호출 지점을 읽어 로스터 일곱 개를 모두 바로잡는다. 찍힌 명령은 수치가 가리키는 모집단으로 좁혔다. 적힌 수치와 트리가 어긋나면 고칠 방법까지 알려 주며 실패하는 단위 테스트도 더했다.
+
+---
+
+## 문제 정의
+
+수치가 마지막으로 맞았던 것은 `f0bf3a2c`(#1121, 44)였다. 그 뒤로 호출 파일이 다섯 개 들어왔는데, 본문에 이름이 오른 것은 그중 하나뿐이었다. 이슈는 어긋남을 커밋 단위로 추적했다. 로스터를 강제하는 장치는 없었다. `make verify`는 크레이트 버전, CUDA 커널 dtype 키, llama-server 매니페스트는 검사하지만 로스터는 보지 않는다. 그래서 마스크 헬퍼를 부르는 새 계열이 들어올 때마다 이 확인 수단은 소리 없이 틀려졌다.
+
+첫 커밋 리뷰는 낡은 수치보다 나쁜 실패를 찾아냈다. 호출하지 않는 쪽을 호출자로 적은 로스터다.
+
+- **`create_causal_mask_with_window`**는 Gemma2, Gemma3, Qwen3를 적고 있었다. Gemma2와 Qwen3는 `causal_attention`에 창 크기 `0`을 넘기므로 일반 인과 마스크 분기로 간다. Gemma3는 `causal_attention`을 아예 부르지 않고, 창 마스크를 `create_sliding_window_prefill_mask`에서 얻는다. 0이 아닌 창을 넘겨 실제로 이 함수에 도달하는 계열은 Baichuan, Cohere2, Cohere2MoE, CohereCompass, Exaone4, ExaoneMoE, Gemma3n, Gemma4, IQuestLoopCoder, Laguna, Mellum, Ministral3, MuseGlimmer, Step3P5다.
+- **`softplus`**는 `lib.rs`에 있는 `ffi::softplus`의 cxx 선언과, Apertus가 따로 정의한 스칼라 `fn softplus(x: f32)`를 호출자로 셌다. 그러면서 `pub use ffi::*` 때문에 `mlxcel_core::softplus`가 FFI 함수 그 자체라는 점을 놓쳤다. Mamba, Mamba2, Jamba, RecurrentGemma, FalconH1, GraniteMoeHybrid, NemotronH, Plamo2와 오디오 어텐션 파일 둘은 FFI 함수를 직접 부르고 래퍼를 거치지 않는다. `utils::softplus`를 부르는 것은 GatedDelta, Laguna, DeepSeekV4MoE뿐이다.
+
+어느 헬퍼든 바꾸기 전에 이 로스터를 읽은 기여자는 엉뚱한 모델을 확인했을 것이다.
+
+---
+
+## 변경 요약
+
+- **로스터.** `create_causal_mask`는 49를 적고, 모든 파일을 이름 붙은 그룹에 넣는다. Laguna는 하이브리드 그룹, CohereCompass는 슬라이딩 윈도 그룹에 들어가고, GLM4-MoE-Lite MTP 드래프터와 LFM2 DSpark 드래프터는 각자 계열에 합쳤다. 'src/models 밖' 문장은 이제 grep 결과를 빠짐없이 다룬다. 여기엔 `cache.rs`의 테스트 전용 사용과 Qwen3.5 MTP 드래프터의 주석 언급도 들어간다. 형제 로스터 여섯 개는 직접 호출자와, 래퍼나 공유 `causal_attention` 디스패치를 거쳐 오는 호출자를 구분한다. grep이 잘못 잡은 결과도 그렇다고 명시한다. `repeat_kv`와 `softcap`은 이미 정확해서 손대지 않았다.
+- **재생성 명령.** 이제 `grep -rln '\bcreate_causal_mask(' src/models --include='*.rs' | grep -v 'tests\.rs$'`이고, 적힌 수치를 그대로 돌려준다. `docs/code-guidelines.md`의 사본도 같은 명령이다. 가이드라인의 예시는 저절로 낡을 수치 대신 `N`을 쓴다.
+- **가드 테스트** `utils::tests::create_causal_mask_roster_count_matches_repo`:
+  - `src/models`를 `std::fs`로 훑는다. `DirEntry::file_type()`으로 재귀하므로 `grep -r`처럼 심볼릭 링크를 따라가지 않는다.
+  - 단어 경계에 걸리는 `create_causal_mask(`를 담은 파일을 세고, 이름이 `tests.rs`로 끝나는 파일은 뺀다(`diffusion_gemma/tests.rs`도 여기서 빠진다).
+  - `include_str!("utils.rs")`의 고정 문장 접두어에서 적힌 수치를 읽어 둘이 같은지 단언한다.
+  - 실패하면 적힌 수와 잰 수, 정렬된 파일 목록, 고칠 파일과 줄, 다시 돌릴 명령을 출력한다. 줄 번호는 마커 위치에서 계산하므로 낡지 않는다.
+  - 계산한 루트에서 워크스페이스의 `utils.rs`에 닿지 못할 때(벤더링 빌드 등)만 건너뛰고, 그 밖에는 `src/models`가 있다고 단언한다. I/O 오류는 엉뚱한 어긋남 메시지가 아니라 경로와 함께 패닉한다. 의존성은 늘리지 않는다.
+
+---
+
+## 기술적 선택과 그 이유
+
+**`make verify-*` 스크립트가 아닌 단위 테스트.** 수치는 고정 접두어 뒤의 정수 하나이고, `verify-test`는 이미 모든 PR에서 돈다. 스크립트로 하면 정수 하나 때문에 Makefile 대상과 CI 잡을 새로 만들어야 한다. 비교 대상이던 스크립트형 방식은 `scripts/ci/check_kernel_dtype_keys.py`이고, 이 경우에는 기각했다.
+
+**앞 문자 `:`는 여전히 센다.** 이슈는 앞 문자가 `_`, 영숫자, `:`인 매치를 빼라고 했다. 그런데 `:`까지 빼면 35가 나온다. 14개 파일이 이 헬퍼를 `utils::create_causal_mask(`로 부르기 때문이다. 그러면 테스트가 문서 주석이 고정한 grep 정의와 어긋난다. 구현은 `grep`의 `\b` 의미를 따르고, 누군가 이슈 문구에 맞춰 '고치지' 않도록 그 규칙 옆에 이유를 주석으로 남겼다.
+
+**수치만 보고 계열 이름은 보지 않는다.** 형제 로스터는 수치가 아니라 계열 이름을 적으므로 비교할 정수가 없다. 부재 탐지나 계열-경로 대응표 같은 일반 `// Used by:` 검사기는 #1141의 설계 문제로 남겨 범위 밖에 둔다.
+
+---
+
+## 검증
+
+- 재생성 명령은 기준 커밋에서 이 셸의 `grep`, BSD `/usr/bin/grep`, `rg` 모두로 49를 돌려준다.
+- 음성 증명: 수치를 48로, 다음엔 50으로 고치면 가드가 고칠 방법을 담은 메시지 전체와 함께 실패하고, 49로 되돌리면 통과한다.
+- 첫 커밋에서 워크스페이스 게이트(바이너리 123개, 11,015 통과, 0 실패, 359 무시), `-D warnings` 워크스페이스 clippy, fmt, `make verify-versions` / `verify-kernel-dtype-keys` / `verify-llama-compat`가 모두 통과했다. 리뷰 수정 커밋은 같은 파일의 문서 주석과 테스트 모듈만 건드리므로, `mlxcel-core` lib 전체와 워크스페이스 clippy로 다시 검증했다.
+
+---
+
+## 학습 포인트
+
+- **호출하지 않는 쪽을 적은 로스터는 불완전한 로스터보다 나쁘다.** 불완전한 로스터는 독자를 더 찾아보게 만든다. 틀린 로스터는 영향이 없는 Gemma2와 Qwen3를 확인하게 하고, 실제로 영향받는 열네 계열은 건너뛰게 만든다. 수치 가드로는 이것을 잡을 수 없고, 호출 지점마다 인자를 읽어야만 잡힌다. 창 로스터의 오류도 리뷰에서 그렇게 찾았다.
+- **정의는 세 곳에서 같아야 한다.** 문장, 찍힌 명령, 테스트가 각자 '호출 파일이란 무엇인가'를 담는다. 셋은 한 번 어긋난 적이 있다(명령은 `src`, 문장은 `src/models`). 이 PR 이후로는 나머지 둘이 어긋나면 테스트가 실패한다.
+
+---
+
+## 후속 과제
+
+- `utils.rs`, `layers.rs`, `switch_layers.rs`, `gated_delta.rs`를 대상으로 하는 일반 `// Used by:` 검사기는 #1141로 계속 열려 있다. 그 기준 중 '현재 `main`에서 그대로 통과'는 이제 `utils.rs`에 대해서는 다시 참이 됐다.

--- a/docs/code-guidelines.md
+++ b/docs/code-guidelines.md
@@ -72,7 +72,7 @@ Past roughly a dozen callers, a hand-written roster is wrong by the next release
 ///
 /// The caller set is too large to enumerate by name without going stale, so
 /// the groups above are a summary. Regenerate the exact list with
-/// `grep -rln '\bcreate_causal_mask(' src --include='*.rs'`.
+/// `grep -rln '\bcreate_causal_mask(' src/models --include='*.rs' | grep -v 'tests\.rs$'`.
 pub fn create_causal_mask(size: i32, offset: i32) -> UniquePtr<MlxArray> {
 ```
 

--- a/docs/code-guidelines.md
+++ b/docs/code-guidelines.md
@@ -63,7 +63,7 @@ Past roughly a dozen callers, a hand-written roster is wrong by the next release
 ```rust
 /// Used by: decoders that materialize an explicit prefill mask instead of
 /// leaving `mask: None` for fused SDPA to apply causality itself. At this
-/// commit that is 44 non-test files under `src/models`, in four groups.
+/// commit that is N non-test files under `src/models`, in four groups.
 /// (groups and representatives ...)
 ///
 /// Not used by the mainstream dense decoders (Llama3, Mixtral, Gemma2 and

--- a/src/lib/mlxcel-core/src/utils.rs
+++ b/src/lib/mlxcel-core/src/utils.rs
@@ -105,7 +105,9 @@ pub fn slice_axis(x: &MlxArray, axis: i32, start: i32, end: i32) -> UniquePtr<Ml
 /// DeepSeekV3.2, MiniCPM3, GptOss, AFMoE, Step3P5, LongcatFlashNgram,
 /// BailingMoeLinear, GLM4MoeLite, Qwen3.5, KimiK3. Outside `src/models` the
 /// callers are `lib.rs`, `layers.rs`, the tensor-parallel Llama runtime, the
-/// GLM4 pipeline stage executor, and disaggregated handoff.
+/// GLM4 pipeline stage executor, and disaggregated handoff; the grep also
+/// matches `cache.rs` (calls inside its `#[cfg(test)]` module) and
+/// `drafter/qwen3_5_mtp/layer.rs` (a comment mention, not a call).
 ///
 /// Not used by the mainstream dense decoders (Llama3, Mixtral, Gemma, Gemma2,
 /// Cohere, Phi, GLM4, StarCoder2, Qwen3Moe, OLMoE and similar): they pass
@@ -668,9 +670,14 @@ pub fn create_causal_bool_mask(size: i32, offset: i32) -> UniquePtr<MlxArray> {
 }
 
 /// Create a causal attention mask with sliding window.
-/// Used by: Gemma4 and the tensor-parallel Llama runtime directly. Gemma2,
-/// Gemma3, Gemma3n, Qwen3, Ministral and other windowed-attention callers
-/// arrive indirectly, through `lib.rs`'s shared `causal_attention` dispatch.
+/// Used by: Gemma4 and the tensor-parallel Llama runtime directly. The rest
+/// arrive indirectly, through `lib.rs`'s shared `causal_attention` dispatch
+/// whenever it is called with a nonzero window: Baichuan, Cohere2,
+/// Cohere2MoE, CohereCompass, Exaone4, ExaoneMoE, Gemma3n, Gemma4,
+/// IQuestLoopCoder, Laguna, Mellum, Ministral3, MuseGlimmer, Step3P5. Gemma2
+/// and Qwen3 also call `causal_attention`, but always pass window `0`, so
+/// they never reach this function; Gemma3 does not call `causal_attention`
+/// at all (its window mask comes from `create_sliding_window_prefill_mask`).
 ///
 /// # Arguments
 /// * `size` - Size of the query sequence
@@ -773,11 +780,13 @@ pub fn create_causal_mask_with_window(
 /// Create a sliding-window causal mask sized to the *full* key axis, without
 /// the `min(size + offset, window)` cap applied by [`create_causal_mask_with_window`].
 /// Used by: Gemma4 and Laguna directly, plus `lib.rs`'s shared dispatch for a
-/// single-pass prefill longer than the sliding window. Gemma3, Cohere2,
-/// Cohere2MoE, CohereCompass, Gemma3n and Olmo3 dense prefill (#413) reach it
-/// only indirectly, through the [`create_sliding_window_prefill_mask`] /
-/// [`create_sliding_window_prefill_mask_dense`] wrappers below, not via a
-/// direct call site.
+/// single-pass prefill longer than the sliding window (#413). Every caller of
+/// [`create_sliding_window_prefill_mask`] (GptOss, Mellum, Exaone4, ExaoneMoE,
+/// Ministral3, Step3P5, Gemma3, Gemma4, AFMoE, DeepSeekV4, the tensor-parallel
+/// Llama runtime) and of [`create_sliding_window_prefill_mask_dense`]
+/// (Cohere2, Cohere2MoE, CohereCompass, Gemma3n, Olmo3) reaches this function
+/// only indirectly, through those wrappers below, not via a direct call
+/// site.
 ///
 /// # Arguments
 /// * `size` - Size of the query sequence
@@ -1023,11 +1032,12 @@ pub fn relu_squared(x: &MlxArray) -> UniquePtr<MlxArray> {
 ///// Numerically stable softplus activation: log(1 + exp(x)).
 /// Uses logaddexp(x, 0) internally to match Python's mx.logaddexp(x, 0).
 /// This avoids float16 overflow for values >= ~11.09 (exp(x) > float16 max).
-/// Used by: Mamba, Mamba2, Jamba, GatedDelta, RecurrentGemma, Laguna, Apertus,
-/// DeepSeekV4MoE, FalconH1, GraniteMoeHybrid, NemotronH, Plamo2 (SSM and
-/// gated-recurrence families), the shared audio attention tower
-/// (`audio/attention.rs`, `audio/gemma3n/attention.rs`), and `lib.rs`'s
-/// generic dispatch.
+/// Used by: this wrapper is called directly by GatedDelta, Laguna and
+/// DeepSeekV4MoE. Mamba, Mamba2, Jamba, RecurrentGemma, FalconH1,
+/// GraniteMoeHybrid, NemotronH, Plamo2, and the shared audio attention tower
+/// (`audio/attention.rs`, `audio/gemma3n/attention.rs`) instead call the raw
+/// `ffi::softplus` this wraps directly (re-exported as
+/// `mlxcel_core::softplus`), bypassing this function.
 #[inline]
 pub fn softplus(x: &MlxArray) -> UniquePtr<MlxArray> {
     ffi::softplus(x)
@@ -1348,21 +1358,28 @@ mod embedding_mask_tests;
 mod tests {
     use super::*;
 
-    /// Guards the `create_causal_mask` caller-roster count in the doc
-    /// comment above (`src/lib/mlxcel-core/src/utils.rs:95`) against silent
-    /// drift. See issue #1767: five files joined the caller set across four
-    /// PRs while the stated count stayed frozen; #1141 tracks the broader
-    /// `// Used by:` staleness problem this only guards for
-    /// `create_causal_mask`.
+    /// Guards the `create_causal_mask` caller-roster count sentence in this
+    /// file's doc comment against silent drift. See issue #1767: five files
+    /// joined the caller set across four PRs while the stated count stayed
+    /// frozen; #1141 tracks the broader `// Used by:` staleness problem this
+    /// only guards for `create_causal_mask`.
     #[test]
     fn create_causal_mask_roster_count_matches_repo() {
         let repo_root = std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("../../..");
-        let models_dir = repo_root.join("src/models");
-        if !models_dir.exists() {
-            // A vendored or packaged build of mlxcel-core has no `src/models`
-            // sibling in its tree; there is nothing to check.
+        let repo_utils_rs = repo_root.join("src/lib/mlxcel-core/src/utils.rs");
+        if !repo_utils_rs.exists() {
+            // Not a full workspace checkout (e.g. mlxcel-core vendored or
+            // published standalone), so there is no `src/models` sibling
+            // tree to walk.
             return;
         }
+        let models_dir = repo_root.join("src/models");
+        assert!(
+            models_dir.is_dir(),
+            "expected {} to exist alongside {}",
+            models_dir.display(),
+            repo_utils_rs.display()
+        );
 
         let mut rs_files = Vec::new();
         collect_rs_files(&models_dir, &mut rs_files);
@@ -1389,35 +1406,49 @@ mod tests {
         let measured = caller_files.len();
 
         let utils_src = include_str!("utils.rs");
-        let stated = extract_stated_causal_mask_count(utils_src).unwrap_or_else(|| {
+        let (marker_pos, stated) = find_stated_causal_mask_count(utils_src).unwrap_or_else(|| {
             panic!(
-                "the create_causal_mask roster lost its count sentence in \
-                 src/lib/mlxcel-core/src/utils.rs"
+                "the create_causal_mask doc comment lost its count sentence: expected to find \
+                 `that is <N> non-test files under` in src/lib/mlxcel-core/src/utils.rs"
             )
         });
+        let count_line = line_number_at(utils_src, marker_pos);
 
         assert_eq!(
             stated, measured,
-            "create_causal_mask roster drift: src/lib/mlxcel-core/src/utils.rs:95 states \
-             {stated} non-test caller files under src/models, but {measured} were found: \
-             {caller_files:?}. To fix, update the count sentence at \
-             src/lib/mlxcel-core/src/utils.rs:95 and regenerate the roster with: \
+            "create_causal_mask roster drift: src/lib/mlxcel-core/src/utils.rs:{count_line} \
+             states {stated} non-test caller files under src/models, but {measured} were \
+             found: {caller_files:?}. To fix, update the count sentence at \
+             src/lib/mlxcel-core/src/utils.rs:{count_line} and regenerate the roster with: \
              grep -rln '\\bcreate_causal_mask(' src/models --include='*.rs' | grep -v 'tests\\.rs$'"
         );
     }
 
-    /// Recursively collects every `*.rs` file under `dir` into `out`.
+    /// Recursively collects every `*.rs` file under `dir` into `out`. Uses
+    /// `DirEntry::file_type()` (an `lstat`, not a `stat`) rather than
+    /// `Path::is_dir()`/`is_file()`, so a symlinked directory or file is
+    /// neither recursed into nor collected, matching `grep -r`'s default of
+    /// not following symlinks.
     fn collect_rs_files(dir: &std::path::Path, out: &mut Vec<std::path::PathBuf>) {
-        let entries = match std::fs::read_dir(dir) {
-            Ok(entries) => entries,
-            Err(_) => return,
-        };
-        for entry in entries.flatten() {
-            let path = entry.path();
-            if path.is_dir() {
-                collect_rs_files(&path, out);
-            } else if path.extension().and_then(|e| e.to_str()) == Some("rs") {
-                out.push(path);
+        let entries = std::fs::read_dir(dir)
+            .unwrap_or_else(|e| panic!("failed to read directory {}: {e}", dir.display()));
+        for entry in entries {
+            let entry = entry.unwrap_or_else(|e| {
+                panic!(
+                    "failed to read a directory entry under {}: {e}",
+                    dir.display()
+                )
+            });
+            let file_type = entry
+                .file_type()
+                .unwrap_or_else(|e| panic!("failed to stat {}: {e}", entry.path().display()));
+            if file_type.is_dir() {
+                collect_rs_files(&entry.path(), out);
+            } else if file_type.is_file() {
+                let path = entry.path();
+                if path.extension().and_then(|e| e.to_str()) == Some("rs") {
+                    out.push(path);
+                }
             }
         }
     }
@@ -1431,7 +1462,12 @@ mod tests {
     /// calls to this function; requiring the literal trailing `(` in the
     /// needle already rules those out; the preceding-character check further
     /// guards against a hypothetical differently-prefixed identifier ending
-    /// in the same name.
+    /// in the same name. A preceding `:` still counts as a valid match: 14
+    /// files under `src/models` call the qualified `utils::create_causal_mask(`
+    /// or `mlxcel_core::utils::create_causal_mask(`, and `\b` in the frozen
+    /// grep definition matches there too (`:` is not a word character), so
+    /// excluding it would measure 35 instead of the grep's 49 and disagree
+    /// with the definition this test exists to enforce.
     fn calls_create_causal_mask(contents: &str) -> bool {
         const NEEDLE: &str = "create_causal_mask(";
         let bytes = contents.as_bytes();
@@ -1451,26 +1487,43 @@ mod tests {
         false
     }
 
-    /// Extracts the caller count from the fixed sentence prefix `that is `
-    /// / ` non-test files under` in the `create_causal_mask` doc comment
-    /// (`src/lib/mlxcel-core/src/utils.rs:95`), taking the first match of
-    /// the full pattern (digits between the two fixed strings).
-    fn extract_stated_causal_mask_count(utils_src: &str) -> Option<usize> {
+    /// Locates the fixed sentence prefix `that is ` / ` non-test files
+    /// under` in the `create_causal_mask` doc comment, taking the first
+    /// match of the full pattern (digits between the two fixed strings).
+    /// Returns the byte offset of the `that is ` prefix together with the
+    /// parsed count; the offset lets the caller compute the sentence's
+    /// current line number instead of hardcoding one that would go stale if
+    /// lines are ever inserted above it.
+    fn find_stated_causal_mask_count(utils_src: &str) -> Option<(usize, usize)> {
         const MARKER: &str = "that is ";
         const SUFFIX: &str = " non-test files under";
         let mut search_start = 0;
         while let Some(rel_pos) = utils_src[search_start..].find(MARKER) {
-            let marker_end = search_start + rel_pos + MARKER.len();
+            let marker_start = search_start + rel_pos;
+            let marker_end = marker_start + MARKER.len();
             let after = &utils_src[marker_end..];
             let digits_end = after
                 .find(|c: char| !c.is_ascii_digit())
                 .unwrap_or(after.len());
-            if digits_end > 0 && after[digits_end..].starts_with(SUFFIX) {
-                return after[..digits_end].parse().ok();
+            if digits_end > 0
+                && after[digits_end..].starts_with(SUFFIX)
+                && let Ok(count) = after[..digits_end].parse::<usize>()
+            {
+                return Some((marker_start, count));
             }
             search_start = marker_end;
         }
         None
+    }
+
+    /// 1-based line number of byte offset `pos` within `text`, counting the
+    /// newlines that precede it.
+    fn line_number_at(text: &str, pos: usize) -> usize {
+        text.as_bytes()[..pos]
+            .iter()
+            .filter(|&&b| b == b'\n')
+            .count()
+            + 1
     }
 
     #[test]

--- a/src/lib/mlxcel-core/src/utils.rs
+++ b/src/lib/mlxcel-core/src/utils.rs
@@ -92,20 +92,20 @@ pub fn slice_axis(x: &MlxArray, axis: i32, start: i32, end: i32) -> UniquePtr<Ml
 ///
 /// Used by: decoders that materialize an explicit prefill mask instead of
 /// leaving `mask: None` for fused SDPA to apply causality itself. At this
-/// commit that is 45 non-test files under `src/models`, in four groups.
+/// commit that is 49 non-test files under `src/models`, in four groups.
 /// Hybrid and mixed-layer stacks that build one mask at the full-attention
 /// offset: Jamba, FalconH1, NemotronH, NemotronNas, Plamo2, Qwen3Next,
-/// KimiLinear, GraniteMoeHybrid, MiniMaxM3, Lfm2, RecurrentGemma.
+/// KimiLinear, GraniteMoeHybrid, MiniMaxM3, Lfm2, RecurrentGemma, Laguna.
 /// Sliding-window, chunked and dual-attention families that build a separate
 /// global mask per forward: Gemma3, Gemma4, Gemma3n, DiffusionGemma, Cohere2,
-/// Exaone4, Olmo3, Ministral3, Mistral4, Mellum, Llama4. VLM decoders that
-/// thread a mask down from the multimodal wrapper: Qwen2VL, Qwen3VL, GLM4V,
-/// Ernie4.5MoeVL, HunyuanVL, PaddleOcrVL, FalconOcr. MLA and custom-attention
-/// decoders that add the mask to scores by hand: DeepSeekV3, DeepSeekV3.2,
-/// MiniCPM3, GptOss, AFMoE, Step3P5, LongcatFlashNgram, BailingMoeLinear,
-/// GLM4MoeLite, Qwen3.5, KimiK3. Outside `src/models` the callers are `lib.rs`,
-/// `layers.rs`, the tensor-parallel Llama runtime, the GLM4 pipeline stage
-/// executor, and disaggregated handoff.
+/// CohereCompass, Exaone4, Olmo3, Ministral3, Mistral4, Mellum, Llama4. VLM
+/// decoders that thread a mask down from the multimodal wrapper: Qwen2VL,
+/// Qwen3VL, GLM4V, Ernie4.5MoeVL, HunyuanVL, PaddleOcrVL, FalconOcr. MLA and
+/// custom-attention decoders that add the mask to scores by hand: DeepSeekV3,
+/// DeepSeekV3.2, MiniCPM3, GptOss, AFMoE, Step3P5, LongcatFlashNgram,
+/// BailingMoeLinear, GLM4MoeLite, Qwen3.5, KimiK3. Outside `src/models` the
+/// callers are `lib.rs`, `layers.rs`, the tensor-parallel Llama runtime, the
+/// GLM4 pipeline stage executor, and disaggregated handoff.
 ///
 /// Not used by the mainstream dense decoders (Llama3, Mixtral, Gemma, Gemma2,
 /// Cohere, Phi, GLM4, StarCoder2, Qwen3Moe, OLMoE and similar): they pass
@@ -114,7 +114,7 @@ pub fn slice_axis(x: &MlxArray, axis: i32, start: i32, end: i32) -> UniquePtr<Ml
 ///
 /// The caller set is too large to enumerate by name without going stale, so
 /// the groups above are a summary. Regenerate the exact list with
-/// `grep -rln '\bcreate_causal_mask(' src --include='*.rs'`.
+/// `grep -rln '\bcreate_causal_mask(' src/models --include='*.rs' | grep -v 'tests\.rs$'`.
 pub fn create_causal_mask(size: i32, offset: i32) -> UniquePtr<MlxArray> {
     additive_causal_window_mask(size, offset, None)
 }
@@ -668,7 +668,9 @@ pub fn create_causal_bool_mask(size: i32, offset: i32) -> UniquePtr<MlxArray> {
 }
 
 /// Create a causal attention mask with sliding window.
-/// Used by: Gemma2, Gemma3, Gemma3n, Gemma4, Qwen3, Ministral and other windowed-attention callers
+/// Used by: Gemma4 and the tensor-parallel Llama runtime directly. Gemma2,
+/// Gemma3, Gemma3n, Qwen3, Ministral and other windowed-attention callers
+/// arrive indirectly, through `lib.rs`'s shared `causal_attention` dispatch.
 ///
 /// # Arguments
 /// * `size` - Size of the query sequence
@@ -770,7 +772,12 @@ pub fn create_causal_mask_with_window(
 
 /// Create a sliding-window causal mask sized to the *full* key axis, without
 /// the `min(size + offset, window)` cap applied by [`create_causal_mask_with_window`].
-/// Used by: Gemma 3, Gemma 4 single-pass prefill longer than the sliding window, Cohere2/Gemma3n/Olmo3 dense prefill (#413), Laguna sliding layers
+/// Used by: Gemma4 and Laguna directly, plus `lib.rs`'s shared dispatch for a
+/// single-pass prefill longer than the sliding window. Gemma3, Cohere2,
+/// Cohere2MoE, CohereCompass, Gemma3n and Olmo3 dense prefill (#413) reach it
+/// only indirectly, through the [`create_sliding_window_prefill_mask`] /
+/// [`create_sliding_window_prefill_mask_dense`] wrappers below, not via a
+/// direct call site.
 ///
 /// # Arguments
 /// * `size` - Size of the query sequence
@@ -832,9 +839,10 @@ pub fn create_causal_mask_with_window_full(
 /// softmax to NaN and decode as `<pad>`).
 ///
 /// Used by: GptOss, Mellum, Exaone4, ExaoneMoE, Ministral3, Step3P5, Gemma3,
-/// Gemma4 sliding-window prefill mask construction. Gemma4 additionally
-/// routes through `trim_mask_to_keys`, which now sees this mask's key axis
-/// match the cache return exactly.
+/// Gemma4, AFMoE, DeepSeekV4 and the tensor-parallel Llama runtime for
+/// sliding-window prefill mask construction. Gemma4 additionally routes
+/// through `trim_mask_to_keys`, which now sees this mask's key axis match the
+/// cache return exactly.
 ///
 /// [`RotatingKVCache`]: crate::cache::RotatingKVCache
 pub fn create_sliding_window_prefill_mask(
@@ -883,7 +891,8 @@ pub fn create_sliding_window_prefill_mask(
 /// keys once it has rolled over, so the clamped mask is the matching shape.
 /// See issue #413.
 ///
-/// Used by: Cohere2, Gemma3n, Olmo3 sliding-window prefill mask construction.
+/// Used by: Cohere2, Cohere2MoE, CohereCompass, Gemma3n, Olmo3 sliding-window
+/// prefill mask construction.
 pub fn create_sliding_window_prefill_mask_dense(
     size: i32,
     sliding_offset: i32,
@@ -1014,7 +1023,11 @@ pub fn relu_squared(x: &MlxArray) -> UniquePtr<MlxArray> {
 ///// Numerically stable softplus activation: log(1 + exp(x)).
 /// Uses logaddexp(x, 0) internally to match Python's mx.logaddexp(x, 0).
 /// This avoids float16 overflow for values >= ~11.09 (exp(x) > float16 max).
-/// Used by: Mamba, Mamba2, Jamba, GatedDelta, RecurrentGemma, Laguna
+/// Used by: Mamba, Mamba2, Jamba, GatedDelta, RecurrentGemma, Laguna, Apertus,
+/// DeepSeekV4MoE, FalconH1, GraniteMoeHybrid, NemotronH, Plamo2 (SSM and
+/// gated-recurrence families), the shared audio attention tower
+/// (`audio/attention.rs`, `audio/gemma3n/attention.rs`), and `lib.rs`'s
+/// generic dispatch.
 #[inline]
 pub fn softplus(x: &MlxArray) -> UniquePtr<MlxArray> {
     ffi::softplus(x)
@@ -1302,7 +1315,8 @@ fn get_pipeline_mode() -> PipelineMode {
 /// * `layer_idx` - Zero-based index of the layer that was just executed.
 /// * `total_layers` - Total number of transformer layers in the model.
 ///
-/// Used by: Llama3, Qwen3, Gemma, Gemma2, Gemma3
+/// Used by: Llama3, Qwen3, Gemma, Gemma2, Gemma3, Gemma4, Apertus, SeedOss,
+/// and the pipeline stage executor (`distributed/pipeline/stage_executor/common.rs`)
 #[inline]
 pub fn pipeline_hint(hidden: &MlxArray, layer_idx: usize, total_layers: usize) {
     static MODE: OnceLock<PipelineMode> = OnceLock::new();
@@ -1333,6 +1347,131 @@ mod embedding_mask_tests;
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// Guards the `create_causal_mask` caller-roster count in the doc
+    /// comment above (`src/lib/mlxcel-core/src/utils.rs:95`) against silent
+    /// drift. See issue #1767: five files joined the caller set across four
+    /// PRs while the stated count stayed frozen; #1141 tracks the broader
+    /// `// Used by:` staleness problem this only guards for
+    /// `create_causal_mask`.
+    #[test]
+    fn create_causal_mask_roster_count_matches_repo() {
+        let repo_root = std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("../../..");
+        let models_dir = repo_root.join("src/models");
+        if !models_dir.exists() {
+            // A vendored or packaged build of mlxcel-core has no `src/models`
+            // sibling in its tree; there is nothing to check.
+            return;
+        }
+
+        let mut rs_files = Vec::new();
+        collect_rs_files(&models_dir, &mut rs_files);
+
+        let mut caller_files: Vec<String> = rs_files
+            .into_iter()
+            .filter(|path| {
+                let file_name = path.file_name().and_then(|n| n.to_str()).unwrap_or("");
+                !file_name.ends_with("tests.rs")
+            })
+            .filter(|path| {
+                let contents = std::fs::read_to_string(path)
+                    .unwrap_or_else(|e| panic!("failed to read {}: {e}", path.display()));
+                calls_create_causal_mask(&contents)
+            })
+            .map(|path| {
+                path.strip_prefix(&repo_root)
+                    .unwrap_or(&path)
+                    .to_string_lossy()
+                    .replace('\\', "/")
+            })
+            .collect();
+        caller_files.sort();
+        let measured = caller_files.len();
+
+        let utils_src = include_str!("utils.rs");
+        let stated = extract_stated_causal_mask_count(utils_src).unwrap_or_else(|| {
+            panic!(
+                "the create_causal_mask roster lost its count sentence in \
+                 src/lib/mlxcel-core/src/utils.rs"
+            )
+        });
+
+        assert_eq!(
+            stated, measured,
+            "create_causal_mask roster drift: src/lib/mlxcel-core/src/utils.rs:95 states \
+             {stated} non-test caller files under src/models, but {measured} were found: \
+             {caller_files:?}. To fix, update the count sentence at \
+             src/lib/mlxcel-core/src/utils.rs:95 and regenerate the roster with: \
+             grep -rln '\\bcreate_causal_mask(' src/models --include='*.rs' | grep -v 'tests\\.rs$'"
+        );
+    }
+
+    /// Recursively collects every `*.rs` file under `dir` into `out`.
+    fn collect_rs_files(dir: &std::path::Path, out: &mut Vec<std::path::PathBuf>) {
+        let entries = match std::fs::read_dir(dir) {
+            Ok(entries) => entries,
+            Err(_) => return,
+        };
+        for entry in entries.flatten() {
+            let path = entry.path();
+            if path.is_dir() {
+                collect_rs_files(&path, out);
+            } else if path.extension().and_then(|e| e.to_str()) == Some("rs") {
+                out.push(path);
+            }
+        }
+    }
+
+    /// True if `contents` calls `create_causal_mask(`, matched the same way
+    /// as the regeneration command's `\bcreate_causal_mask(` grep pattern: a
+    /// literal `create_causal_mask(` substring not immediately preceded by
+    /// an identifier character (ASCII alphanumeric or `_`). A plain
+    /// `contains` on the bare function name would also credit
+    /// `create_causal_mask_with_window(` and `create_causal_mask_with_left_padding(`
+    /// calls to this function; requiring the literal trailing `(` in the
+    /// needle already rules those out; the preceding-character check further
+    /// guards against a hypothetical differently-prefixed identifier ending
+    /// in the same name.
+    fn calls_create_causal_mask(contents: &str) -> bool {
+        const NEEDLE: &str = "create_causal_mask(";
+        let bytes = contents.as_bytes();
+        let mut search_start = 0;
+        while let Some(rel_pos) = contents[search_start..].find(NEEDLE) {
+            let pos = search_start + rel_pos;
+            let preceded_by_identifier_char = pos > 0
+                && bytes
+                    .get(pos - 1)
+                    .map(|&b| b.is_ascii_alphanumeric() || b == b'_')
+                    .unwrap_or(false);
+            if !preceded_by_identifier_char {
+                return true;
+            }
+            search_start = pos + 1;
+        }
+        false
+    }
+
+    /// Extracts the caller count from the fixed sentence prefix `that is `
+    /// / ` non-test files under` in the `create_causal_mask` doc comment
+    /// (`src/lib/mlxcel-core/src/utils.rs:95`), taking the first match of
+    /// the full pattern (digits between the two fixed strings).
+    fn extract_stated_causal_mask_count(utils_src: &str) -> Option<usize> {
+        const MARKER: &str = "that is ";
+        const SUFFIX: &str = " non-test files under";
+        let mut search_start = 0;
+        while let Some(rel_pos) = utils_src[search_start..].find(MARKER) {
+            let marker_end = search_start + rel_pos + MARKER.len();
+            let after = &utils_src[marker_end..];
+            let digits_end = after
+                .find(|c: char| !c.is_ascii_digit())
+                .unwrap_or(after.len());
+            if digits_end > 0 && after[digits_end..].starts_with(SUFFIX) {
+                return after[..digits_end].parse().ok();
+            }
+            search_start = marker_end;
+        }
+        None
+    }
 
     #[test]
     fn test_slice_axis_basic() {


### PR DESCRIPTION
## Summary

The create_causal_mask caller-roster doc comment in utils.rs stated 45 non-test files under src/models while a fresh grep at this branch's base commit (8ad62d4b) returns 49, and its own printed regeneration command searched all of src instead of src/models, returning 64. This corrects the roster and its six sibling rosters, narrows the regeneration command to match the population the count sentence actually describes, and adds a unit test that fails when the two disagree.

## What changed

- `src/lib/mlxcel-core/src/utils.rs`: create_causal_mask count corrected to 49, Laguna and CohereCompass added to its groups, the two undocumented drafter files folded into their existing family names, the regeneration command narrowed to `grep -rln '\bcreate_causal_mask(' src/models --include='*.rs' | grep -v 'tests\.rs$'`, and the "outside src/models" sentence extended with the two remaining grep hits (`cache.rs`, test-only; `drafter/qwen3_5_mtp/layer.rs`, a comment mention).
- Six sibling rosters corrected against fresh greps and each call site: create_causal_mask_with_window, create_causal_mask_with_window_full, create_sliding_window_prefill_mask, create_sliding_window_prefill_mask_dense, softplus, pipeline_hint. Each now states which callers reach it directly, which arrive only through a wrapper or shared dispatch, and (for create_causal_mask_with_window and softplus) which grep hits were false matches (an FFI declaration, a differently-named function that only shares a name) rather than real callers. repeat_kv and softcap were already accurate and are untouched.
- New test `utils::tests::create_causal_mask_roster_count_matches_repo`: walks `src/models` with `std::fs` (following no symlinks, matching `grep -r`), counts files matching `create_causal_mask(` at a word boundary (excluding files ending in `tests.rs`), reads the stated count from the doc comment via `include_str!`, and asserts they match. The failure message computes the count sentence's current line number from the marker's position rather than hardcoding it. Returns early only when this file's own path is unreachable from the computed repo root (not a full workspace checkout); otherwise asserts `src/models` exists. Adds no dependency.
- `docs/code-guidelines.md`: the worked example no longer hardcodes a count that goes stale on its own (now `N`), and its own regeneration command is the same narrowed `src/models` form.

## Regeneration command and output

```
$ grep -rln '\bcreate_causal_mask(' src/models --include='*.rs' | grep -v 'tests\.rs$' | wc -l
      49
```

The 49 files match the sentence at `src/lib/mlxcel-core/src/utils.rs:95` and the assertion in the new test.

## Negative proof

Temporarily edited the count sentence to 48, then to 50, re-ran the guard alone, then restored 49.

```
$ cargo test --profile test-fast --features metal,accelerate -p mlxcel-core --lib utils::tests::create_causal_mask_roster_count_matches_repo
```

At 48 (stated one below the true count):

```
thread 'utils::tests::create_causal_mask_roster_count_matches_repo' panicked at src/lib/mlxcel-core/src/utils.rs:1417:9:
assertion `left == right` failed: create_causal_mask roster drift: src/lib/mlxcel-core/src/utils.rs:95 states 48 non-test caller files under src/models, but 49 were found: ["src/models/afmoe.rs", ... "src/models/step3p5.rs"]. To fix, update the count sentence at src/lib/mlxcel-core/src/utils.rs:95 and regenerate the roster with: grep -rln '\bcreate_causal_mask(' src/models --include='*.rs' | grep -v 'tests\.rs$'
  left: 48
 right: 49
test utils::tests::create_causal_mask_roster_count_matches_repo ... FAILED
```

At 50 (stated one above the true count):

```
thread 'utils::tests::create_causal_mask_roster_count_matches_repo' panicked at src/lib/mlxcel-core/src/utils.rs:1417:9:
assertion `left == right` failed: create_causal_mask roster drift: src/lib/mlxcel-core/src/utils.rs:95 states 50 non-test caller files under src/models, but 49 were found: [...same 49 files...]. To fix, update the count sentence at src/lib/mlxcel-core/src/utils.rs:95 and regenerate the roster with: grep -rln '\bcreate_causal_mask(' src/models --include='*.rs' | grep -v 'tests\.rs$'
  left: 50
 right: 49
test utils::tests::create_causal_mask_roster_count_matches_repo ... FAILED
```

At the restored count of 49 the test passes again. The line number in both messages (`utils.rs:95`) is computed from the count sentence's marker position at test time, not hardcoded.

## Test plan

- [x] `cargo test --profile test-fast --features metal,accelerate -p mlxcel-core --lib utils::` (40 passed, includes the new guard)
- [x] `cargo clippy -p mlxcel-core --lib --tests --profile test-fast --features metal,accelerate -- -D warnings` (clean)
- [x] `cargo fmt --all -- --check` (clean)
- [x] Negative proof above at 48 and 50, restored to 49
- [x] Workspace gate on the first commit (35e1fb76): `cargo test --workspace --profile test-fast --features metal,accelerate` ran 123 binaries, 11015 passed, 0 failed, 359 ignored; `cargo clippy --workspace --all-targets -- -D warnings` and `cargo fmt --check` clean; `make verify-versions`, `make verify-kernel-dtype-keys`, `make verify-llama-compat` all OK. The review-fix commit (58109836) only edits doc comments and the test module in the same two files; on it, the full `mlxcel-core` lib suite (1731 passed, 0 failed) and workspace clippy with `-D warnings` and fmt were re-run and are clean.

Closes #1767

