### PR TITLE
test: add reason strings to bare #[ignore] attributes

### DIFF
--- a/src/downloader/tests.rs
+++ b/src/downloader/tests.rs
@@ -544,7 +544,7 @@ async fn stream_file_cleans_up_tempfile_on_error() {
 // Integration test that hits the real Hugging Face Hub. Marked `#[ignore]`
 // per the issue acceptance criteria so CI does not depend on network access.
 #[test]
-#[ignore]
+#[ignore = "hits the real Hugging Face Hub; CI must not depend on network access"]
 fn live_download_smoke_test() {
     // Use a tiny repo so the test stays cheap when explicitly requested with
     // `cargo test -- --ignored`.

--- a/src/models/diffusion_gemma/tests.rs
+++ b/src/models/diffusion_gemma/tests.rs
@@ -445,7 +445,7 @@ fn dense_windowed_mask_is_correct_for_multi_token_offset_forward() {
 ///
 /// `cargo test --release --lib models::diffusion_gemma::tests::real_model_forward_determinism -- --ignored --nocapture`
 #[test]
-#[ignore]
+#[ignore = "real-model regression test; needs the DiffusionGemma checkpoint on disk"]
 fn real_model_forward_determinism() {
     let dir = std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
         .join("models/diffusiongemma-26B-A4B-it-4bit");
@@ -800,7 +800,7 @@ fn sanitize_drops_clip_calibration_when_unclipped() {
 ///
 /// `cargo test --release --lib models::diffusion_gemma::tests::real_model_loads_vision_front_end -- --ignored --nocapture`
 #[test]
-#[ignore]
+#[ignore = "real-model regression test; needs the DiffusionGemma checkpoint on disk"]
 fn real_model_loads_vision_front_end() {
     let dir = std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
         .join("models/diffusiongemma-26B-A4B-it-4bit");

--- a/src/tokenizer/tiktoken_tests.rs
+++ b/src/tokenizer/tiktoken_tests.rs
@@ -117,7 +117,7 @@ fn qwen_image_tags_encode_as_single_specials() {
 }
 
 #[test]
-#[ignore] // Requires model files
+#[ignore = "requires model files on disk"]
 fn test_load_tiktoken() {
     let tokenizer = TiktokenTokenizer::from_file(&tiktoken_file(), &test_model_path());
     assert!(
@@ -132,7 +132,7 @@ fn test_load_tiktoken() {
 }
 
 #[test]
-#[ignore] // Requires model files
+#[ignore = "requires model files on disk"]
 fn test_encode_decode_roundtrip() {
     let t = TiktokenTokenizer::from_file(&tiktoken_file(), &test_model_path()).unwrap();
     let text = "Hello, world!";
@@ -143,7 +143,7 @@ fn test_encode_decode_roundtrip() {
 }
 
 #[test]
-#[ignore] // Requires model files
+#[ignore = "requires model files on disk"]
 fn test_encode_chinese() {
     let t = TiktokenTokenizer::from_file(&tiktoken_file(), &test_model_path()).unwrap();
     let text = "你好，世界";
@@ -154,7 +154,7 @@ fn test_encode_chinese() {
 }
 
 #[test]
-#[ignore] // Requires model files
+#[ignore = "requires model files on disk"]
 fn test_special_tokens() {
     let t = TiktokenTokenizer::from_file(&tiktoken_file(), &test_model_path()).unwrap();
     let text = "<|eos|>";

--- a/tests/deepseek_v4_real_model.rs
+++ b/tests/deepseek_v4_real_model.rs
@@ -52,7 +52,7 @@ use mlxcel::{CxxGenerator, LanguageModel, SamplingConfig, initialize_runtime, lo
 const MODEL_DIR: &str = "deepseek-v4-flash-4bit";
 
 #[test]
-#[ignore]
+#[ignore = "real-model heavy (~151 GB checkpoint on disk; needs a high-memory Apple Silicon host)"]
 fn deepseek_v4_real_model_loads_and_generates_coherently() {
     let model_dir = repo_model_dir(MODEL_DIR);
     if !model_dir.join("config.json").exists() {
@@ -108,7 +108,7 @@ fn deepseek_v4_real_model_loads_and_generates_coherently() {
 }
 
 #[test]
-#[ignore]
+#[ignore = "real-model heavy (~151 GB checkpoint on disk; needs a high-memory Apple Silicon host)"]
 fn deepseek_v4_real_model_decode_crosses_pooling_windows() {
     // A longer decode than one compress window (ratio 4) plus one full
     // simple window boundary region, so decode-mode pooling emission and the
@@ -142,7 +142,7 @@ fn deepseek_v4_real_model_decode_crosses_pooling_windows() {
 }
 
 #[test]
-#[ignore]
+#[ignore = "real-model heavy (~151 GB checkpoint on disk; needs a high-memory Apple Silicon host)"]
 fn deepseek_v4_real_model_long_context_hits_sparse_and_compressed_paths() {
     // The sparse split-softmax and the batched/decode HiSA selection only
     // run once a ratio-4 layer's pooled count exceeds index_topk (512), i.e.
@@ -233,7 +233,7 @@ fn deepseek_v4_real_model_long_context_hits_sparse_and_compressed_paths() {
 /// world knowledge. Making the answer purely synthetic would test retrieval
 /// harder and be far less stable on a base checkpoint at this length.
 #[test]
-#[ignore]
+#[ignore = "real-model heavy (~151 GB checkpoint on disk; needs a high-memory Apple Silicon host)"]
 fn deepseek_v4_real_model_long_context_engages_hisa_hierarchy() {
     let model_dir = repo_model_dir(MODEL_DIR);
     if !model_dir.join("config.json").exists() {
@@ -359,7 +359,7 @@ fn deepseek_v4_real_model_long_context_engages_hisa_hierarchy() {
 /// crash or a degenerate output in any band shows up.
 ///
 #[test]
-#[ignore]
+#[ignore = "real-model heavy (~151 GB checkpoint on disk; needs a high-memory Apple Silicon host)"]
 fn deepseek_v4_real_model_hisa_decode_cost_scaling() {
     let model_dir = repo_model_dir(MODEL_DIR);
     if !model_dir.join("config.json").exists() {

--- a/tests/ernie4_5_moe_vl_parity.rs
+++ b/tests/ernie4_5_moe_vl_parity.rs
@@ -129,7 +129,7 @@ fn text_only_forward_produces_finite_logits() {
 /// special-token-only degeneration is visible. Ignored by default; run with
 /// `--ignored --nocapture` when debugging.
 #[test]
-#[ignore]
+#[ignore = "diagnostic; needs a real ERNIE-4.5 MoE VL checkpoint on disk"]
 fn debug_image_greedy_ids() {
     let Some(dir) = model_dir() else { return };
     let (model, tokenizer) = mlxcel::load_model(&dir).expect("load ERNIE-4.5-VL");

--- a/tests/got_ocr_prompt_parity.rs
+++ b/tests/got_ocr_prompt_parity.rs
@@ -78,7 +78,7 @@ fn resolve_checkpoint() -> Option<std::path::PathBuf> {
 }
 
 #[test]
-#[ignore]
+#[ignore = "needs a GOT-OCR 2.0 checkpoint on disk"]
 fn got_prompt_ids_match_the_reference_tokenizer() {
     let Some(model_dir) = resolve_checkpoint() else {
         eprintln!(
@@ -137,7 +137,7 @@ fn got_prompt_ids_match_the_reference_tokenizer() {
 }
 
 #[test]
-#[ignore]
+#[ignore = "needs a GOT-OCR 2.0 checkpoint on disk"]
 fn got_format_mode_prompt_ids_match_the_reference_tokenizer() {
     let Some(model_dir) = resolve_checkpoint() else {
         eprintln!("Skipping: no GOT-OCR 2.0 checkpoint found.");
@@ -164,7 +164,7 @@ fn got_format_mode_prompt_ids_match_the_reference_tokenizer() {
 /// id. The render is the builtin GOT template's output, which is what
 /// `ChatTemplateProcessor` hands the runtime for a chat request.
 #[test]
-#[ignore]
+#[ignore = "needs a GOT-OCR 2.0 checkpoint on disk"]
 fn server_render_and_cli_instruction_tokenize_identically() {
     let Some(model_dir) = resolve_checkpoint() else {
         eprintln!("Skipping: no GOT-OCR 2.0 checkpoint found.");

--- a/tests/qwen38_mtp_chain_parity.rs
+++ b/tests/qwen38_mtp_chain_parity.rs
@@ -124,7 +124,7 @@ fn forward_tokens(model: &Qwen35Model, tokens: &[i32], caches: &mut [Qwen3NextCa
 }
 
 #[test]
-#[ignore]
+#[ignore = "real-model heavy"]
 fn block_verify_chain_matches_single_token_chain() {
     let target_dir = CANDIDATE_TARGETS
         .iter()
@@ -199,7 +199,7 @@ fn block_verify_chain_matches_single_token_chain() {
 /// every GPU is that a passing probe implies a passing chain, because the
 /// gate turns MTP on off the back of it.
 #[test]
-#[ignore]
+#[ignore = "real-model heavy"]
 fn the_exactness_probe_never_passes_where_the_block_chain_diverges() {
     let target_dir = CANDIDATE_TARGETS
         .iter()
@@ -444,7 +444,7 @@ fn assert_parity_and_standard_arms_are_distinguishable() {
 /// cargo test --test qwen38_mtp_chain_parity --release --features metal,accelerate -- --ignored --nocapture parity_kernel_cost
 /// ```
 #[test]
-#[ignore]
+#[ignore = "real-model heavy"]
 fn parity_kernel_cost_vs_standard() {
     if !mlxcel_core::metal_is_available() {
         eprintln!("skipping: chain-parity kernel is Metal-only");
@@ -520,7 +520,7 @@ fn parity_kernel_cost_vs_standard() {
 /// cargo test --test qwen38_mtp_chain_parity --release --features metal,accelerate -- --ignored --nocapture verify_forward_cost
 /// ```
 #[test]
-#[ignore]
+#[ignore = "real-model heavy"]
 fn verify_forward_cost_scaling() {
     let Some(target_dir) = CANDIDATE_TARGETS
         .iter()
@@ -609,7 +609,7 @@ fn greedy() -> SamplingConfig {
 /// runs. Any divergence from the classic chain is therefore in the adapter's
 /// prefill or the multi-token verify forward itself.
 #[test]
-#[ignore]
+#[ignore = "real-model heavy; needs a Qwen 3.5-family checkpoint on disk"]
 fn adapter_chain_with_perfect_drafts_matches_classic_chain() {
     let Some(target_dir) = CANDIDATE_TARGETS
         .iter()
@@ -675,7 +675,7 @@ fn adapter_chain_with_perfect_drafts_matches_classic_chain() {
 /// conditions on the accepted prefix, so its argmax must still follow the
 /// classic chain; any divergence isolates the rollback path.
 #[test]
-#[ignore]
+#[ignore = "real-model heavy; needs a Qwen 3.5-family checkpoint on disk"]
 fn adapter_chain_with_rejected_drafts_matches_classic_chain() {
     let Some(target_dir) = CANDIDATE_TARGETS
         .iter()

--- a/tests/qwen3_omni_moe_parity.rs
+++ b/tests/qwen3_omni_moe_parity.rs
@@ -63,7 +63,7 @@ fn audio_out_len_formula() {
 /// Diagnostic: greedy-decode a few steps after a TEMPLATED image prefill and
 /// dump raw ids. Ignored by default.
 #[test]
-#[ignore]
+#[ignore = "diagnostic; needs a real Qwen3-Omni checkpoint on disk"]
 fn debug_templated_image_greedy_ids() {
     let Some(dir) = model_dir() else { return };
     let (model, tokenizer) = mlxcel::load_model(&dir).expect("load qwen3-omni");


### PR DESCRIPTION
## Summary

Fill every bare `#[ignore]` and `#[ignore] // comment` attribute under `src/` and `tests/` with a reason string in the `#[ignore = "..."]` form, matching the convention used by the other ~350 ignore attributes in the tree. In every case the reason text was already adjacent in the file — a module doc comment, a `MODEL_DIR` const, an `eprintln!` skip message, or a trailing comment.

Closes #1698

## Changes

Eight files, 23 sites:

| File | Sites | Reason |
|------|-------|--------|
| `tests/deepseek_v4_real_model.rs` | 5 | real-model heavy (~151 GB checkpoint) |
| `tests/qwen38_mtp_chain_parity.rs` | 6 | real-model heavy; needs Qwen 3.5-family checkpoint |
| `tests/got_ocr_prompt_parity.rs` | 3 | needs a GOT-OCR 2.0 checkpoint on disk |
| `tests/qwen3_omni_moe_parity.rs` | 1 | diagnostic; needs real Qwen3-Omni checkpoint |
| `tests/ernie4_5_moe_vl_parity.rs` | 1 | diagnostic; needs real ERNIE-4.5 MoE VL checkpoint |
| `src/models/diffusion_gemma/tests.rs` | 2 | real-model regression test; needs DiffusionGemma checkpoint |
| `src/downloader/tests.rs` | 1 | hits the real Hugging Face Hub; CI must not depend on network |
| `src/tokenizer/tiktoken_tests.rs` | 4 | requires model files on disk (moved from trailing `//` comment) |

## Verification

```bash
# Zero bare #[ignore] remaining:
grep -rn '^\s*#\[ignore\]\s*$' src/ tests/ --include='*.rs'
# (empty)

# Zero trailing-comment style remaining:
grep -rn '#\[ignore\] //' src/ tests/ --include='*.rs'
# (empty)
```

No logic changes — purely mechanical text moves into attribute reason strings.

## Acceptance Criteria (from #1698)

- [x] Zero bare `#[ignore]` remains under `src/` and `tests/`