### PR TITLE
test(rocm): verify mlxcel-server chat completions on gfx1151

### DIFF
--- a/docs/benchmark_results/rocm-correctness-gfx1151-2026-09-12.md
+++ b/docs/benchmark_results/rocm-correctness-gfx1151-2026-09-12.md
@@ -106,6 +106,22 @@ Perplexity deltas stay inside +/- 0.5% except for the two shortest runs (`qwen3-
 
 An earlier plan was to run the same trace twice on one backend to establish a same-device noise floor, then require the cross-backend difference to sit inside it. That is unnecessary here. The threshold sweep above already shows where the disagreements stop, and it stops at a specific measured value (a 1.125 gap) rather than at a line borrowed from same-device noise. A floor would answer a question this data already answers directly.
 
+## Serving on ROCm
+
+`mlxcel-server` was built from the merged `1206f863` (`make release-rocm`) and run on this host for one dense and one MoE checkpoint, one at a time so neither competed for the GPU. `scripts/server_chat_smoke.sh` is the check, so the result is reproducible rather than a transcript of hand-typed curl calls.
+
+| Check | `Meta-Llama-3.1-8B-Instruct-4bit` | `Qwen3-30B-A3B-4bit`, `MLXCEL_FUSED_MOE=0` |
+|---|---|---|
+| `GET /health` | 200, `{"status":"ok"}` | 200, `{"status":"ok"}` |
+| `GET /v1/models` | 200, the loaded id | 200, the loaded id |
+| `POST /v1/chat/completions`, non-streaming | 200, `finish_reason: stop`, content `Paris.` (0.46 s) | 200, `finish_reason: stop`, content `Paris.` after 205 tokens (3.51 s) |
+| `POST /v1/chat/completions`, streaming | 200, 12 SSE frames closed by `[DONE]`, assembled `One, two, three, four, five.` | 200, 221 SSE frames closed by `[DONE]`, `finish_reason: stop` |
+| Script verdict | `OK` | `OK` |
+
+Both models answered coherently, the streaming and non-streaming paths agreed, and neither server log carried an error, a panic or a terminate. The MoE model runs through `gather_qmm` because the fused MoE kernel has no ROCm port (#1803).
+
+Two things about the check are worth recording, because both look like backend faults and are not. `model` is a required field on the request body, and omitting it returns 422 with a deserialization message. And a thinking model fills `reasoning_content` before `content`, so a budget too small to close the thinking block yields `finish_reason: length` with empty `content`: `Qwen3-0.6B-4bit` does this even at 2048 tokens. The script reads both channels and names which one carried the text, the same answer `scripts/ab_output_equality.sh` reaches with `--show-reasoning`.
+
 ## The test gate alongside the matrix
 
 `make verify-test-rocm` runs the workspace suite against a ROCm build. It is the broader of the two checks and it is not green: the missing primitives in #1825 throw through the cxx bridge, which ends in `std::terminate`, so a binary that reaches one aborts rather than reporting a failure. Run at the same commit as the traces, with aborting tests skipped so the rest of each binary can finish:
@@ -144,9 +160,17 @@ The checkpoint directory name is host-local: this host holds `models/mlx/Qwen3-3
 
 `compare_logit_traces.py` prints the largest reference gap at a disagreement on every run, so the 1.125 figure above is reproducible from any pair without a separate script.
 
+The serving check:
+
+```bash
+MLXCEL_FUSED_MOE=0 ./target/release/mlxcel-server -m models/mlx/Qwen3-30B-A3B-4bit --port 8080 &
+./scripts/server_chat_smoke.sh --port 8080
+```
+
 ## Known gaps at the time of this run
 
 - Fused MoE has no ROCm kernel, so MoE models run through `gather_qmm` (#1803).
 - `FFT`, `Hadamard` and `SearchSorted` are `NO_GPU` stubs, so audio, TurboQuant KV cache and stochastic speculative decoding abort (#1825).
 - Only affine 4-bit was traced. mxfp4, mxfp8 and nvfp4 coverage is #1806, #1807 and #1808.
 - Prefill through the sorted large-row `gather_qmm` path is slow on both dtypes (#1814).
+- The model matrix in #1809 also names a sliding-window model, an SSM hybrid pair and a VLM. Those rows are not in this run; they wait on #1803 and #1805.

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -359,6 +359,21 @@ On a UMA host the GPU shares memory with the operating system and with any
 other GPU process, so check `rocm-smi --showpids` for other tenants before
 loading a large model.
 
+To check the HTTP server rather than the CLI, start it and run the chat smoke
+script against it. Both a dense and an affine MoE checkpoint pass on `gfx1151`;
+the results are in
+[`docs/benchmark_results/rocm-correctness-gfx1151-2026-09-12.md`](benchmark_results/rocm-correctness-gfx1151-2026-09-12.md).
+
+```bash
+MLXCEL_FUSED_MOE=0 ./target/release/mlxcel-server -m models/mlx/Qwen3-30B-A3B-4bit --port 8080 &
+./scripts/server_chat_smoke.sh --port 8080
+```
+
+The script checks `/health`, `/v1/models`, and `/v1/chat/completions` both
+streaming and non-streaming. It counts the reasoning channel as output, so a
+thinking model that spends its whole budget inside the thinking block reports
+`channel=reasoning only` rather than looking like an empty response.
+
 ### Current status
 
 | Area | Status on ROCm |
@@ -371,6 +386,7 @@ loading a large model.
 | GPU faults | May show up as NaN output or a hang instead of an error (lablup/mlxcel#1804). |
 | Memory estimation on UMA hosts | Reads host RAM, not the VRAM carve-out; set `MLXCEL_MEMORY_LIMIT` if a model that fits is refused (lablup/mlxcel#1805). |
 | Diagnostics | Print a CUDA compute capability line for the AMD device (lablup/mlxcel#1805). |
+| `mlxcel-server` chat completions | Work for dense and affine MoE checkpoints, streaming and non-streaming; verified with `scripts/server_chat_smoke.sh`. |
 | Windows, multiple GPUs, distributed inference | Not supported. |
 
 Decode throughput measured on the tested configuration, for orientation only

--- a/scripts/server_chat_smoke.sh
+++ b/scripts/server_chat_smoke.sh
@@ -1,0 +1,108 @@
+#!/usr/bin/env bash
+# Chat-completions smoke check against a running mlxcel-server.
+#
+# It boots nothing: point it at a server you started, and it exercises the four
+# things a "does serving work on this backend" claim rests on, in order, and
+# fails on the first one that does not hold.
+#
+#   1. `GET /health` answers 200.
+#   2. `GET /v1/models` answers 200 and reports the id the request must use.
+#   3. `POST /v1/chat/completions` non-streaming returns content and a
+#      `finish_reason` of `stop`.
+#   4. The same request with `"stream": true` returns SSE frames, closes with
+#      `[DONE]`, and assembles to non-empty text.
+#
+# Two things this gets wrong if written by hand, and why they are handled here:
+#
+#   1. `model` is a required field on the request body. Omitting it returns 422
+#      with a deserialization message, which reads like a server fault and is
+#      not one. The id comes from `/v1/models` rather than from the caller.
+#   2. The reasoning channel. A thinking model (Qwen3 and family) fills
+#      `reasoning_content` before `content`, and a small model can spend the
+#      whole budget there without ever closing its thinking block. Judging on
+#      `content` alone then reports a working backend as broken, which is the
+#      same trap `ab_output_equality.sh` documents and answers with
+#      `--show-reasoning`. Both channels count as generated text here, and the
+#      output names which one carried it, so a reasoning-only answer reads as
+#      what it is rather than as an empty response.
+#
+# Usage:
+#   ./scripts/server_chat_smoke.sh --port 8080
+#   ./scripts/server_chat_smoke.sh --base-url http://127.0.0.1:8080 --max-tokens 4096
+set -uo pipefail
+
+base=""
+port=8080
+host=127.0.0.1
+max_tokens=2048
+timeout=600
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --base-url) base=$2; shift 2 ;;
+    --port) port=$2; shift 2 ;;
+    --host) host=$2; shift 2 ;;
+    --max-tokens) max_tokens=$2; shift 2 ;;
+    --timeout) timeout=$2; shift 2 ;;
+    -h|--help) sed -n '2,29p' "$0"; exit 0 ;;
+    *) echo "unknown argument: $1" >&2; exit 2 ;;
+  esac
+done
+[ -n "$base" ] || base="http://${host}:${port}"
+
+fail() { echo "FAIL: $*" >&2; exit 1; }
+
+code=$(curl -s -m 15 -o /tmp/.mlxcel_smoke_health -w '%{http_code}' "$base/health")
+[ "$code" = 200 ] || fail "GET /health returned $code"
+echo "health          200 $(cat /tmp/.mlxcel_smoke_health)"
+
+code=$(curl -s -m 15 -o /tmp/.mlxcel_smoke_models -w '%{http_code}' "$base/v1/models")
+[ "$code" = 200 ] || fail "GET /v1/models returned $code"
+model=$(python3 -c "import json;d=json.load(open('/tmp/.mlxcel_smoke_models'));print(d['data'][0]['id'])") || fail "GET /v1/models returned no model id"
+echo "models          200 $model"
+
+req=$(mktemp); trap 'rm -f "$req" /tmp/.mlxcel_smoke_*' EXIT
+printf '{"model":"%s","messages":[{"role":"user","content":"Name the capital of France in one word."}],"max_tokens":%s,"temperature":0,"stream":false}\n' "$model" "$max_tokens" > "$req"
+code=$(curl -s -m "$timeout" -H 'Content-Type: application/json' -d @"$req" -o /tmp/.mlxcel_smoke_chat -w '%{http_code}' "$base/v1/chat/completions")
+[ "$code" = 200 ] || fail "non-streaming chat returned $code: $(head -c 300 /tmp/.mlxcel_smoke_chat)"
+python3 - /tmp/.mlxcel_smoke_chat <<'PY' || exit 1
+import json, sys
+c = json.load(open(sys.argv[1]))["choices"][0]
+content = c["message"].get("content") or ""
+reasoning = c["message"].get("reasoning_content") or ""
+channel = "content" if content.strip() else ("reasoning only" if reasoning.strip() else "none")
+shown = (content or reasoning)[:60]
+print(f"chat            200 finish_reason={c.get('finish_reason')} channel={channel} text={shown!r}")
+if not (content.strip() or reasoning.strip()):
+    print("FAIL: the response carried no generated text in either channel", file=sys.stderr)
+    sys.exit(1)
+PY
+
+printf '{"model":"%s","messages":[{"role":"user","content":"Count from one to five, words only."}],"max_tokens":%s,"temperature":0,"stream":true}\n' "$model" "$max_tokens" > "$req"
+curl -s -N -m "$timeout" -H 'Content-Type: application/json' -d @"$req" "$base/v1/chat/completions" > /tmp/.mlxcel_smoke_sse || fail "streaming chat request failed"
+python3 - /tmp/.mlxcel_smoke_sse <<'PY' || exit 1
+import json, sys
+frames = 0; text = ""; reasoning = ""; done = False; finish = None
+for line in open(sys.argv[1]):
+    line = line.strip()
+    if not line.startswith("data:"):
+        continue
+    payload = line[5:].strip()
+    if payload == "[DONE]":
+        done = True
+        continue
+    frames += 1
+    choice = json.loads(payload)["choices"][0]
+    delta = choice.get("delta", {})
+    text += delta.get("content") or ""
+    reasoning += delta.get("reasoning_content") or ""
+    finish = choice.get("finish_reason") or finish
+channel = "content" if text.strip() else ("reasoning only" if reasoning.strip() else "none")
+shown = (text or reasoning)[:60]
+print(f"chat stream     200 frames={frames} done={done} finish_reason={finish} channel={channel} text={shown!r}")
+if not (frames and done and (text.strip() or reasoning.strip())):
+    print("FAIL: streaming produced no frames, no [DONE], or no generated text", file=sys.stderr)
+    sys.exit(1)
+PY
+
+echo "OK"


