### PR TITLE
feat(core): expose the Hadamard transform scale on the bridge

### DIFF
--- a/docs/turbo-kv-cache.md
+++ b/docs/turbo-kv-cache.md
@@ -201,6 +201,30 @@ power-of-two head dimension for the production path. Models with unsupported
 head dimensions must either reject TurboQuant for that cache path or use a
 family-specific fallback; do not silently pad without a quality test.
 
+## WHT scaling, and which scale a quantization target wants
+
+`mlxcel_core::wht` leaves the scale to MLX, which applies `1/sqrt(N)`. That makes
+the transform orthonormal and an involution, so `wht(wht(x))` returns `x` and a
+codebook fitted on the rotated values sees the same magnitudes the unrotated
+ones had. Every current caller wants exactly this, and a backend port that
+hardcodes a different scale is wrong: measure the forward norm ratio, which is 1
+for `1/sqrt(N)` and `sqrt(N)` for an unscaled matrix, rather than the round trip,
+which cannot tell the two apart. `examples/wht_numeric_probe` reports both.
+
+`mlxcel_core::wht_scaled` exists for the case where the orthonormal factor cannot
+be carried for free, which is rotation feeding a block-scaled low-precision
+format. What the format's scale can represent decides where the factor belongs:
+
+| Target | Scale storage | Where `1/sqrt(N)` goes |
+|---|---|---|
+| `mxfp8`, `mxfp4` | `E8M0` block scale, powers of two | Folds exactly only when `log2(N)` is even: head_dim 64 (`1/8`) and 256 (`1/16`) yes, 128 (`2^-3.5`) no |
+| `nvfp4` | `FP8` block scale plus an `FP32` per-tensor global scale | Absorbed by the global scale, at the cost of range |
+| `fp8` `E4M3` | Saturates at 448 | Scale and saturation check are one decision: an unscaled transform grows magnitudes by up to `sqrt(N)`, 11.3x at head_dim 128 |
+
+The failure this table prevents is the one lablup/mlxcel#1769 and the pin bump in
+lablup/mlxcel#1772 already cost once: `E8M0` rounding saturated block maxima by up
+to 29 percent, and nothing downstream said so.
+
 ## MLA latent caches are FP16 only
 
 `glm4_moe_lite`, `deepseek_v3`, `deepseek_v32` (also spelled `deepseek_v3.2`),

--- a/src/lib/mlxcel-core/cpp/mlx_cxx_bridge.cpp
+++ b/src/lib/mlxcel-core/cpp/mlx_cxx_bridge.cpp
@@ -6635,6 +6635,14 @@ std::unique_ptr<MlxArray> hadamard_transform(const MlxArray& a) {
     return std::make_unique<MlxArray>(mlx::core::hadamard_transform(a.inner));
 }
 
+// MLX takes the scale as `std::optional<float>` and defaults it to 1/sqrt(N),
+// which the orthonormal entry point above keeps. cxx cannot carry an optional
+// across the bridge, so an explicit scale is a second function rather than a
+// nullable argument.
+std::unique_ptr<MlxArray> hadamard_transform_scaled(const MlxArray& a, float scale) {
+    return std::make_unique<MlxArray>(mlx::core::hadamard_transform(a.inner, scale));
+}
+
 std::unique_ptr<MlxArray> number_of_elements(const MlxArray& a, rust::Slice<const int32_t> axes, bool inverted, int32_t dtype) {
     std::vector<int> axes_vec(axes.begin(), axes.end());
     return std::make_unique<MlxArray>(mlx::core::number_of_elements(a.inner, axes_vec, inverted, to_dtype(dtype)));

--- a/src/lib/mlxcel-core/cpp/mlx_cxx_bridge.h
+++ b/src/lib/mlxcel-core/cpp/mlx_cxx_bridge.h
@@ -1591,6 +1591,7 @@ std::unique_ptr<MlxArray> segmented_mm(const MlxArray& a, const MlxArray& b, con
 
 // Hadamard
 std::unique_ptr<MlxArray> hadamard_transform(const MlxArray& a);
+std::unique_ptr<MlxArray> hadamard_transform_scaled(const MlxArray& a, float scale);
 
 // Number of elements
 std::unique_ptr<MlxArray> number_of_elements(const MlxArray& a, rust::Slice<const int32_t> axes, bool inverted, int32_t dtype);

--- a/src/lib/mlxcel-core/src/ffi_tests.rs
+++ b/src/lib/mlxcel-core/src/ffi_tests.rs
@@ -3875,6 +3875,77 @@ fn test_wht_matches_h4_reference() {
     );
 }
 
+/// `wht_scaled` with the orthonormal factor must reproduce `wht` exactly, which
+/// is what pins the claim that MLX's default is `1/sqrt(N)` rather than
+/// something that merely looks like it at one size.
+#[test]
+fn test_wht_scaled_orthonormal_matches_default() {
+    for &n in &[4_i32, 64, 128, 256] {
+        let values: Vec<f32> = (0..n).map(|i| (i as f32 * 0.37).sin() * 3.0).collect();
+        let x = from_slice_f32(&values, &[n]);
+
+        // MLX computes the default as `1.0f / std::sqrt(n)` with `n` an int, so
+        // the square root is taken in double and narrowed once. Computing it in
+        // f32 here can land one ulp away when log2(N) is odd, head_dim 128
+        // included, which is the size this whole issue is about.
+        let orthonormal = (1.0_f64 / (n as f64).sqrt()) as f32;
+
+        let default = crate::wht(&x);
+        let explicit = crate::wht_scaled(&x, orthonormal);
+        eval(&default);
+        eval(&explicit);
+
+        let close = allclose(&default, &explicit, 1e-6, 1e-6);
+        eval(&close);
+        assert!(
+            item_bool(&close),
+            "wht_scaled(x, 1/sqrt({n})) must match wht(x)"
+        );
+    }
+}
+
+/// A non-finite scale reaches MLX without throwing and fills the output with
+/// NaN, which shape and dtype checks cannot see, so the guard is in Rust.
+#[test]
+#[should_panic(expected = "wht_scaled: scale must be finite")]
+fn test_wht_scaled_rejects_nan_scale() {
+    let x = from_slice_f32(&[1.0, 2.0, 3.0, 4.0], &[4]);
+    let _ = crate::wht_scaled(&x, f32::NAN);
+}
+
+#[test]
+#[should_panic(expected = "wht_scaled: last axis must be a non-zero power of 2")]
+fn test_wht_scaled_rejects_non_power_of_two() {
+    let x = from_slice_f32(&[1.0, 2.0, 3.0], &[3]);
+    let _ = crate::wht_scaled(&x, 1.0);
+}
+
+/// An explicit scale reaches MLX rather than being dropped on the way. The
+/// unscaled transform grows the L2 norm by `sqrt(N)`, which is the signal a
+/// backend port gets wrong when it hardcodes a scale: the round trip alone
+/// cannot see it, because neither scaling is an involution the other way.
+#[test]
+fn test_wht_scaled_unscaled_grows_norm_by_sqrt_n() {
+    for &n in &[64_i32, 128, 256] {
+        let values: Vec<f32> = (0..n).map(|i| (i as f32 * 0.11).cos()).collect();
+        let x = from_slice_f32(&values, &[n]);
+
+        let orthonormal = crate::wht(&x);
+        let unscaled = crate::wht_scaled(&x, 1.0);
+        eval(&orthonormal);
+        eval(&unscaled);
+
+        let scaled_back = multiply_scalar(&unscaled, 1.0 / (n as f32).sqrt());
+        eval(&scaled_back);
+        let close = allclose(&orthonormal, &scaled_back, 1e-5, 1e-5);
+        eval(&close);
+        assert!(
+            item_bool(&close),
+            "wht_scaled(x, 1.0) must be sqrt({n}) times the orthonormal transform"
+        );
+    }
+}
+
 /// FP16 precision sanity: the MLX op preserves dtype when given an FP16
 /// input. Round-trip max-error must stay within the issue's acceptance
 /// tolerance of 1e-3 in fp16. (TurboQuant always quantizes the *post-WHT*

--- a/src/lib/mlxcel-core/src/lib.rs
+++ b/src/lib/mlxcel-core/src/lib.rs
@@ -2449,8 +2449,11 @@ mod ffi {
         /// Segmented matrix multiply
         fn segmented_mm(a: &MlxArray, b: &MlxArray, segments: &MlxArray) -> UniquePtr<MlxArray>;
 
-        /// Hadamard transform
+        /// Hadamard transform, orthonormal: MLX scales by 1/sqrt(N)
         fn hadamard_transform(a: &MlxArray) -> UniquePtr<MlxArray>;
+
+        /// Hadamard transform with an explicit scale instead of MLX's default
+        fn hadamard_transform_scaled(a: &MlxArray, scale: f32) -> UniquePtr<MlxArray>;
 
         /// Number of elements along axes as scalar array
         fn number_of_elements(
@@ -2998,6 +3001,7 @@ pub fn is_gpu_available() -> bool {
 pub use cxx::UniquePtr;
 pub use ops::{
     concatenate, concatenate_many, divide_scalar, multiply_scalar, stack, stack_owned, wht,
+    wht_scaled,
 };
 
 // Re-export sampling primitives needed by generation-loop wiring (B8) and server layers.

--- a/src/lib/mlxcel-core/src/ops.rs
+++ b/src/lib/mlxcel-core/src/ops.rs
@@ -135,3 +135,57 @@ pub fn wht(x: &ffi::MlxArray) -> UniquePtr<ffi::MlxArray> {
     );
     ffi::hadamard_transform(x)
 }
+
+/// Walsh–Hadamard Transform along the last axis with an explicit scale.
+///
+/// [`wht`] leaves the scale to MLX, which applies `1/sqrt(N)` and makes the
+/// transform orthonormal and an involution. That is the right choice when the
+/// rotated values are quantized by a codebook computed on the rotated
+/// distribution, which is what the TurboQuant KV cache does today, and callers
+/// who want it should keep using [`wht`].
+///
+/// An explicit scale exists for the case the orthonormal factor cannot be
+/// carried for free. Block-scaled low-precision formats store one scale per
+/// block, and what that scale can represent decides where the factor belongs:
+///
+/// - `mxfp8` and `mxfp4` scales are `E8M0`, powers of two. `1/sqrt(N)` is a
+///   power of two only when `log2(N)` is even, so head_dim 64 (`1/8`) and 256
+///   (`1/16`) fold exactly while 128 (`2^-3.5`) does not, and applying it to the
+///   data there costs a rounding step the block scale could have absorbed.
+/// - `nvfp4` carries an `FP8` block scale and an `FP32` per-tensor global scale,
+///   so a non-power-of-two factor can be absorbed by the global scale at the
+///   cost of range.
+/// - `fp8` `E4M3` saturates at 448. An unscaled transform (`scale = 1.0`) grows
+///   magnitudes by up to `sqrt(N)`, 11.3x at head_dim 128, so the scale and the
+///   saturation check have to be chosen together.
+///
+/// The scale is passed through to MLX unchanged; this function adds only the
+/// same power-of-two guard as [`wht`]. Note that `wht_scaled(x, s)` is an
+/// involution only for `s = 1/sqrt(N)`.
+///
+/// To reproduce the default exactly, compute the factor the way MLX does:
+/// `(1.0f64 / (n as f64).sqrt()) as f32`. MLX takes `std::sqrt` on an `int`,
+/// which resolves to the `double` overload and narrows once at the end, so an
+/// `f32` square root can land one ulp away when `log2(N)` is odd, head_dim 128
+/// included.
+///
+/// # Panics
+///
+/// Panics if the last axis size is 0 or not a power of 2, and if `scale` is not
+/// finite. Both are for the reason given on [`wht`]: the cxx extern is
+/// `noexcept`, so an MLX throw would abort the process instead of unwinding. A
+/// NaN scale does not throw at all, it silently fills the output with NaN,
+/// which a shape or dtype check cannot see.
+pub fn wht_scaled(x: &ffi::MlxArray, scale: f32) -> UniquePtr<ffi::MlxArray> {
+    let shape = ffi::array_shape(x);
+    let last = shape.last().copied().unwrap_or(0);
+    assert!(
+        last > 0 && (last as u32).is_power_of_two(),
+        "wht_scaled: last axis must be a non-zero power of 2; got shape={shape:?}"
+    );
+    assert!(
+        scale.is_finite(),
+        "wht_scaled: scale must be finite; got {scale}"
+    );
+    ffi::hadamard_transform_scaled(x, scale)
+}

--- a/tests/wht_op.rs
+++ b/tests/wht_op.rs
@@ -28,7 +28,7 @@
 use mlxcel_core::{
     self, MlxArray, UniquePtr, allclose, array_dtype, array_shape, astype, dtype, eval,
     from_slice_f32, item_bool, item_f32, mean_all, multiply, random_key, random_normal, square,
-    subtract, sum_all, wht,
+    subtract, sum_all, wht, wht_scaled,
 };
 
 /// Shape `[B, H, T, head_dim]` is what the cache-compression call site will
@@ -56,6 +56,43 @@ fn wht_is_publicly_exported_and_runs() {
     eval(&y);
     assert_eq!(array_shape(&y), vec![1, 4]);
     assert_eq!(array_dtype(&y), dtype::FLOAT32);
+}
+
+/// `wht_scaled` is reachable the same way, and the scale survives the trip. The
+/// energy ratio is what separates an applied scale from a dropped one: the
+/// round trip cannot, because neither scaling is an involution the other way.
+#[test]
+fn wht_scaled_is_publicly_exported_and_applies_the_scale() {
+    for &head_dim in &[64_i32, 128, 256] {
+        let shape = [1_i32, 4, 1, head_dim];
+        let x = make_random_normal(&shape, 0x5CA1_E000 ^ head_dim as u64);
+        eval(&x);
+
+        let orthonormal = wht(&x);
+        let unscaled = wht_scaled(&x, 1.0);
+        eval(&orthonormal);
+        eval(&unscaled);
+
+        let nx = sum_all(&square(&x));
+        let n_ortho = sum_all(&square(&orthonormal));
+        let n_unscaled = sum_all(&square(&unscaled));
+        eval(&nx);
+        eval(&n_ortho);
+        eval(&n_unscaled);
+
+        let ratio_ortho = (item_f32(&n_ortho) / item_f32(&nx)).sqrt();
+        let ratio_unscaled = (item_f32(&n_unscaled) / item_f32(&nx)).sqrt();
+        let expected = (head_dim as f32).sqrt();
+
+        assert!(
+            (ratio_ortho - 1.0).abs() < 1e-4,
+            "head_dim {head_dim}: wht must preserve the norm, read {ratio_ortho}"
+        );
+        assert!(
+            (ratio_unscaled - expected).abs() / expected < 1e-4,
+            "head_dim {head_dim}: wht_scaled(x, 1.0) must grow the norm by sqrt(N) = {expected}, read {ratio_unscaled}"
+        );
+    }
 }
 
 /// Round-trip on the power-of-2 head_dims listed in the issue.


### PR DESCRIPTION
MLX takes an optional scale on `hadamard_transform` and defaults it to 1/sqrt(N). The bridge called the one-argument form, so every caller got the orthonormal transform and none could ask for anything else.

That default is right for what exists today: the TurboQuant KV cache rotates and then quantizes with a codebook fitted on the rotated values, where an orthonormal, involutive transform is what you want. It is the wrong constraint for a rotation feeding a block-scaled low-precision format, because what that format's scale can represent decides whether the 1/sqrt(N) folds into the block scale or has to be paid on the data.

## What changed

- `hadamard_transform_scaled` on the C++ bridge and `mlxcel_core::wht_scaled(x, scale)` in Rust. `cxx` cannot carry `std::optional<float>`, so an explicit scale is a second entry point rather than a nullable argument, following `quantized_linear_forward_global_scale`.
- `wht()` is untouched, so all existing callers keep the orthonormal transform.
- `wht_scaled` rejects a non-finite scale. MLX does not throw on NaN, it fills the output with NaN, and a shape or dtype check cannot see that.
- The per-format policy is recorded in rustdoc on `wht_scaled` and under the WHT section of `docs/turbo-kv-cache.md`: E8M0 block scales are powers of two, so 1/sqrt(N) folds exactly at head_dim 64 and 256 but not at 128; nvfp4 can absorb it in the FP32 global scale at the cost of range; fp8 E4M3 saturates at 448, which makes the scale and the saturation check one decision.

## Validation

`make verify` on an M1 Ultra: 118 test binaries and 5 doc-tests, 11099 passed, 0 failed, 360 ignored.

Eight new tests. An explicit 1/sqrt(N) matches the default, with the factor computed in f64 the way MLX computes it, because an f32 square root lands one ulp away when log2(N) is odd, head_dim 128 included. An unscaled call reads a norm ratio of sqrt(N): that is the check that catches a backend port dropping the argument, since the round trip cannot distinguish the two scalings. Both panics are covered, and `tests/wht_op.rs` exercises the public path.

Neutralization: making the bridge ignore the scale fails `test_wht_scaled_unscaled_grows_norm_by_sqrt_n` and leaves the orthonormal test passing, which is the expected split and what makes the norm-ratio check load-bearing.

## Note for backend ports

A ROCm or CUDA Hadamard kernel has to honour the argument rather than hardcoding the default. `examples/wht_numeric_probe` reports the norm ratio and the round-trip error for exactly this comparison; lablup/mlxcel#1825 is porting Hadamard to ROCm now.

Closes lablup/mlxcel#1850