### PR DESCRIPTION
#1809 asks for `mlxcel-server` serving chat completions on ROCm for one dense and one MoE model, which was the last of its acceptance criteria with nothing behind it. Both pass on a Radeon 8060S at the merged 1206f863: `Meta-Llama-3.1-8B-Instruct-4bit` and `Qwen3-30B-A3B-4bit` with `MLXCEL_FUSED_MOE=0` answer coherently, streaming and non-streaming agree, and neither server log carries an error, a panic or a terminate.

`scripts/server_chat_smoke.sh` is the check rather than a transcript of hand-typed curl calls, so the claim is reproducible and the two traps it hides stay hidden. `model` is a required field on the request body and omitting it returns a 422 deserialization error that reads like a server fault. And a thinking model fills `reasoning_content` before `content`, so a budget too small to close the thinking block yields `finish_reason: length` with empty `content`: `Qwen3-0.6B-4bit` does this even at 2048 tokens. The script reads both channels and names which one carried the text, the same answer `scripts/ab_output_equality.sh` reaches with `--show-reasoning`, and fails only when neither channel produced anything.

The results doc gains a serving section and the reproduction command; `docs/installation.md` gains the same command in the ROCm verification steps and a status row. The remaining #1809 gap is the rest of the model matrix, which waits on #1803 and #1805.

Refs #1809

Validated on gfx1151 with the release ROCm build from 1206f863: both models pass `scripts/server_chat_smoke.sh`, and `scripts/ci/check_cross_repo_refs.py` plus `scripts/insert_apache_header.py --check` pass. No Rust code changes, so no backend but ROCm is affected by anything here.

Refs #1809
